### PR TITLE
[ICIJ/datashare#840] refactor Auth to avoid side effects

### DIFF
--- a/src/api/resources/Auth.js
+++ b/src/api/resources/Auth.js
@@ -6,7 +6,8 @@ import { getCookie } from 'tiny-cookie'
 const api = new Api()
 
 export default class Auth {
-  constructor () {
+  constructor (mode) {
+    this.mode = mode
     this.cachedUsername = null
   }
 
@@ -23,8 +24,8 @@ export default class Auth {
 
   async _checkAuthentication () {
     try {
-      if (process.env.NODE_ENV === 'development') {
-        return 'local'
+      if (this.mode.name === 'local') {
+        return 'local' // default username
       }
       return this._getCookieUsername() || await this._getBasicAuthUserName()
     } catch (_) {

--- a/src/components/Api.vue
+++ b/src/components/Api.vue
@@ -64,11 +64,9 @@
 
 <script>
 import Api from '@/api'
-import Auth from '@/api/resources/Auth'
 import utils from '@/mixins/utils'
 
 const api = new Api()
-const auth = new Auth()
 
 /**
  * A page to manage user's API keys.
@@ -95,18 +93,18 @@ export default {
   },
   methods: {
     async getHashedApiKey () {
-      const username = await auth.getUsername()
+      const username = await this.$core.auth.getUsername()
       const { hashedKey } = await api.getApiKey(username)
       this.hashedKey = hashedKey
     },
     async createApiKey () {
-      const username = await auth.getUsername()
+      const username = await this.$core.auth.getUsername()
       const { apiKey } = await api.createApiKey(username)
       this.apiKey = apiKey
       await this.getHashedApiKey()
     },
     async deleteApiKey () {
-      const username = await auth.getUsername()
+      const username = await this.$core.auth.getUsername()
       await api.deleteApiKey(username)
       this.hashedKey = null
     }

--- a/src/components/DocumentTagsForm.vue
+++ b/src/components/DocumentTagsForm.vue
@@ -110,7 +110,7 @@ export default {
     }, 200),
     async addTag () {
       this.$set(this, 'isReady', false)
-      await this.$store.dispatch('document/tag', { documents: this.documents, tag: this.tag })
+      await this.$store.dispatch('document/tag', { documents: this.documents, tag: this.tag, userId: this.$core.auth.getUsername() })
       this.$set(this, 'tag', '')
       this.$set(this, 'suggestions', [])
       this.$set(this, 'isReady', true)

--- a/src/components/document/DocumentNavbar.vue
+++ b/src/components/document/DocumentNavbar.vue
@@ -118,7 +118,7 @@ export default {
       this.$root.$el.style.setProperty('--document-navbar-height', height)
     },
     async toggleAsRecommended () {
-      await this.$store.dispatch('document/toggleAsRecommended')
+      await this.$store.dispatch('document/toggleAsRecommended', await this.$core.auth.getUsername())
       await this.$store.dispatch('search/getRecommendationsByProject')
     },
     scrollToTop () {

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -47,10 +47,12 @@ class Core extends Behaviors {
   /**
    * Create an application
    * @param {Object} LocalVue - The Vue class to instantiate the application with.
+   * @param auth - The authentication service
    */
-  constructor (LocalVue = Vue) {
+  constructor (LocalVue = Vue, auth = new Auth(mode('local'))) {
     super(LocalVue)
     this.LocalVue = LocalVue
+    this._auth = auth
     // Disable production tip when not in production
     this.LocalVue.config.productionTip = process.env.NODE_ENV === 'development'
     // Setup deferred state
@@ -178,6 +180,7 @@ class Core extends Behaviors {
       this.config.merge(serverSettings)
       // Create the default project for the current user or redirect to login
       await this.createDefaultProject()
+      this._auth = new Auth(mode(serverSettings.mode))
       // Set the default project
       if (this.store.state.search.index === '') {
         this.store.commit('search/index', this.getDefaultProject())
@@ -304,7 +307,6 @@ class Core extends Behaviors {
    * @type {Auth}
    */
   get auth () {
-    this._auth = this._auth || new Auth()
     return this._auth
   }
   /**

--- a/src/modes/index.js
+++ b/src/modes/index.js
@@ -1,7 +1,8 @@
 import local from './local'
 import server from './server'
 
-export default (mode = 'local') => {
+export default (modeName = 'local') => {
   // Return the right values according to the mode or fallback to `local`
-  return { local, server }[mode.toLowerCase()] || local
+  const modes = { local, server }
+  return modes[modeName.toLowerCase()] || local
 }

--- a/src/modes/local.js
+++ b/src/modes/local.js
@@ -1,4 +1,5 @@
 export default {
+  modeName: 'local',
   multipleProjects: false,
   manageDocuments: true
 }

--- a/src/modes/server.js
+++ b/src/modes/server.js
@@ -1,6 +1,7 @@
 import local from './local'
 
 export default Object.assign({ ...local }, {
+  modeName: 'server',
   multipleProjects: true,
   manageDocuments: false
 })

--- a/src/pages/DocumentView.vue
+++ b/src/pages/DocumentView.vue
@@ -129,47 +129,49 @@ export default {
       return this.$store.getters['pipelines/applyPipelineChainByCategory']('document-view-tabs')
     },
     tabs () {
-      return !this.doc ? [] : [
-        {
-          name: 'extracted-text',
-          label: 'document.extractedText',
-          component: () => import('@/components/document/DocumentTabExtractedText'),
-          icon: 'align-left',
-          props: {
-            document: this.doc,
-            q: this.q
+      return !this.doc
+        ? []
+        : [
+          {
+            name: 'extracted-text',
+            label: 'document.extractedText',
+            component: () => import('@/components/document/DocumentTabExtractedText'),
+            icon: 'align-left',
+            props: {
+              document: this.doc,
+              q: this.q
+            }
+          },
+          {
+            name: 'preview',
+            label: 'document.preview',
+            component: () => import('@/components/document/DocumentTabPreview'),
+            icon: 'eye',
+            props: {
+              document: this.doc
+            }
+          },
+          {
+            name: 'details',
+            label: 'document.tabDetails',
+            component: () => import('@/components/document/DocumentTabDetails'),
+            icon: 'info-circle',
+            props: {
+              document: this.doc,
+              parentDocument: this.parentDocument
+            }
+          },
+          {
+            name: 'named-entities',
+            label: 'document.namedEntities',
+            hidden: this.$config.isnt('manageDocuments') && !this.doc.hasNerTags,
+            component: () => import('@/components/document/DocumentTabNamedEntities'),
+            icon: 'database',
+            props: {
+              document: this.doc
+            }
           }
-        },
-        {
-          name: 'preview',
-          label: 'document.preview',
-          component: () => import('@/components/document/DocumentTabPreview'),
-          icon: 'eye',
-          props: {
-            document: this.doc
-          }
-        },
-        {
-          name: 'details',
-          label: 'document.tabDetails',
-          component: () => import('@/components/document/DocumentTabDetails'),
-          icon: 'info-circle',
-          props: {
-            document: this.doc,
-            parentDocument: this.parentDocument
-          }
-        },
-        {
-          name: 'named-entities',
-          label: 'document.namedEntities',
-          hidden: this.$config.isnt('manageDocuments') && !this.doc.hasNerTags,
-          component: () => import('@/components/document/DocumentTabNamedEntities'),
-          icon: 'database',
-          props: {
-            document: this.doc
-          }
-        }
-      ]
+        ]
     },
     indexActiveTab () {
       return findIndex(this.visibleTabs, tab => tab.name === this.activeTab)
@@ -195,7 +197,7 @@ export default {
       await this.$store.dispatch('document/getParent')
       await this.$store.dispatch('document/getRoot')
       await this.$store.dispatch('document/getTags')
-      await this.$store.dispatch('document/getRecommendationsByDocuments')
+      await this.$store.dispatch('document/getRecommendationsByDocuments', this.$core.auth.getUsername())
       if (this.doc) {
         await this.api.addHistoryEvent(this.doc.index, 'DOCUMENT', this.doc.slicedNameToString, this.doc.route)
         const container = this.$el.closest('.ps-container')

--- a/src/pages/Error.vue
+++ b/src/pages/Error.vue
@@ -2,7 +2,6 @@
 import { FontAwesomeLayers } from '@fortawesome/vue-fontawesome'
 
 import Api from '@/api'
-import Auth from '@/api/resources/Auth'
 import VersionNumber from '@/components/VersionNumber'
 import utils from '@/mixins/utils'
 import settings from '@/utils/settings'
@@ -34,8 +33,7 @@ export default {
     }
   },
   async mounted () {
-    const auth = new Auth()
-    this.username = await auth.getUsername()
+    this.username = await this.$core.auth.getUsername()
   },
   computed: {
     titleAsString () {

--- a/src/store/pipelines/UsernameIsYouPipeline.js
+++ b/src/store/pipelines/UsernameIsYouPipeline.js
@@ -1,7 +1,8 @@
 import Auth from '@/api/resources/Auth'
 import IdentityPipeline from './IdentityPipeline'
+import server from '@/modes'
 
-export const auth = new Auth()
+export const auth = new Auth(server())
 
 class UsernameIsYouPipeline extends IdentityPipeline {
   async apply (username) {

--- a/tests/unit/specs/api/resources/Auth.spec.js
+++ b/tests/unit/specs/api/resources/Auth.spec.js
@@ -1,9 +1,9 @@
 import axios from 'axios'
 import { removeCookie, setCookie } from 'tiny-cookie'
-
+import mode from '@/modes'
 import Auth from '@/api/resources/Auth'
 
-const auth = new Auth()
+const auth = new Auth(mode())
 
 jest.mock('axios')
 

--- a/tests/unit/specs/pages/Error.spec.js
+++ b/tests/unit/specs/pages/Error.spec.js
@@ -1,13 +1,20 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils'
 import { setCookie, removeCookie } from 'tiny-cookie'
-
 import { Core } from '@/core'
 import Error from '@/pages/Error'
+import mode from '@/modes'
+import Auth from '@/api/resources/Auth'
 
-const { i18n, localVue } = Core.init(createLocalVue()).useAll()
-
-describe('Error.vue', () => {
+describe('Error.vue local mode', () => {
   let wrapper
+  let i18n
+  let localVue
+
+  beforeEach(() => {
+    const core = Core.init(createLocalVue()).useAll()
+    i18n = core.i18n
+    localVue = core.localVue
+  })
 
   it('should display a custom title', () => {
     const propsData = { title: 'This is wrong!' }
@@ -26,13 +33,22 @@ describe('Error.vue', () => {
     // Render again
     expect(wrapper.find('.error__header').exists()).toBeTruthy()
   })
+})
+
+describe('Error.vue server mode', () => {
+  let wrapper
+  let i18n
+  let localVue
+  beforeEach(() => {
+    const core = Core.init(createLocalVue(), new Auth(mode('server'))).useAll()
+    i18n = core.i18n
+    localVue = core.localVue
+  })
 
   it('should not display a header when user is logged out in server mode', async () => {
-    // Mock the user session
     removeCookie(process.env.VUE_APP_DS_COOKIE_NAME)
     // Mock the isServer property
-    const computed = { isServer: () => true }
-    wrapper = shallowMount(Error, { i18n, localVue, computed })
+    wrapper = shallowMount(Error, { i18n, localVue })
     // Flush promises
     await (new Promise(resolve => setImmediate(resolve)))
     // Render again

--- a/tests/unit/specs/store/modules/document.spec.js
+++ b/tests/unit/specs/store/modules/document.spec.js
@@ -211,17 +211,16 @@ describe('DocumentStore', () => {
 
       axios.request.mockClear()
 
-      await store.dispatch('document/toggleAsRecommended')
+      await store.dispatch('document/toggleAsRecommended', userId)
 
-      expect(axios.request).toBeCalledTimes(2)
-      expect(axios.request).toBeCalledWith({ url: Api.getFullUrl('/api/users/me') })
+      expect(axios.request).toBeCalledTimes(1)
       expect(axios.request).toBeCalledWith(expect.objectContaining({
         url: Api.getFullUrl(`/api/${index}/documents/batchUpdate/recommend`),
         method: 'POST',
         data: ['doc_01']
       }))
       expect(store.state.document.isRecommended).toBeTruthy()
-      expect(indexOf(store.state.document.recommendedBy, userId)).toBeGreaterThan(-1)
+      expect(store.state.document.recommendedBy).toEqual([userId])
     })
 
     it('should UNMARK these documents as recommended', async () => {


### PR DESCRIPTION
The refactor that we made with CD and MC.

The aim was to centralize Auth access from client with `this.$core.auth` and avoid buiding Auth.

Second it was to remove the line dependent from dev mode.