### PR TITLE
chore: add code formatter and linter to the codebase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,9 @@ workflows:
   test_and_publish_doc:
     jobs:
       - build
+      - lint:
+          requires: 
+            - build
       - test:
           requires:
             - build
@@ -48,6 +51,19 @@ jobs:
           key: bundle-cache-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - ~/datashare-client
+  
+  # This job will run linters on the vue and js code
+  lint:
+    docker:
+      - image: cimg/node:16.16.0
+    working_directory: ~/datashare-client
+    steps:
+      - restore_cache:
+          name: Restore app bundle (repo + dependencies) from the `build` job
+          key: bundle-cache-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
+          name: Run linter
+          command: yarn lint
 
   # This job will run unit tests for the client
   test:

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+/dist
+*.config.js
+config.yml
+/public/docs
+*.hbs
+/README.md

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
     jest: true,
     node: true
   },
-  extends: ['plugin:vue/strongly-recommended', 'plugin:vue/recommended', 'standard', 'prettier'],
+  extends: ['plugin:vue/recommended', 'standard', 'prettier'],
   plugins: ['prettier'],
   rules: {
     'prettier/prettier': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,20 @@
+module.exports = {
+  env: {
+    jest: true,
+    node: true
+  },
+  extends: ['plugin:vue/strongly-recommended', 'standard', 'plugin:vue/essential', '@vue/standard', 'prettier'],
+  plugins: ['prettier'],
+  rules: {
+    'prettier/prettier': 'error',
+    'import/no-webpack-loader-syntax': 'off',
+    'no-useless-escape': 'off',
+    'lines-between-class-members': 'off',
+    'template-curly-spacing': 'off',
+    'vue/custom-event-name-casing': 'off',
+    'import/no-extraneous-dependencies': 'off'
+  },
+  parserOptions: {
+    parser: 'babel-eslint'
+  }
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
     jest: true,
     node: true
   },
-  extends: ['plugin:vue/strongly-recommended', 'standard', 'prettier'],
+  extends: ['plugin:vue/strongly-recommended', 'plugin:vue/recommended', 'standard', 'prettier'],
   plugins: ['prettier'],
   rules: {
     'prettier/prettier': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
     'lines-between-class-members': 'off',
     'template-curly-spacing': 'off',
     'vue/custom-event-name-casing': 'off',
-    'import/no-extraneous-dependencies': 'off'
+    'import/no-extraneous-dependencies': 'off',
+    'vue/require-default-prop': 'off'
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
     jest: true,
     node: true
   },
-  extends: ['plugin:vue/strongly-recommended', 'standard', 'plugin:vue/essential', '@vue/standard', 'prettier'],
+  extends: ['plugin:vue/strongly-recommended', 'standard', 'prettier'],
   plugins: ['prettier'],
   rules: {
     'prettier/prettier': 'error',
@@ -13,8 +13,5 @@ module.exports = {
     'template-curly-spacing': 'off',
     'vue/custom-event-name-casing': 'off',
     'import/no-extraneous-dependencies': 'off'
-  },
-  parserOptions: {
-    parser: 'babel-eslint'
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
     jest: true,
     node: true
   },
-  extends: ['plugin:vue/recommended', 'standard', 'prettier'],
+  extends: ['standard', 'plugin:vue/recommended', 'prettier'],
   plugins: ['prettier'],
   rules: {
     'prettier/prettier': 'error',
@@ -13,6 +13,10 @@ module.exports = {
     'template-curly-spacing': 'off',
     'vue/custom-event-name-casing': 'off',
     'import/no-extraneous-dependencies': 'off',
-    'vue/require-default-prop': 'off'
+    'vue/require-default-prop': 'off',
+    'vue/no-v-html': 'off'
+  },
+  parserOptions: {
+    parser: 'babel-eslint'
   }
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+/dist
+*.config.js
+config.yml
+/public/docs
+*.hbs
+/README.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,0 @@
-/dist
-*.config.js
-config.yml
-/public/docs
-*.hbs
-/README.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "semi": false,
+  "trailingComma": "none",
+  "printWidth": 120
+}

--- a/bin/collectHooks.js
+++ b/bin/collectHooks.js
@@ -8,9 +8,9 @@ const { repository } = require('../package.json')
 const DOC_PATH = join('public', 'docs', 'client')
 
 const build = Handlebars.compile(readFileSync('bin/DOCS.HOOKS.hbs', 'UTF-8'))
-const joinToDoc = path => join(DOC_PATH, path)
+const joinToDoc = (path) => join(DOC_PATH, path)
 
-function srcToGithubWikiPath (src) {
+function srcToGithubWikiPath(src) {
   const name = basename(src, '.vue')
   const path = src.split('/').slice(1, -1).map(capitalize).join('-›-')
   return `Client-›-${path}-›-${name}`
@@ -19,7 +19,7 @@ function srcToGithubWikiPath (src) {
 // Collect hook occurrences with `git grep`
 const occurrences = execSync('git grep --line --no-color --extended-regexp \'<hook name="(.*:\\w*)"\'').toString()
 // Each line is an occurrence, with 3 columns separated by :
-const hooks = compact(occurrences.split('\n')).map(occurrence => {
+const hooks = compact(occurrences.split('\n')).map((occurrence) => {
   const path = occurrence.split(':')[0]
   const line = occurrence.split(':')[1]
   const match = occurrence.split(':').slice(2).join(':')

--- a/bin/collectTocForComponentsDoc.js
+++ b/bin/collectTocForComponentsDoc.js
@@ -9,15 +9,15 @@ const RE_DESCRIPTION = /^>+(.*)$/
 const DOC_PATH = join('public', 'docs', 'client')
 
 const buildToc = Handlebars.compile(readFileSync('bin/DOCS.COMPONENTS.hbs', 'UTF-8'))
-const joinToDoc = path => join(DOC_PATH, path)
+const joinToDoc = (path) => join(DOC_PATH, path)
 
 const components = {
-  collectToc (files) {
-    return files.map(filepath => {
+  collectToc(files) {
+    return files.map((filepath) => {
       const content = readFileSync(filepath, 'UTF-8')
-      const nonEmptyLines = content.split('\n').filter(l => l.length > 0)
+      const nonEmptyLines = content.split('\n').filter((l) => l.length > 0)
       const fallbackTitle = basename(filepath, '.md')
-      const titleIndex = findIndex(nonEmptyLines, l => l.match(RE_HEADER))
+      const titleIndex = findIndex(nonEmptyLines, (l) => l.match(RE_HEADER))
       const title = trimStart(nonEmptyLines[titleIndex], '# ') || fallbackTitle
       const nextToTitle = nonEmptyLines[titleIndex + 1] || ''
       const description = nextToTitle.match(RE_DESCRIPTION) ? trimStart(nextToTitle, '> ') : ''
@@ -26,7 +26,7 @@ const components = {
       return { title, description, path, wikiPath }
     })
   },
-  collectAllTocs () {
+  collectAllTocs() {
     return Object.entries(this).reduce((result, [key, value]) => {
       if (isArrayLike(value)) {
         result[key] = this.collectToc(value)
@@ -34,19 +34,19 @@ const components = {
       return result
     }, {})
   },
-  get widgets () {
+  get widgets() {
     return glob.sync(joinToDoc('Client-›-Components-›-Widget*.md'))
   },
-  get filters () {
+  get filters() {
     return glob.sync(joinToDoc('Client-›-Components-›-Filter-›-Types-›-Filter*.md'))
   },
-  get pages () {
+  get pages() {
     return glob.sync(joinToDoc('Client-›-Pages-›-*.md'))
   },
-  get others () {
+  get others() {
     const all = glob.sync(joinToDoc('Client-›-Components-›-*.md'))
-    return filter(all, f => {
-      const sw = target => startsWith(basename(f).split('-›-').pop(), target)
+    return filter(all, (f) => {
+      const sw = (target) => startsWith(basename(f).split('-›-').pop(), target)
       return sw('Filters') || !(sw('Filter') || sw('Widget'))
     })
   }

--- a/loaders/ignore-loader.js
+++ b/loaders/ignore-loader.js
@@ -1,4 +1,4 @@
-module.exports = function ignoreLoader (content) {
+module.exports = function ignoreLoader(content) {
   this && this.cacheable && this.cacheable()
   return ''
 }

--- a/loaders/metadata-loader.js
+++ b/loaders/metadata-loader.js
@@ -7,7 +7,7 @@ const xss = require('xss')
 const { basename, extname, relative } = require('path')
 const { marked } = require('marked')
 
-function slugger (value) {
+function slugger(value) {
   return value
     .toLowerCase()
     .trim()
@@ -15,7 +15,7 @@ function slugger (value) {
     .replace(/\s/g, '-')
 }
 
-module.exports = function metadataLoader (source) {
+module.exports = function metadataLoader(source) {
   this && this.cacheable && this.cacheable()
 
   const resourcePath = relative('./public/docs/', this.resourcePath)
@@ -31,7 +31,7 @@ module.exports = function metadataLoader (source) {
     Object.assign(metadata, {
       title,
       ...attributes,
-      headings: filter(headings, h => h.depth > 1).map(h => {
+      headings: filter(headings, (h) => h.depth > 1).map((h) => {
         const text = xss(marked.parse(h.text), { stripIgnoreTag: true, whiteList: {} })
         const id = slugger(text)
         return { text, id }

--- a/loaders/metadata-strip-loader.js
+++ b/loaders/metadata-strip-loader.js
@@ -1,6 +1,6 @@
 const frontmatter = require('front-matter')
 
-module.exports = function metadataStripLoader (source) {
+module.exports = function metadataStripLoader(source) {
   this && this.cacheable && this.cacheable()
   const { body } = frontmatter(source)
   return body

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "test:unit": "vue-cli-service test:unit --testPathPattern=/unit/ --maxWorkers=2",
     "test:unit:watch": "vue-cli-service test:unit --testPathPattern=/unit/ --watch",
     "test:e2e": "vue-cli-service test:e2e",
-    "lint": "vue-cli-service lint",
-    "linte": "eslint --ext .js,.vue src",
+    "lint": "eslint --ext .js,.vue src",
+    "lint:fix": "yarn lint --fix",
     "test": "yarn test:unit && yarn test:e2e",
     "doc": "yarn doc:api && yarn doc:hooks && yarn doc:components && yarn doc:components:toc && yarn doc:widgets",
     "doc:api": "npm_config_yes=true npx jsdoc-to-markdown --template bin/DOCS.API.hbs src/core/*.js > 'public/docs/client/Client-›-API.md'",
@@ -127,10 +127,10 @@
   },
   "lint-staged": {
     "*.js": [
-      "vue-cli-service lint"
+    "eslint --ext .js,.vue src"
     ],
     "*.vue": [
-      "vue-cli-service lint"
+    "eslint --ext .js,.vue src"
     ]
   },
   "majestic": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:unit": "vue-cli-service test:unit --testPathPattern=/unit/ --maxWorkers=2",
     "test:unit:watch": "vue-cli-service test:unit --testPathPattern=/unit/ --watch",
     "test:e2e": "vue-cli-service test:e2e",
-    "lint": "eslint --ext .js,.vue src",
+    "lint": "eslint --ext .js,.vue .",
     "lint:fix": "yarn lint --fix",
     "test": "yarn test:unit && yarn test:e2e",
     "doc": "yarn doc:api && yarn doc:hooks && yarn doc:components && yarn doc:components:toc && yarn doc:widgets",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:unit:watch": "vue-cli-service test:unit --testPathPattern=/unit/ --watch",
     "test:e2e": "vue-cli-service test:e2e",
     "lint": "vue-cli-service lint",
+    "linte": "eslint --ext .js,.vue src",
     "test": "yarn test:unit && yarn test:e2e",
     "doc": "yarn doc:api && yarn doc:hooks && yarn doc:components && yarn doc:components:toc && yarn doc:widgets",
     "doc:api": "npm_config_yes=true npx jsdoc-to-markdown --template bin/DOCS.API.hbs src/core/*.js > 'public/docs/client/Client-›-API.md'",
@@ -82,8 +83,10 @@
     "babel-plugin-transform-require-context": "^0.1.1",
     "canvas": "^2.9.3",
     "eslint": "^7.30.0",
+    "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-node": "^11.0.0",
+    "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-standard": "^5.0.0",
     "eslint-plugin-vue": "^7.13.0",
@@ -104,35 +107,6 @@
     "sass-resources-loader": "^2.2.4",
     "vue-template-compiler": "2.7.10",
     "whatwg-fetch": "^3.5.0"
-  },
-  "eslintConfig": {
-    "root": true,
-    "env": {
-      "node": true
-    },
-    "extends": [
-      "plugin:vue/essential",
-      "@vue/standard"
-    ],
-    "rules": {
-      "import/no-webpack-loader-syntax": "off",
-      "no-useless-escape": "off",
-      "lines-between-class-members": "off",
-      "template-curly-spacing": "off",
-      "vue/custom-event-name-casing": "off",
-      "indent": [
-        "error",
-        2,
-        {
-          "ignoredNodes": [
-            "TemplateLiteral"
-          ]
-        }
-      ]
-    },
-    "parserOptions": {
-      "parser": "babel-eslint"
-    }
   },
   "postcss": {
     "plugins": {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -9,124 +9,141 @@ const Method = Object.freeze({
 })
 
 export class Api {
-  constructor (_axios, _EventBus) {
+  constructor(_axios, _EventBus) {
     this.axios = _axios
     this.eventBus = _EventBus
   }
-  tree (path) {
+  tree(path) {
     return this.sendAction('/api/tree/' + trim(path, '/'), { method: Method.GET })
   }
-  index ({ ocr = false, filter = true, language = null } = {}) {
+  index({ ocr = false, filter = true, language = null } = {}) {
     const ocrLanguage = language
-    const options = Object.fromEntries(Object.entries({ ocr, filter, language, ocrLanguage }).filter(([_, v]) => v !== null))
+    const options = Object.fromEntries(
+      Object.entries({ ocr, filter, language, ocrLanguage }).filter(([_, v]) => v !== null)
+    )
     const data = { options }
     return this.sendActionAsText('/api/task/batchUpdate/index/file', { method: Method.POST, data })
   }
-  indexPath (path, { ocr = false, filter = true, language = null } = {}) {
+  indexPath(path, { ocr = false, filter = true, language = null } = {}) {
     const ocrLanguage = language
-    const options = Object.fromEntries(Object.entries({ ocr, filter, language, ocrLanguage }).filter(([_, v]) => v !== null))
+    const options = Object.fromEntries(
+      Object.entries({ ocr, filter, language, ocrLanguage }).filter(([_, v]) => v !== null)
+    )
     const data = Object.fromEntries(Object.entries({ options }).filter(([_, v]) => v != null))
     const trimedPath = trim(path, '/')
     return this.sendActionAsText(`/api/task/batchUpdate/index/${trimedPath}`, { method: Method.POST, data })
   }
-  runBatchSearch () {
+  runBatchSearch() {
     return this.sendAction('/api/task/batchSearch', { method: Method.POST })
   }
-  runBatchDownload (options) {
+  runBatchDownload(options) {
     return this.sendAction('/api/task/batchDownload', { method: Method.POST, data: { options } })
   }
-  findNames (pipeline, options) {
+  findNames(pipeline, options) {
     return this.sendActionAsText(`/api/task/findNames/${pipeline}`, { method: Method.POST, data: { options } })
   }
-  stopPendingTasks () {
+  stopPendingTasks() {
     return this.sendAction('/api/task/stopAll', { method: Method.PUT })
   }
-  stopTask (name) {
-    return this.sendActionAsText((`/api/task/stop/${encodeURIComponent(name)}`), { method: Method.PUT })
+  stopTask(name) {
+    return this.sendActionAsText(`/api/task/stop/${encodeURIComponent(name)}`, { method: Method.PUT })
   }
-  deleteTask (name) {
+  deleteTask(name) {
     return this.sendAction(`/api/task/clean/${encodeURIComponent(name)}`, { method: Method.DELETE })
   }
-  deleteDoneTasks () {
+  deleteDoneTasks() {
     return this.sendAction('/api/task/clean', { method: Method.POST })
   }
-  getTasks (filter) {
+  getTasks(filter) {
     return this.sendAction('/api/task/all', { params: { filter } })
   }
-  createProject (project) {
+  createProject(project) {
     return this.sendActionAsText(`/api/index/${project}`, { method: Method.PUT })
   }
-  deleteAll (project) {
+  deleteAll(project) {
     return this.sendActionAsText(`/api/project/${project}`, { method: Method.DELETE })
   }
-  getVersion () {
+  getVersion() {
     return this.sendAction('/version')
   }
-  getSettings () {
+  getSettings() {
     return this.sendAction('/settings')
   }
-  setSettings (settings) {
+  setSettings(settings) {
     const headers = { 'Content-Type': 'application/json' }
     const responseType = 'text'
     return this.sendAction('/api/settings', { method: 'PATCH', data: { data: settings }, headers, responseType })
   }
-  deleteNamedEntitiesByMentionNorm (project, mentionNorm) {
+  deleteNamedEntitiesByMentionNorm(project, mentionNorm) {
     return this.sendActionAsText(`/api/${project}/namedEntities/hide/${mentionNorm}`, { method: Method.PUT })
   }
-  getSource (document, config = {}) {
+  getSource(document, config = {}) {
     return this.sendAction(document.url, config)
   }
-  getStarredDocuments (project) {
+  getStarredDocuments(project) {
     return this.sendAction(`/api/${project}/documents/starred`)
   }
-  starDocuments (project, data) {
+  starDocuments(project, data) {
     return this.sendActionAsText(`/api/${project}/documents/batchUpdate/star`, { method: Method.POST, data })
   }
-  unstarDocuments (project, data) {
+  unstarDocuments(project, data) {
     return this.sendActionAsText(`/api/${project}/documents/batchUpdate/unstar`, { method: Method.POST, data })
   }
-  getTags (project, documentId) {
+  getTags(project, documentId) {
     return this.sendAction(`/api/${project}/documents/tags/${documentId}`)
   }
-  tagDocument (project, documentId, routingId, data) {
-    return this.sendActionAsText(`/api/${project}/documents/tag/${documentId}?routing=${routingId}`, { method: Method.PUT, data })
+  tagDocument(project, documentId, routingId, data) {
+    return this.sendActionAsText(`/api/${project}/documents/tag/${documentId}?routing=${routingId}`, {
+      method: Method.PUT,
+      data
+    })
   }
-  untagDocument (project, documentId, routingId, data) {
-    return this.sendActionAsText(`/api/${project}/documents/untag/${documentId}?routing=${routingId}`, { method: Method.PUT, data })
+  untagDocument(project, documentId, routingId, data) {
+    return this.sendActionAsText(`/api/${project}/documents/untag/${documentId}?routing=${routingId}`, {
+      method: Method.PUT,
+      data
+    })
   }
-  tagDocuments (project, docIds, tags) {
-    return this.sendActionAsText(`/api/${project}/documents/batchUpdate/tag`, { method: Method.POST, data: { docIds, tags } })
+  tagDocuments(project, docIds, tags) {
+    return this.sendActionAsText(`/api/${project}/documents/batchUpdate/tag`, {
+      method: Method.POST,
+      data: { docIds, tags }
+    })
   }
-  untagDocuments (project, docIds, tags) {
-    return this.sendActionAsText(`/api/${project}/documents/batchUpdate/untag`, { method: Method.POST, data: { docIds, tags } })
+  untagDocuments(project, docIds, tags) {
+    return this.sendActionAsText(`/api/${project}/documents/batchUpdate/untag`, {
+      method: Method.POST,
+      data: { docIds, tags }
+    })
   }
-  getDocumentSlice (project, documentId, offset, limit, targetLanguage = null, routing = null) {
+  getDocumentSlice(project, documentId, offset, limit, targetLanguage = null, routing = null) {
     const params = { limit, offset, routing, targetLanguage }
     return this.sendAction(`/api/${project}/documents/content/${documentId}`, { method: Method.GET, params })
   }
-  searchDocument (project, documentId, query, targetLanguage, routing = null) {
+  searchDocument(project, documentId, query, targetLanguage, routing = null) {
     const params = { query, routing, targetLanguage }
     return this.sendAction(`/api/${project}/documents/searchContent/${documentId}`, { method: Method.GET, params })
   }
-  batchSearch (name, csvFile, description, project, phraseMatch, fuzziness, fileTypes, paths, published) {
+  batchSearch(name, csvFile, description, project, phraseMatch, fuzziness, fileTypes, paths, published) {
     const data = new FormData()
     data.append('name', name)
     data.append('csvFile', csvFile)
     data.append('description', description)
     data.append('phrase_matches', phraseMatch)
     data.append('fuzziness', fuzziness)
-    map(fileTypes, fileType => data.append('fileTypes', fileType.mime))
-    map(paths, path => data.append('paths', path))
+    map(fileTypes, (fileType) => data.append('fileTypes', fileType.mime))
+    map(paths, (path) => data.append('paths', path))
     data.append('published', published)
     return this.sendActionAsText(`/api/batch/search/${project}`, { method: Method.POST, data })
   }
-  getBatchSearch (batchId) {
+  getBatchSearch(batchId) {
     return this.sendActionAsText(`/api/batch/search/${batchId}`)
   }
-  getBatchSearchQueries (batchId) {
+  getBatchSearchQueries(batchId) {
     return this.sendActionAsText(`/api/batch/search/${batchId}/queries`)
   }
-  getBatchSearches (from = 0,
+  getBatchSearches(
+    from = 0,
     size = 100,
     sort = 'batch_date',
     order = 'asc',
@@ -135,114 +152,115 @@ export class Api {
     project = [],
     state = [],
     batchDate = null,
-    publishState = null) {
+    publishState = null
+  ) {
     const data = { from, size, sort, order, query, field, project, state, batchDate, publishState }
     return this.sendActionAsText('/api/batch/search', { method: Method.POST, data })
   }
-  getBatchSearchResults (batchId, from = 0, size = 100, queries = [], sort = 'doc_nb', order = 'desc') {
+  getBatchSearchResults(batchId, from = 0, size = 100, queries = [], sort = 'doc_nb', order = 'desc') {
     const data = { from, size, queries, sort, order }
     return this.sendActionAsText(`/api/batch/search/result/${batchId}`, { method: Method.POST, data })
   }
-  copyBatchSearch (batchId, name, description) {
+  copyBatchSearch(batchId, name, description) {
     const data = { name, description }
     return this.sendActionAsText(`/api/batch/search/copy/${batchId}`, { method: Method.POST, data })
   }
-  deleteBatchSearch (batchId) {
+  deleteBatchSearch(batchId) {
     return this.sendActionAsText(`/api/batch/search/${batchId}`, { method: Method.DELETE })
   }
-  deleteBatchSearches () {
+  deleteBatchSearches() {
     return this.sendActionAsText('/api/batch/search', { method: Method.DELETE })
   }
-  updateBatchSearch (batchId, published) {
+  updateBatchSearch(batchId, published) {
     return this.sendAction(`/api/batch/search/${batchId}`, { method: 'PATCH', data: { data: { published } } })
   }
-  static getFullUrl (path) {
+  static getFullUrl(path) {
     const base = process.env.VUE_APP_DS_HOST || `${window.location.protocol}//${window.location.host}`
     const url = new URL(path, base)
     return url.href
   }
-  isDownloadAllowed (project) {
+  isDownloadAllowed(project) {
     return this.sendActionAsText(`/api/project/isDownloadAllowed/${project}`)
   }
-  retrieveNotes (project) {
+  retrieveNotes(project) {
     return this.sendAction(replace(`/api/${project}/notes`, '//', '/'))
   }
-  getUser () {
+  getUser() {
     return this.sendAction('/api/users/me')
   }
-  getUserHistory (type, from, size) {
+  getUserHistory(type, from, size) {
     const params = { type: type, from: from, size: size }
     return this.sendAction('/api/users/me/history', { method: Method.GET, params })
   }
-  addHistoryEvent (projectIds, type, name, uri) {
+  addHistoryEvent(projectIds, type, name, uri) {
     const data = { projectIds, type, name, uri }
     return this.sendActionAsText('/api/users/me/history', { method: Method.PUT, data })
   }
-  deleteUserHistory (type) {
+  deleteUserHistory(type) {
     return this.sendAction('/api/users/me/history', { method: Method.DELETE, params: { type: type } })
   }
-  deleteUserEvent (id) {
+  deleteUserEvent(id) {
     return this.sendAction('/api/users/me/history/event', { method: Method.DELETE, params: { id: id } })
   }
-  setMarkAsRecommended (project, data) {
+  setMarkAsRecommended(project, data) {
     return this.sendActionAsText(`/api/${project}/documents/batchUpdate/recommend`, { method: Method.POST, data })
   }
-  setUnmarkAsRecommended (project, data) {
+  setUnmarkAsRecommended(project, data) {
     return this.sendActionAsText(`/api/${project}/documents/batchUpdate/unrecommend`, { method: Method.POST, data })
   }
-  getRecommendationsByDocuments (project, docId) {
+  getRecommendationsByDocuments(project, docId) {
     return this.sendAction(`/api/users/recommendationsby?project=${project}&docIds=${docId}`)
   }
-  getRecommendationsByProject (project) {
+  getRecommendationsByProject(project) {
     return this.sendAction('/api/users/recommendations', { method: Method.GET, params: { project } })
   }
-  getDocumentsRecommendedBy (project, users = []) {
+  getDocumentsRecommendedBy(project, users = []) {
     const userids = join(users)
     return this.sendAction(`/api/${project}/documents/recommendations`, { method: Method.GET, params: { userids } })
   }
-  getNerPipelines () {
+  getNerPipelines() {
     return this.sendAction('/api/ner/pipelines')
   }
-  getApiKey (userId) {
+  getApiKey(userId) {
     return this.sendActionAsText(`/api/key/${userId}`, { method: Method.GET })
   }
-  createApiKey (userId) {
+  createApiKey(userId) {
     return this.sendActionAsText(`/api/key/${userId}`, { method: Method.PUT })
   }
-  deleteApiKey (userId) {
+  deleteApiKey(userId) {
     return this.sendActionAsText(`/api/key/${userId}`, { method: Method.DELETE })
   }
-  getPlugins (query = '') {
+  getPlugins(query = '') {
     return this.sendAction(`/api/plugins?filter=.*${toLower(query)}.*`)
   }
-  installPluginFromId (pluginId) {
+  installPluginFromId(pluginId) {
     return this.sendAction(`/api/plugins/install?id=${pluginId}`, { method: Method.PUT })
   }
-  installPluginFromUrl (pluginUrl) {
+  installPluginFromUrl(pluginUrl) {
     return this.sendAction(`/api/plugins/install?url=${pluginUrl}`, { method: Method.PUT })
   }
-  uninstallPlugin (pluginId) {
+  uninstallPlugin(pluginId) {
     return this.sendAction(`/api/plugins/uninstall?id=${pluginId}`, { method: Method.DELETE })
   }
-  getExtensions (query = '') {
+  getExtensions(query = '') {
     return this.sendAction(`/api/extensions?filter=.*${toLower(query)}.*`)
   }
-  installExtensionFromId (extensionId) {
+  installExtensionFromId(extensionId) {
     return this.sendAction(`/api/extensions/install?id=${extensionId}`, { method: Method.PUT })
   }
-  installExtensionFromUrl (extensionUrl) {
+  installExtensionFromUrl(extensionUrl) {
     return this.sendAction(`/api/extensions/install?url=${extensionUrl}`, { method: Method.PUT })
   }
-  uninstallExtension (extensionId) {
+  uninstallExtension(extensionId) {
     return this.sendAction(`/api/extensions/uninstall?id=${extensionId}`, { method: Method.DELETE })
   }
-  ocrLanguages () {
+  ocrLanguages() {
     return this.sendAction('/api/settings/ocr/languages')
   }
-  textLanguages () {
+  textLanguages() {
     return this.sendAction('/api/settings/text/languages')
   }
-  async sendAction (url, config = {}) {
+  async sendAction(url, config = {}) {
     try {
       const r = await this.axios?.request({ url: Api.getFullUrl(url), ...config })
       return r ? r.data : null
@@ -251,7 +269,7 @@ export class Api {
       throw error
     }
   }
-  async sendActionAsText (url, config = {}) {
+  async sendActionAsText(url, config = {}) {
     const headers = { 'Content-Type': 'text/plain;charset=UTF-8' }
     const responseType = 'text'
     return this.sendAction(url, { headers, responseType, ...config })

--- a/src/api/resources/Auth.js
+++ b/src/api/resources/Auth.js
@@ -3,35 +3,35 @@ import get from 'lodash/get'
 import { getCookie } from 'tiny-cookie'
 
 export default class Auth {
-  constructor (mode, api) {
+  constructor(mode, api) {
     this.mode = mode
     this.api = api
     this.cachedUsername = null
   }
 
-  async getUsername () {
+  async getUsername() {
     if (!this.cachedUsername) {
       this.cachedUsername = await this._checkAuthentication()
     }
     return this.cachedUsername
   }
 
-  reset () {
+  reset() {
     this.cachedUsername = null
   }
 
-  async _checkAuthentication () {
+  async _checkAuthentication() {
     try {
       if (this.mode.name === 'local') {
         return 'local' // default username
       }
-      return this._getCookieUsername() || await this._getBasicAuthUserName()
+      return this._getCookieUsername() || (await this._getBasicAuthUserName())
     } catch (_) {
       return null
     }
   }
 
-  async _getBasicAuthUserName () {
+  async _getBasicAuthUserName() {
     try {
       const response = await this.api.getUser()
       setTimeout(() => this.reset(), 43200 * 1000)
@@ -44,7 +44,7 @@ export default class Auth {
     }
   }
 
-  _getCookieUsername () {
+  _getCookieUsername() {
     const cookie = getCookie(process.env.VUE_APP_DS_COOKIE_NAME, JSON.parse)
     return get(cookie, 'login', null)
   }

--- a/src/api/resources/Document.js
+++ b/src/api/resources/Document.js
@@ -14,66 +14,69 @@ const _root = '_ROOT'
 const _separator = '/'
 
 export default class Document extends EsDoc {
-  constructor (raw, parent = null, root = null) {
+  constructor(raw, parent = null, root = null) {
     super(raw)
     this.parent = parent
     this.root = root
   }
-  nl2br (str) {
-    return trim(str).split('\n').map(row => `<p>${row}</p>`).join('')
+  nl2br(str) {
+    return trim(str)
+      .split('\n')
+      .map((row) => `<p>${row}</p>`)
+      .join('')
   }
-  translationIn (targetLanguage) {
+  translationIn(targetLanguage) {
     return find(this.translations, { target_language: targetLanguage })
   }
-  translatedContentIn (targetLanguage) {
+  translatedContentIn(targetLanguage) {
     const translation = this.translationIn(targetLanguage)
     return translation ? translation.content : null
   }
-  meta (name, defaultValue) {
+  meta(name, defaultValue) {
     const tikaMetadataName = `metadata.tika_metadata_${this.shortMetaName(name)}`
     return get(this.source, tikaMetadataName, defaultValue)
   }
-  valueAsQueryParam (name, value) {
+  valueAsQueryParam(name, value) {
     return `${name}:"${value}"`
   }
-  metaAsQueryParam (name, defaultValue) {
+  metaAsQueryParam(name, defaultValue) {
     const tikaMetadataName = `metadata.tika_metadata_${this.shortMetaName(name)}`
     return this.valueAsQueryParam(tikaMetadataName, this.meta(name, defaultValue))
   }
-  shortMetaName (name) {
+  shortMetaName(name) {
     return name.replace('tika_metadata_', '')
   }
-  set parent (parent) {
+  set parent(parent) {
     this[_parent] = parent ? new Document(parent) : null
   }
-  get parent () {
+  get parent() {
     return this[_parent]
   }
-  set root (root) {
+  set root(root) {
     this[_root] = root ? new Document(root) : null
   }
-  get root () {
+  get root() {
     return this[_root]
   }
-  get content () {
+  get content() {
     return this.get('_source.content')
   }
-  set content (content) {
+  set content(content) {
     this.set('_source.content', content)
   }
-  get metas () {
+  get metas() {
     return keys(this.source.metadata || {})
   }
-  get shortId () {
+  get shortId() {
     return this.id.slice(0, 10)
   }
-  get path () {
+  get path() {
     return this.get('_source.path', '')
   }
-  get tags () {
+  get tags() {
     return this.get('_source.tags', [])
   }
-  get folder () {
+  get folder() {
     // Extract location parts
     const parts = this.path.split(_separator)
     // Remove the file name
@@ -81,16 +84,16 @@ export default class Document extends EsDoc {
     // And return the new path
     return parts.join(_separator) + _separator
   }
-  get location () {
+  get location() {
     return this.folder.split(Murmur.config.get('dataDir', process.env.VUE_APP_DATA_PREFIX)).pop()
   }
-  get basename () {
+  get basename() {
     return last(this.path.split(_separator))
   }
-  get extension () {
+  get extension() {
     return extname(this.basename).toLowerCase()
   }
-  get resourceName () {
+  get resourceName() {
     let resourceName = trim(this.get('_source.metadata.tika_metadata_resourcename', this.shortId))
     if (startsWith(resourceName, '=?') && endsWith(resourceName, '?=')) {
       const resourceNameArray = resourceName.split('?')
@@ -98,19 +101,20 @@ export default class Document extends EsDoc {
     }
     return resourceName
   }
-  get title () {
+  get title() {
     const titles = [this.shortId, this.basename]
     if (this.extractionLevel > 0) {
       titles.push(this.resourceName)
     }
     return last(compact(titles))
   }
-  get subject () {
+  get subject() {
     const titles = [this.title]
     if (this.isEmail) {
       titles.push(trim(this.get('_source.metadata.tika_metadata_dc_title', '')))
-      const subject = this.get('_source.metadata.tika_metadata_subject', null) ??
-                      this.get('_source.metadata.tika_metadata_dc_subject', '')
+      const subject =
+        this.get('_source.metadata.tika_metadata_subject', null) ??
+        this.get('_source.metadata.tika_metadata_dc_subject', '')
       titles.push(trim(subject))
     }
     if (this.isTweet) {
@@ -118,10 +122,10 @@ export default class Document extends EsDoc {
     }
     return last(compact(titles))
   }
-  get cleanSubject () {
+  get cleanSubject() {
     return this.subject.replace(/((.{1,4})\s?:\s?)*(.+)/i, '$3')
   }
-  get slicedName () {
+  get slicedName() {
     if (this.extractionLevel === 0) {
       return [this.title]
     }
@@ -132,75 +136,75 @@ export default class Document extends EsDoc {
     // - the document title
     return [this.basename].concat([distance].slice(0, distance)).concat(this.title)
   }
-  get slicedNameToString () {
+  get slicedNameToString() {
     return this.slicedName.join(' › ')
   }
-  get highlight () {
+  get highlight() {
     return this.raw.highlight
   }
-  get route () {
+  get route() {
     return `/ds/${this.index}/${this.id}/${this.routing}`
   }
-  get url () {
+  get url() {
     return `/api/${this.index}/documents/src/${this.id}?routing=${this.routing}`
   }
-  get fullUrl () {
+  get fullUrl() {
     return Api.getFullUrl(this.url)
   }
-  get inlineFullUrl () {
+  get inlineFullUrl() {
     const url = new URL(this.fullUrl)
     url.searchParams.set('inline', true)
     return url.href
   }
-  get rootUrl () {
+  get rootUrl() {
     return `/api/${this.index}/documents/src/${this.routing}?routing=${this.routing}`
   }
-  get fullRootUrl () {
+  get fullRootUrl() {
     return Api.getFullUrl(this.rootUrl)
   }
-  get contentType () {
+  get contentType() {
     return this.source.contentType || 'unknown'
   }
-  get contentTypeLabel () {
+  get contentTypeLabel() {
     return get(types, [this.contentType, 'label'], null)
   }
-  get contentTypeDescription () {
+  get contentTypeDescription() {
     return get(types, [this.contentType, 'description'], {})
   }
-  get contentTypeWarning () {
+  get contentTypeWarning() {
     return get(types, [this.contentType, 'warning'], {})
   }
-  get contentTypeIcon () {
+  get contentTypeIcon() {
     return findContentTypeIcon(this.contentType)
   }
-  get rootContentType () {
+  get rootContentType() {
     return this.root ? this.root.source.contentType : 'unknown'
   }
-  get rootContentTypeLabel () {
+  get rootContentTypeLabel() {
     return get(types, [this.rootContentType, 'label'], null)
   }
-  get standardExtension () {
+  get standardExtension() {
     return get(types, [this.contentType, 'extensions', 0], null)
   }
-  get standardExtensions () {
+  get standardExtensions() {
     return get(types, [this.contentType, 'extensions'], [])
   }
-  get hasStandardExtension () {
+  get hasStandardExtension() {
     return this.standardExtensions.indexOf(this.extension) > -1
   }
-  get hasContentTypeWarning () {
+  get hasContentTypeWarning() {
     return !!get(types, [this.contentType, 'warning'], false)
   }
-  get hasContent () {
+  get hasContent() {
     return this.get('_source.content', null) !== null
   }
-  get hasTranslatedContent () {
+  get hasTranslatedContent() {
     return this.get('_source.content_translated', null) !== null
   }
-  get hasSubject () {
+  get hasSubject() {
     return this.subject && this.subject !== this.title
   }
-  get creationDate () {
+  get creationDate() {
     const creationDate = this.source.metadata.tika_metadata_dcterms_created
     if (creationDate && !isNaN(Date.parse(creationDate))) {
       return new Date(creationDate)
@@ -208,31 +212,31 @@ export default class Document extends EsDoc {
       return null
     }
   }
-  get creationDateHuman () {
+  get creationDateHuman() {
     return this.creationDate ? moment(this.creationDate).format('LLL') : null
   }
-  get creationDateHumanShort () {
+  get creationDateHumanShort() {
     return this.creationDate ? moment(this.creationDate).format('L LT') : null
   }
-  get extractionLevel () {
+  get extractionLevel() {
     return this.get('_source.extractionLevel', 0)
   }
-  get contentTextLength () {
+  get contentTextLength() {
     return this.get('_source.contentTextLength', 0)
   }
-  get contentLength () {
+  get contentLength() {
     return this.get('_source.contentLength')
   }
-  get humanSize () {
+  get humanSize() {
     return humanSize(this.contentLength, true)
   }
-  get index () {
+  get index() {
     return this.raw._index
   }
-  get routerParams () {
+  get routerParams() {
     return pick(this, ['index', 'id', 'routing'])
   }
-  get serializedForStorage () {
+  get serializedForStorage() {
     return pick(this.raw, [
       '_id',
       '_routing',
@@ -247,42 +251,42 @@ export default class Document extends EsDoc {
       '_source.metadata.tika_metadata_dc_title'
     ])
   }
-  get threadIndex () {
+  get threadIndex() {
     return this.get('_source.metadata.tika_metadata_message_raw_header_thread_index', null)
   }
-  get messageId () {
+  get messageId() {
     return this.get('_source.metadata.tika_metadata_message_raw_header_message_id', null)
   }
-  get messageFrom () {
+  get messageFrom() {
     return this.get('_source.metadata.tika_metadata_message_from', null)
   }
-  get messageTo () {
+  get messageTo() {
     return this.get('_source.metadata.tika_metadata_message_to', null)
   }
-  get excerpt () {
+  get excerpt() {
     const content = this.get('highlight.content[0]', '')
     return trim(content)
   }
-  set translations (translations) {
+  set translations(translations) {
     this.set('_source.content_translated', translations)
   }
-  get translations () {
+  get translations() {
     const translations = this.get('_source.content_translated', [])
-    return filter(translations, t => t.content !== '')
+    return filter(translations, (t) => t.content !== '')
   }
-  get isEmail () {
+  get isEmail() {
     return this.contentType.indexOf('message/') === 0 || this.contentType === 'application/vnd.ms-outlook'
   }
-  get isTweet () {
+  get isTweet() {
     return this.contentType === 'application/json; twint'
   }
-  get isPdf () {
+  get isPdf() {
     return this.contentType === 'application/pdf'
   }
-  get isTiff () {
+  get isTiff() {
     return this.contentType === 'image/tiff'
   }
-  get isSpreadsheet () {
+  get isSpreadsheet() {
     const spreadsheetTypes = [
       'application/vnd.oasis.opendocument.spreadsheet',
       'application/vnd.oasis.opendocument.spreadsheet-template',
@@ -293,26 +297,26 @@ export default class Document extends EsDoc {
     ]
     return spreadsheetTypes.indexOf(this.contentType) > -1
   }
-  get isImage () {
+  get isImage() {
     return this.contentType.indexOf('image/') === 0
   }
-  get isJson () {
+  get isJson() {
     return this.contentType.indexOf('application/json') === 0
   }
-  get hasTranslations () {
+  get hasTranslations() {
     return this.translations.length > 0
   }
-  get hasNerTags () {
+  get hasNerTags() {
     return this.get('_source.nerTags', []).length > 0
   }
-  get hasBigContentTextLength () {
+  get hasBigContentTextLength() {
     // 25,000 characters
     return this.contentTextLength === undefined || this.contentTextLength === 0 || this.contentTextLength > 25e3
   }
-  static get esName () {
+  static get esName() {
     return 'Document'
   }
-  static create (raw) {
+  static create(raw) {
     return new Document(raw)
   }
 }

--- a/src/api/resources/EsDoc.js
+++ b/src/api/resources/EsDoc.js
@@ -3,11 +3,11 @@ import { cloneDeep, extend, get, set } from 'lodash'
 const _raw = '_RAW'
 
 export default class EsDoc {
-  constructor (raw) {
+  constructor(raw) {
     this[_raw] = cloneDeep(raw)
     this.map(raw)
   }
-  map (raw) {
+  map(raw) {
     // Map the given object to document attribute
     return extend(this, {
       id: raw._id,
@@ -16,26 +16,26 @@ export default class EsDoc {
       type: raw._type
     })
   }
-  get (path, defaultValue) {
+  get(path, defaultValue) {
     return get(this.raw, path, defaultValue)
   }
-  set (path, value) {
+  set(path, value) {
     return set(this.raw, path, value)
   }
-  get source () {
+  get source() {
     return this.get('_source', {})
   }
-  get raw () {
+  get raw() {
     return this[_raw]
   }
-  get serializedForStorage () {
+  get serializedForStorage() {
     return this.raw
   }
-  static match (hit) {
+  static match(hit) {
     const raw = hit.raw || hit
     return get(raw, '_source.type', 'Document') === (this.esName || this.name)
   }
-  static create (raw, parent) {
+  static create(raw, parent) {
     return new EsDoc(raw, parent)
   }
 }

--- a/src/api/resources/EsDocList.js
+++ b/src/api/resources/EsDocList.js
@@ -6,57 +6,60 @@ import NamedEntity from '@/api/resources/NamedEntity'
 const _raw = '_RAW'
 
 export default class EsDocList {
-  constructor (raw) {
+  constructor(raw) {
     this[_raw] = isEmpty(raw) ? EsDocList.emptyRaw : raw
   }
-  get (path, defaultValue) {
+  get(path, defaultValue) {
     return get(this[_raw], path, defaultValue)
   }
-  set (path, value) {
+  set(path, value) {
     return set(this[_raw], path, value)
   }
-  push (path, value) {
+  push(path, value) {
     const arr = this.get(path, [])
     arr.push(value)
     return this.set(path, arr)
   }
-  prepend (path, value) {
+  prepend(path, value) {
     const arr = this.get(path, [])
     remove(arr, value)
     return this.set(path, [value].concat(arr))
   }
-  orderBy (iteratees, orders) {
+  orderBy(iteratees, orders) {
     this.set('hits.hits', orderBy(this.get('hits.hits', []), iteratees, orders))
   }
-  removeDuplicates () {
-    this.set('hits.hits', uniqBy(this.get('hits.hits', []), d => d._id))
+  removeDuplicates() {
+    this.set(
+      'hits.hits',
+      uniqBy(this.get('hits.hits', []), (d) => d._id)
+    )
   }
-  append (raw) {
+  append(raw) {
     const response = new EsDocList(raw)
-    response.hits.forEach(hit => this.push('hits.hits', hit))
+    response.hits.forEach((hit) => this.push('hits.hits', hit))
   }
-  get hits () {
-    return map(this.get('hits.hits', []), hit => {
+  get hits() {
+    return map(this.get('hits.hits', []), (hit) => {
       return EsDocList.instantiate(hit)
     })
   }
-  get aggregations () {
+  get aggregations() {
     return this[_raw].aggregations || {}
   }
-  get total () {
+  get total() {
     return this[_raw].hits.total.value
   }
-  static instantiate (hit) {
-    const Type = find(EsDocList.types, Type => Type.match(hit))
+  static instantiate(hit) {
+    const Type = find(EsDocList.types, (Type) => Type.match(hit))
     return new Type(hit)
   }
-  static none () {
+  static none() {
     return new EsDocList(EsDocList.emptyRaw)
   }
-  static get emptyRaw () {
+  static get emptyRaw() {
     return { hits: { hits: [], total: { value: 0, relation: 'eq' } } }
   }
-  static get types () {
+  static get types() {
     return [Document, NamedEntity]
   }
 }

--- a/src/api/resources/NamedEntity.js
+++ b/src/api/resources/NamedEntity.js
@@ -2,10 +2,10 @@ import { get } from 'lodash'
 import EsDoc from './EsDoc'
 
 export default class NamedEntity extends EsDoc {
-  get category () {
+  get category() {
     return this.source.category.toLowerCase()
   }
-  get offsets () {
+  get offsets() {
     /**
      * This ensures retro compatibility with Named Entities extracted
      * prior to 9.15.0 with a single offset.
@@ -17,13 +17,13 @@ export default class NamedEntity extends EsDoc {
     }
     return get(this, 'source.offsets', [])
   }
-  get length () {
+  get length() {
     return this.source.mention.length
   }
-  get mention () {
+  get mention() {
     return this.source.mention
   }
-  static get esName () {
+  static get esName() {
     return 'NamedEntity'
   }
 }

--- a/src/components/Api.vue
+++ b/src/components/Api.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="api h-100 container pt-4">
     <div v-if="isServer">
-      <div class="api__create-key card card-body text-center" v-if="!hasHashedKey">
+      <div v-if="!hasHashedKey" class="api__create-key card card-body text-center">
         <div class="mb-3">
           <fa icon="key" size="3x" />
         </div>
         <p class="lead" v-html="$t('api.key.why')"></p>
-        <b-button @click="createApiKey" variant="primary">
+        <b-button variant="primary" @click="createApiKey">
           <fa icon="plus" class="mr-1"></fa>
           {{ $t('api.newApiKey') }}
         </b-button>
@@ -26,7 +26,7 @@
                 {{ $t('api.key.unavailable') }}
               </span>
               –
-              <a class="font-weight-bold text-link" @click.prevent="createApiKey" href="#">
+              <a class="font-weight-bold text-link" href="#" @click.prevent="createApiKey">
                 <fa icon="redo" />
                 {{ $t('api.key.regenerate') }}
               </a>
@@ -90,9 +90,6 @@ export default {
       apiKey: null
     }
   },
-  async created() {
-    await this.getHashedApiKey()
-  },
   computed: {
     hasHashedKey() {
       return !!this.hashedKey
@@ -100,6 +97,9 @@ export default {
     hasApiKey() {
       return !!this.apiKey
     }
+  },
+  async created() {
+    await this.getHashedApiKey()
   },
   methods: {
     async getHashedApiKey() {

--- a/src/components/Api.vue
+++ b/src/components/Api.vue
@@ -32,7 +32,11 @@
               </a>
             </div>
             <div class="mx-3">
-              <confirm-button class="api__key__delete btn btn-outline-danger" :confirmed="deleteApiKey" :description="$t('api.key.delete.description')">
+              <confirm-button
+                class="api__key__delete btn btn-outline-danger"
+                :confirmed="deleteApiKey"
+                :description="$t('api.key.delete.description')"
+              >
                 <fa icon="trash-alt" />
                 {{ $t('api.key.delete.button') }}
               </confirm-button>
@@ -46,13 +50,22 @@
         {{ $t('api.noAccess') }}
       </b-alert>
     </div>
-    <b-modal size="md" :title="$t('api.key.created')" :visible="hasApiKey" lazy ok-only body-class="p-0" footer-class="card-footer" @hidden="apiKey = null">
+    <b-modal
+      size="md"
+      :title="$t('api.key.created')"
+      :visible="hasApiKey"
+      lazy
+      ok-only
+      body-class="p-0"
+      footer-class="card-footer"
+      @hidden="apiKey = null"
+    >
       <div class="card-body border-top border-bottom">
         <p>
           {{ $t('api.key.warning') }}
         </p>
         <div class="input-group input-group-sm">
-          <input class="form-control text-monospace" :value="apiKey">
+          <input class="form-control text-monospace" :value="apiKey" />
           <div class="input-group-append">
             <haptic-copy :text="apiKey" class="btn-outline-primary" label="Copy" />
           </div>
@@ -71,36 +84,36 @@ import utils from '@/mixins/utils'
 export default {
   name: 'Api',
   mixins: [utils],
-  data () {
+  data() {
     return {
       hashedKey: null,
       apiKey: null
     }
   },
-  async created () {
+  async created() {
     await this.getHashedApiKey()
   },
   computed: {
-    hasHashedKey () {
+    hasHashedKey() {
       return !!this.hashedKey
     },
-    hasApiKey () {
+    hasApiKey() {
       return !!this.apiKey
     }
   },
   methods: {
-    async getHashedApiKey () {
+    async getHashedApiKey() {
       const username = await this.$core.auth.getUsername()
       const { hashedKey } = await this.$core.api.getApiKey(username)
       this.hashedKey = hashedKey
     },
-    async createApiKey () {
+    async createApiKey() {
       const username = await this.$core.auth.getUsername()
       const { apiKey } = await this.$core.api.createApiKey(username) // why hash is not returned at the same time?
       this.apiKey = apiKey
       await this.getHashedApiKey()
     },
-    async deleteApiKey () {
+    async deleteApiKey() {
       const username = await this.$core.auth.getUsername()
       await this.$core.api.deleteApiKey(username)
       this.hashedKey = null
@@ -110,11 +123,10 @@ export default {
 </script>
 
 <style lang="scss">
-  .api {
-
-    &__create-key {
-      margin: auto;
-      max-width: $modal-md;
-    }
+.api {
+  &__create-key {
+    margin: auto;
+    max-width: $modal-md;
   }
+}
 </style>

--- a/src/components/AppNav.vue
+++ b/src/components/AppNav.vue
@@ -28,14 +28,14 @@ export default {
     SearchBar,
     SearchLayoutSelector
   },
-  mounted () {
+  mounted() {
     this.saveComponentHeight()
   },
-  updated () {
+  updated() {
     this.saveComponentHeight()
   },
   methods: {
-    saveComponentHeight () {
+    saveComponentHeight() {
       const height = `${this.$el.offsetHeight}px`
       // Save component height in a CSS variable after it's been update
       this.$root.$el.style.setProperty('--core-nav-height', height)
@@ -45,34 +45,34 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .app__nav {
-    color: $body-color;
-    position: relative;
-    width: auto;
-    z-index: 25;
+.app__nav {
+  color: $body-color;
+  position: relative;
+  width: auto;
+  z-index: 25;
 
-    @media (max-width: $document-float-breakpoint-width) {
-      z-index: 15;
-    }
+  @media (max-width: $document-float-breakpoint-width) {
+    z-index: 15;
+  }
 
-    .search--grid &, .search--table & {
-      z-index: 15;
-    }
+  .search--grid &,
+  .search--table & {
+    z-index: 15;
+  }
 
-    &__container {
+  &__container {
+    &__main {
+      border-radius: $border-radius-lg 0 0 0;
+      position: relative;
+      white-space: nowrap;
+      z-index: $zindex-fixed + 30;
 
-      &__main {
-        border-radius: $border-radius-lg 0 0 0;
-        position:relative;
-        white-space: nowrap;
-        z-index: $zindex-fixed + 30;
-
-        &__search-bar {
-          max-width: 880px;
-          padding: 0;
-          position: relative;
-        }
+      &__search-bar {
+        max-width: 880px;
+        padding: 0;
+        position: relative;
       }
     }
   }
+}
 </style>

--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -4,7 +4,7 @@
     <vue-perfect-scrollbar class="app-sidebar__container flex-grow-1 d-flex flex-column">
       <div class="d-flex align-items-center justify-content-center">
         <router-link class="app-sidebar__container__brand align-items-center flex-grow-1" :to="{ name: 'landing' }">
-          <img src="~images/logo-color.svg" alt="Datashare" class="app-sidebar__container__brand__logo">
+          <img src="~images/logo-color.svg" alt="Datashare" class="app-sidebar__container__brand__logo" />
         </router-link>
         <div>
           <a @click="hideSidebar()" class="app-sidebar__container__toggle text-white">
@@ -19,7 +19,8 @@
             class="app-sidebar__container__menu__item__link"
             :title="$t('menu.search')"
             :to="{ name: 'search', query }"
-            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }">
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
+          >
             <fa icon="search" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
               {{ $t(reduced ? 'menu.searchShort' : 'menu.search') }}
@@ -31,7 +32,8 @@
             class="app-sidebar__container__menu__item__link"
             :title="$t('menu.tasks')"
             :to="{ name: 'tasks' }"
-            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }">
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
+          >
             <fa icon="rocket" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
               {{ $t(reduced ? 'menu.tasksShort' : 'menu.tasks') }}
@@ -44,7 +46,8 @@
             @click.prevent="$root.$emit('history::toggle')"
             :title="$t('menu.history')"
             :to="{ name: 'user-history' }"
-            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }">
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
+          >
             <fa icon="clock" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
               {{ $t(reduced ? 'menu.historyShort' : 'menu.history') }}
@@ -56,7 +59,8 @@
             class="app-sidebar__container__menu__item__link"
             :title="$t('menu.insights')"
             :to="{ name: 'insights' }"
-            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }">
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
+          >
             <fa icon="chart-bar" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
               {{ $t(reduced ? 'menu.insightsShort' : 'menu.insights') }}
@@ -69,7 +73,8 @@
               class="app-sidebar__container__menu__item__link"
               :title="$t('menu.settings')"
               :to="{ name: 'settings' }"
-              v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }">
+              v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
+            >
               <fa icon="cog" fixed-width></fa>
               <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
                 {{ $t(reduced ? 'menu.settingsShort' : 'menu.settings') }}
@@ -82,10 +87,13 @@
       <hook name="app-sidebar.help:before"></hook>
       <ul class="app-sidebar__container__menu list-unstyled">
         <li class="app-sidebar__container__menu__item">
-          <a class="app-sidebar__container__menu__item__link"
-             :href="faqLink"
-             target="_blank"
-             :title="$t('menu.faq')" v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }">
+          <a
+            class="app-sidebar__container__menu__item__link"
+            :href="faqLink"
+            target="_blank"
+            :title="$t('menu.faq')"
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
+          >
             <fa icon="question" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
               {{ $t(reduced ? 'menu.faqShort' : 'menu.faq') }}
@@ -93,11 +101,13 @@
           </a>
         </li>
         <li class="app-sidebar__container__menu__item app-sidebar__container__menu__item--help">
-          <a class="app-sidebar__container__menu__item__link"
-             :href="helpLink"
-             target="_blank"
-             :title="$t('menu.help')"
-             v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }">
+          <a
+            class="app-sidebar__container__menu__item__link"
+            :href="helpLink"
+            target="_blank"
+            :title="$t('menu.help')"
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
+          >
             <fa icon="ambulance" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
               {{ $t(reduced ? 'menu.helpShort' : 'menu.help') }}
@@ -117,8 +127,10 @@
           </h5>
           <ul class="app-sidebar__container__menu app-sidebar__container__menu--borderless list-unstyled">
             <li class="app-sidebar__container__menu__item" v-for="meta in currentRouteDocs" :key="meta.resourcePath">
-              <router-link class="app-sidebar__container__menu__item__link app-sidebar__container__menu__item__link--tree"
-                           :to="{ name: 'docs', params: meta }">
+              <router-link
+                class="app-sidebar__container__menu__item__link app-sidebar__container__menu__item__link--tree"
+                :to="{ name: 'docs', params: meta }"
+              >
                 <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
                   {{ meta.title }}
                 </span>
@@ -127,25 +139,31 @@
           </ul>
         </div>
         <ul v-else class="app-sidebar__container__menu list-unstyled">
-          <li class="app-sidebar__container__menu__item"  :data-badge="currentRouteDocs.length">
-            <b-button class="app-sidebar__container__menu__item__link"
-                      :data-badge="currentRouteDocs.length"
-                      href="#"
-                      id="app-menu-user-guide"
-                      variant="none">
+          <li class="app-sidebar__container__menu__item" :data-badge="currentRouteDocs.length">
+            <b-button
+              class="app-sidebar__container__menu__item__link"
+              :data-badge="currentRouteDocs.length"
+              href="#"
+              id="app-menu-user-guide"
+              variant="none"
+            >
               <fa icon="book" fixed-width></fa>
               <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
                 {{ $t(reduced ? 'menu.userGuidesShort' : 'menu.userGuides') }}
               </span>
-              <b-popover target="app-menu-user-guide"
-                         custom-class="popover-body-p-0"
-                         triggers="click blur"
-                         @show="$root.$emit('bv::hide::tooltip')">
+              <b-popover
+                target="app-menu-user-guide"
+                custom-class="popover-body-p-0"
+                triggers="click blur"
+                @show="$root.$emit('bv::hide::tooltip')"
+              >
                 <div class="dropdown-menu show position-static border-0 px-2 bg-transparent">
-                  <router-link class="dropdown-item"
-                               :key="meta.resourcePath"
-                               :to="{ name: 'docs', params: meta }"
-                               v-for="meta in currentRouteDocs">
+                  <router-link
+                    class="dropdown-item"
+                    :key="meta.resourcePath"
+                    :to="{ name: 'docs', params: meta }"
+                    v-for="meta in currentRouteDocs"
+                  >
                     {{ meta.title }}
                   </router-link>
                 </div>
@@ -166,28 +184,34 @@
           </locales-menu>
         </li>
         <li class="app-sidebar__container__menu__item app-sidebar__container__menu__item--logout" v-if="isServer">
-          <a v-if="isBasicAuth"
+          <a
+            v-if="isBasicAuth"
             @click.prevent="showModal"
             class="app-sidebar__container__menu__item__link app-sidebar__container__menu__item__link--basic-auth"
             :title="$t('menu.logout')"
-            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }">
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
+          >
             <fa icon="sign-out-alt" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
               {{ $t('menu.logoutShort') }}
             </span>
             <b-modal
-               hide-footer
-               class="app-sidebar__container__menu__item__link__modal"
-               ref="logout-modal"
-               size="md"
-               :title="$t('menu.logout')">
-              <p> {{ $t('menu.logoutModal') }}</p>
+              hide-footer
+              class="app-sidebar__container__menu__item__link__modal"
+              ref="logout-modal"
+              size="md"
+              :title="$t('menu.logout')"
+            >
+              <p>{{ $t('menu.logoutModal') }}</p>
             </b-modal>
           </a>
-          <a v-else class="app-sidebar__container__menu__item__link"
-             :href="logoutLink"
-             :title="$t('menu.logout')"
-             v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }">
+          <a
+            v-else
+            class="app-sidebar__container__menu__item__link"
+            :href="logoutLink"
+            :title="$t('menu.logout')"
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
+          >
             <fa icon="sign-out-alt" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
               {{ $t('menu.logoutShort') }}
@@ -198,10 +222,12 @@
       <hook name="app-sidebar.locales:after"></hook>
     </vue-perfect-scrollbar>
     <div class="app-sidebar__version">
-      <version-number class="d-inline-block"
-                      :label="reduced ? '' : 'Version'"
-                      :no-icon="reduced"
-                      :tooltip-placement="reduced ? 'righttop' : 'top'"></version-number>
+      <version-number
+        class="d-inline-block"
+        :label="reduced ? '' : 'Version'"
+        :no-icon="reduced"
+        :tooltip-placement="reduced ? 'righttop' : 'top'"
+      ></version-number>
     </div>
     <div class="app-sidebar__data-location" v-if="!isServer" v-show="!reduced">
       <mounted-data-location></mounted-data-location>
@@ -235,52 +261,52 @@ export default {
     VuePerfectScrollbar
   },
   computed: {
-    query () {
+    query() {
       return this.$store.getters['search/toRouteQueryWithStamp']()
     },
-    tooltipsClass () {
+    tooltipsClass() {
       return this.reduced ? '' : 'd-none'
     },
-    logoutLink () {
+    logoutLink() {
       return Api.getFullUrl(process.env.VUE_APP_DS_AUTH_SIGNOUT)
     },
-    helpLink () {
+    helpLink() {
       return this.$config.get('helpLink', settings.helpLink)
     },
-    faqLink () {
+    faqLink() {
       return this.$config.get('faqLink', settings.faqLink)
     },
     reduced: {
-      get () {
+      get() {
         return this.$store.state.app.sidebar.reduced
       },
-      set (toggle) {
+      set(toggle) {
         return this.$store.dispatch('app/toggleSidebar', toggle)
       }
     },
-    isBasicAuth () {
+    isBasicAuth() {
       return this.$config && this.$config.get('authFilter') === 'org.icij.datashare.session.BasicAuthAdaptorFilter'
     }
   },
   watch: {
-    $route () {
+    $route() {
       this.$root.$emit('bv::hide::tooltip', 'app-sidebar-link-label')
     }
   },
-  mounted () {
+  mounted() {
     this.$nextTick(this.saveComponentWidth)
   },
   methods: {
-    hideSidebar () {
+    hideSidebar() {
       this.reduced = !this.reduced
       this.$nextTick(this.saveComponentWidth)
     },
-    saveComponentWidth () {
+    saveComponentWidth() {
       const width = `${this.$el.offsetWidth}px`
       // Save component width in a CSS variable after it's been update
       this.$root.$el.style.setProperty('--core-sidebar-width', width)
     },
-    async showModal () {
+    async showModal() {
       this.$refs['logout-modal'].show()
     }
   }
@@ -288,291 +314,296 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  $item-tree-color: rgba($app-sidebar-color, .5);
-  $item-tree-width: 2px;
+$item-tree-color: rgba($app-sidebar-color, 0.5);
+$item-tree-width: 2px;
 
-  .app-sidebar {
-    background: $app-sidebar-bg;
+.app-sidebar {
+  background: $app-sidebar-bg;
+  bottom: 0;
+  box-shadow: 0 0 $app-sidebar-width * 0.5 0 #000;
+  color: $app-sidebar-color;
+  height: 100vh;
+  left: 0;
+  max-width: $app-sidebar-width;
+  min-width: 60px;
+  position: fixed;
+  top: 0;
+  width: $app-sidebar-width;
+  z-index: $zindex-sticky;
+
+  &--reduced {
+    box-shadow: none;
+    width: $app-sidebar-reduced-width;
+  }
+
+  &__backdrop {
+    background: rgba($modal-backdrop-bg, $modal-backdrop-opacity);
     bottom: 0;
-    box-shadow: 0 0 $app-sidebar-width * 0.5 0 #000;
-    color: $app-sidebar-color;
-    height: 100vh;
     left: 0;
-    max-width: $app-sidebar-width;
-    min-width: 60px;
     position: fixed;
+    right: 0;
     top: 0;
-    width: $app-sidebar-width;
-    z-index: $zindex-sticky;
+    z-index: -1;
 
-    &--reduced {
-      box-shadow: none;
-      width: $app-sidebar-reduced-width;
+    .app-sidebar--reduced & {
+      display: none;
     }
+  }
 
-    &__backdrop {
-      background: rgba($modal-backdrop-bg, $modal-backdrop-opacity);
-      bottom: 0;
-      left: 0;
-      position: fixed;
-      right: 0;
-      top: 0;
-      z-index: -1;
+  &__container {
+    &__brand,
+    &__brand:hover,
+    &__brand:focus,
+    &__brand {
+      color: inherit;
+      display: flex;
+      font-size: 1.5rem;
+      justify-content: flex-start;
+      max-width: $app-context-sidebar-width;
+      padding: $spacer $spacer * 1.75;
+      pointer-events: auto;
+      text-decoration: none;
+      width: 100%;
 
       .app-sidebar--reduced & {
         display: none;
       }
     }
 
-    &__container {
-      &__brand, &__brand:hover, &__brand:focus, &__brand {
-        color: inherit;
-        display: flex;
-        font-size: 1.5rem;
-        justify-content: flex-start;
-        max-width: $app-context-sidebar-width;
-        padding: $spacer $spacer * 1.75;
-        pointer-events: auto;
-        text-decoration: none;
-        width: 100%;
-
-        .app-sidebar--reduced & {
-          display: none;
-        }
-      }
-
-      &__brand__logo {
-        height: $app-nav-brand-height;
-      }
-
-      &__toggle {
-        margin: $spacer;
-        height: 40px;
-        width: 40px;
-        text-align: center;
-        line-height: 40px;
-        display: block;
-        border-radius: 1.5rem;
-        padding: 0;
-
-        &:hover {
-          background: $app-sidebar-border-color;
-        }
-
-        .app-sidebar--reduced & {
-          transform: rotate(180deg);
-          transform-origin: center center;
-        }
-      }
-
-      &__heading {
-        margin: $spacer * 0.5 0;
-        padding: $spacer * 1.5 ($spacer * 1.75) 0;
-        position: relative;
-        display: flex;
-        font-size: $font-size-sm;
-        font-weight: bold;
-
-        .app-sidebar--reduced & {
-          margin: $spacer-xs $spacer-xs 0;
-          flex-direction: column;
-          text-align: center;
-          padding: $spacer-lg $spacer-xs $spacer;
-        }
-
-        &:not(&--borderless):before {
-          content:"";
-          border-top: $app-sidebar-border-color 1px solid;
-          position: absolute;
-          top: 0;
-          left: $spacer;
-          right: $spacer;
-        }
-
-        & .svg-inline--fa {
-          font-size: 1.2rem;
-
-          .app-sidebar:not(.app-sidebar--reduced) & {
-            margin-right: $spacer;
-          }
-
-          .app-sidebar--reduced & {
-            margin: 0 auto $spacer-xs;
-            display: block;
-          }
-        }
-
-        &__label {
-
-          .app-sidebar--reduced & {
-            font-size: 0.7rem;
-          }
-        }
-      }
-
-      &__menu {
-        position: relative;
-        padding-top: $spacer;
-        margin-bottom: $spacer;
-
-        &:not(&--borderless):before {
-          content:"";
-          border-top: $app-sidebar-border-color 1px solid;
-          position: absolute;
-          top: 0;
-          left: $spacer;
-          right: $spacer;
-        }
-
-        &--borderless {
-          padding-top: 0;
-        }
-
-        &__item {
-          position: relative;
-
-          &:last-of-type &__link--tree:before {
-            transform: none;
-            height: calc(50% + #{$item-tree-width * 0.5});
-            top: 0;
-          }
-
-          &__link, &__link.btn {
-            margin: $spacer-xs $spacer;
-            padding: $spacer-sm;
-            color: $app-sidebar-link-color;
-            display: flex;
-            border-radius: $border-radius;
-            font-size: $font-size-sm;
-            font-weight: bold;
-
-            .app-sidebar--reduced & {
-              flex-direction: column;
-              text-align: center;
-              margin: $spacer-xs;
-              padding: $spacer-sm $spacer-xs $spacer-xs;
-            }
-
-            &.router-link-active, &:hover, &:active {
-              background: mix($app-sidebar-color, $app-sidebar-bg, 5%);
-              color: $app-sidebar-color;
-            }
-
-            &.router-link-active:before {
-              background: $secondary;
-              bottom: 0;
-              box-shadow: 2px 0 $spacer 0 $secondary;
-              content: "";
-              left: 0;
-              position: absolute;
-              top: 0;
-              width: 2px;
-            }
-
-            &.router-link-active .svg-inline--fa {
-              color: $secondary;
-            }
-
-            &[data-badge]:after {
-              content: attr(data-badge);
-              position: absolute;
-              left: calc(50% + 0.5em);
-              top: 0.25em;
-              background: $secondary;
-              color: white;
-              font-size: 0.75em;
-              font-weight: $badge-font-weight;
-              padding: $badge-padding-y $badge-padding-x;
-              border-radius: $badge-border-radius;
-            }
-
-            &--disabled,
-            &--disabled:hover {
-              color: $text-muted;
-              cursor: not-allowed;
-              text-decoration: none;
-            }
-
-            &--tree {
-              font-weight: normal;
-              position: relative;
-              padding: $spacer * 0.5 $spacer * 0.75;
-              margin-top: 0;
-              margin-bottom: 0;
-              margin-left: $spacer * 3.25;
-
-              &:before {
-                content: "";
-                position: absolute;
-                right: calc(100% + #{$spacer * 0.5});
-                top: 50%;
-                transform: translateY(-50%);
-                width: $item-tree-width;
-                background: $item-tree-color;
-                height: 100%;
-              }
-
-              &:after {
-                content: "";
-                position: absolute;
-                right: 100%;
-                top: 50%;
-                transform: translateY(-50%);
-                height: $item-tree-width;
-                background: $item-tree-color;
-                width: $spacer * 0.5;
-              }
-            }
-
-            & .svg-inline--fa {
-              font-size: 1.2rem;
-
-              .app-sidebar:not(.app-sidebar--reduced) & {
-                margin-right: $spacer;
-              }
-
-              .app-sidebar--reduced & {
-                margin: 0 auto $spacer-xs;
-                display: block;
-              }
-            }
-
-            &__label {
-
-              .app-sidebar--reduced & {
-                font-size: 0.7rem;
-              }
-            }
-          }
-        }
-      }
+    &__brand__logo {
+      height: $app-nav-brand-height;
     }
 
-    &__version {
-      z-index: 100;
-      position: relative;
-      text-align: left;
+    &__toggle {
+      margin: $spacer;
+      height: 40px;
+      width: 40px;
+      text-align: center;
+      line-height: 40px;
+      display: block;
+      border-radius: 1.5rem;
+      padding: 0;
 
-      &:before {
-        content: "";
-        position: absolute;
-        bottom: 100%;
-        left: 0;
-        right: 0;
-        height: $spacer;
-        pointer-events: none;
+      &:hover {
+        background: $app-sidebar-border-color;
       }
 
       .app-sidebar--reduced & {
-        text-align: center;
-        padding: 0 0 $spacer;
+        transform: rotate(180deg);
+        transform-origin: center center;
       }
     }
 
-    &__version, &__data-location {
-      color: $app-sidebar-link-color;
-      padding: 0 $spacer * 1.7 $spacer $spacer * 1.5;
+    &__heading {
+      margin: $spacer * 0.5 0;
+      padding: $spacer * 1.5 ($spacer * 1.75) 0;
+      position: relative;
+      display: flex;
       font-size: $font-size-sm;
+      font-weight: bold;
+
+      .app-sidebar--reduced & {
+        margin: $spacer-xs $spacer-xs 0;
+        flex-direction: column;
+        text-align: center;
+        padding: $spacer-lg $spacer-xs $spacer;
+      }
+
+      &:not(&--borderless):before {
+        content: '';
+        border-top: $app-sidebar-border-color 1px solid;
+        position: absolute;
+        top: 0;
+        left: $spacer;
+        right: $spacer;
+      }
+
+      & .svg-inline--fa {
+        font-size: 1.2rem;
+
+        .app-sidebar:not(.app-sidebar--reduced) & {
+          margin-right: $spacer;
+        }
+
+        .app-sidebar--reduced & {
+          margin: 0 auto $spacer-xs;
+          display: block;
+        }
+      }
+
+      &__label {
+        .app-sidebar--reduced & {
+          font-size: 0.7rem;
+        }
+      }
+    }
+
+    &__menu {
+      position: relative;
+      padding-top: $spacer;
+      margin-bottom: $spacer;
+
+      &:not(&--borderless):before {
+        content: '';
+        border-top: $app-sidebar-border-color 1px solid;
+        position: absolute;
+        top: 0;
+        left: $spacer;
+        right: $spacer;
+      }
+
+      &--borderless {
+        padding-top: 0;
+      }
+
+      &__item {
+        position: relative;
+
+        &:last-of-type &__link--tree:before {
+          transform: none;
+          height: calc(50% + #{$item-tree-width * 0.5});
+          top: 0;
+        }
+
+        &__link,
+        &__link.btn {
+          margin: $spacer-xs $spacer;
+          padding: $spacer-sm;
+          color: $app-sidebar-link-color;
+          display: flex;
+          border-radius: $border-radius;
+          font-size: $font-size-sm;
+          font-weight: bold;
+
+          .app-sidebar--reduced & {
+            flex-direction: column;
+            text-align: center;
+            margin: $spacer-xs;
+            padding: $spacer-sm $spacer-xs $spacer-xs;
+          }
+
+          &.router-link-active,
+          &:hover,
+          &:active {
+            background: mix($app-sidebar-color, $app-sidebar-bg, 5%);
+            color: $app-sidebar-color;
+          }
+
+          &.router-link-active:before {
+            background: $secondary;
+            bottom: 0;
+            box-shadow: 2px 0 $spacer 0 $secondary;
+            content: '';
+            left: 0;
+            position: absolute;
+            top: 0;
+            width: 2px;
+          }
+
+          &.router-link-active .svg-inline--fa {
+            color: $secondary;
+          }
+
+          &[data-badge]:after {
+            content: attr(data-badge);
+            position: absolute;
+            left: calc(50% + 0.5em);
+            top: 0.25em;
+            background: $secondary;
+            color: white;
+            font-size: 0.75em;
+            font-weight: $badge-font-weight;
+            padding: $badge-padding-y $badge-padding-x;
+            border-radius: $badge-border-radius;
+          }
+
+          &--disabled,
+          &--disabled:hover {
+            color: $text-muted;
+            cursor: not-allowed;
+            text-decoration: none;
+          }
+
+          &--tree {
+            font-weight: normal;
+            position: relative;
+            padding: $spacer * 0.5 $spacer * 0.75;
+            margin-top: 0;
+            margin-bottom: 0;
+            margin-left: $spacer * 3.25;
+
+            &:before {
+              content: '';
+              position: absolute;
+              right: calc(100% + #{$spacer * 0.5});
+              top: 50%;
+              transform: translateY(-50%);
+              width: $item-tree-width;
+              background: $item-tree-color;
+              height: 100%;
+            }
+
+            &:after {
+              content: '';
+              position: absolute;
+              right: 100%;
+              top: 50%;
+              transform: translateY(-50%);
+              height: $item-tree-width;
+              background: $item-tree-color;
+              width: $spacer * 0.5;
+            }
+          }
+
+          & .svg-inline--fa {
+            font-size: 1.2rem;
+
+            .app-sidebar:not(.app-sidebar--reduced) & {
+              margin-right: $spacer;
+            }
+
+            .app-sidebar--reduced & {
+              margin: 0 auto $spacer-xs;
+              display: block;
+            }
+          }
+
+          &__label {
+            .app-sidebar--reduced & {
+              font-size: 0.7rem;
+            }
+          }
+        }
+      }
     }
   }
+
+  &__version {
+    z-index: 100;
+    position: relative;
+    text-align: left;
+
+    &:before {
+      content: '';
+      position: absolute;
+      bottom: 100%;
+      left: 0;
+      right: 0;
+      height: $spacer;
+      pointer-events: none;
+    }
+
+    .app-sidebar--reduced & {
+      text-align: center;
+      padding: 0 0 $spacer;
+    }
+  }
+
+  &__version,
+  &__data-location {
+    color: $app-sidebar-link-color;
+    padding: 0 $spacer * 1.7 $spacer $spacer * 1.5;
+    font-size: $font-size-sm;
+  }
+}
 </style>

--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -67,21 +67,19 @@
             </span>
           </router-link>
         </li>
-        <template>
-          <li class="app-sidebar__container__menu__item">
-            <router-link
-              v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
-              class="app-sidebar__container__menu__item__link"
-              :title="$t('menu.settings')"
-              :to="{ name: 'settings' }"
-            >
-              <fa icon="cog" fixed-width></fa>
-              <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
-                {{ $t(reduced ? 'menu.settingsShort' : 'menu.settings') }}
-              </span>
-            </router-link>
-          </li>
-        </template>
+        <li class="app-sidebar__container__menu__item">
+          <router-link
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
+            class="app-sidebar__container__menu__item__link"
+            :title="$t('menu.settings')"
+            :to="{ name: 'settings' }"
+          >
+            <fa icon="cog" fixed-width></fa>
+            <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
+              {{ $t(reduced ? 'menu.settingsShort' : 'menu.settings') }}
+            </span>
+          </router-link>
+        </li>
       </ul>
       <hook name="app-sidebar.menu:after"></hook>
       <hook name="app-sidebar.help:before"></hook>

--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -7,7 +7,7 @@
           <img src="~images/logo-color.svg" alt="Datashare" class="app-sidebar__container__brand__logo" />
         </router-link>
         <div>
-          <a @click="hideSidebar()" class="app-sidebar__container__toggle text-white">
+          <a class="app-sidebar__container__toggle text-white" @click="hideSidebar()">
             <fa icon="bars"></fa>
           </a>
         </div>
@@ -16,10 +16,10 @@
       <ul class="app-sidebar__container__menu list-unstyled">
         <li class="app-sidebar__container__menu__item">
           <router-link
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
             class="app-sidebar__container__menu__item__link"
             :title="$t('menu.search')"
             :to="{ name: 'search', query }"
-            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
           >
             <fa icon="search" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
@@ -29,10 +29,10 @@
         </li>
         <li class="app-sidebar__container__menu__item app-sidebar__container__menu__item--tasks">
           <router-link
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
             class="app-sidebar__container__menu__item__link"
             :title="$t('menu.tasks')"
             :to="{ name: 'tasks' }"
-            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
           >
             <fa icon="rocket" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
@@ -42,11 +42,11 @@
         </li>
         <li class="app-sidebar__container__menu__item">
           <router-link
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
             class="app-sidebar__container__menu__item__link"
-            @click.prevent="$root.$emit('history::toggle')"
             :title="$t('menu.history')"
             :to="{ name: 'user-history' }"
-            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
+            @click.prevent="$root.$emit('history::toggle')"
           >
             <fa icon="clock" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
@@ -56,10 +56,10 @@
         </li>
         <li class="app-sidebar__container__menu__item">
           <router-link
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
             class="app-sidebar__container__menu__item__link"
             :title="$t('menu.insights')"
             :to="{ name: 'insights' }"
-            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
           >
             <fa icon="chart-bar" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
@@ -70,10 +70,10 @@
         <template>
           <li class="app-sidebar__container__menu__item">
             <router-link
+              v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
               class="app-sidebar__container__menu__item__link"
               :title="$t('menu.settings')"
               :to="{ name: 'settings' }"
-              v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
             >
               <fa icon="cog" fixed-width></fa>
               <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
@@ -88,11 +88,11 @@
       <ul class="app-sidebar__container__menu list-unstyled">
         <li class="app-sidebar__container__menu__item">
           <a
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
             class="app-sidebar__container__menu__item__link"
             :href="faqLink"
             target="_blank"
             :title="$t('menu.faq')"
-            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
           >
             <fa icon="question" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
@@ -102,11 +102,11 @@
         </li>
         <li class="app-sidebar__container__menu__item app-sidebar__container__menu__item--help">
           <a
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
             class="app-sidebar__container__menu__item__link"
             :href="helpLink"
             target="_blank"
             :title="$t('menu.help')"
-            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
           >
             <fa icon="ambulance" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
@@ -126,7 +126,7 @@
             </span>
           </h5>
           <ul class="app-sidebar__container__menu app-sidebar__container__menu--borderless list-unstyled">
-            <li class="app-sidebar__container__menu__item" v-for="meta in currentRouteDocs" :key="meta.resourcePath">
+            <li v-for="meta in currentRouteDocs" :key="meta.resourcePath" class="app-sidebar__container__menu__item">
               <router-link
                 class="app-sidebar__container__menu__item__link app-sidebar__container__menu__item__link--tree"
                 :to="{ name: 'docs', params: meta }"
@@ -141,10 +141,10 @@
         <ul v-else class="app-sidebar__container__menu list-unstyled">
           <li class="app-sidebar__container__menu__item" :data-badge="currentRouteDocs.length">
             <b-button
+              id="app-menu-user-guide"
               class="app-sidebar__container__menu__item__link"
               :data-badge="currentRouteDocs.length"
               href="#"
-              id="app-menu-user-guide"
               variant="none"
             >
               <fa icon="book" fixed-width></fa>
@@ -159,10 +159,10 @@
               >
                 <div class="dropdown-menu show position-static border-0 px-2 bg-transparent">
                   <router-link
-                    class="dropdown-item"
-                    :key="meta.resourcePath"
-                    :to="{ name: 'docs', params: meta }"
                     v-for="meta in currentRouteDocs"
+                    :key="meta.resourcePath"
+                    class="dropdown-item"
+                    :to="{ name: 'docs', params: meta }"
                   >
                     {{ meta.title }}
                   </router-link>
@@ -176,29 +176,29 @@
       <hook name="app-sidebar.locales:before"></hook>
       <ul class="app-sidebar__container__menu list-unstyled mb-0">
         <li class="app-sidebar__container__menu__item app-sidebar__container__menu__item--locale">
-          <locales-menu class="app-sidebar__container__menu__item__link text-wrap" v-slot="{ currentLocale }">
+          <locales-menu v-slot="{ currentLocale }" class="app-sidebar__container__menu__item__link text-wrap">
             <fa icon="globe" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
               {{ currentLocale.label }}
             </span>
           </locales-menu>
         </li>
-        <li class="app-sidebar__container__menu__item app-sidebar__container__menu__item--logout" v-if="isServer">
+        <li v-if="isServer" class="app-sidebar__container__menu__item app-sidebar__container__menu__item--logout">
           <a
             v-if="isBasicAuth"
-            @click.prevent="showModal"
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
             class="app-sidebar__container__menu__item__link app-sidebar__container__menu__item__link--basic-auth"
             :title="$t('menu.logout')"
-            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
+            @click.prevent="showModal"
           >
             <fa icon="sign-out-alt" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
               {{ $t('menu.logoutShort') }}
             </span>
             <b-modal
+              ref="logout-modal"
               hide-footer
               class="app-sidebar__container__menu__item__link__modal"
-              ref="logout-modal"
               size="md"
               :title="$t('menu.logout')"
             >
@@ -207,10 +207,10 @@
           </a>
           <a
             v-else
+            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
             class="app-sidebar__container__menu__item__link"
             :href="logoutLink"
             :title="$t('menu.logout')"
-            v-b-tooltip.right="{ customClass: tooltipsClass, id: 'app-sidebar-link-label' }"
           >
             <fa icon="sign-out-alt" fixed-width></fa>
             <span class="flex-grow-1 app-sidebar__container__menu__item__link__label">
@@ -229,7 +229,7 @@
         :tooltip-placement="reduced ? 'righttop' : 'top'"
       ></version-number>
     </div>
-    <div class="app-sidebar__data-location" v-if="!isServer" v-show="!reduced">
+    <div v-if="!isServer" v-show="!reduced" class="app-sidebar__data-location">
       <mounted-data-location></mounted-data-location>
     </div>
   </div>
@@ -252,7 +252,6 @@ import { Api } from '@/api'
  */
 export default {
   name: 'AppSidebar',
-  mixins: [docs, utils],
   components: {
     Hook,
     LocalesMenu,
@@ -260,6 +259,7 @@ export default {
     VersionNumber,
     VuePerfectScrollbar
   },
+  mixins: [docs, utils],
   computed: {
     query() {
       return this.$store.getters['search/toRouteQueryWithStamp']()

--- a/src/components/AppliedSearchFilters.vue
+++ b/src/components/AppliedSearchFilters.vue
@@ -19,14 +19,14 @@ export default {
     ResetFiltersButton
   },
   computed: {
-    filters () {
+    filters() {
       const filters = []
-      this.$store.getters['search/retrieveQueryTerms'].forEach(term => {
+      this.$store.getters['search/retrieveQueryTerms'].forEach((term) => {
         term.value = term.label
         filters.push(term)
       })
-      this.$store.getters['search/instantiatedFilters'].forEach(filter => {
-        filter.values.forEach(value => {
+      this.$store.getters['search/instantiatedFilters'].forEach((filter) => {
+        filter.values.forEach((value) => {
           let label = filter.itemLabel ? filter.itemLabel({ key: value, key_as_string: value }) : value
           label = this.$te(label) ? this.$t(label) : label
           // Indexing Date filter is filtering by month

--- a/src/components/AppliedSearchFilters.vue
+++ b/src/components/AppliedSearchFilters.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="applied-search-filters d-flex flex-wrap pt-1" v-if="filters.length">
+  <div v-if="filters.length" class="applied-search-filters d-flex flex-wrap pt-1">
     <applied-search-filters-item v-for="(filter, index) in filters" :key="index" :filter="filter" hide-filter-label />
     <reset-filters-button variant="link" class="text-muted badge font-weight-normal" auto-hiding />
   </div>

--- a/src/components/AppliedSearchFiltersItem.vue
+++ b/src/components/AppliedSearchFiltersItem.vue
@@ -1,11 +1,13 @@
 <template>
-  <b-badge class="applied-search-filters-item p-0 my-1 mr-2 mw-100 text-truncate"
+  <b-badge
+    class="applied-search-filters-item p-0 my-1 mr-2 mw-100 text-truncate"
     v-b-tooltip.html
     variant="warning"
     @click.prevent="deleteQueryTerm()"
     :id="appliedSearchFiltersItemId"
     :pill="hideFilterLabel"
-    :class="appliedSearchFiltersItemClassList">
+    :class="appliedSearchFiltersItemClassList"
+  >
     <span class="applied-search-filters-item__wrapper d-inline-flex flex-column">
       <span class="applied-search-filters-item__wrapper__label p-1" v-if="!hideFilterLabel">
         {{ filterName }}
@@ -62,22 +64,22 @@ export default {
     displayUser
   },
   computed: {
-    appliedSearchFiltersItemId () {
+    appliedSearchFiltersItemId() {
       return uniqueId('applied-search-filters-item-')
     },
-    appliedSearchFiltersItemClassList () {
+    appliedSearchFiltersItemClassList() {
       return {
         'applied-search-filters-item--negation': this.filter.negation,
         'applied-search-filters-item--read-only': this.readOnly
       }
     },
-    displayedFilterValue () {
+    displayedFilterValue() {
       return this.filter.label || this.filterValue
     },
-    filterValue () {
+    filterValue() {
       return this.$options.filters.displayUser(this.filter.value)
     },
-    filterName () {
+    filterName() {
       if (this.isQueryTerm) {
         return this.$t('filter.searchTerm')
       }
@@ -85,12 +87,12 @@ export default {
       const localeKey = `filter.${name}`
       return this.$te(localeKey) ? this.$t(localeKey) : name
     },
-    isQueryTerm () {
+    isQueryTerm() {
       return !('name' in this.filter) || this.filter.name === 'q'
     }
   },
   methods: {
-    async deleteQueryTerm () {
+    async deleteQueryTerm() {
       if (this.readOnly) {
         return
       }
@@ -110,23 +112,22 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .applied-search-filters-item {
-    cursor: pointer;
+.applied-search-filters-item {
+  cursor: pointer;
 
-    &--negation {
-      text-decoration: line-through;
-    }
+  &--negation {
+    text-decoration: line-through;
+  }
 
-    &__wrapper {
-
-      &__label {
-        font-size: 0.8em;
-        background: #fff;
-        border: 1px solid $warning;
-        border-bottom: 0;
-        text-transform: uppercase;
-        border-radius: $border-radius-sm $border-radius-sm 0 0;
-      }
+  &__wrapper {
+    &__label {
+      font-size: 0.8em;
+      background: #fff;
+      border: 1px solid $warning;
+      border-bottom: 0;
+      text-transform: uppercase;
+      border-radius: $border-radius-sm $border-radius-sm 0 0;
     }
   }
+}
 </style>

--- a/src/components/AppliedSearchFiltersItem.vue
+++ b/src/components/AppliedSearchFiltersItem.vue
@@ -1,19 +1,19 @@
 <template>
   <b-badge
-    class="applied-search-filters-item p-0 my-1 mr-2 mw-100 text-truncate"
-    v-b-tooltip.html
-    variant="warning"
-    @click.prevent="deleteQueryTerm()"
     :id="appliedSearchFiltersItemId"
+    v-b-tooltip.html
+    class="applied-search-filters-item p-0 my-1 mr-2 mw-100 text-truncate"
+    variant="warning"
     :pill="hideFilterLabel"
     :class="appliedSearchFiltersItemClassList"
+    @click.prevent="deleteQueryTerm()"
   >
     <span class="applied-search-filters-item__wrapper d-inline-flex flex-column">
-      <span class="applied-search-filters-item__wrapper__label p-1" v-if="!hideFilterLabel">
+      <span v-if="!hideFilterLabel" class="applied-search-filters-item__wrapper__label p-1">
         {{ filterName }}
       </span>
       <span class="applied-search-filters-item__wrapper__value p-1">
-        <fa icon="times-circle" v-if="!readOnly" />
+        <fa v-if="!readOnly" icon="times-circle" />
         {{ displayedFilterValue }}
       </span>
     </span>
@@ -40,6 +40,9 @@ import displayUser from '@/filters/displayUser'
  */
 export default {
   name: 'AppliedSearchFiltersItem',
+  filters: {
+    displayUser
+  },
   props: {
     /**
      * The applied filter
@@ -59,9 +62,6 @@ export default {
     hideFilterLabel: {
       type: Boolean
     }
-  },
-  filters: {
-    displayUser
   },
   computed: {
     appliedSearchFiltersItemId() {

--- a/src/components/BatchDownloadActions.vue
+++ b/src/components/BatchDownloadActions.vue
@@ -127,7 +127,7 @@ export default {
 
 <template>
   <div class="batch-download-actions">
-    <b-btn variant="link" size="sm" class="p-1" :id="togglerId">
+    <b-btn :id="togglerId" variant="link" size="sm" class="p-1">
       <fa icon="ellipsis" fixed-width class="mx-1" />
     </b-btn>
     <b-popover
@@ -137,15 +137,15 @@ export default {
       triggers="focus"
       :target="popoverTarget"
     >
-      <b-dropdown-item-button @click="relaunchTask()" class="batch-download-actions__relaunch">
+      <b-dropdown-item-button class="batch-download-actions__relaunch" @click="relaunchTask()">
         <fa icon="redo" fixed-width class="mr-1" />
         {{ $t('batchDownloadActions.relaunch') }}
       </b-dropdown-item-button>
-      <b-dropdown-item :to="uri" class="batch-download-actions__search" v-if="uri">
+      <b-dropdown-item v-if="uri" :to="uri" class="batch-download-actions__search">
         <fa icon="search" fixed-width class="mr-1" />
         {{ $t('batchDownloadActions.search') }}
       </b-dropdown-item>
-      <b-dropdown-item-button disabled class="batch-download-actions__search" v-else>
+      <b-dropdown-item-button v-else disabled class="batch-download-actions__search">
         <fa icon="search" fixed-width class="mr-1" />
         {{ $t('batchDownloadActions.search') }}
       </b-dropdown-item-button>

--- a/src/components/BatchDownloadActions.vue
+++ b/src/components/BatchDownloadActions.vue
@@ -22,31 +22,31 @@ export default {
      */
     value: {
       type: Object,
-      default: () => ({ })
+      default: () => ({})
     }
   },
   computed: {
-    isTaskRunning () {
+    isTaskRunning() {
       return this.state.toUpperCase() === 'RUNNING'
     },
-    popoverTarget () {
+    popoverTarget() {
       return `#${this.togglerId}`
     },
-    projects () {
-      return this?.value?.projects?.map(p => p.name) || []
+    projects() {
+      return this?.value?.projects?.map((p) => p.name) || []
     },
-    uri () {
+    uri() {
       return this?.value?.uri || null
     },
-    togglerId () {
+    togglerId() {
       return uniqueId('batch-download-actions-')
     }
   },
   methods: {
-    closePopover () {
+    closePopover() {
       this.$root.$emit('bv::hide::popover', this.togglerId)
     },
-    async deleteTask () {
+    async deleteTask() {
       try {
         this.closePopover()
         await this.$core.api.deleteTask(this.name)
@@ -55,7 +55,7 @@ export default {
         this.notifyDeleteFailed(error)
       }
     },
-    async relaunchTask () {
+    async relaunchTask() {
       try {
         this.closePopover()
         const projectIds = this.projects
@@ -67,7 +67,7 @@ export default {
         this.notifyRelaunchFailed(error)
       }
     },
-    notifyRelaunchSucceed () {
+    notifyRelaunchSucceed() {
       const title = this.$t('batchDownload.relaunch.succeed')
       const variant = 'success'
       const body = this.$t('batchDownload.relaunch.succeedBody')
@@ -79,7 +79,7 @@ export default {
        */
       this.$emit('relaunched', this.value)
     },
-    notifyRelaunchFailed (error) {
+    notifyRelaunchFailed(error) {
       const title = this.$t('batchDownload.relaunch.failed')
       const variant = 'danger'
       const body = this.$t('batchDownload.relaunch.failedBody')
@@ -91,7 +91,7 @@ export default {
        */
       this.$emit('relaunchFailed', error)
     },
-    notifyDeleteSucceed () {
+    notifyDeleteSucceed() {
       /**
        * The batch download was deleted successfully
        *
@@ -99,7 +99,7 @@ export default {
        */
       this.$emit('deleted', this.value)
     },
-    notifyDeleteFailed (error) {
+    notifyDeleteFailed(error) {
       const title = this.$t('batchDownload.delete.failed')
       const variant = 'danger'
       const body = this.$t('batchDownload.delete.failedBody')
@@ -111,10 +111,10 @@ export default {
        */
       this.$emit('deleteFailed', error)
     },
-    parseQuery () {
+    parseQuery() {
       return JSON.parse(this.value.query || null) ?? {}
     },
-    tryToParseQuery () {
+    tryToParseQuery() {
       try {
         return this.parseQuery()
       } catch (_) {
@@ -135,7 +135,8 @@ export default {
       custom-class="popover-body-p-0 popover-body-overflow-hidden dropdown-menu shadow popover-white"
       placement="left"
       triggers="focus"
-      :target="popoverTarget">
+      :target="popoverTarget"
+    >
       <b-dropdown-item-button @click="relaunchTask()" class="batch-download-actions__relaunch">
         <fa icon="redo" fixed-width class="mr-1" />
         {{ $t('batchDownloadActions.relaunch') }}

--- a/src/components/BatchSearchActions.vue
+++ b/src/components/BatchSearchActions.vue
@@ -1,10 +1,12 @@
 <template>
   <div class="batch-search-actions">
-    <b-btn class="batch-search-actions__item"
-           id="batch-search-actions-filters-toggle"
-           v-b-tooltip.hover
-           variant="light"
-           :title="$t('batchSearchResultsFilters.queries.heading')">
+    <b-btn
+      class="batch-search-actions__item"
+      id="batch-search-actions-filters-toggle"
+      v-b-tooltip.hover
+      variant="light"
+      :title="$t('batchSearchResultsFilters.queries.heading')"
+    >
       <fa icon="filter" />
       <span class="sr-only">
         {{ $t('batchSearchResultsFilters.queries.heading') }}
@@ -13,61 +15,73 @@
         {{ nbSelectedQueries | humanNumber }}
       </b-badge>
       <keep-alive>
-        <b-popover custom-class="popover-body-p-0"
-                  lazy
-                  placement="bottom"
-                  target="batch-search-actions-filters-toggle"
-                  triggers="focus" >
+        <b-popover
+          custom-class="popover-body-p-0"
+          lazy
+          placement="bottom"
+          target="batch-search-actions-filters-toggle"
+          triggers="focus"
+        >
           <batch-search-results-filters :query-keys="queryKeys" :indices="projects" hide-border />
         </b-popover>
       </keep-alive>
     </b-btn>
 
-    <confirm-button class="batch-search-actions__item batch-search-actions__item--delete btn btn-light ml-2"
-                    v-b-tooltip.hover
-                    v-if="isMyBatchSearch"
-                    :confirmed="deleteBatchSearch"
-                    :label="$t('batchSearch.delete')"
-                    :no="$t('global.no')"
-                    :yes="$t('global.yes')"
-                    :title="$t('batchSearch.delete')">
+    <confirm-button
+      class="batch-search-actions__item batch-search-actions__item--delete btn btn-light ml-2"
+      v-b-tooltip.hover
+      v-if="isMyBatchSearch"
+      :confirmed="deleteBatchSearch"
+      :label="$t('batchSearch.delete')"
+      :no="$t('global.no')"
+      :yes="$t('global.yes')"
+      :title="$t('batchSearch.delete')"
+    >
       <fa icon="trash-alt" />
       <span class="sr-only">
         {{ $t('batchSearch.delete') }}
       </span>
     </confirm-button>
 
-    <b-btn class="batch-search-actions__item action batch-search-actions__item--relaunch ml-2"
-           v-if="isMyBatchSearch && isEnded"
-           variant="light"
-           @click="$refs['batch-search-copy-form'].show()"
-           :disabled="isRelaunched">
+    <b-btn
+      class="batch-search-actions__item action batch-search-actions__item--relaunch ml-2"
+      v-if="isMyBatchSearch && isEnded"
+      variant="light"
+      @click="$refs['batch-search-copy-form'].show()"
+      :disabled="isRelaunched"
+    >
       <fa icon="redo" />
       {{ $t('batchSearchResults.relaunch') }}
-      <b-modal body-class="p-0"
-               hide-footer
-               ref="batch-search-copy-form"
-               size="md"
-               :title="$t('batchSearchResults.relaunchTitle')">
+      <b-modal
+        body-class="p-0"
+        hide-footer
+        ref="batch-search-copy-form"
+        size="md"
+        :title="$t('batchSearchResults.relaunchTitle')"
+      >
         <batch-search-copy-form :batch-search="batchSearch" />
       </b-modal>
     </b-btn>
 
-    <b-btn class="batch-search-actions__item batch-search-actions__item--download-queries ml-2"
-           variant="light"
-           v-b-tooltip.hover
-           :title="$t('batchSearchResults.downloadQueriesTooltip')"
-           :href="downloadQueriesUrl">
+    <b-btn
+      class="batch-search-actions__item batch-search-actions__item--download-queries ml-2"
+      variant="light"
+      v-b-tooltip.hover
+      :title="$t('batchSearchResults.downloadQueriesTooltip')"
+      :href="downloadQueriesUrl"
+    >
       <fa icon="download" />
       {{ $t('batchSearchResults.downloadQueries') }}
     </b-btn>
 
-    <b-btn class="batch-search-actions__item batch-search-actions__item--download-results ml-2"
-           v-if="isEnded"
-           variant="primary"
-           v-b-tooltip.hover
-           :title="$t('batchSearchResults.downloadQueriesTooltip')"
-           :href="downloadResultsUrl">
+    <b-btn
+      class="batch-search-actions__item batch-search-actions__item--download-results ml-2"
+      v-if="isEnded"
+      variant="primary"
+      v-b-tooltip.hover
+      :title="$t('batchSearchResults.downloadQueriesTooltip')"
+      :href="downloadResultsUrl"
+    >
       <fa icon="download" />
       {{ $t('batchSearchResults.downloadResults') }}
     </b-btn>
@@ -103,7 +117,7 @@ export default {
   filters: {
     humanNumber
   },
-  data () {
+  data() {
     return {
       isMyBatchSearch: false,
       isRelaunched: false
@@ -111,31 +125,31 @@ export default {
   },
   computed: {
     ...mapGetters('batchSearch', ['nbSelectedQueries', 'queryKeys']),
-    user () {
+    user() {
       return get(this, 'batchSearch.user.id')
     },
-    uuid () {
+    uuid() {
       return get(this, 'batchSearch.uuid')
     },
-    projects () {
-      return get(this, 'batchSearch.projects').map(project => project.name)
+    projects() {
+      return get(this, 'batchSearch.projects').map((project) => project.name)
     },
-    isEnded () {
+    isEnded() {
       return ['SUCCESS', 'FAILURE'].indexOf(this.batchSearch.state) > -1
     },
-    downloadQueriesUrl () {
+    downloadQueriesUrl() {
       return Api.getFullUrl(`/api/batch/search/${this.uuid}/queries?format=csv`)
     },
-    downloadResultsUrl () {
+    downloadResultsUrl() {
       return Api.getFullUrl(`/api/batch/search/result/csv/${this.uuid}`)
     }
   },
-  async created () {
-    this.isMyBatchSearch = await this.$core.auth.getUsername() === this.user
+  async created() {
+    this.isMyBatchSearch = (await this.$core.auth.getUsername()) === this.user
     this.getQueries()
   },
   methods: {
-    async deleteBatchSearch () {
+    async deleteBatchSearch() {
       const batchId = this.uuid
       const isDeleted = await this.$store.dispatch('batchSearch/deleteBatchSearch', { batchId })
       if (isDeleted) {
@@ -145,7 +159,7 @@ export default {
       }
       this.$router.push({ name: 'batch-search' })
     },
-    getQueries () {
+    getQueries() {
       return this.$store.dispatch('batchSearch/getBatchSearchQueries', this.uuid)
     }
   }
@@ -153,19 +167,18 @@ export default {
 </script>
 
 <style lang="scss">
-  .batch-search-actions {
+.batch-search-actions {
+  &__item {
+    position: relative;
 
-    &__item {
-      position: relative;
-
-      & &__counter {
-        margin: 0;
-        position: absolute;
-        right: 0;
-        top: 0;
-        transform: translate(50%, -50%);
-        z-index: 100;
-      }
+    & &__counter {
+      margin: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+      transform: translate(50%, -50%);
+      z-index: 100;
     }
   }
+}
 </style>

--- a/src/components/BatchSearchActions.vue
+++ b/src/components/BatchSearchActions.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="batch-search-actions">
     <b-btn
-      class="batch-search-actions__item"
       id="batch-search-actions-filters-toggle"
       v-b-tooltip.hover
+      class="batch-search-actions__item"
       variant="light"
       :title="$t('batchSearchResultsFilters.queries.heading')"
     >
@@ -11,7 +11,7 @@
       <span class="sr-only">
         {{ $t('batchSearchResultsFilters.queries.heading') }}
       </span>
-      <b-badge variant="secondary" class="batch-search-actions__item__counter" v-if="nbSelectedQueries">
+      <b-badge v-if="nbSelectedQueries" variant="secondary" class="batch-search-actions__item__counter">
         {{ nbSelectedQueries | humanNumber }}
       </b-badge>
       <keep-alive>
@@ -28,9 +28,9 @@
     </b-btn>
 
     <confirm-button
-      class="batch-search-actions__item batch-search-actions__item--delete btn btn-light ml-2"
-      v-b-tooltip.hover
       v-if="isMyBatchSearch"
+      v-b-tooltip.hover
+      class="batch-search-actions__item batch-search-actions__item--delete btn btn-light ml-2"
       :confirmed="deleteBatchSearch"
       :label="$t('batchSearch.delete')"
       :no="$t('global.no')"
@@ -44,18 +44,18 @@
     </confirm-button>
 
     <b-btn
-      class="batch-search-actions__item action batch-search-actions__item--relaunch ml-2"
       v-if="isMyBatchSearch && isEnded"
+      class="batch-search-actions__item action batch-search-actions__item--relaunch ml-2"
       variant="light"
-      @click="$refs['batch-search-copy-form'].show()"
       :disabled="isRelaunched"
+      @click="$refs['batch-search-copy-form'].show()"
     >
       <fa icon="redo" />
       {{ $t('batchSearchResults.relaunch') }}
       <b-modal
+        ref="batch-search-copy-form"
         body-class="p-0"
         hide-footer
-        ref="batch-search-copy-form"
         size="md"
         :title="$t('batchSearchResults.relaunchTitle')"
       >
@@ -64,9 +64,9 @@
     </b-btn>
 
     <b-btn
+      v-b-tooltip.hover
       class="batch-search-actions__item batch-search-actions__item--download-queries ml-2"
       variant="light"
-      v-b-tooltip.hover
       :title="$t('batchSearchResults.downloadQueriesTooltip')"
       :href="downloadQueriesUrl"
     >
@@ -75,10 +75,10 @@
     </b-btn>
 
     <b-btn
-      class="batch-search-actions__item batch-search-actions__item--download-results ml-2"
       v-if="isEnded"
-      variant="primary"
       v-b-tooltip.hover
+      class="batch-search-actions__item batch-search-actions__item--download-results ml-2"
+      variant="primary"
       :title="$t('batchSearchResults.downloadQueriesTooltip')"
       :href="downloadResultsUrl"
     >
@@ -102,6 +102,13 @@ import humanNumber from '@/filters/humanNumber'
  */
 export default {
   name: 'BatchSearchActions',
+  components: {
+    BatchSearchResultsFilters,
+    BatchSearchCopyForm
+  },
+  filters: {
+    humanNumber
+  },
   props: {
     /**
      * The batch search meta data
@@ -109,13 +116,6 @@ export default {
     batchSearch: {
       type: Object
     }
-  },
-  components: {
-    BatchSearchResultsFilters,
-    BatchSearchCopyForm
-  },
-  filters: {
-    humanNumber
   },
   data() {
     return {

--- a/src/components/BatchSearchClearFilters.vue
+++ b/src/components/BatchSearchClearFilters.vue
@@ -26,11 +26,6 @@ const SEARCH_PARAMS_LOCAL = Object.freeze({
 export default {
   name: 'BatchSearchClearFilters',
   mixins: [utils],
-  methods: {
-    deleteFilters() {
-      return this.$router.push({ name: 'batch-search', query: {} })
-    }
-  },
   computed: {
     filters() {
       const keys = Object.keys(SEARCH_PARAMS_LOCAL)
@@ -42,6 +37,11 @@ export default {
     hasActiveFilter() {
       const isContained = this.currentFilters.filter((f) => this.filters.includes(f)).length !== 0
       return this.currentFilters.length !== 0 && isContained
+    }
+  },
+  methods: {
+    deleteFilters() {
+      return this.$router.push({ name: 'batch-search', query: {} })
     }
   }
 }

--- a/src/components/BatchSearchClearFilters.vue
+++ b/src/components/BatchSearchClearFilters.vue
@@ -1,15 +1,16 @@
 <template>
-  <b-btn :disabled="!hasActiveFilter"
-         class="batch-search-clear-filters text-muted "
-         variant="link"
-         @click="deleteFilters">
-    <fa icon="filter-circle-xmark"/>
+  <b-btn
+    :disabled="!hasActiveFilter"
+    class="batch-search-clear-filters text-muted"
+    variant="link"
+    @click="deleteFilters"
+  >
+    <fa icon="filter-circle-xmark" />
     {{ $t('batchSearch.clearFilters') }}
   </b-btn>
 </template>
 
 <script>
-
 import utils from '@/mixins/utils'
 const SEARCH_PARAMS_LOCAL = Object.freeze({
   query: true,
@@ -26,24 +27,20 @@ export default {
   name: 'BatchSearchClearFilters',
   mixins: [utils],
   methods: {
-    deleteFilters () {
+    deleteFilters() {
       return this.$router.push({ name: 'batch-search', query: {} })
     }
   },
   computed: {
-    filters () {
+    filters() {
       const keys = Object.keys(SEARCH_PARAMS_LOCAL)
-      return this.isServer
-        ? keys
-        : keys.filter(key =>
-          SEARCH_PARAMS_LOCAL[key]
-        )
+      return this.isServer ? keys : keys.filter((key) => SEARCH_PARAMS_LOCAL[key])
     },
-    currentFilters () {
+    currentFilters() {
       return Object.keys(this.$route?.query)
     },
-    hasActiveFilter () {
-      const isContained = this.currentFilters.filter(f => this.filters.includes(f)).length !== 0
+    hasActiveFilter() {
+      const isContained = this.currentFilters.filter((f) => this.filters.includes(f)).length !== 0
       return this.currentFilters.length !== 0 && isContained
     }
   }

--- a/src/components/BatchSearchCopyForm.vue
+++ b/src/components/BatchSearchCopyForm.vue
@@ -2,7 +2,7 @@
   <b-form @submit.prevent="copyBatchSearch">
     <div class="card w-100">
       <div class="card-body pb-1">
-        <b-form-group label-size="sm" :label="`${ $t('batchSearch.name') } *`">
+        <b-form-group label-size="sm" :label="`${$t('batchSearch.name')} *`">
           <b-form-input v-model="name" type="text" required />
         </b-form-group>
         <b-form-group label-size="sm" :label="$t('batchSearch.description')">
@@ -16,7 +16,7 @@
       </div>
       <div class="card-footer">
         <div class="d-flex justify-content-end align-items-center">
-          <b-btn type="submit"  variant="primary">
+          <b-btn type="submit" variant="primary">
             {{ $t('global.submit') }}
           </b-btn>
         </div>
@@ -26,7 +26,6 @@
 </template>
 
 <script>
-
 /**
  * A form to copy batch search
  */
@@ -41,7 +40,7 @@ export default {
       default: () => ({})
     }
   },
-  data () {
+  data() {
     return {
       deleteAfterRelaunch: false,
       description: this.batchSearch.description,
@@ -49,7 +48,7 @@ export default {
     }
   },
   methods: {
-    async runBatchSearch () {
+    async runBatchSearch() {
       try {
         await this.$store.dispatch('indexing/runBatchSearch')
         this.$root.$bvToast.toast(this.$t('batchSearch.success'), { noCloseButton: true, variant: 'success' })
@@ -57,7 +56,7 @@ export default {
         this.$root.$bvToast.toast(this.$t('batchSearch.error'), { noCloseButton: true, variant: 'danger' })
       }
     },
-    async copyBatchSearch () {
+    async copyBatchSearch() {
       try {
         const { uuid: batchId } = this.batchSearch
         await this.$core.api.copyBatchSearch(batchId, this.name, this.description)

--- a/src/components/BatchSearchFilter.vue
+++ b/src/components/BatchSearchFilter.vue
@@ -1,19 +1,17 @@
 <template>
   <div class="batch-search-filter d-flex align-items-baseline">
     <span class="batch-search-filter__label">
-        {{ name }}
+      {{ name }}
     </span>
-    <b-btn :id="btnId"
-           class="batch-search-filter__toggle"
-           :class="btnClassName"
-           radius
-           variant="outline">
-      <fa icon="filter"/>
+    <b-btn :id="btnId" class="batch-search-filter__toggle" :class="btnClassName" radius variant="outline">
+      <fa icon="filter" />
     </b-btn>
-    <batch-search-filter-badge :active="active"/>
-    <b-popover custom-class="batch-search-filter__popover popover-white popover-body-p-0"
-               :target="btnId"
-               triggers="focus">
+    <batch-search-filter-badge :active="active" />
+    <b-popover
+      custom-class="batch-search-filter__popover popover-white popover-body-p-0"
+      :target="btnId"
+      triggers="focus"
+    >
       <slot></slot>
     </b-popover>
   </div>
@@ -46,20 +44,20 @@ export default {
     }
   },
   computed: {
-    btnClassName () {
+    btnClassName() {
       return `batch-search-filter__toggle--${this.id}`
     },
-    btnId () {
+    btnId() {
       return `${this.btnClassName}-id`
     }
   }
 }
 </script>
 <style lang="scss" scoped>
-.batch-search-filter{
-  &__toggle{
-    padding:  0 0.2em;
-    margin:  0 0 0 1em;
+.batch-search-filter {
+  &__toggle {
+    padding: 0 0.2em;
+    margin: 0 0 0 1em;
     line-height: 1.3em;
   }
 }

--- a/src/components/BatchSearchFilterBadge.vue
+++ b/src/components/BatchSearchFilterBadge.vue
@@ -1,8 +1,10 @@
 <template>
-  <fa class="batch-search-filter-badge text-secondary"
-      :class="{'batch-search-filter-badge--inactive':!active}"
-      icon="circle"
-      width="8px"></fa>
+  <fa
+    class="batch-search-filter-badge text-secondary"
+    :class="{ 'batch-search-filter-badge--inactive': !active }"
+    icon="circle"
+    width="8px"
+  ></fa>
 </template>
 
 <script>
@@ -17,7 +19,7 @@ export default {
 }
 </script>
 <style lang="scss">
-.batch-search-filter-badge--inactive{
+.batch-search-filter-badge--inactive {
   visibility: hidden;
 }
 </style>

--- a/src/components/BatchSearchFilterDate.vue
+++ b/src/components/BatchSearchFilterDate.vue
@@ -1,8 +1,15 @@
 <template>
   <batch-search-filter :id="id" :name="name" :active="isActive">
     <keep-alive>
-      <date-picker is-range color="gray" :max-date="new Date()" v-model="selectedDateRange"
-        :model-config="modelConfig" :key="`date-${id}`" :locale="locale">
+      <date-picker
+        is-range
+        color="gray"
+        :max-date="new Date()"
+        v-model="selectedDateRange"
+        :model-config="modelConfig"
+        :key="`date-${id}`"
+        :locale="locale"
+      >
       </date-picker>
     </keep-alive>
   </batch-search-filter>
@@ -36,27 +43,27 @@ export default {
     }
   },
   methods: {
-    startTimeAdjust (start) {
+    startTimeAdjust(start) {
       return moment(start).locale(this.$i18n.locale).startOf('day').valueOf()
     },
-    endTimeAdjust (end) {
+    endTimeAdjust(end) {
       return moment(end).locale(this.$i18n.locale).endOf('day').valueOf()
     }
   },
   computed: {
-    isActive () {
+    isActive() {
       return this.date !== null
     },
-    modelConfig () {
+    modelConfig() {
       return {
         type: 'number'
       }
     },
-    locale () {
+    locale() {
       return this.$i18n.locale
     },
     selectedDateRange: {
-      get () {
+      get() {
         if (this.date?.start && this.date?.end) {
           const start = this.startTimeAdjust(this.date?.start)
           const end = this.endTimeAdjust(this.date?.end)
@@ -64,11 +71,10 @@ export default {
         }
         return this.date
       },
-      set (values) {
+      set(values) {
         this.$emit('update', values)
       }
     }
-
   }
 }
 </script>

--- a/src/components/BatchSearchFilterDate.vue
+++ b/src/components/BatchSearchFilterDate.vue
@@ -2,12 +2,12 @@
   <batch-search-filter :id="id" :name="name" :active="isActive">
     <keep-alive>
       <date-picker
+        :key="`date-${id}`"
+        v-model="selectedDateRange"
         is-range
         color="gray"
         :max-date="new Date()"
-        v-model="selectedDateRange"
         :model-config="modelConfig"
-        :key="`date-${id}`"
         :locale="locale"
       >
       </date-picker>
@@ -42,14 +42,6 @@ export default {
       type: Object
     }
   },
-  methods: {
-    startTimeAdjust(start) {
-      return moment(start).locale(this.$i18n.locale).startOf('day').valueOf()
-    },
-    endTimeAdjust(end) {
-      return moment(end).locale(this.$i18n.locale).endOf('day').valueOf()
-    }
-  },
   computed: {
     isActive() {
       return this.date !== null
@@ -74,6 +66,14 @@ export default {
       set(values) {
         this.$emit('update', values)
       }
+    }
+  },
+  methods: {
+    startTimeAdjust(start) {
+      return moment(start).locale(this.$i18n.locale).startOf('day').valueOf()
+    },
+    endTimeAdjust(end) {
+      return moment(end).locale(this.$i18n.locale).endOf('day').valueOf()
     }
   }
 }

--- a/src/components/BatchSearchFilterDropdown.vue
+++ b/src/components/BatchSearchFilterDropdown.vue
@@ -1,7 +1,13 @@
 <template>
   <batch-search-filter class="batch-search-filter-dropdown" :id="id" :name="name" :active="isActive">
     <keep-alive>
-      <selectable-dropdown v-model="selectedValues" :items="items" deactivate-keys :multiple="multiple" class="shadow-none border-0">
+      <selectable-dropdown
+        v-model="selectedValues"
+        :items="items"
+        deactivate-keys
+        :multiple="multiple"
+        class="shadow-none border-0"
+      >
         <template #item-label="{ item }">
           <slot name="label" :item="item">{{ labelItem(item) }}</slot>
         </template>
@@ -43,23 +49,24 @@ export default {
     }
   },
   methods: {
-    labelItem (item) {
+    labelItem(item) {
       return item && item.label ? item.label : item
     }
   },
   computed: {
-    isActive () {
-      return this.values?.length > 0 || (this.values?.value !== undefined)
+    isActive() {
+      return this.values?.length > 0 || this.values?.value !== undefined
     },
     selectedValues: {
-      get () {
+      get() {
         return this.values
       },
-      set (values) {
-        if (!isEqual(values, this.values)) { this.$emit('update', values) }
+      set(values) {
+        if (!isEqual(values, this.values)) {
+          this.$emit('update', values)
+        }
       }
     }
-
   }
 }
 </script>

--- a/src/components/BatchSearchFilterDropdown.vue
+++ b/src/components/BatchSearchFilterDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <batch-search-filter class="batch-search-filter-dropdown" :id="id" :name="name" :active="isActive">
+  <batch-search-filter :id="id" class="batch-search-filter-dropdown" :name="name" :active="isActive">
     <keep-alive>
       <selectable-dropdown
         v-model="selectedValues"
@@ -48,11 +48,6 @@ export default {
       type: Boolean
     }
   },
-  methods: {
-    labelItem(item) {
-      return item && item.label ? item.label : item
-    }
-  },
   computed: {
     isActive() {
       return this.values?.length > 0 || this.values?.value !== undefined
@@ -66,6 +61,11 @@ export default {
           this.$emit('update', values)
         }
       }
+    }
+  },
+  methods: {
+    labelItem(item) {
+      return item && item.label ? item.label : item
     }
   }
 }

--- a/src/components/BatchSearchFilterQuery.vue
+++ b/src/components/BatchSearchFilterQuery.vue
@@ -26,18 +26,12 @@ import utils from '@/mixins/utils'
 
 export default {
   name: 'BatchSearchFilterQuery',
-  mixins: [utils],
   components: { SearchBarInputDropdown, SearchBarInput },
+  mixins: [utils],
   data() {
     return {
       field: this.getField(this.$route?.query?.field),
       search: this.$route?.query?.query ?? ''
-    }
-  },
-  watch: {
-    $route(value) {
-      this.search = value?.query?.query
-      this.field = this.getField(value?.query?.field)
     }
   },
   computed: {
@@ -57,6 +51,12 @@ export default {
     emptySearch() {
       const urlQ = this.$route?.query?.query ?? ''
       return this.search?.length === 0 && urlQ === this.search
+    }
+  },
+  watch: {
+    $route(value) {
+      this.search = value?.query?.query
+      this.field = this.getField(value?.query?.field)
     }
   },
   methods: {

--- a/src/components/BatchSearchFilterQuery.vue
+++ b/src/components/BatchSearchFilterQuery.vue
@@ -1,16 +1,17 @@
 <template>
   <form class="batch-search-filter-query col-md-6 px-0" @submit.prevent="filterByQuery">
-    <search-bar-input v-model="search"
-                      :placeholder="$t('batchSearch.placeholder')"
-                      class="batch-search-filter-query__input"
-                      hide-tips
-                      :disableSubmit="emptySearch"
+    <search-bar-input
+      v-model="search"
+      :placeholder="$t('batchSearch.placeholder')"
+      class="batch-search-filter-query__input"
+      hide-tips
+      :disable-submit="emptySearch"
     >
       <template #fields>
         <search-bar-input-dropdown
           v-model="field"
-          :fieldOptions="fieldOptions"
-          :fieldOptionsPath="fieldOptionsPath"
+          :field-options="fieldOptions"
+          :field-options-path="fieldOptionsPath"
           class="batch-search-filter-query__field"
         />
       </template>
@@ -27,50 +28,52 @@ export default {
   name: 'BatchSearchFilterQuery',
   mixins: [utils],
   components: { SearchBarInputDropdown, SearchBarInput },
-  data () {
+  data() {
     return {
       field: this.getField(this.$route?.query?.field),
       search: this.$route?.query?.query ?? ''
     }
   },
   watch: {
-    $route (value) {
+    $route(value) {
       this.search = value?.query?.query
       this.field = this.getField(value?.query?.field)
     }
   },
   computed: {
-    fieldOptions () {
+    fieldOptions() {
       const options = ['all', 'name', 'description']
       if (this.isServer) {
         options.push('user_id')
       }
       return options
     },
-    fieldOptionsPath () {
+    fieldOptionsPath() {
       return ['batchSearch', 'field']
     },
-    unchangedParams () {
+    unchangedParams() {
       return this.search === this.$route?.query?.query && this.field === this.$route?.query?.field
     },
-    emptySearch () {
+    emptySearch() {
       const urlQ = this.$route?.query?.query ?? ''
       return this.search?.length === 0 && urlQ === this.search
     }
   },
   methods: {
-    filterByQuery () {
+    filterByQuery() {
       const params = this.$route?.query ?? {}
-      return this.$router.push({
-        name: 'batch-search',
-        query: { ...params, page: 1, query: this.search, field: this.field }
-      }).catch((_) => {
-        if (!this.unchangedParams) {
-          return Promise.reject(_)
-        }
-      })
+      return this.$router
+        .push({
+          name: 'batch-search',
+          query: { ...params, page: 1, query: this.search, field: this.field }
+        })
+        .catch((_) => {
+          if (!this.unchangedParams) {
+            return Promise.reject(_)
+          }
+        })
     },
-    getField (value) {
+    getField(value) {
       return this.fieldOptions?.includes(value) ? value : 'all'
     }
   }

--- a/src/components/BatchSearchForm.vue
+++ b/src/components/BatchSearchForm.vue
@@ -108,13 +108,13 @@
               <b-badge
                 class="mt-2 mr-2 pl-1 batch-search-form__advanced-filters"
                 @click.prevent="deleteFileType(index)"
-                :key="fileType.mime"
+                :key="oneFileType.mime"
                 pill
-                v-for="(fileType, index) in fileTypes"
+                v-for="(oneFileType, index) in fileTypes"
                 variant="warning"
               >
                 <fa icon="times-circle"></fa>
-                {{ fileType.label }}
+                {{ oneFileType.label }}
               </b-badge>
             </b-form-group>
             <b-form-group label-size="sm" :label="$t('batchSearch.path')">
@@ -147,13 +147,13 @@
                 <b-badge
                   class="mt-2 mr-2 pl-1 batch-search-form__advanced-filters"
                   @click.prevent="deletePath(index)"
-                  :key="path"
+                  :key="onePath"
                   pill
-                  v-for="(path, index) in paths"
+                  v-for="(onePath, index) in paths"
                   variant="warning"
                 >
                   <fa icon="times-circle"></fa>
-                  {{ path }}
+                  {{ onePath }}
                 </b-badge>
               </div>
             </b-form-group>

--- a/src/components/BatchSearchForm.vue
+++ b/src/components/BatchSearchForm.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="batch-search-form">
     <b-form @submit.prevent="onSubmit">
-      <h5 class="py-2 h6 text-uppercase text-muted" v-if="!hideTitle">
+      <h5 v-if="!hideTitle" class="py-2 h6 text-uppercase text-muted">
         {{ $t('batchSearch.heading') }}
       </h5>
       <div class="card w-100" :class="{ 'border-0': hideBorder }">
@@ -35,7 +35,7 @@
           <b-form-group label-size="sm" :label="$t('batchSearch.description')">
             <b-form-textarea v-model="description" rows="2" max-rows="6"></b-form-textarea>
           </b-form-group>
-          <b-form-group label-size="sm" :label="`${$t('batchSearch.projects')} *`" v-if="isServer">
+          <b-form-group v-if="isServer" label-size="sm" :label="`${$t('batchSearch.projects')} *`">
             <div class="batch-search-form__projects container p-0">
               <b-form-checkbox-group v-model="projects" stacked>
                 <b-form-checkbox
@@ -50,9 +50,9 @@
             </div>
           </b-form-group>
           <b-form-group
+            v-if="isServer"
             label-size="sm"
             :description="$t('batchSearch.publishedDescription')"
-            v-if="isServer"
             class="published"
           >
             <b-form-checkbox v-model="published" switch>
@@ -72,7 +72,7 @@
               </b-form-checkbox>
             </b-form-group>
             <b-form-group label-size="sm" class="mb-0" :label="fuzzinessLabel" :description="fuzzinessDescription">
-              <b-form-input type="number" v-model="fuzziness" min="0" :max="maxFuzziness"></b-form-input>
+              <b-form-input v-model="fuzziness" type="number" min="0" :max="maxFuzziness"></b-form-input>
             </b-form-group>
             <p class="help small">
               <a :href="fuzzinessLearnMore" target="_blank" class="text-muted">
@@ -92,11 +92,11 @@
               </b-overlay>
               <selectable-dropdown
                 ref="suggestionFileTypes"
+                :hide="!suggestionFileTypes.length"
+                :items="suggestionFileTypes"
                 @input="selectFileType"
                 @click.native="searchFileType"
                 @deactivate="hideSuggestionsFileTypes"
-                :hide="!suggestionFileTypes.length"
-                :items="suggestionFileTypes"
               >
                 <template #item-label="{ item }">
                   <div :id="item.mime">
@@ -106,12 +106,12 @@
                 </template>
               </selectable-dropdown>
               <b-badge
-                class="mt-2 mr-2 pl-1 batch-search-form__advanced-filters"
-                @click.prevent="deleteFileType(index)"
-                :key="oneFileType.mime"
-                pill
                 v-for="(oneFileType, index) in fileTypes"
+                :key="oneFileType.mime"
+                class="mt-2 mr-2 pl-1 batch-search-form__advanced-filters"
+                pill
                 variant="warning"
+                @click.prevent="deleteFileType(index)"
               >
                 <fa icon="times-circle"></fa>
                 {{ oneFileType.label }}
@@ -122,35 +122,35 @@
                 {{ $t('batchSearch.selectFolder') }}
               </div>
               <b-modal
+                id="modal-select-path"
                 body-class="p-0 border-bottom"
                 cancel-variant="outline-primary"
                 :cancel-title="$t('global.cancel')"
                 hide-header
-                id="modal-select-path"
                 lazy
-                @ok="setPaths()"
                 :ok-title="$t('batchSearch.selectFolder')"
                 scrollable
                 size="lg"
+                @ok="setPaths()"
               >
                 <tree-view
+                  v-model="path"
                   count
                   size
-                  @checked="selectedPaths = $event"
                   :projects="projects"
                   selectable
                   :selected-paths="selectedPaths"
-                  v-model="path"
+                  @checked="selectedPaths = $event"
                 ></tree-view>
               </b-modal>
               <div>
                 <b-badge
-                  class="mt-2 mr-2 pl-1 batch-search-form__advanced-filters"
-                  @click.prevent="deletePath(index)"
-                  :key="onePath"
-                  pill
                   v-for="(onePath, index) in paths"
+                  :key="onePath"
+                  class="mt-2 mr-2 pl-1 batch-search-form__advanced-filters"
+                  pill
                   variant="warning"
+                  @click.prevent="deletePath(index)"
                 >
                   <fa icon="times-circle"></fa>
                   {{ onePath }}
@@ -202,10 +202,13 @@ import types from '@/utils/types.json'
  */
 export default {
   name: 'BatchSearchForm',
-  mixins: [utils],
   components: {
     TreeView
   },
+  filters: {
+    startCase
+  },
+  mixins: [utils],
   props: {
     /**
      * Disables rendering of the form title
@@ -293,9 +296,6 @@ export default {
   },
   created() {
     this.$set(this, 'projects', [this.availableProjects[0]] || [])
-  },
-  filters: {
-    startCase
   },
   methods: {
     verifyQueryLimit(csv) {

--- a/src/components/BatchSearchForm.vue
+++ b/src/components/BatchSearchForm.vue
@@ -6,18 +6,10 @@
       </h5>
       <div class="card w-100" :class="{ 'border-0': hideBorder }">
         <div class="card-body pb-1">
-          <b-form-group
-            label-size="sm"
-            :label="`${$t('batchSearch.name')} *`">
-            <b-form-input
-              v-model="name"
-              type="text"
-              required></b-form-input>
+          <b-form-group label-size="sm" :label="`${$t('batchSearch.name')} *`">
+            <b-form-input v-model="name" type="text" required></b-form-input>
           </b-form-group>
-          <b-form-group
-            label-size="sm"
-            class="mb-0"
-            :label="`${$t('batchSearch.fileLabel')} *`">
+          <b-form-group label-size="sm" class="mb-0" :label="`${$t('batchSearch.fileLabel')} *`">
             <template slot="description">
               <div v-html="$t('batchSearch.fileDescription')"></div>
             </template>
@@ -28,31 +20,30 @@
               class="text-truncate"
               :state="Boolean(csvFile)"
               no-drop
-              required></b-form-file>
+              required
+            ></b-form-file>
           </b-form-group>
           <p class="help small">
             <a
               class="text-muted"
               href="https://icij.gitbook.io/datashare/all/batch-search-documents#write-your-queries-in-a-spreadsheet"
-              target="_blank">
+              target="_blank"
+            >
               {{ $t('batchSearch.learnMore') }}
             </a>
           </p>
-          <b-form-group
-            label-size="sm"
-            :label="$t('batchSearch.description')">
-            <b-form-textarea
-              v-model="description"
-              rows="2"
-              max-rows="6"></b-form-textarea>
+          <b-form-group label-size="sm" :label="$t('batchSearch.description')">
+            <b-form-textarea v-model="description" rows="2" max-rows="6"></b-form-textarea>
           </b-form-group>
-          <b-form-group
-            label-size="sm"
-            :label="`${$t('batchSearch.projects')} *`"
-            v-if="isServer">
+          <b-form-group label-size="sm" :label="`${$t('batchSearch.projects')} *`" v-if="isServer">
             <div class="batch-search-form__projects container p-0">
               <b-form-checkbox-group v-model="projects" stacked>
-                <b-form-checkbox v-for="project in availableProjects" :key="project" :value="project" :disabled="isProjectDisabled(project)">
+                <b-form-checkbox
+                  v-for="project in availableProjects"
+                  :key="project"
+                  :value="project"
+                  :disabled="isProjectDisabled(project)"
+                >
                   {{ project | startCase }}
                 </b-form-checkbox>
               </b-form-checkbox-group>
@@ -62,10 +53,9 @@
             label-size="sm"
             :description="$t('batchSearch.publishedDescription')"
             v-if="isServer"
-            class="published">
-            <b-form-checkbox
-              v-model="published"
-              switch>
+            class="published"
+          >
+            <b-form-checkbox v-model="published" switch>
               {{ $t('batchSearch.published') }}
             </b-form-checkbox>
           </b-form-group>
@@ -76,34 +66,20 @@
             </span>
           </div>
           <b-collapse id="advanced-filters" v-model="showAdvancedFilters" class="pt-2">
-            <b-form-group
-              label-size="sm"
-              :description="phraseMatchDescription">
-              <b-form-checkbox
-                v-model="phraseMatch"
-                switch>
+            <b-form-group label-size="sm" :description="phraseMatchDescription">
+              <b-form-checkbox v-model="phraseMatch" switch>
                 {{ $t('batchSearch.phraseMatch') }}
               </b-form-checkbox>
             </b-form-group>
-            <b-form-group
-              label-size="sm"
-              class="mb-0"
-              :label="fuzzinessLabel"
-              :description="fuzzinessDescription">
-              <b-form-input
-                type="number"
-                v-model="fuzziness"
-                min="0"
-                :max="maxFuzziness"></b-form-input>
+            <b-form-group label-size="sm" class="mb-0" :label="fuzzinessLabel" :description="fuzzinessDescription">
+              <b-form-input type="number" v-model="fuzziness" min="0" :max="maxFuzziness"></b-form-input>
             </b-form-group>
             <p class="help small">
               <a :href="fuzzinessLearnMore" target="_blank" class="text-muted">
                 {{ $t('batchSearch.learnMore') }}
               </a>
             </p>
-            <b-form-group
-              label-size="sm"
-              :label="$t('batchSearch.fileTypes')">
+            <b-form-group label-size="sm" :label="$t('batchSearch.fileTypes')">
               <b-overlay :show="$wait.is('load all file types')" rounded opacity="0.6" spinner-small>
                 <b-form-input
                   ref="fileType"
@@ -111,7 +87,8 @@
                   autocomplete="off"
                   :disabled="$wait.is('load all file types')"
                   @input="searchFileTypes"
-                  @keydown.enter.prevent="searchFileType"></b-form-input>
+                  @keydown.enter.prevent="searchFileType"
+                ></b-form-input>
               </b-overlay>
               <selectable-dropdown
                 ref="suggestionFileTypes"
@@ -119,8 +96,9 @@
                 @click.native="searchFileType"
                 @deactivate="hideSuggestionsFileTypes"
                 :hide="!suggestionFileTypes.length"
-                :items="suggestionFileTypes">
-                <template v-slot:item-label="{ item }">
+                :items="suggestionFileTypes"
+              >
+                <template #item-label="{ item }">
                   <div :id="item.mime">
                     {{ item.label }}
                   </div>
@@ -133,14 +111,13 @@
                 :key="fileType.mime"
                 pill
                 v-for="(fileType, index) in fileTypes"
-                variant="warning">
+                variant="warning"
+              >
                 <fa icon="times-circle"></fa>
                 {{ fileType.label }}
               </b-badge>
             </b-form-group>
-            <b-form-group
-              label-size="sm"
-              :label="$t('batchSearch.path')">
+            <b-form-group label-size="sm" :label="$t('batchSearch.path')">
               <div v-b-modal.modal-select-path class="mr-3 py-1 px-2 border btn btn-link">
                 {{ $t('batchSearch.selectFolder') }}
               </div>
@@ -154,15 +131,17 @@
                 @ok="setPaths()"
                 :ok-title="$t('batchSearch.selectFolder')"
                 scrollable
-                size="lg">
+                size="lg"
+              >
                 <tree-view
                   count
                   size
                   @checked="selectedPaths = $event"
                   :projects="projects"
                   selectable
-                  :selectedPaths="selectedPaths"
-                  v-model="path"></tree-view>
+                  :selected-paths="selectedPaths"
+                  v-model="path"
+                ></tree-view>
               </b-modal>
               <div>
                 <b-badge
@@ -171,7 +150,8 @@
                   :key="path"
                   pill
                   v-for="(path, index) in paths"
-                  variant="warning">
+                  variant="warning"
+                >
                   <fa icon="times-circle"></fa>
                   {{ path }}
                 </b-badge>
@@ -193,8 +173,19 @@
 
 <script>
 import {
-  compact, concat, each, filter, flatten, get, has,
-  includes, isEmpty, map, range, startCase, uniq
+  compact,
+  concat,
+  each,
+  filter,
+  flatten,
+  get,
+  has,
+  includes,
+  isEmpty,
+  map,
+  range,
+  startCase,
+  uniq
 } from 'lodash'
 // In order to be mocked in the test class
 import throttle from 'lodash/throttle'
@@ -229,7 +220,7 @@ export default {
       type: Boolean
     }
   },
-  data () {
+  data() {
     return {
       allFileTypes: [],
       csvFile: null,
@@ -250,38 +241,45 @@ export default {
     }
   },
   computed: {
-    maxFuzziness () {
+    maxFuzziness() {
       return this.phraseMatch ? 100 : 2
     },
-    availableProjects () {
+    availableProjects() {
       return this.$core.projects
     },
-    phraseMatchDescription () {
-      return this.$t('batchSearch.phraseMatchDescription') + (this.phraseMatch ? '' : ' ' + this.$t('batchSearch.phraseMatchDescriptionOperators'))
+    phraseMatchDescription() {
+      return (
+        this.$t('batchSearch.phraseMatchDescription') +
+        (this.phraseMatch ? '' : ' ' + this.$t('batchSearch.phraseMatchDescriptionOperators'))
+      )
     },
-    fuzzinessLabel () {
+    fuzzinessLabel() {
       return this.phraseMatch ? this.$t('batchSearch.proximitySearches') : this.$t('batchSearch.fuzziness')
     },
-    fuzzinessDescription () {
-      return this.phraseMatch ? this.$t('batchSearch.proximitySearchesDescription') : this.$t('batchSearch.fuzzinessDescription')
+    fuzzinessDescription() {
+      return this.phraseMatch
+        ? this.$t('batchSearch.proximitySearchesDescription')
+        : this.$t('batchSearch.fuzzinessDescription')
     },
-    fuzzinessLearnMore () {
-      return this.phraseMatch ? 'https://icij.gitbook.io/datashare/faq-definitions/what-are-proximity-searches' : 'https://icij.gitbook.io/datashare/faq-definitions/what-is-fuzziness'
+    fuzzinessLearnMore() {
+      return this.phraseMatch
+        ? 'https://icij.gitbook.io/datashare/faq-definitions/what-are-proximity-searches'
+        : 'https://icij.gitbook.io/datashare/faq-definitions/what-is-fuzziness'
     },
-    advancedFiltersIcon () {
+    advancedFiltersIcon() {
       return this.showAdvancedFilters ? 'angle-down' : 'angle-right'
     },
-    fuse () {
+    fuse() {
       const keys = ['extensions', 'label', 'mime']
       const options = { distance: 100, keys, shouldSort: true }
       return new Fuse(this.allFileTypes, options)
     }
   },
   watch: {
-    phraseMatch () {
+    phraseMatch() {
       this.$set(this, 'fuzziness', 0)
     },
-    projects () {
+    projects() {
       this.$set(this, 'fileType', '')
       this.$set(this, 'fileTypes', [])
       this.$set(this, 'paths', [])
@@ -289,18 +287,18 @@ export default {
       this.hideSuggestionsFileTypes()
       this.retrieveFileTypes()
     },
-    showAdvancedFilters () {
+    showAdvancedFilters() {
       this.retrieveFileTypes()
     }
   },
-  created () {
+  created() {
     this.$set(this, 'projects', [this.availableProjects[0]] || [])
   },
   filters: {
     startCase
   },
   methods: {
-    verifyQueryLimit (csv) {
+    verifyQueryLimit(csv) {
       let csvQueries
       const reader = new FileReader()
       reader.readAsBinaryString(csv)
@@ -309,25 +307,25 @@ export default {
         return csvQueries.length >= 3
       }
     },
-    parseCsvQueries (queries) {
+    parseCsvQueries(queries) {
       const csvData = []
       const lbreak = queries.split('\n')
-      lbreak.forEach(res => {
+      lbreak.forEach((res) => {
         csvData.push(res.split(','))
       })
       return csvData
     },
-    selectFileType (fileType = null) {
+    selectFileType(fileType = null) {
       this.$set(this, 'selectedFileType', fileType || this.selectedFileType)
     },
     searchFileTypes: throttle(function () {
       const fileTypes = this.fuse.search(this.fileType).map(({ item }) => item)
-      const fileTypesWithoutSelection = filter(fileTypes, item => {
+      const fileTypesWithoutSelection = filter(fileTypes, (item) => {
         return !includes(map(this.fileTypes, 'mime'), item.mime)
       })
       this.$set(this, 'suggestionFileTypes', fileTypesWithoutSelection)
     }, 200),
-    searchFileType () {
+    searchFileType() {
       if (this.selectedFileType) {
         this.fileTypes.push(this.selectedFileType)
         this.hideSuggestionsFileTypes()
@@ -335,17 +333,17 @@ export default {
         if (this.$refs && this.$refs.fileType) this.$refs.fileType.focus()
       }
     },
-    hideSuggestionsFileTypes () {
+    hideSuggestionsFileTypes() {
       this.$set(this, 'suggestionFileTypes', [])
     },
-    deleteFileType (index) {
+    deleteFileType(index) {
       this.fileTypes.splice(index, 1)
     },
-    async retrieveFileTypes () {
+    async retrieveFileTypes() {
       if (this.showAdvancedFilters && isEmpty(this.allFileTypes)) {
         this.$wait.start('load all file types')
         const aggTypes = await this.aggregate('contentType', 'contentType')
-        each(aggTypes, aggType => {
+        each(aggTypes, (aggType) => {
           const extensions = has(types, aggType) ? types[aggType].extensions : []
           const label = has(types, aggType) ? types[aggType].label : aggType
           this.allFileTypes.push({ extensions, label, mime: aggType })
@@ -353,14 +351,14 @@ export default {
         this.$wait.end('load all file types')
       }
     },
-    setPaths () {
+    setPaths() {
       this.$set(this, 'paths', this.selectedPaths)
       this.$set(this, 'path', this.$config.get('mountedDataDir') || this.$config.get('dataDir'))
     },
-    deletePath (index) {
+    deletePath(index) {
       this.paths.splice(index, 1)
     },
-    resetForm () {
+    resetForm() {
       this.$set(this, 'csvFile', null)
       this.$set(this, 'description', '')
       this.$set(this, 'fileType', '')
@@ -373,9 +371,19 @@ export default {
       this.$set(this, 'published', true)
       this.$set(this, 'showAdvancedFilters', false)
     },
-    async onSubmit () {
+    async onSubmit() {
       try {
-        await this.$store.dispatch('batchSearch/onSubmit', { name: this.name, csvFile: this.csvFile, description: this.description, projects: this.projects, phraseMatch: this.phraseMatch, fuzziness: this.fuzziness, fileTypes: this.fileTypes, paths: this.paths, published: this.published })
+        await this.$store.dispatch('batchSearch/onSubmit', {
+          name: this.name,
+          csvFile: this.csvFile,
+          description: this.description,
+          projects: this.projects,
+          phraseMatch: this.phraseMatch,
+          fuzziness: this.fuzziness,
+          fileTypes: this.fileTypes,
+          paths: this.paths,
+          published: this.published
+        })
         this.resetForm()
         if (this.$config.is('manageDocuments')) {
           try {
@@ -396,13 +404,16 @@ export default {
         this.$emit('submit')
       }
     },
-    async aggregate (field, name) {
+    async aggregate(field, name) {
       let body, options, responses, searchResult
       let after = null
       let result = []
       while (responses === undefined || responses.length === 10) {
         options = after ? { after } : {}
-        body = bodybuilder().size(0).agg('composite', { sources: [{ field: { terms: { field } } }] }, options, name).build()
+        body = bodybuilder()
+          .size(0)
+          .agg('composite', { sources: [{ field: { terms: { field } } }] }, options, name)
+          .build()
         searchResult = await elasticsearch.search({ index: this.projects.join(','), body })
         after = get(searchResult, ['aggregations', name, 'after_key'], null)
         responses = get(searchResult, ['aggregations', name, 'buckets'], [])
@@ -410,8 +421,8 @@ export default {
       }
       return result
     },
-    buildTreeFromPaths (paths) {
-      const tree = map(paths, path => {
+    buildTreeFromPaths(paths) {
+      const tree = map(paths, (path) => {
         const subpath = path.replace(this.$config.get('dataDir', ''), '')
         const split = compact(subpath.split('/'))
         const arr = []
@@ -422,16 +433,19 @@ export default {
       })
       return uniq(flatten(tree))
     },
-    manageError (errorCode, manageDocuments) {
+    manageError(errorCode, manageDocuments) {
       if (errorCode === 413) {
-        this.$root.$bvToast.toast(this.$t('batchSearch.submitQueryLimitError'), { noCloseButton: true, variant: 'danger' })
+        this.$root.$bvToast.toast(this.$t('batchSearch.submitQueryLimitError'), {
+          noCloseButton: true,
+          variant: 'danger'
+        })
       } else if (manageDocuments) {
         this.$root.$bvToast.toast(this.$t('batchSearch.error'), { noCloseButton: true, variant: 'danger' })
       } else {
         this.$root.$bvToast.toast(this.$t('batchSearch.submitError'), { noCloseButton: true, variant: 'danger' })
       }
     },
-    isProjectDisabled (project) {
+    isProjectDisabled(project) {
       return this.projects.length === 1 && this.projects[0] === project
     }
   }
@@ -439,18 +453,18 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .batch-search-form {
-    .form-group small {
-      line-height: 1.2;
-    }
-
-    &__advanced-filters {
-      cursor: pointer;
-    }
-
-    .container {
-      max-height: 5vw;
-      overflow-y: scroll;
-    }
+.batch-search-form {
+  .form-group small {
+    line-height: 1.2;
   }
+
+  &__advanced-filters {
+    cursor: pointer;
+  }
+
+  .container {
+    max-height: 5vw;
+    overflow-y: scroll;
+  }
+}
 </style>

--- a/src/components/BatchSearchResultsFilters.vue
+++ b/src/components/BatchSearchResultsFilters.vue
@@ -14,7 +14,8 @@
           right
           :text="$t(`search.results.sort.${sortField}`)"
           variant="link"
-          v-if="hasMultipleQueries">
+          v-if="hasMultipleQueries"
+        >
           <b-dropdown-item v-for="key in sortFields" :key="key" @click="sort(key)" :active="key === sortField">
             {{ $t(`search.results.sort.${key}`) }}
           </b-dropdown-item>
@@ -23,7 +24,8 @@
       <div class="batch-search-results-filters__queries__search text-dark">
         <search-form-control
           :placeholder="$t('batchSearchResultsFilters.filterQueries')"
-          v-model="queriesFilter"></search-form-control>
+          v-model="queriesFilter"
+        ></search-form-control>
       </div>
       <div class="small">
         <selectable-dropdown
@@ -31,11 +33,12 @@
           class="batch-search-results-filters__queries__dropdown border-0 m-0 p-0"
           deactivate-keys
           multiple
-          scrollerHeight="280px"
-          :height=35
+          scroller-height="280px"
+          :height="35"
           v-model="selectedQueries"
           :eq="(item, other) => item.label === other.label"
-          :items="filteredQueries">
+          :items="filteredQueries"
+        >
           <template #item-label="{ item }">
             <div class="d-flex batch-search-results-filters__queries__dropdown__item">
               <span class="flex-grow-1 text-truncate batch-search-results-filters__queries__dropdown__item__label">
@@ -48,7 +51,8 @@
               </span>
               <span
                 class="batch-search-results-filters__queries__dropdown__item__search"
-                @click.stop.prevent="executeSearch(item.label)">
+                @click.stop.prevent="executeSearch(item.label)"
+              >
                 <fa icon="search" class="text-tertiary"></fa>
               </span>
             </div>
@@ -89,7 +93,7 @@ export default {
   components: {
     SearchFormControl
   },
-  data () {
+  data() {
     return {
       queriesFilter: null,
       sortField: 'count',
@@ -97,62 +101,62 @@ export default {
     }
   },
   computed: {
-    fuse () {
+    fuse() {
       const keys = ['label']
       const options = { shouldSort: false, keys }
       return new Fuse(this.queries, options)
     },
-    queries () {
+    queries() {
       if (this.sortField === 'count') {
         return orderBy(this.queryKeys, ['count'], ['desc'])
       } else {
         return this.queryKeys
       }
     },
-    filteredQueries () {
-      return this.queriesFilter ? this.fuse.search(this.queriesFilter).map(result => result.item) : this.queries
+    filteredQueries() {
+      return this.queriesFilter ? this.fuse.search(this.queriesFilter).map((result) => result.item) : this.queries
     },
-    hasMultipleQueries () {
+    hasMultipleQueries() {
       return this.queries && this.queries.length > 1
     },
     selectedQueries: {
-      set (queries) {
+      set(queries) {
         this.$store.commit('batchSearch/selectedQueries', cloneDeep(queries))
         this.updateRoute()
       },
-      get () {
+      get() {
         return this.$store.state.batchSearch.selectedQueries
       }
     },
-    routeQuery () {
+    routeQuery() {
       return this.$route?.query ?? {}
     }
   },
-  mounted () {
+  mounted() {
     this.readQueryFromRoute()
   },
   watch: {
-    $route () {
+    $route() {
       this.readQueryFromRoute()
     }
   },
   methods: {
-    updateRoute () {
+    updateRoute() {
       const queries = compact(map(this.selectedQueries, 'label'))
       if (!isEqual(this.routeQuery.queries || [], queries)) {
         const query = { ...this.routeQuery, queries }
         this.$router.push({ name: 'batch-search.results', query }).catch(() => {})
       }
     },
-    executeSearch (q) {
+    executeSearch(q) {
       this.$store.commit('search/reset')
       this.$router.push({ name: 'search', query: { q, indices: this.indices.join(',') } }).catch(() => {})
     },
-    sort (queriesSort) {
+    sort(queriesSort) {
       const query = { ...this.routeQuery, queries_sort: queriesSort }
       this.$router.push({ name: 'batch-search.results', query }).catch(() => {})
     },
-    readQueryFromRoute () {
+    readQueryFromRoute() {
       if (this.$route?.query?.queries_sort === 'default') {
         this.$set(this, 'sortField', 'default')
       } else {
@@ -160,54 +164,53 @@ export default {
       }
 
       const queries = castArray(this.$route?.query?.queries ?? [])
-      this.selectedQueries = queries.map(label => find(this.queries, { label }))
+      this.selectedQueries = queries.map((label) => find(this.queries, { label }))
     }
   }
 }
 </script>
 
 <style lang="scss" scoped>
-  .batch-search-results-filters {
-    max-width: 90vw;
-    width: 300px;
+.batch-search-results-filters {
+  max-width: 90vw;
+  width: 300px;
 
-    &__queries {
-      &__search {
-        background-color: $card-cap-bg;
-        padding: $card-spacer-y $card-spacer-x;
+  &__queries {
+    &__search {
+      background-color: $card-cap-bg;
+      padding: $card-spacer-y $card-spacer-x;
+    }
+
+    &__sort {
+      z-index: 1001;
+
+      &:deep(.btn.dropdown-toggle) {
+        color: white;
+        text-decoration: none;
       }
+    }
 
-      &__sort {
-        z-index: 1001;
+    &__dropdown {
+      border-radius: 0;
+      max-height: 280px;
+      overflow: auto;
 
-        &:deep(.btn.dropdown-toggle) {
-          color: white;
-          text-decoration: none;
+      &__item {
+        &__search:not([aria-describedby]) {
+          display: none;
         }
-      }
 
-      &__dropdown {
-        border-radius: 0;
-        max-height: 280px;
-        overflow: auto;
+        &:hover .batch-search-results-filters__queries__dropdown__item__search {
+          color: inherit;
+          cursor: pointer;
+          display: block;
+        }
 
-        &__item {
-
-          &__search:not([aria-describedby]) {
-            display: none;
-          }
-
-          &:hover .batch-search-results-filters__queries__dropdown__item__search {
-            color: inherit;
-            cursor: pointer;
-            display: block;
-          }
-
-          &:hover .batch-search-results-filters__queries__dropdown__item__count {
-            display: none;
-          }
+        &:hover .batch-search-results-filters__queries__dropdown__item__count {
+          display: none;
         }
       }
     }
   }
+}
 </style>

--- a/src/components/BatchSearchResultsFilters.vue
+++ b/src/components/BatchSearchResultsFilters.vue
@@ -5,37 +5,37 @@
         <span class="flex-grow-1 my-auto">
           {{ $t('batchSearchResultsFilters.queries.heading') }}
         </span>
-        <span class="mr-2" v-if="hasMultipleQueries">
+        <span v-if="hasMultipleQueries" class="mr-2">
           {{ $t('search.results.sort.sort') }}
         </span>
         <b-dropdown
+          v-if="hasMultipleQueries"
           class="batch-search-results-filters__queries__sort"
           toggle-class="p-0"
           right
           :text="$t(`search.results.sort.${sortField}`)"
           variant="link"
-          v-if="hasMultipleQueries"
         >
-          <b-dropdown-item v-for="key in sortFields" :key="key" @click="sort(key)" :active="key === sortField">
+          <b-dropdown-item v-for="key in sortFields" :key="key" :active="key === sortField" @click="sort(key)">
             {{ $t(`search.results.sort.${key}`) }}
           </b-dropdown-item>
         </b-dropdown>
       </h6>
       <div class="batch-search-results-filters__queries__search text-dark">
         <search-form-control
-          :placeholder="$t('batchSearchResultsFilters.filterQueries')"
           v-model="queriesFilter"
+          :placeholder="$t('batchSearchResultsFilters.filterQueries')"
         ></search-form-control>
       </div>
       <div class="small">
         <selectable-dropdown
           v-if="filteredQueries.length"
+          v-model="selectedQueries"
           class="batch-search-results-filters__queries__dropdown border-0 m-0 p-0"
           deactivate-keys
           multiple
           scroller-height="280px"
           :height="35"
-          v-model="selectedQueries"
           :eq="(item, other) => item.label === other.label"
           :items="filteredQueries"
         >
@@ -75,6 +75,9 @@ import SearchFormControl from '@/components/SearchFormControl'
  */
 export default {
   name: 'BatchSearchResultsFilters',
+  components: {
+    SearchFormControl
+  },
   props: {
     /**
      * The batch search query keys
@@ -89,9 +92,6 @@ export default {
     indices: {
       type: [String, Array]
     }
-  },
-  components: {
-    SearchFormControl
   },
   data() {
     return {
@@ -132,13 +132,13 @@ export default {
       return this.$route?.query ?? {}
     }
   },
-  mounted() {
-    this.readQueryFromRoute()
-  },
   watch: {
     $route() {
       this.readQueryFromRoute()
     }
+  },
+  mounted() {
+    this.readQueryFromRoute()
   },
   methods: {
     updateRoute() {

--- a/src/components/BatchSearchStatus.vue
+++ b/src/components/BatchSearchStatus.vue
@@ -7,10 +7,17 @@
         </div>
         <div v-if="batchSearch.errorMessage">
           <template v-if="errorMessageAsJson">
-            <json-formatter  class="batch-search-status__modal__error-message" :json="errorMessageAsJson" :open="4" :config="{ theme: 'dark' }" />
+            <json-formatter
+              class="batch-search-status__modal__error-message"
+              :json="errorMessageAsJson"
+              :open="4"
+              :config="{ theme: 'dark' }"
+            />
           </template>
           <template v-else>
-            <pre class="batch-search-status__modal__error-message mt-3 mb-0"><code>{{ batchSearch.errorMessage }}</code></pre>
+            <pre
+              class="batch-search-status__modal__error-message mt-3 mb-0"
+            ><code>{{ batchSearch.errorMessage }}</code></pre>
           </template>
           <div class="mt-2" v-html="$t('batchSearch.errorMessage')"></div>
         </div>
@@ -50,13 +57,13 @@ export default {
     }
   },
   computed: {
-    isFailed () {
+    isFailed() {
       return this.batchSearch.state.toLowerCase() === 'failure'
     },
-    isSpinning () {
+    isSpinning() {
       return this.batchSearch.state.toLowerCase() === 'running'
     },
-    getStateIcon () {
+    getStateIcon() {
       const state = this.batchSearch.state.toLowerCase()
       const icons = {
         failure: 'times-circle',
@@ -66,7 +73,7 @@ export default {
       }
       return get(icons, state, 'ban')
     },
-    errorMessageAsJson () {
+    errorMessageAsJson() {
       const re = /{"error":.+}/gm
       const message = this.batchSearch.errorMessage || ''
       const match = message.match(re)
@@ -85,36 +92,35 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .batch-search-status {
-    &__badge {
-      cursor: pointer;
+.batch-search-status {
+  &__badge {
+    cursor: pointer;
+  }
+
+  &__modal {
+    &__error-query {
+      font-size: $font-size-lg;
+
+      &:deep(code) {
+        background-color: $light;
+        border: 1px gray solid;
+        border-radius: 3px;
+        margin-right: 0.2rem;
+        padding: 0 2px;
+      }
     }
 
-    &__modal {
+    &__error-message {
+      background-color: black;
+      color: white;
+      padding: $spacer;
+      overflow: auto;
 
-      &__error-query {
-        font-size: $font-size-lg;
-
-        &:deep(code) {
-          background-color: $light;
-          border: 1px gray solid;
-          border-radius: 3px;
-          margin-right: .2rem;
-          padding: 0 2px;
-        }
-      }
-
-      &__error-message {
-        background-color: black;
-        color: white;
-        padding: $spacer;
-        overflow: auto;
-
-        code {
-          white-space: normal;
-          display: block;
-        }
+      code {
+        white-space: normal;
+        display: block;
       }
     }
   }
+}
 </style>

--- a/src/components/BatchSearchStatus.vue
+++ b/src/components/BatchSearchStatus.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="batch-search-status">
     <ellipse-status :status="batchSearch.state" :no-badge="noLabel" horizontal>
-      <template #error v-if="isFailed">
+      <template v-if="isFailed" #error>
         <div v-if="batchSearch.errorQuery" class="batch-search-status__modal__error-query mb-2 font-weight-bolder">
           <span v-html="$t('batchSearch.errorQuery', { query: batchSearch.errorQuery })"></span>
         </div>
@@ -41,6 +41,10 @@ export default {
   components: {
     EllipseStatus,
     JsonFormatter
+  },
+  filters: {
+    capitalize,
+    toVariant
   },
   props: {
     /**
@@ -83,10 +87,6 @@ export default {
         return null
       }
     }
-  },
-  filters: {
-    capitalize,
-    toVariant
   }
 }
 </script>

--- a/src/components/BatchSearchTable.vue
+++ b/src/components/BatchSearchTable.vue
@@ -14,31 +14,49 @@
       striped
       tbody-tr-class="batch-search-table__item"
       thead-tr-class="batch-search-table__head text-nowrap"
-      @sort-changed="sortChanged">
+      @sort-changed="sortChanged"
+    >
       <template #table-busy>
-        <content-placeholder slot="waiting" class="p-3" v-for="index in 3" :key="index" :rows="placeholderRows"/>
+        <content-placeholder slot="waiting" class="p-3" v-for="index in 3" :key="index" :rows="placeholderRows" />
       </template>
-      <template #empty >
-        <p class="batch-search-table__item__no-item text-center m-0" v-html="noItemMessage"/>
+      <template #empty>
+        <p class="batch-search-table__item__no-item text-center m-0" v-html="noItemMessage" />
       </template>
       <!-- Filterable Headers -->
       <template #head(state)="{ field }">
-        <batch-search-filter-dropdown v-model="selectedStates" :items="states" :id="field.key" :name="field.label" multiple>
-          <template #label="{item}">
-            {{$t(`batchSearch.status.${item.toLowerCase()}`).toUpperCase()}}
+        <batch-search-filter-dropdown
+          v-model="selectedStates"
+          :items="states"
+          :id="field.key"
+          :name="field.label"
+          multiple
+        >
+          <template #label="{ item }">
+            {{ $t(`batchSearch.status.${item.toLowerCase()}`).toUpperCase() }}
           </template>
         </batch-search-filter-dropdown>
       </template>
       <template #head(projects)="{ field }">
-        <batch-search-filter-dropdown v-model="selectedProjects" :items="projects" :id="field.key" :name="field.label" multiple/>
+        <batch-search-filter-dropdown
+          v-model="selectedProjects"
+          :items="projects"
+          :id="field.key"
+          :name="field.label"
+          multiple
+        />
       </template>
       <template #head(date)="{ field }">
-        <batch-search-filter-date v-model="selectedDateRange" :date="selectedDateRange" :id="field.key" :name="field.label"/>
+        <batch-search-filter-date
+          v-model="selectedDateRange"
+          :date="selectedDateRange"
+          :id="field.key"
+          :name="field.label"
+        />
       </template>
       <template #head(published)="{ field }">
         <batch-search-filter-dropdown v-model="selectedStatus" :items="status" :id="field.key" :name="field.label">
-          <template #label="{item}">
-            {{$t(`batchSearch.${item.label}`)}}
+          <template #label="{ item }">
+            {{ $t(`batchSearch.${item.label}`) }}
           </template>
         </batch-search-filter-dropdown>
       </template>
@@ -50,9 +68,9 @@
         <p class="m-0 text-muted small">{{ item.description }}</p>
       </template>
       <template #cell(queries)="{ item }">
-          <span class="batch-search-table__item__queries">
-            {{ item.formatNbQueries }}
-          </span>
+        <span class="batch-search-table__item__queries">
+          {{ item.formatNbQueries }}
+        </span>
       </template>
       <template #cell(state)="{ item }">
         <batch-search-status :batch-search="item" />
@@ -62,7 +80,7 @@
       </template>
       <!-- eslint-disable-next-line vue/valid-v-slot -->
       <template #cell(user.id)="{ item }">
-        <user-display v-if="item.hasUser" :username="item.userId" style="vertical-align:center"/>
+        <user-display v-if="item.hasUser" :username="item.userId" style="vertical-align: center" />
       </template>
       <template #cell(nbResults)="{ item }">
         <span class="batch-search-table__item__results">{{ item.formatNbResults }}</span>
@@ -71,9 +89,9 @@
         {{ item.isPublished }}
       </template>
       <template #cell(projects)="{ item }">
-          <span class="batch-search-table__item__projects text-truncate" v-b-tooltip.hover :title="item.projectNames">
-            {{ item.projectNames }}
-          </span>
+        <span class="batch-search-table__item__projects text-truncate" v-b-tooltip.hover :title="item.projectNames">
+          {{ item.projectNames }}
+        </span>
       </template>
     </b-table>
 
@@ -82,7 +100,8 @@
       :link-gen="linkGen"
       :number-of-pages="numberOfPages"
       class="mt-2 mx-auto"
-      use-router/>
+      use-router
+    />
   </div>
 </template>
 
@@ -122,7 +141,7 @@ export default {
   name: 'BatchSearchTable',
   mixins: [polling, utils],
   components: { UserDisplay, BatchSearchStatus, BatchSearchFilterDate, BatchSearchFilterDropdown },
-  data () {
+  data() {
     return {
       status: [
         BATCHSEARCH_STATUS[BATCHSEARCH_STATUS_VALUE.PUBLISHED],
@@ -137,16 +156,16 @@ export default {
       ]
     }
   },
-  mounted () {
+  mounted() {
     this.fetchAndRegisterPollWithLoader()
   },
   watch: {
-    $route () {
+    $route() {
       return this.fetchWithLoader()
     }
   },
   methods: {
-    createBatchSearchRoute ({
+    createBatchSearchRoute({
       page = this.page,
       sort = this.selectedSort.sort,
       order = this.selectedSort.order,
@@ -166,16 +185,18 @@ export default {
         query: queryParams
       }
     },
-    removeEmptySearchParams (query) {
+    removeEmptySearchParams(query) {
       if (!query.query?.length) delete query?.query
       if (!query?.publishState) delete query?.publishState
       if (!query?.project || !query?.project?.length) delete query?.project
       if (!query?.state || !query?.state?.length) delete query?.state
     },
-    async fetch () {
+    async fetch() {
       const from = (this.page - 1) * this.perPage
       const size = this.perPage
-      const batchDate = this.selectedDateRange ? [`${this.selectedDateRange.start}`, `${this.selectedDateRange.end}`] : null
+      const batchDate = this.selectedDateRange
+        ? [`${this.selectedDateRange.start}`, `${this.selectedDateRange.end}`]
+        : null
       const params = {
         from,
         size,
@@ -190,32 +211,32 @@ export default {
       }
       return this.$store.dispatch('batchSearch/getBatchSearches', params)
     },
-    async fetchWithLoader () {
+    async fetchWithLoader() {
       this.$wait.start('load batchSearches')
       this.$Progress.start()
       await this.fetch()
       this.$Progress.finish()
       this.$wait.end('load batchSearches')
     },
-    async  fetchAndRegisterPollWithLoader () {
+    async fetchAndRegisterPollWithLoader() {
       this.$wait.start('load batchSearches')
       this.$Progress.start()
       await this.fetchAndRegisterPoll()
       this.$Progress.finish()
       this.$wait.end('load batchSearches')
     },
-    async fetchForPoll () {
+    async fetchForPoll() {
       await this.fetch()
       // Continue to poll data if they are pending batch searches and we are on page 1
       return this.page === 1 && this.hasPendingBatchSearches
     },
-    async fetchAndRegisterPoll () {
+    async fetchAndRegisterPoll() {
       await this.fetch()
       const fn = this.fetchForPoll
       const timeout = () => random(1000, 4000)
       this.registerPollOnce({ fn, timeout })
     },
-    generateTo (item) {
+    generateTo(item) {
       const baseTo = {
         name: 'batch-search.results',
         params: {
@@ -234,35 +255,35 @@ export default {
         ...(searchQueryExists && { query: { query: this.search } })
       }
     },
-    getProjectsNames (item) {
-      return item.projects?.map(project => project.name).join(', ') ?? ''
+    getProjectsNames(item) {
+      return item.projects?.map((project) => project.name).join(', ') ?? ''
     },
 
-    linkGen (page) {
+    linkGen(page) {
       return this.createBatchSearchRoute({ page })
     },
-    serverField (field) {
+    serverField(field) {
       return this.isServer ? field : null
     },
-    async sortChanged (ctx) {
+    async sortChanged(ctx) {
       this.selectedSort = {
         sort: this.fieldNameByKey(ctx.sortBy),
         order: ctx.sortDesc ? SORT_ORDER.DESC : SORT_ORDER.ASC
       }
     },
-    fieldNameByKey (fieldKey) {
-      return find(this.fields, item => item.key === fieldKey)?.name
+    fieldNameByKey(fieldKey) {
+      return find(this.fields, (item) => item.key === fieldKey)?.name
     },
-    fieldKeyByName (fieldName) {
-      return find(this.fields, item => item.name === fieldName)?.key
+    fieldKeyByName(fieldName) {
+      return find(this.fields, (item) => item.name === fieldName)?.key
     },
-    updateRoute (params) {
+    updateRoute(params) {
       return this.$router.push(this.createBatchSearchRoute(params))
     }
   },
   computed: {
     ...mapState('batchSearch', ['total']),
-    displayBatchSearches () {
+    displayBatchSearches() {
       return this.$store.state.batchSearch.batchSearches.map((batchSearch) => {
         return {
           ...batchSearch,
@@ -278,7 +299,7 @@ export default {
         }
       })
     },
-    fields () {
+    fields() {
       return compact([
         {
           key: 'state',
@@ -330,123 +351,120 @@ export default {
         })
       ])
     },
-    hasPendingBatchSearches () {
+    hasPendingBatchSearches() {
       const RUNNING = settings.batchSearch.status.running
       const QUEUED = settings.batchSearch.status.queued
       const pendingStates = [RUNNING, QUEUED]
       return some(this.displayBatchSearches, ({ state }) => pendingStates.includes(state))
     },
-    howToLink () {
+    howToLink() {
       const { href } = this.$router.resolve('/docs/all-batch-search-documents')
       return href
     },
-    isBusy () {
+    isBusy() {
       return this.$wait.waiting('load batchSearches')
     },
-    search () {
+    search() {
       return this.$route?.query?.query ?? ''
     },
-    field () {
+    field() {
       const fieldValue = this.$route?.query?.field
       return this.fieldOptions?.includes(fieldValue) ? fieldValue : 'all'
     },
-    fieldOptions () {
+    fieldOptions() {
       const options = ['all', 'name', 'description']
       if (this.isServer) {
         options.push('user_id')
       }
       return options
     },
-    noItemMessage () {
+    noItemMessage() {
       return this.$t('batchSearch.emptyWithFilter')
     },
-    numberOfPages () {
+    numberOfPages() {
       return Math.ceil(this.total / this.perPage)
     },
-    projects () {
+    projects() {
       return this.$core.projects
     },
     selectedDateRange: {
-      get () {
+      get() {
         const start = parseInt(this.$route?.query?.dateStart)
         const end = parseInt(this.$route?.query?.dateEnd)
         const areNumber = !Number.isNaN(start) && !Number.isNaN(end)
         return areNumber ? { start, end } : null
       },
-      set (batchDate) {
+      set(batchDate) {
         return this.$router.push(this.createBatchSearchRoute({ batchDate }))
       }
     },
     selectedProjects: {
-      get () {
+      get() {
         const param = this.$route?.query?.project
         let projects = param
         if (typeof param === 'string') {
           projects = param?.split(',') ?? []
         }
-        return projects?.filter(p => this.projects.includes(p)) ?? []
+        return projects?.filter((p) => this.projects.includes(p)) ?? []
       },
-      set (values) {
+      set(values) {
         const project = values?.length > 0 ? values?.join(',') : null
-        return this.$router.push(
-          this.createBatchSearchRoute({ project }))
+        return this.$router.push(this.createBatchSearchRoute({ project }))
       }
     },
-    isDesc () {
+    isDesc() {
       return this.selectedSort.order === SORT_ORDER.DESC
     },
-    page () {
+    page() {
       const value = parseInt(this.$route?.query?.page)
       return !isNaN(value) && value > 0 ? value : 1
     },
-    sort () {
+    sort() {
       const sortNameFromQuery = this.$route?.query?.sort?.toLowerCase()
       const sortKeyExists = this.fieldKeyByName(sortNameFromQuery)
       return sortKeyExists ? sortNameFromQuery : settings.batchSearch.sort
     },
-    order () {
+    order() {
       return SORT_ORDER[this.$route?.query?.order?.toUpperCase()] ?? settings.batchSearch.order
     },
     selectedSort: {
-      get () {
+      get() {
         return { sort: this.sort, order: this.order }
       },
-      set ({ sort, order }) {
+      set({ sort, order }) {
         const params = { page: this.page, sort: sort, order: order }
         return this.updateRoute(params)
       }
     },
     selectedStates: {
-      get () {
+      get() {
         let states = this.$route?.query?.state
         if (typeof states === 'string') {
           states = states?.split(',') ?? []
         }
-        return states?.map(p => p.toUpperCase()).filter(p => this.states.includes(p)) ?? []
+        return states?.map((p) => p.toUpperCase()).filter((p) => this.states.includes(p)) ?? []
       },
-      set (values) {
+      set(values) {
         const state = values?.length > 0 ? values?.join(',') : null
-        return this.$router.push(
-          this.createBatchSearchRoute({ state }))
+        return this.$router.push(this.createBatchSearchRoute({ state }))
       }
     },
-    publicationStatus () {
+    publicationStatus() {
       return BATCHSEARCH_STATUS[this.$route?.query?.publishState]?.value ?? null
     },
     selectedStatus: {
-      get () {
+      get() {
         return BATCHSEARCH_STATUS[this.$route?.query?.publishState] ?? null
       },
-      set (status) {
+      set(status) {
         const publishState = status?.value ?? null
-        return this.$router.push(
-          this.createBatchSearchRoute({ publishState }))
+        return this.$router.push(this.createBatchSearchRoute({ publishState }))
       }
     },
-    sortBy () {
+    sortBy() {
       return this.fieldKeyByName(this.selectedSort.sort)
     },
-    states () {
+    states() {
       return Object.values(settings.batchSearch.status)
     }
   }
@@ -461,6 +479,5 @@ export default {
       max-width: 10vw;
     }
   }
-
 }
 </style>

--- a/src/components/BatchSearchTable.vue
+++ b/src/components/BatchSearchTable.vue
@@ -23,12 +23,12 @@
         <p class="batch-search-table__item__no-item text-center m-0" v-html="noItemMessage" />
       </template>
       <!-- Filterable Headers -->
-      <template #head(state)="{ stateField }">
+      <template #head(state)="{ field }">
         <batch-search-filter-dropdown
           v-model="selectedStates"
           :items="states"
-          :id="stateField.key"
-          :name="stateField.label"
+          :id="field.key"
+          :name="field.label"
           multiple
         >
           <template #label="{ item }">
@@ -36,30 +36,25 @@
           </template>
         </batch-search-filter-dropdown>
       </template>
-      <template #head(projects)="{ projectField }">
+      <template #head(projects)="{ field }">
         <batch-search-filter-dropdown
           v-model="selectedProjects"
           :items="projects"
-          :id="projectField.key"
-          :name="projectField.label"
+          :id="field.key"
+          :name="field.label"
           multiple
         />
       </template>
-      <template #head(date)="{ dateField }">
+      <template #head(date)="{ field }">
         <batch-search-filter-date
           v-model="selectedDateRange"
           :date="selectedDateRange"
-          :id="dateField.key"
-          :name="dateField.label"
+          :id="field.key"
+          :name="field.label"
         />
       </template>
-      <template #head(published)="{ publishedField }">
-        <batch-search-filter-dropdown
-          v-model="selectedStatus"
-          :items="status"
-          :id="publishedField.key"
-          :name="publishedField.label"
-        >
+      <template #head(published)="{ field }">
+        <batch-search-filter-dropdown v-model="selectedStatus" :items="status" :id="field.key" :name="field.label">
           <template #label="{ item }">
             {{ $t(`batchSearch.${item.label}`) }}
           </template>
@@ -175,7 +170,7 @@ export default {
       sort = this.selectedSort.sort,
       order = this.selectedSort.order,
       query = this.search,
-      field = this.field,
+      field = this.fieldValue,
       project = this.selectedProjects,
       state = this.selectedStates,
       batchDate = this.selectedDateRange,
@@ -208,7 +203,7 @@ export default {
         sort: this.selectedSort.sort,
         order: this.selectedSort.order,
         query: this.search,
-        field: this.field,
+        field: this.fieldValue,
         project: this.selectedProjects,
         state: this.selectedStates,
         batchDate,
@@ -372,7 +367,7 @@ export default {
     search() {
       return this.$route?.query?.query ?? ''
     },
-    field() {
+    fieldValue() {
       const fieldValue = this.$route?.query?.field
       return this.fieldOptions?.includes(fieldValue) ? fieldValue : 'all'
     },

--- a/src/components/BatchSearchTable.vue
+++ b/src/components/BatchSearchTable.vue
@@ -17,7 +17,7 @@
       @sort-changed="sortChanged"
     >
       <template #table-busy>
-        <content-placeholder slot="waiting" class="p-3" v-for="index in 3" :key="index" :rows="placeholderRows" />
+        <content-placeholder v-for="index in 3" slot="waiting" :key="index" class="p-3" :rows="placeholderRows" />
       </template>
       <template #empty>
         <p class="batch-search-table__item__no-item text-center m-0" v-html="noItemMessage" />
@@ -25,9 +25,9 @@
       <!-- Filterable Headers -->
       <template #head(state)="{ field }">
         <batch-search-filter-dropdown
+          :id="field.key"
           v-model="selectedStates"
           :items="states"
-          :id="field.key"
           :name="field.label"
           multiple
         >
@@ -38,23 +38,23 @@
       </template>
       <template #head(projects)="{ field }">
         <batch-search-filter-dropdown
+          :id="field.key"
           v-model="selectedProjects"
           :items="projects"
-          :id="field.key"
           :name="field.label"
           multiple
         />
       </template>
       <template #head(date)="{ field }">
         <batch-search-filter-date
+          :id="field.key"
           v-model="selectedDateRange"
           :date="selectedDateRange"
-          :id="field.key"
           :name="field.label"
         />
       </template>
       <template #head(published)="{ field }">
-        <batch-search-filter-dropdown v-model="selectedStatus" :items="status" :id="field.key" :name="field.label">
+        <batch-search-filter-dropdown :id="field.key" v-model="selectedStatus" :items="status" :name="field.label">
           <template #label="{ item }">
             {{ $t(`batchSearch.${item.label}`) }}
           </template>
@@ -89,7 +89,7 @@
         {{ item.isPublished }}
       </template>
       <template #cell(projects)="{ item }">
-        <span class="batch-search-table__item__projects text-truncate" v-b-tooltip.hover :title="item.projectNames">
+        <span v-b-tooltip.hover class="batch-search-table__item__projects text-truncate" :title="item.projectNames">
           {{ item.projectNames }}
         </span>
       </template>
@@ -139,8 +139,8 @@ const SORT_ORDER = Object.freeze({
 
 export default {
   name: 'BatchSearchTable',
-  mixins: [polling, utils],
   components: { UserDisplay, BatchSearchStatus, BatchSearchFilterDate, BatchSearchFilterDropdown },
+  mixins: [polling, utils],
   data() {
     return {
       status: [
@@ -156,13 +156,13 @@ export default {
       ]
     }
   },
-  mounted() {
-    this.fetchAndRegisterPollWithLoader()
-  },
   watch: {
     $route() {
       return this.fetchWithLoader()
     }
+  },
+  mounted() {
+    this.fetchAndRegisterPollWithLoader()
   },
   methods: {
     createBatchSearchRoute({

--- a/src/components/BatchSearchTable.vue
+++ b/src/components/BatchSearchTable.vue
@@ -156,131 +156,6 @@ export default {
       ]
     }
   },
-  watch: {
-    $route() {
-      return this.fetchWithLoader()
-    }
-  },
-  mounted() {
-    this.fetchAndRegisterPollWithLoader()
-  },
-  methods: {
-    createBatchSearchRoute({
-      page = this.page,
-      sort = this.selectedSort.sort,
-      order = this.selectedSort.order,
-      query = this.search,
-      field = this.fieldValue,
-      project = this.selectedProjects,
-      state = this.selectedStates,
-      batchDate = this.selectedDateRange,
-      publishState = this.publicationStatus
-    }) {
-      batchDate = batchDate ? { dateStart: batchDate?.start, dateEnd: batchDate?.end } : null
-      const queryParams = { query, page, sort, order, field, project, state, ...batchDate, publishState }
-      this.removeEmptySearchParams(queryParams)
-
-      return {
-        name: 'batch-search',
-        query: queryParams
-      }
-    },
-    removeEmptySearchParams(query) {
-      if (!query.query?.length) delete query?.query
-      if (!query?.publishState) delete query?.publishState
-      if (!query?.project || !query?.project?.length) delete query?.project
-      if (!query?.state || !query?.state?.length) delete query?.state
-    },
-    async fetch() {
-      const from = (this.page - 1) * this.perPage
-      const size = this.perPage
-      const batchDate = this.selectedDateRange
-        ? [`${this.selectedDateRange.start}`, `${this.selectedDateRange.end}`]
-        : null
-      const params = {
-        from,
-        size,
-        sort: this.selectedSort.sort,
-        order: this.selectedSort.order,
-        query: this.search,
-        field: this.fieldValue,
-        project: this.selectedProjects,
-        state: this.selectedStates,
-        batchDate,
-        publishState: this.publicationStatus
-      }
-      return this.$store.dispatch('batchSearch/getBatchSearches', params)
-    },
-    async fetchWithLoader() {
-      this.$wait.start('load batchSearches')
-      this.$Progress.start()
-      await this.fetch()
-      this.$Progress.finish()
-      this.$wait.end('load batchSearches')
-    },
-    async fetchAndRegisterPollWithLoader() {
-      this.$wait.start('load batchSearches')
-      this.$Progress.start()
-      await this.fetchAndRegisterPoll()
-      this.$Progress.finish()
-      this.$wait.end('load batchSearches')
-    },
-    async fetchForPoll() {
-      await this.fetch()
-      // Continue to poll data if they are pending batch searches and we are on page 1
-      return this.page === 1 && this.hasPendingBatchSearches
-    },
-    async fetchAndRegisterPoll() {
-      await this.fetch()
-      const fn = this.fetchForPoll
-      const timeout = () => random(1000, 4000)
-      this.registerPollOnce({ fn, timeout })
-    },
-    generateTo(item) {
-      const baseTo = {
-        name: 'batch-search.results',
-        params: {
-          index: this.getProjectsNames(item).replace(/\s/g, ''),
-          uuid: item.uuid
-        },
-        query: {
-          page: 1,
-          sort: settings.batchSearchResults.sort,
-          order: settings.batchSearchResults.order
-        }
-      }
-      const searchQueryExists = this.search
-      return {
-        ...baseTo,
-        ...(searchQueryExists && { query: { query: this.search } })
-      }
-    },
-    getProjectsNames(item) {
-      return item.projects?.map((project) => project.name).join(', ') ?? ''
-    },
-
-    linkGen(page) {
-      return this.createBatchSearchRoute({ page })
-    },
-    serverField(field) {
-      return this.isServer ? field : null
-    },
-    async sortChanged(ctx) {
-      this.selectedSort = {
-        sort: this.fieldNameByKey(ctx.sortBy),
-        order: ctx.sortDesc ? SORT_ORDER.DESC : SORT_ORDER.ASC
-      }
-    },
-    fieldNameByKey(fieldKey) {
-      return find(this.fields, (item) => item.key === fieldKey)?.name
-    },
-    fieldKeyByName(fieldName) {
-      return find(this.fields, (item) => item.name === fieldName)?.key
-    },
-    updateRoute(params) {
-      return this.$router.push(this.createBatchSearchRoute(params))
-    }
-  },
   computed: {
     ...mapState('batchSearch', ['total']),
     displayBatchSearches() {
@@ -466,6 +341,131 @@ export default {
     },
     states() {
       return Object.values(settings.batchSearch.status)
+    }
+  },
+  watch: {
+    $route() {
+      return this.fetchWithLoader()
+    }
+  },
+  mounted() {
+    this.fetchAndRegisterPollWithLoader()
+  },
+  methods: {
+    createBatchSearchRoute({
+      page = this.page,
+      sort = this.selectedSort.sort,
+      order = this.selectedSort.order,
+      query = this.search,
+      field = this.fieldValue,
+      project = this.selectedProjects,
+      state = this.selectedStates,
+      batchDate = this.selectedDateRange,
+      publishState = this.publicationStatus
+    }) {
+      batchDate = batchDate ? { dateStart: batchDate?.start, dateEnd: batchDate?.end } : null
+      const queryParams = { query, page, sort, order, field, project, state, ...batchDate, publishState }
+      this.removeEmptySearchParams(queryParams)
+
+      return {
+        name: 'batch-search',
+        query: queryParams
+      }
+    },
+    removeEmptySearchParams(query) {
+      if (!query.query?.length) delete query?.query
+      if (!query?.publishState) delete query?.publishState
+      if (!query?.project || !query?.project?.length) delete query?.project
+      if (!query?.state || !query?.state?.length) delete query?.state
+    },
+    async fetch() {
+      const from = (this.page - 1) * this.perPage
+      const size = this.perPage
+      const batchDate = this.selectedDateRange
+        ? [`${this.selectedDateRange.start}`, `${this.selectedDateRange.end}`]
+        : null
+      const params = {
+        from,
+        size,
+        sort: this.selectedSort.sort,
+        order: this.selectedSort.order,
+        query: this.search,
+        field: this.fieldValue,
+        project: this.selectedProjects,
+        state: this.selectedStates,
+        batchDate,
+        publishState: this.publicationStatus
+      }
+      return this.$store.dispatch('batchSearch/getBatchSearches', params)
+    },
+    async fetchWithLoader() {
+      this.$wait.start('load batchSearches')
+      this.$Progress.start()
+      await this.fetch()
+      this.$Progress.finish()
+      this.$wait.end('load batchSearches')
+    },
+    async fetchAndRegisterPollWithLoader() {
+      this.$wait.start('load batchSearches')
+      this.$Progress.start()
+      await this.fetchAndRegisterPoll()
+      this.$Progress.finish()
+      this.$wait.end('load batchSearches')
+    },
+    async fetchForPoll() {
+      await this.fetch()
+      // Continue to poll data if they are pending batch searches and we are on page 1
+      return this.page === 1 && this.hasPendingBatchSearches
+    },
+    async fetchAndRegisterPoll() {
+      await this.fetch()
+      const fn = this.fetchForPoll
+      const timeout = () => random(1000, 4000)
+      this.registerPollOnce({ fn, timeout })
+    },
+    generateTo(item) {
+      const baseTo = {
+        name: 'batch-search.results',
+        params: {
+          index: this.getProjectsNames(item).replace(/\s/g, ''),
+          uuid: item.uuid
+        },
+        query: {
+          page: 1,
+          sort: settings.batchSearchResults.sort,
+          order: settings.batchSearchResults.order
+        }
+      }
+      const searchQueryExists = this.search
+      return {
+        ...baseTo,
+        ...(searchQueryExists && { query: { query: this.search } })
+      }
+    },
+    getProjectsNames(item) {
+      return item.projects?.map((project) => project.name).join(', ') ?? ''
+    },
+
+    linkGen(page) {
+      return this.createBatchSearchRoute({ page })
+    },
+    serverField(field) {
+      return this.isServer ? field : null
+    },
+    async sortChanged(ctx) {
+      this.selectedSort = {
+        sort: this.fieldNameByKey(ctx.sortBy),
+        order: ctx.sortDesc ? SORT_ORDER.DESC : SORT_ORDER.ASC
+      }
+    },
+    fieldNameByKey(fieldKey) {
+      return find(this.fields, (item) => item.key === fieldKey)?.name
+    },
+    fieldKeyByName(fieldName) {
+      return find(this.fields, (item) => item.name === fieldName)?.key
+    },
+    updateRoute(params) {
+      return this.$router.push(this.createBatchSearchRoute(params))
     }
   }
 }

--- a/src/components/BatchSearchTable.vue
+++ b/src/components/BatchSearchTable.vue
@@ -23,12 +23,12 @@
         <p class="batch-search-table__item__no-item text-center m-0" v-html="noItemMessage" />
       </template>
       <!-- Filterable Headers -->
-      <template #head(state)="{ field }">
+      <template #head(state)="{ stateField }">
         <batch-search-filter-dropdown
           v-model="selectedStates"
           :items="states"
-          :id="field.key"
-          :name="field.label"
+          :id="stateField.key"
+          :name="stateField.label"
           multiple
         >
           <template #label="{ item }">
@@ -36,25 +36,30 @@
           </template>
         </batch-search-filter-dropdown>
       </template>
-      <template #head(projects)="{ field }">
+      <template #head(projects)="{ projectField }">
         <batch-search-filter-dropdown
           v-model="selectedProjects"
           :items="projects"
-          :id="field.key"
-          :name="field.label"
+          :id="projectField.key"
+          :name="projectField.label"
           multiple
         />
       </template>
-      <template #head(date)="{ field }">
+      <template #head(date)="{ dateField }">
         <batch-search-filter-date
           v-model="selectedDateRange"
           :date="selectedDateRange"
-          :id="field.key"
-          :name="field.label"
+          :id="dateField.key"
+          :name="dateField.label"
         />
       </template>
-      <template #head(published)="{ field }">
-        <batch-search-filter-dropdown v-model="selectedStatus" :items="status" :id="field.key" :name="field.label">
+      <template #head(published)="{ publishedField }">
+        <batch-search-filter-dropdown
+          v-model="selectedStatus"
+          :items="status"
+          :id="publishedField.key"
+          :name="publishedField.label"
+        >
           <template #label="{ item }">
             {{ $t(`batchSearch.${item.label}`) }}
           </template>

--- a/src/components/ContentTypeBadge.vue
+++ b/src/components/ContentTypeBadge.vue
@@ -4,39 +4,39 @@ import types from '@/utils/types'
 import { findContentTypeIcon } from '@/utils/font-awesome-files'
 
 /**
-   * A small badge to display content type nicely.
-   */
+ * A small badge to display content type nicely.
+ */
 export default {
   name: 'ContentTypeBadge',
   props: {
     /**
-       * Content type to display
-       */
+     * Content type to display
+     */
     value: {
       type: String
     },
     /**
-       * Document name to extract the extension in case the content type is not reconized.
-       */
+     * Document name to extract the extension in case the content type is not reconized.
+     */
     documentName: {
       type: String,
       default: null
     }
   },
   computed: {
-    icon () {
+    icon() {
       return findContentTypeIcon(this.value)
     },
-    extension () {
+    extension() {
       return get(types, [this.value, 'extensions', 0], this.extensionFallback)
     },
-    extensionFallback () {
+    extensionFallback() {
       if (this.documentName) {
         return '.' + this.documentName.split('.').pop()
       }
       return '.' + this.value.split('/').pop()
     },
-    title () {
+    title() {
       const descriptions = get(types, [this.value, 'description'], {})
       return descriptions[this.$i18n.locale] || descriptions.en
     }
@@ -54,16 +54,16 @@ export default {
 </template>
 
 <style lang="scss">
-  .content-type-badge {
-    padding: $badge-padding-y $badge-pill-padding-x;
-    border: currentColor 1px solid;
-    border-radius: $badge-pill-border-radius;
-    font-weight: $badge-font-weight;
-    background: $light;
-    color: $text-muted;
+.content-type-badge {
+  padding: $badge-padding-y $badge-pill-padding-x;
+  border: currentColor 1px solid;
+  border-radius: $badge-pill-border-radius;
+  font-weight: $badge-font-weight;
+  background: $light;
+  color: $text-muted;
 
-    &__icon {
-      color: $body-color;
-    }
+  &__icon {
+    color: $body-color;
   }
+}
 </style>

--- a/src/components/ContentTypeBadge.vue
+++ b/src/components/ContentTypeBadge.vue
@@ -45,7 +45,7 @@ export default {
 </script>
 
 <template>
-  <span class="content-type-badge" :title="title" v-b-tooltip>
+  <span v-b-tooltip class="content-type-badge" :title="title">
     <fa :icon="icon" class="content-type-badge__icon" fixed-width />
     <span class="content-type-badge__extension">
       {{ extension }}

--- a/src/components/DocumentActions.vue
+++ b/src/components/DocumentActions.vue
@@ -1,11 +1,11 @@
 <template>
   <component :is="noBtnGroup ? 'div' : 'b-btn-group'" :vertical="vertical" class="document-actions align-items-center">
     <a
+      :id="starBtnId"
       class="document-actions__star btn"
       :class="starBtnClassDefinition"
-      @click.prevent="toggleStarDocument()"
       href
-      :id="starBtnId"
+      @click.prevent="toggleStarDocument()"
     >
       <fa :icon="[isStarred ? 'fa' : 'far', 'star']" fixed-width />
       <span class="ml-2" :class="{ 'sr-only': !starBtnLabel }">
@@ -19,10 +19,10 @@
     <template v-if="canIDownload">
       <b-btn-group :class="downloadBtnGroupClass">
         <a
+          :id="downloadBtnId"
           class="document-actions__download btn"
           :class="downloadBtnClass"
           :href="document.fullUrl"
-          :id="downloadBtnId"
           target="_blank"
         >
           <fa icon="download" fixed-width />
@@ -54,10 +54,10 @@
     <template v-if="canIDownload && hasRoot">
       <b-btn-group :class="downloadBtnGroupClass">
         <a
+          :id="downloadRootBtnId"
           class="document-actions__download-root btn"
           :class="downloadBtnClass"
           :href="document.fullRootUrl"
-          :id="downloadRootBtnId"
           target="_blank"
         >
           <fa icon="download" fixed-width />
@@ -87,9 +87,9 @@
     </template>
 
     <router-link-popup
+      :id="popupBtnId"
       class="document-actions__popup btn"
       :class="popupBtnClass"
-      :id="popupBtnId"
       :to="{ name: 'document-modal', params: document.routerParams }"
     >
       <fa icon="external-link-alt" fixed-width />

--- a/src/components/DocumentActions.vue
+++ b/src/components/DocumentActions.vue
@@ -1,18 +1,16 @@
 <template>
-  <component
-    :is="noBtnGroup ? 'div' : 'b-btn-group'"
-    :vertical="vertical"
-    class="document-actions align-items-center">
+  <component :is="noBtnGroup ? 'div' : 'b-btn-group'" :vertical="vertical" class="document-actions align-items-center">
     <a
       class="document-actions__star btn"
       :class="starBtnClassDefinition"
       @click.prevent="toggleStarDocument()"
       href
-      :id="starBtnId">
+      :id="starBtnId"
+    >
       <fa :icon="[isStarred ? 'fa' : 'far', 'star']" fixed-width />
       <span class="ml-2" :class="{ 'sr-only': !starBtnLabel }">
-      {{ $t('document.starButton') }}
-    </span>
+        {{ $t('document.starButton') }}
+      </span>
     </a>
     <b-tooltip :target="starBtnId" :placement="tooltipsPlacement">
       {{ $t('document.starFile') }}
@@ -25,7 +23,8 @@
           :class="downloadBtnClass"
           :href="document.fullUrl"
           :id="downloadBtnId"
-          target="_blank">
+          target="_blank"
+        >
           <fa icon="download" fixed-width />
           <span class="ml-2" :class="{ 'sr-only': !downloadBtnLabel }">
             {{ $t('document.downloadButton') }}
@@ -35,7 +34,8 @@
           v-if="displayDownloadWithoutMetadata && hasCleanableContentType"
           right
           toggle-class="py-0"
-          size="sm">
+          size="sm"
+        >
           <b-dropdown-item :href="documentFullUrlWithoutMetadata">
             {{ $t('document.downloadWithoutMetadata') }}
           </b-dropdown-item>
@@ -45,7 +45,8 @@
         :placement="tooltipsPlacement"
         :target="downloadBtnId"
         :title="document.contentTypeLabel"
-        triggers="hover focus">
+        triggers="hover focus"
+      >
         <document-type-card :document="document" />
       </b-popover>
     </template>
@@ -57,7 +58,8 @@
           :class="downloadBtnClass"
           :href="document.fullRootUrl"
           :id="downloadRootBtnId"
-          target="_blank">
+          target="_blank"
+        >
           <fa icon="download" fixed-width />
           <span class="ml-2" :class="{ 'sr-only': !downloadBtnLabel }">
             {{ $t('document.downloadRootButton') }}
@@ -67,7 +69,8 @@
           v-if="displayDownloadWithoutMetadata && hasRootCleanableContentType"
           right
           toggle-class="py-0"
-          size="sm">
+          size="sm"
+        >
           <b-dropdown-item :href="rootDocumentFullUrlWithoutMetadata">
             {{ $t('document.downloadWithoutMetadata') }}
           </b-dropdown-item>
@@ -77,7 +80,8 @@
         :placement="tooltipsPlacement"
         :target="downloadRootBtnId"
         :title="document.rootContentTypeLabel"
-        triggers="hover focus">
+        triggers="hover focus"
+      >
         <document-type-card :document="document.root" />
       </b-popover>
     </template>
@@ -86,7 +90,8 @@
       class="document-actions__popup btn"
       :class="popupBtnClass"
       :id="popupBtnId"
-      :to="{ name: 'document-modal', params: document.routerParams }">
+      :to="{ name: 'document-modal', params: document.routerParams }"
+    >
       <fa icon="external-link-alt" fixed-width />
       <span class="ml-2" :class="{ 'sr-only': !popupBtnLabel }">
         {{ $t('document.externalWindow') }}
@@ -207,63 +212,60 @@ export default {
       type: Boolean
     }
   },
-  data () {
+  data() {
     return {
-      cleanableContentTypes: [
-        'application/pdf',
-        'application/msword'
-      ]
+      cleanableContentTypes: ['application/pdf', 'application/msword']
     }
   },
   computed: {
     ...mapState('starred', { starredDocuments: 'documents' }),
-    isStarred () {
+    isStarred() {
       const { index, id } = this.document
       return findIndex(this.starredDocuments, { index, id }) > -1
     },
-    starBtnClassDefinition () {
+    starBtnClassDefinition() {
       return {
         [this.starredBtnClass]: this.isStarred,
         ...this.classAttributeToObject(this.starBtnClass)
       }
     },
-    starBtnId () {
+    starBtnId() {
       return uniqueId('document-actions-star-button-')
     },
-    downloadBtnId () {
+    downloadBtnId() {
       return uniqueId('document-actions-download-button-')
     },
-    downloadRootBtnId () {
+    downloadRootBtnId() {
       return uniqueId('document-actions-download-root-button-')
     },
-    popupBtnId () {
+    popupBtnId() {
       return uniqueId('document-actions-popup-button-')
     },
-    documentFullUrlWithoutMetadata () {
+    documentFullUrlWithoutMetadata() {
       return this.document.fullUrl + '&filter_metadata=true'
     },
-    rootDocumentFullUrlWithoutMetadata () {
+    rootDocumentFullUrlWithoutMetadata() {
       return this.document.fullRootUrl + '&filter_metadata=true'
     },
-    canIDownload () {
+    canIDownload() {
       return this.isDownloadAllowed
     },
-    hasRoot () {
+    hasRoot() {
       return this.document.root
     },
-    hasCleanableContentType () {
+    hasCleanableContentType() {
       return this.cleanableContentTypes.includes(this.document.contentType)
     },
-    hasRootCleanableContentType () {
+    hasRootCleanableContentType() {
       return this.hasRoot && this.cleanableContentTypes.includes(this.document.root.contentType)
     }
   },
   methods: {
-    classAttributeToObject (str) {
+    classAttributeToObject(str) {
       const list = str.split(' ')
-      return Object.assign({}, ...list.map(key => ({ [key]: true })))
+      return Object.assign({}, ...list.map((key) => ({ [key]: true })))
     },
-    async toggleStarDocument () {
+    async toggleStarDocument() {
       try {
         await this.$store.dispatch('starred/toggleStarDocument', this.document)
       } catch (_) {

--- a/src/components/DocumentAttachments.vue
+++ b/src/components/DocumentAttachments.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="document-attachments" v-if="total !== null && total > 0">
+  <div v-if="total !== null && total > 0" class="document-attachments">
     <h6>{{ $tc('document.attachments.heading', total, { total }) }}</h6>
     <ul class="document-attachments__list list-unstyled d-flex-inline">
-      <li v-for="attachment in attachments" class="document-attachments__list__item" :key="attachment.id">
+      <li v-for="attachment in attachments" :key="attachment.id" class="document-attachments__list__item">
         <router-link
           :to="{ name: 'document', params: attachment.routerParams }"
           class="document-attachments__list__item__link d-flex-inline"
@@ -12,7 +12,7 @@
         </router-link>
       </li>
     </ul>
-    <a v-if="total && attachments.length < total" @click.prevent="loadMore" href="#" class="document-attachments__more">
+    <a v-if="total && attachments.length < total" href="#" class="document-attachments__more" @click.prevent="loadMore">
       <fa icon="plus" fixed-width class="mr-1" />
       {{ $t('document.attachments.more') }}
     </a>
@@ -45,6 +45,17 @@ export default {
       size: 50
     }
   },
+  computed: {
+    attachments() {
+      return flatten(this.pages.map((page) => page.hits))
+    },
+    total() {
+      return this.pages.length ? this.pages[0].total : null
+    },
+    from() {
+      return sum(this.pages.map((page) => page.hits.length))
+    }
+  },
   async mounted() {
     await this.loadMore()
     this.$emit('document:attachments', this.total)
@@ -66,17 +77,6 @@ export default {
         .rawOption('_source', { includes: ['*'], excludes: ['content'] })
         .from(this.from)
         .size(this.size)
-    }
-  },
-  computed: {
-    attachments() {
-      return flatten(this.pages.map((page) => page.hits))
-    },
-    total() {
-      return this.pages.length ? this.pages[0].total : null
-    },
-    from() {
-      return sum(this.pages.map((page) => page.hits.length))
     }
   }
 }

--- a/src/components/DocumentAttachments.vue
+++ b/src/components/DocumentAttachments.vue
@@ -3,7 +3,10 @@
     <h6>{{ $tc('document.attachments.heading', total, { total }) }}</h6>
     <ul class="document-attachments__list list-unstyled d-flex-inline">
       <li v-for="attachment in attachments" class="document-attachments__list__item" :key="attachment.id">
-        <router-link :to="{ name: 'document', params: attachment.routerParams }" class="document-attachments__list__item__link d-flex-inline">
+        <router-link
+          :to="{ name: 'document', params: attachment.routerParams }"
+          class="document-attachments__list__item__link d-flex-inline"
+        >
           <fa :icon="attachment.contentTypeIcon" fixed-width class="mr-1 mt-1" />
           <span>{{ attachment.slicedName.pop() }}</span>
         </router-link>
@@ -35,19 +38,19 @@ export default {
       type: Object
     }
   },
-  data () {
+  data() {
     return {
       pages: [],
       isReady: false,
       size: 50
     }
   },
-  async mounted () {
+  async mounted() {
     await this.loadMore()
     this.$emit('document:attachments', this.total)
   },
   methods: {
-    async loadMore () {
+    async loadMore() {
       this.isReady = false
       const { index } = this.document
       const body = this.searchBody().build()
@@ -55,7 +58,7 @@ export default {
       this.pages.push(new Response(response))
       this.isReady = true
     },
-    searchBody () {
+    searchBody() {
       return bodybuilder()
         .query('match', 'type', 'Document')
         .query('match', 'extractionLevel', this.document.extractionLevel + 1)
@@ -66,52 +69,49 @@ export default {
     }
   },
   computed: {
-    attachments () {
-      return flatten(this.pages.map(page => page.hits))
+    attachments() {
+      return flatten(this.pages.map((page) => page.hits))
     },
-    total () {
+    total() {
       return this.pages.length ? this.pages[0].total : null
     },
-    from () {
-      return sum(this.pages.map(page => page.hits.length))
+    from() {
+      return sum(this.pages.map((page) => page.hits.length))
     }
   }
 }
 </script>
 
 <style lang="scss">
-  .document-attachments {
+.document-attachments {
+  &__list {
+    &__item {
+      &__link {
+        display: inline-block;
+        padding: $spacer * 0.25 $spacer * 0.5;
+        margin-bottom: $spacer * 0.25;
+        background: $secondary;
+        color: white;
 
-    &__list {
-
-      &__item {
-
-        &__link {
-          display: inline-block;
-          padding: $spacer * 0.25 $spacer * 0.5;
-          margin-bottom: $spacer * 0.25;
-          background: $secondary;
+        &:hover {
+          text-decoration: none;
+          background: lighten($secondary, 5);
           color: white;
-
-          &:hover {
-            text-decoration: none;
-            background: lighten($secondary, 5);
-            color: white;
-          }
         }
       }
     }
+  }
 
-    &__more {
-      display: inline-block;
-      padding: $spacer * 0.25 $spacer * 0.5;
-      margin-bottom: $spacer * 0.25;
-      background: $light;
+  &__more {
+    display: inline-block;
+    padding: $spacer * 0.25 $spacer * 0.5;
+    margin-bottom: $spacer * 0.25;
+    background: $light;
 
-      &:hover {
-        text-decoration: white;
-        background: white;
-      }
+    &:hover {
+      text-decoration: white;
+      background: white;
     }
   }
+}
 </style>

--- a/src/components/DocumentContent.vue
+++ b/src/components/DocumentContent.vue
@@ -354,13 +354,13 @@ export default {
         @select="localSearchTerm = $event"
       />
       <document-local-search-input
-        class="ml-auto"
         v-model="localSearchTerm"
+        class="ml-auto"
         :activated.sync="hasStickyToolbox"
-        @next="findNextLocalSearchTerm"
-        @previous="findPreviousLocalSearchTerm"
         :search-occurrences="localSearchOccurrences"
         :search-index="localSearchIndex"
+        @next="findNextLocalSearchTerm"
+        @previous="findPreviousLocalSearchTerm"
       />
       <hook name="document.content.toolbox:after"></hook>
     </div>
@@ -380,12 +380,12 @@ export default {
 
     <hook name="document.content.body:before"></hook>
     <document-content-slices
+      ref="slices"
       :bufferize-all="!!localSearchOccurrences"
       :class="{ 'document-content__body--rtl': isRightToLeft }"
       :slices="virtualContentSlices"
-      @placeholder-visible="onContentSlicePlaceholderVisible"
       class="document-content__body container-fluid py-3"
-      ref="slices"
+      @placeholder-visible="onContentSlicePlaceholderVisible"
     />
     <hook name="document.content.body:after"></hook>
 

--- a/src/components/DocumentContentSlice.vue
+++ b/src/components/DocumentContentSlice.vue
@@ -8,7 +8,7 @@ export default {
     }
   },
   computed: {
-    cookedContent () {
+    cookedContent() {
       return this.slice.get(this.slice).cookedContent
     }
   }

--- a/src/components/DocumentContentSlicePlaceholder.vue
+++ b/src/components/DocumentContentSlicePlaceholder.vue
@@ -54,7 +54,7 @@ export default {
 
 <template>
   <div class="document-content-slice-placeholder">
-    <div v-for="i in 20" :key="i" v-once>
+    <div v-for="i in 20" v-once :key="i">
       <content-placeholder :rows="contentPlaceholderRows" class="p-0 my-3" :style="rowStyle()" />
     </div>
   </div>

--- a/src/components/DocumentContentSlicePlaceholder.vue
+++ b/src/components/DocumentContentSlicePlaceholder.vue
@@ -10,7 +10,7 @@ export default {
       required: true
     }
   },
-  data () {
+  data() {
     return {
       observer: null,
       contentPlaceholderRows: [
@@ -21,30 +21,30 @@ export default {
       ]
     }
   },
-  mounted () {
+  mounted() {
     return this.bindObserver()
   },
   methods: {
-    async bindObserver () {
+    async bindObserver() {
       this.observer = this.createObserver()
       // Ensure the element is mounted before binding it to the observer
       await this.$nextTick()
       // Observe the component element
       this.observer.observe(this.$el)
     },
-    createObserver () {
-      return new IntersectionObserver(async entries => {
+    createObserver() {
+      return new IntersectionObserver(async (entries) => {
         if (entries[0].isIntersecting) {
           /**
-             * The placeholder enters the viewport.
-             *
-             * @event visible
-             */
+           * The placeholder enters the viewport.
+           *
+           * @event visible
+           */
           this.$emit('visible', this.slice)
         }
       })
     },
-    rowStyle () {
+    rowStyle() {
       const width = `${random(10, 100)}%`
       return { width }
     }
@@ -61,7 +61,7 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  .document-content-slice-placeholder {
-    min-height: 60vh;
-  }
+.document-content-slice-placeholder {
+  min-height: 60vh;
+}
 </style>

--- a/src/components/DocumentContentSlices.vue
+++ b/src/components/DocumentContentSlices.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="document-content-slices">
     <dynamic-scroller
+      :key="version"
+      ref="scroller"
       :buffer="scrollBuffer"
       :items="slices"
-      :key="version"
       :min-item-size="85"
-      ref="scroller"
       page-mode
     >
       <template #default="{ item, index, active }">
@@ -29,6 +29,11 @@ export default {
     DynamicScroller,
     DynamicScrollerItem
   },
+  filters: {
+    sliceComponent({ placeholder = false } = {}) {
+      return placeholder ? DocumentContentSlicePlaceholder : DocumentContentSlice
+    }
+  },
   props: {
     slices: {
       type: Array,
@@ -43,16 +48,6 @@ export default {
       version: 0
     }
   },
-  watch: {
-    bufferizeAll() {
-      this.version++
-    }
-  },
-  filters: {
-    sliceComponent({ placeholder = false } = {}) {
-      return placeholder ? DocumentContentSlicePlaceholder : DocumentContentSlice
-    }
-  },
   computed: {
     scrollBuffer() {
       // Huge buffer to ensure all views are created
@@ -64,6 +59,11 @@ export default {
         container = container?.parentElement
       }
       return container || window
+    }
+  },
+  watch: {
+    bufferizeAll() {
+      this.version++
     }
   },
   methods: {

--- a/src/components/DocumentContentSlices.vue
+++ b/src/components/DocumentContentSlices.vue
@@ -6,17 +6,11 @@
       :key="version"
       :min-item-size="85"
       ref="scroller"
-      page-mode>
-      <template v-slot="{ item, index, active }">
-        <dynamic-scroller-item
-          :active="active"
-          :data-index="index"
-          :item="item"
-          tag="span">
-          <component
-            :is="item | sliceComponent"
-            :slice="item"
-            @visible="onPlaceholderVisible" />
+      page-mode
+    >
+      <template #default="{ item, index, active }">
+        <dynamic-scroller-item :active="active" :data-index="index" :item="item" tag="span">
+          <component :is="item | sliceComponent" :slice="item" @visible="onPlaceholderVisible" />
         </dynamic-scroller-item>
       </template>
     </dynamic-scroller>
@@ -38,33 +32,33 @@ export default {
   props: {
     slices: {
       type: Array,
-      default: () => ([])
+      default: () => []
     },
     bufferizeAll: {
       type: Boolean
     }
   },
-  data () {
+  data() {
     return {
       version: 0
     }
   },
   watch: {
-    bufferizeAll () {
+    bufferizeAll() {
       this.version++
     }
   },
   filters: {
-    sliceComponent ({ placeholder = false } = {}) {
+    sliceComponent({ placeholder = false } = {}) {
       return placeholder ? DocumentContentSlicePlaceholder : DocumentContentSlice
     }
   },
   computed: {
-    scrollBuffer () {
+    scrollBuffer() {
       // Huge buffer to ensure all views are created
       return this.bufferizeAll ? 9e3 * this.slices.length : 300
     },
-    scrollableContainer () {
+    scrollableContainer() {
       let container = this.$el.parentElement
       while (container && !hasOverflow(container)) {
         container = container?.parentElement
@@ -73,10 +67,10 @@ export default {
     }
   },
   methods: {
-    onPlaceholderVisible (slice) {
+    onPlaceholderVisible(slice) {
       this.$emit('placeholder-visible', slice)
     },
-    scrollToContentSlice (sliceIndex) {
+    scrollToContentSlice(sliceIndex) {
       const el = this.$el.querySelectorAll('.vue-recycle-scroller__item-view')[sliceIndex]
       const { y: top } = getTranslateValues(el)
       this.scrollableContainer.scrollTo({ top })
@@ -87,5 +81,5 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @import '~node_modules/vue-virtual-scroller/dist/vue-virtual-scroller.css';
+@import '~node_modules/vue-virtual-scroller/dist/vue-virtual-scroller.css';
 </style>

--- a/src/components/DocumentGlobalSearchTermsTags.vue
+++ b/src/components/DocumentGlobalSearchTermsTags.vue
@@ -108,8 +108,8 @@ export default {
       <li v-for="(term, index) in sortedTerms" :key="index" class="list-inline-item">
         <mark
           class="document-global-search-terms-tags__item"
-          :class="getTermIndexClass(index, term)"
-          :style="getTermIndexBorderColor(index)"
+          :class="getTermIndexClass(i, term)"
+          :style="getTermIndexBorderColor(i)"
           @click="$emit('select', term.label)"
         >
           <span class="document-global-search-terms-tags__item__label">

--- a/src/components/DocumentGlobalSearchTermsTags.vue
+++ b/src/components/DocumentGlobalSearchTermsTags.vue
@@ -28,15 +28,6 @@ export default {
       terms: []
     }
   },
-  async mounted() {
-    await this.searchTerms()
-  },
-  watch: {
-    async targetLanguage() {
-      this.terms.splice(0)
-      await this.searchTerms()
-    }
-  },
   computed: {
     queryTerms() {
       return this.$store.getters['search/retrieveContentQueryTerms']
@@ -63,6 +54,15 @@ export default {
         'source.path'
       ]
     }
+  },
+  watch: {
+    async targetLanguage() {
+      this.terms.splice(0)
+      await this.searchTerms()
+    }
+  },
+  async mounted() {
+    await this.searchTerms()
   },
   methods: {
     getTermIndexClass(index, term) {
@@ -100,7 +100,7 @@ export default {
 </script>
 
 <template>
-  <div class="document-global-search-terms-tags d-flex align-items-center" v-if="document && terms.length">
+  <div v-if="document && terms.length" class="document-global-search-terms-tags d-flex align-items-center">
     <div class="mr-2">
       {{ $t('document.researchedTerms') }}
     </div>
@@ -116,23 +116,23 @@ export default {
             {{ term.label }}
           </span>
           <span
+            v-if="term.count === 0 && term.metadata > 0"
             class="document-global-search-terms-tags__item__count document-global-search-terms-tags__item__metadata py-0"
             :style="getTermIndexBackgroundColor(i)"
-            v-if="term.count === 0 && term.metadata > 0"
           >
             {{ $t('document.inMetadata') }}
           </span>
           <span
+            v-else-if="term.count === 0 && term.tags > 0"
             class="document-global-search-terms-tags__item__count document-global-search-terms-tags__item__metadata py-0"
             :style="getTermIndexBackgroundColor(i)"
-            v-else-if="term.count === 0 && term.tags > 0"
           >
             {{ $t('document.inTags') }}
           </span>
           <span
+            v-else
             class="document-global-search-terms-tags__item__count py-0"
             :style="getTermIndexBackgroundColor(i)"
-            v-else
           >
             {{ term.count }}
           </span>

--- a/src/components/DocumentGlobalSearchTermsTags.vue
+++ b/src/components/DocumentGlobalSearchTermsTags.vue
@@ -23,71 +23,71 @@ export default {
       default: null
     }
   },
-  data () {
+  data() {
     return {
       terms: []
     }
   },
-  async mounted () {
+  async mounted() {
     await this.searchTerms()
   },
   watch: {
-    async targetLanguage () {
+    async targetLanguage() {
       this.terms.splice(0)
       await this.searchTerms()
     }
   },
   computed: {
-    queryTerms () {
+    queryTerms() {
       return this.$store.getters['search/retrieveContentQueryTerms']
     },
-    queryTermsWithoutNegation () {
+    queryTermsWithoutNegation() {
       return this.queryTerms.filter(({ negation }) => !negation)
     },
-    index () {
+    index() {
       return this.document.index
     },
-    id () {
+    id() {
       return this.document.id
     },
-    routing () {
+    routing() {
       return this.document.routing
     },
-    sortedTerms () {
+    sortedTerms() {
       return orderBy(this.terms, ['count', 'metadata', 'tags'], ['desc', 'desc', 'desc'])
     },
-    metadataFields () {
+    metadataFields() {
       return [
-        ...keys(this.document.source.metadata).map(m => `source.metadata.${m}`),
+        ...keys(this.document.source.metadata).map((m) => `source.metadata.${m}`),
         'source.language',
         'source.path'
       ]
     }
   },
   methods: {
-    getTermIndexClass (index, term) {
+    getTermIndexClass(index, term) {
       return {
         [`document-global-search-terms-tags__item--index-${index}`]: true
       }
     },
-    searchTermInContent (label) {
+    searchTermInContent(label) {
       const searchParams = [this.index, this.id, label, this.targetLanguage, this.routing]
       return this.$core.api.searchDocument(...searchParams)
     },
-    searchTermInTags (label) {
+    searchTermInTags(label) {
       const needle = label.toLowerCase()
-      const tags = this.document.tags.filter(t => t.toLowerCase().includes(needle))
+      const tags = this.document.tags.filter((t) => t.toLowerCase().includes(needle))
       const count = tags.length
       return { count, tags }
     },
-    searchTermInMetadata (label) {
+    searchTermInMetadata(label) {
       const needle = label.toLowerCase()
       const fields = this.metadataFields
-      const metadata = fields.filter(f => String(get(this.document, f)).toLowerCase().includes(needle))
+      const metadata = fields.filter((f) => String(get(this.document, f)).toLowerCase().includes(needle))
       const count = metadata.length
       return { count, metadata }
     },
-    async searchTerms () {
+    async searchTerms() {
       for (const { label } of this.queryTermsWithoutNegation) {
         const { offsets, count } = await this.searchTermInContent(label)
         const { count: tags } = this.searchTermInTags(label)
@@ -106,26 +106,34 @@ export default {
     </div>
     <ul class="list-inline m-0">
       <li v-for="(term, index) in sortedTerms" :key="index" class="list-inline-item">
-        <mark class="document-global-search-terms-tags__item"
-              :class="getTermIndexClass(index, term)"
-              :style="getTermIndexBorderColor(index)"
-              @click="$emit('select', term.label)">
+        <mark
+          class="document-global-search-terms-tags__item"
+          :class="getTermIndexClass(index, term)"
+          :style="getTermIndexBorderColor(index)"
+          @click="$emit('select', term.label)"
+        >
           <span class="document-global-search-terms-tags__item__label">
             {{ term.label }}
           </span>
-          <span class="document-global-search-terms-tags__item__count document-global-search-terms-tags__item__metadata py-0"
-                :style="getTermIndexBackgroundColor(index)"
-                v-if="term.count === 0 && term.metadata > 0">
+          <span
+            class="document-global-search-terms-tags__item__count document-global-search-terms-tags__item__metadata py-0"
+            :style="getTermIndexBackgroundColor(index)"
+            v-if="term.count === 0 && term.metadata > 0"
+          >
             {{ $t('document.inMetadata') }}
           </span>
-          <span class="document-global-search-terms-tags__item__count document-global-search-terms-tags__item__metadata py-0"
-                :style="getTermIndexBackgroundColor(index)"
-                v-else-if="term.count === 0 && term.tags > 0">
+          <span
+            class="document-global-search-terms-tags__item__count document-global-search-terms-tags__item__metadata py-0"
+            :style="getTermIndexBackgroundColor(index)"
+            v-else-if="term.count === 0 && term.tags > 0"
+          >
             {{ $t('document.inTags') }}
           </span>
-          <span class="document-global-search-terms-tags__item__count py-0"
-                :style="getTermIndexBackgroundColor(index)"
-                v-else>
+          <span
+            class="document-global-search-terms-tags__item__count py-0"
+            :style="getTermIndexBackgroundColor(index)"
+            v-else
+          >
             {{ term.count }}
           </span>
         </mark>
@@ -135,34 +143,33 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  .document-global-search-terms-tags {
-    &__item {
-      border-bottom: 3px solid transparent;
-      cursor: pointer;
+.document-global-search-terms-tags {
+  &__item {
+    border-bottom: 3px solid transparent;
+    cursor: pointer;
 
-      &:hover {
-        box-shadow: 0 3px 0 0 darken(theme-color('mark'), 20%);
-      }
+    &:hover {
+      box-shadow: 0 3px 0 0 darken(theme-color('mark'), 20%);
+    }
 
-      & &__count {
-        border-radius: 0.3rem;
-        display: inline-block;
-        font-size: 0.8rem;
-        font-weight: bold;
-        height: 1.2rem;
-        line-height: 1.2rem;
-        min-width: 1.2rem;
-        padding: 0 0.2rem;
-        position: relative;
-        text-align: center;
-        top: -0.1rem;
-      }
+    & &__count {
+      border-radius: 0.3rem;
+      display: inline-block;
+      font-size: 0.8rem;
+      font-weight: bold;
+      height: 1.2rem;
+      line-height: 1.2rem;
+      min-width: 1.2rem;
+      padding: 0 0.2rem;
+      position: relative;
+      text-align: center;
+      top: -0.1rem;
+    }
 
-      & &__metadata {
-        font-style: italic;
-        font-weight: normal;
-      }
-
+    & &__metadata {
+      font-style: italic;
+      font-weight: normal;
     }
   }
+}
 </style>

--- a/src/components/DocumentGlobalSearchTermsTags.vue
+++ b/src/components/DocumentGlobalSearchTermsTags.vue
@@ -105,7 +105,7 @@ export default {
       {{ $t('document.researchedTerms') }}
     </div>
     <ul class="list-inline m-0">
-      <li v-for="(term, index) in sortedTerms" :key="index" class="list-inline-item">
+      <li v-for="(term, i) in sortedTerms" :key="i" class="list-inline-item">
         <mark
           class="document-global-search-terms-tags__item"
           :class="getTermIndexClass(i, term)"
@@ -117,21 +117,21 @@ export default {
           </span>
           <span
             class="document-global-search-terms-tags__item__count document-global-search-terms-tags__item__metadata py-0"
-            :style="getTermIndexBackgroundColor(index)"
+            :style="getTermIndexBackgroundColor(i)"
             v-if="term.count === 0 && term.metadata > 0"
           >
             {{ $t('document.inMetadata') }}
           </span>
           <span
             class="document-global-search-terms-tags__item__count document-global-search-terms-tags__item__metadata py-0"
-            :style="getTermIndexBackgroundColor(index)"
+            :style="getTermIndexBackgroundColor(i)"
             v-else-if="term.count === 0 && term.tags > 0"
           >
             {{ $t('document.inTags') }}
           </span>
           <span
             class="document-global-search-terms-tags__item__count py-0"
-            :style="getTermIndexBackgroundColor(index)"
+            :style="getTermIndexBackgroundColor(i)"
             v-else
           >
             {{ term.count }}

--- a/src/components/DocumentLocalSearchInput.vue
+++ b/src/components/DocumentLocalSearchInput.vue
@@ -124,16 +124,16 @@ export default {
       </label>
       <div class="input-group">
         <input
+          ref="search"
+          v-shortkey="getKeys('findInDocument')"
           type="search"
           :value="searchTerm"
-          @input="$emit('input', $event.target.value)"
           :placeholder="$t('document.find')"
-          ref="search"
           class="form-control document-local-search-input__term"
-          v-shortkey="getKeys('findInDocument')"
+          @input="$emit('input', $event.target.value)"
           @shortkey="getAction('findInDocument')"
         />
-        <div class="document-local-search-input__count input-group-append w-25" v-if="searchTerm.length > 0">
+        <div v-if="searchTerm.length > 0" class="document-local-search-input__count input-group-append w-25">
           <span v-if="loading" class="input-group-text w-100 text-center d-inline-block">
             <fa icon="circle-notch" spin></fa>
           </span>
@@ -152,15 +152,15 @@ export default {
     <div class="form-group">
       <button
         class="document-local-search-input__previous btn btn-sm p-2"
-        @click="previous"
         :disabled="searchOccurrences === 0 || searchTerm.length === 0"
+        @click="previous"
       >
         <fa icon="angle-up"></fa>
       </button>
       <button
         class="document-local-search-input__next btn btn-sm p-2"
-        @click="next"
         :disabled="searchOccurrences === 0 || searchTerm.length === 0"
+        @click="next"
       >
         <fa icon="angle-down"></fa>
       </button>

--- a/src/components/DocumentLocalSearchInput.vue
+++ b/src/components/DocumentLocalSearchInput.vue
@@ -43,13 +43,13 @@ export default {
       type: Boolean
     }
   },
-  data () {
+  data() {
     return {
       isActive: false
     }
   },
   computed: {
-    shortkeysActions () {
+    shortkeysActions() {
       return {
         activateSearchBar: this.activateSearchBar,
         deactivateSearchBar: this.deactivateSearchBar,
@@ -59,29 +59,29 @@ export default {
         findNextOccurrenceAlt: this.next
       }
     },
-    searchLabel () {
+    searchLabel() {
       return `${this.searchIndex} ${this.$t('document.of')} ${this.searchOccurrences}`
     }
   },
   watch: {
-    searchTerm () {
+    searchTerm() {
       this.activateSearchBar()
     }
   },
   methods: {
-    previous () {
+    previous() {
       /**
        * User selected the previous occurrence of the term
        */
       this.$emit('previous', this.searchTerm)
     },
-    next () {
+    next() {
       /**
        * User selected the next occurrence of the term
        */
       this.$emit('next', this.searchTerm)
     },
-    activateSearchBar () {
+    activateSearchBar() {
       /**
        * User set focus on the search input
        */
@@ -93,7 +93,7 @@ export default {
         }
       })
     },
-    deactivateSearchBar () {
+    deactivateSearchBar() {
       /**
        * User lost focus on the search input
        */
@@ -101,7 +101,7 @@ export default {
       this.$set(this, 'isActive', false)
       this.$emit('input', '')
     },
-    shortkeyAction ({ srcKey }) {
+    shortkeyAction({ srcKey }) {
       if (this.shortkeysActions[srcKey]) {
         return this.shortkeysActions[srcKey]()
       }
@@ -111,18 +111,37 @@ export default {
 </script>
 
 <template>
-  <div class="document-local-search-input form-inline px-3" :class="{ 'document-local-search-input--active': isActive, 'document-local-search-input--pristine': searchTerm.length > 0 }">
+  <div
+    class="document-local-search-input form-inline px-3"
+    :class="{
+      'document-local-search-input--active': isActive,
+      'document-local-search-input--pristine': searchTerm.length > 0
+    }"
+  >
     <div class="form-group py-2 mr-2">
       <label class="sr-only">
         {{ $t('document.search') }}
       </label>
       <div class="input-group">
-        <input type="search" :value="searchTerm" @input="$emit('input', $event.target.value)" :placeholder="$t('document.find')" ref="search" class="form-control document-local-search-input__term" v-shortkey="getKeys('findInDocument')" @shortkey="getAction('findInDocument')" />
+        <input
+          type="search"
+          :value="searchTerm"
+          @input="$emit('input', $event.target.value)"
+          :placeholder="$t('document.find')"
+          ref="search"
+          class="form-control document-local-search-input__term"
+          v-shortkey="getKeys('findInDocument')"
+          @shortkey="getAction('findInDocument')"
+        />
         <div class="document-local-search-input__count input-group-append w-25" v-if="searchTerm.length > 0">
           <span v-if="loading" class="input-group-text w-100 text-center d-inline-block">
             <fa icon="circle-notch" spin></fa>
           </span>
-          <span v-else class="input-group-text w-100 text-center d-inline-block px-0 text-truncate" :title="searchLabel">
+          <span
+            v-else
+            class="input-group-text w-100 text-center d-inline-block px-0 text-truncate"
+            :title="searchLabel"
+          >
             <span>
               {{ searchLabel }}
             </span>
@@ -131,10 +150,18 @@ export default {
       </div>
     </div>
     <div class="form-group">
-      <button class="document-local-search-input__previous btn btn-sm p-2" @click="previous" :disabled="searchOccurrences === 0 || searchTerm.length === 0">
+      <button
+        class="document-local-search-input__previous btn btn-sm p-2"
+        @click="previous"
+        :disabled="searchOccurrences === 0 || searchTerm.length === 0"
+      >
         <fa icon="angle-up"></fa>
       </button>
-      <button class="document-local-search-input__next btn btn-sm p-2" @click="next" :disabled="searchOccurrences === 0 || searchTerm.length === 0">
+      <button
+        class="document-local-search-input__next btn btn-sm p-2"
+        @click="next"
+        :disabled="searchOccurrences === 0 || searchTerm.length === 0"
+      >
         <fa icon="angle-down"></fa>
       </button>
     </div>
@@ -142,34 +169,34 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  .document-local-search-input {
-    justify-content: flex-end;
+.document-local-search-input {
+  justify-content: flex-end;
+  white-space: nowrap;
+
+  &--pristine.form-inline .input-group &__term {
+    border-radius: 1.5em 0 0 1.5em;
+  }
+
+  &.form-inline &__term {
+    border-radius: 1.5em;
+  }
+
+  &__count .input-group-text {
+    border-radius: 0 1.5em 1.5em 0;
+  }
+
+  &.form-inline {
+    flex-wrap: nowrap;
     white-space: nowrap;
 
-    &--pristine.form-inline .input-group &__term {
-      border-radius: 1.5em 0 0 1.5em;
-    }
+    .input-group {
+      width: 300px;
 
-    &.form-inline &__term {
-      border-radius: 1.5em;
-    }
-
-    &__count .input-group-text {
-      border-radius: 0 1.5em 1.5em 0;
-    }
-
-    &.form-inline {
-      flex-wrap: nowrap;
-      white-space: nowrap;
-
-      .input-group {
-        width: 300px;
-
-        .input-group-text {
-          background: $input-bg;
-          border-left: 0;
-        }
+      .input-group-text {
+        background: $input-bg;
+        border-left: 0;
       }
     }
   }
+}
 </style>

--- a/src/components/DocumentSlicedName.vue
+++ b/src/components/DocumentSlicedName.vue
@@ -1,17 +1,20 @@
 <template>
   <component :is="baseComponent" v-bind="baseComponentProps">
-    <span class="document-sliced-name"
-          :class="{
-            'document-sliced-name--sliced': isSliced(),
-            'document-sliced-name--truncate': hasActiveTextTruncate(),
-            'document-sliced-name--has-subject': hasSubject() }">
-      <span class="document-sliced-name__item"
-            :class="{ 'document-sliced-name__item--has-content-type': hasContentSlice(slice) }"
-            :key="index"
-            v-for="(slice, index) in slices">
-        <span v-if="isMiddleSlice(slice)">
-          …
-        </span>
+    <span
+      class="document-sliced-name"
+      :class="{
+        'document-sliced-name--sliced': isSliced(),
+        'document-sliced-name--truncate': hasActiveTextTruncate(),
+        'document-sliced-name--has-subject': hasSubject()
+      }"
+    >
+      <span
+        class="document-sliced-name__item"
+        :class="{ 'document-sliced-name__item--has-content-type': hasContentSlice(slice) }"
+        :key="index"
+        v-for="(slice, index) in slices"
+      >
+        <span v-if="isMiddleSlice(slice)"> … </span>
         <span v-else-if="hasContentSlice(slice)" class="d-inline-flex flex-row align-items-end">
           <span class="document-sliced-name__item__short-id">
             {{ slice }}
@@ -20,9 +23,11 @@
             {{ contentType }}
           </span>
         </span>
-        <router-link v-else-if="hasInteractiveRoot()"
-                     class="document-sliced-name__item__root"
-                     :to="{ name: 'document', params: rootParams }">
+        <router-link
+          v-else-if="hasInteractiveRoot()"
+          class="document-sliced-name__item__root"
+          :to="{ name: 'document', params: rootParams }"
+        >
           {{ slice }}
         </router-link>
         <span v-else class="document-sliced-name__item__single" :title="slice">
@@ -80,48 +85,48 @@ export default {
     }
   },
   methods: {
-    isFirstSlice (slice) {
+    isFirstSlice(slice) {
       return this.slices.indexOf(slice) === 0
     },
-    isLastSlice (slice) {
+    isLastSlice(slice) {
       return this.slices.indexOf(slice) === this.slices.length - 1
     },
-    isMiddleSlice (slice) {
+    isMiddleSlice(slice) {
       return !this.isFirstSlice(slice) && !this.isLastSlice(slice)
     },
-    hasContentSlice (slice) {
+    hasContentSlice(slice) {
       return !this.isFirstSlice(slice) && this.isLastSlice(slice)
     },
-    hasInteractiveRoot () {
+    hasInteractiveRoot() {
       return this.isSliced && this.interactiveRoot
     },
-    hasActiveTextTruncate () {
+    hasActiveTextTruncate() {
       return this.activeTextTruncate !== null
     },
-    hasSubject () {
+    hasSubject() {
       return this.showSubject && !this.isSliced() && this.document.hasSubject
     },
-    isSliced () {
+    isSliced() {
       return this.slices.length > 1
     }
   },
   computed: {
-    slices () {
+    slices() {
       return this.document.slicedName
     },
-    subject () {
+    subject() {
       return this.document.subject
     },
-    contentType () {
+    contentType() {
       return get(types, [this.document.contentType, 'extensions'], [])[0]
     },
-    rootParams () {
+    rootParams() {
       return { id: this.document.source.rootDocument || this.document.id }
     },
-    baseComponent () {
+    baseComponent() {
       return this.hasActiveTextTruncate ? ActiveTextTruncate : 'span'
     },
-    baseComponentProps () {
+    baseComponentProps() {
       if (isString(this.activeTextTruncate) && this.activeTextTruncate !== '') {
         return { direction: this.activeTextTruncate }
       }
@@ -135,45 +140,46 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .document-sliced-name {
-    display: inline-block;
-    padding: 0.1em 0;
+.document-sliced-name {
+  display: inline-block;
+  padding: 0.1em 0;
 
-    &--truncate {
-      white-space: nowrap;
+  &--truncate {
+    white-space: nowrap;
+  }
+
+  &__item {
+    display: inline;
+
+    // Slice separator
+    &:not(:last-child):after {
+      content: '❭';
+      font-size: 0.5em;
+      transform: translateY(-0.25em);
+      line-height: 1em;
+      opacity: 0.5;
+      padding: 0 0.5em;
+      display: inline-block;
     }
 
-    &__item {
-      display: inline;
+    &__content-type {
+      font-weight: normal;
+      opacity: 0.8;
+    }
 
-      // Slice separator
-      &:not(:last-child):after {
-        content: "❭";
-        font-size: 0.5em;
-        transform: translateY(-0.25em);
-        line-height: 1em;
-        opacity: 0.5;
-        padding: 0 0.5em;
-        display: inline-block;
-      }
+    &__root,
+    &__root:hover {
+      color: inherit;
 
-      &__content-type {
+      .document-sliced-name--sliced &:not(a) {
         font-weight: normal;
-        opacity: 0.8;
       }
+    }
 
-      &__root, &__root:hover {
-        color: inherit;
-
-        .document-sliced-name--sliced &:not(a) {
-          font-weight: normal;
-        }
-      }
-
-      .document-sliced-name--sliced &__root,
-      .document-sliced-name--has-subject &__single {
-        opacity: 0.5;
-      }
+    .document-sliced-name--sliced &__root,
+    .document-sliced-name--has-subject &__single {
+      opacity: 0.5;
     }
   }
+}
 </style>

--- a/src/components/DocumentSlicedName.vue
+++ b/src/components/DocumentSlicedName.vue
@@ -9,17 +9,17 @@
       }"
     >
       <span
+        v-for="(slice, index) in slices"
+        :key="index"
         class="document-sliced-name__item"
         :class="{ 'document-sliced-name__item--has-content-type': hasContentSlice(slice) }"
-        :key="index"
-        v-for="(slice, index) in slices"
       >
         <span v-if="isMiddleSlice(slice)"> … </span>
         <span v-else-if="hasContentSlice(slice)" class="d-inline-flex flex-row align-items-end">
           <span class="document-sliced-name__item__short-id">
             {{ slice }}
           </span>
-          <span class="document-sliced-name__item__content-type" v-if="slice === document.shortId">
+          <span v-if="slice === document.shortId" class="document-sliced-name__item__content-type">
             {{ contentType }}
           </span>
         </span>
@@ -84,32 +84,6 @@ export default {
       type: Boolean
     }
   },
-  methods: {
-    isFirstSlice(slice) {
-      return this.slices.indexOf(slice) === 0
-    },
-    isLastSlice(slice) {
-      return this.slices.indexOf(slice) === this.slices.length - 1
-    },
-    isMiddleSlice(slice) {
-      return !this.isFirstSlice(slice) && !this.isLastSlice(slice)
-    },
-    hasContentSlice(slice) {
-      return !this.isFirstSlice(slice) && this.isLastSlice(slice)
-    },
-    hasInteractiveRoot() {
-      return this.isSliced && this.interactiveRoot
-    },
-    hasActiveTextTruncate() {
-      return this.activeTextTruncate !== null
-    },
-    hasSubject() {
-      return this.showSubject && !this.isSliced() && this.document.hasSubject
-    },
-    isSliced() {
-      return this.slices.length > 1
-    }
-  },
   computed: {
     slices() {
       return this.document.slicedName
@@ -134,6 +108,32 @@ export default {
         return { direction: 'rtl' }
       }
       return {}
+    }
+  },
+  methods: {
+    isFirstSlice(slice) {
+      return this.slices.indexOf(slice) === 0
+    },
+    isLastSlice(slice) {
+      return this.slices.indexOf(slice) === this.slices.length - 1
+    },
+    isMiddleSlice(slice) {
+      return !this.isFirstSlice(slice) && !this.isLastSlice(slice)
+    },
+    hasContentSlice(slice) {
+      return !this.isFirstSlice(slice) && this.isLastSlice(slice)
+    },
+    hasInteractiveRoot() {
+      return this.isSliced && this.interactiveRoot
+    },
+    hasActiveTextTruncate() {
+      return this.activeTextTruncate !== null
+    },
+    hasSubject() {
+      return this.showSubject && !this.isSliced() && this.document.hasSubject
+    },
+    isSliced() {
+      return this.slices.length > 1
     }
   }
 }

--- a/src/components/DocumentTagsForm.vue
+++ b/src/components/DocumentTagsForm.vue
@@ -32,17 +32,17 @@
         <li
           class="document-tags-form__tags__tag badge badge-pill mr-2 mb-1"
           :class="[mode === 'light' ? 'border badge-light' : 'badge-dark']"
-          v-for="tag in tags"
-          :key="tag.label"
+          v-for="oneTag in tags"
+          :key="oneTag.label"
         >
-          <span :title="generateTagTooltip(tag)" v-b-tooltip>
-            {{ tag.label }}
+          <span :title="generateTagTooltip(oneTag)" v-b-tooltip>
+            {{ oneTag.label }}
           </span>
           <confirm-button
             class="document-tags-form__tags__tag__delete btn btn-sm"
             :class="mode"
-            :confirmed="() => deleteTag(tag)"
-            v-if="!isCreatedByAdmin(tag)"
+            :confirmed="() => deleteTag(oneTag)"
+            v-if="!isCreatedByAdmin(oneTag)"
             :label="$t('document.tagConfirmation')"
             :no="$t('global.no')"
             :yes="$t('global.yes')"
@@ -78,13 +78,15 @@ export default {
      * The selected document(s)
      */
     document: {
-      type: [Object, Array]
+      type: [Object, Array],
+      default: () => {}
     },
     /**
      * List of existing tags for the selection
      */
     tags: {
-      type: Array
+      type: Array,
+      default: () => []
     },
     /**
      * Display the list of tags

--- a/src/components/DocumentTagsForm.vue
+++ b/src/components/DocumentTagsForm.vue
@@ -7,15 +7,34 @@
             <b-input-group-text slot="prepend">
               <fa icon="tag"></fa>
             </b-input-group-text>
-            <b-form-input v-model="tag" @input="searchTags" required :placeholder="$t('document.tagsNew')" autocomplete="off" autofocus ref="tag"></b-form-input>
+            <b-form-input
+              v-model="tag"
+              @input="searchTags"
+              required
+              :placeholder="$t('document.tagsNew')"
+              autocomplete="off"
+              autofocus
+              ref="tag"
+            ></b-form-input>
           </b-input-group>
         </b-overlay>
-        <selectable-dropdown :items="suggestions" @input="tag = $event" @click.native="addTag" :hide="!suggestions.length" class="document-tags-form__add__suggestions"></selectable-dropdown>
+        <selectable-dropdown
+          :items="suggestions"
+          @input="tag = $event"
+          @click.native="addTag"
+          :hide="!suggestions.length"
+          class="document-tags-form__add__suggestions"
+        ></selectable-dropdown>
       </b-form>
     </div>
     <div class="col-md-8" v-if="displayTags">
       <ul class="document-tags-form__tags list-unstyled mb-0 mt-1">
-        <li class="document-tags-form__tags__tag badge badge-pill mr-2 mb-1" :class="[mode === 'light' ? 'border badge-light': 'badge-dark']" v-for="tag in tags" :key="tag.label">
+        <li
+          class="document-tags-form__tags__tag badge badge-pill mr-2 mb-1"
+          :class="[mode === 'light' ? 'border badge-light' : 'badge-dark']"
+          v-for="tag in tags"
+          :key="tag.label"
+        >
           <span :title="generateTagTooltip(tag)" v-b-tooltip>
             {{ tag.label }}
           </span>
@@ -26,7 +45,8 @@
             v-if="!isCreatedByAdmin(tag)"
             :label="$t('document.tagConfirmation')"
             :no="$t('global.no')"
-            :yes="$t('global.yes')">
+            :yes="$t('global.yes')"
+          >
             <fa icon="times" class="fa-fw pl-2"></fa>
           </confirm-button>
         </li>
@@ -86,7 +106,7 @@ export default {
       default: 'light'
     }
   },
-  data () {
+  data() {
     return {
       isReady: true,
       suggestions: [],
@@ -94,7 +114,7 @@ export default {
     }
   },
   computed: {
-    documents () {
+    documents() {
       return castArray(this.document)
     }
   },
@@ -108,29 +128,42 @@ export default {
       const buckets = get(response, 'aggregations.agg_terms_tags.buckets', [])
       this.$set(this, 'suggestions', map(buckets, 'key'))
     }, 200),
-    async addTag () {
+    async addTag() {
       this.$set(this, 'isReady', false)
-      await this.$store.dispatch('document/tag', { documents: this.documents, tag: this.tag, userId: await this.$core.auth.getUsername() })
+      await this.$store.dispatch('document/tag', {
+        documents: this.documents,
+        tag: this.tag,
+        userId: await this.$core.auth.getUsername()
+      })
       this.$set(this, 'tag', '')
       this.$set(this, 'suggestions', [])
       this.$set(this, 'isReady', true)
-      delay(filterName => this.$root.$emit('filter::refresh', filterName), settings.elasticsearch.waitForAnswer, 'tags')
-      if (!this.displayTags) this.$bvToast.toast(this.$t('document.tagged'), { noCloseButton: true, variant: 'success' })
+      delay(
+        (filterName) => this.$root.$emit('filter::refresh', filterName),
+        settings.elasticsearch.waitForAnswer,
+        'tags'
+      )
+      if (!this.displayTags)
+        this.$bvToast.toast(this.$t('document.tagged'), { noCloseButton: true, variant: 'success' })
       // Focus on the tag input
       if (this.$refs && this.$refs.tag && this.$refs.tag.focus) {
-        this.$nextTick(() => { this.$refs.tag.focus() })
+        this.$nextTick(() => {
+          this.$refs.tag.focus()
+        })
       }
     },
-    async deleteTag (tag) {
+    async deleteTag(tag) {
       this.$set(this, 'isReady', false)
       await this.$store.dispatch('document/deleteTag', { documents: this.documents, tag })
       this.$root.$emit('filter::delete', 'tags', tag)
       this.$set(this, 'isReady', true)
     },
-    generateTagTooltip (tag) {
-      return `${this.$t('document.createdBy')} ${displayUser(tag.user.id)} ${this.$t('document.on')} ${moment(tag.creationDate).format('LLL')}`
+    generateTagTooltip(tag) {
+      return `${this.$t('document.createdBy')} ${displayUser(tag.user.id)} ${this.$t('document.on')} ${moment(
+        tag.creationDate
+      ).format('LLL')}`
     },
-    isCreatedByAdmin (tag) {
+    isCreatedByAdmin(tag) {
       return tag?.user?.id === this.$config.get('userAdmin') || false
     }
   }
@@ -138,43 +171,43 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .document-tags-form {
-    font-size: 1rem;
+.document-tags-form {
+  font-size: 1rem;
 
-    &__add {
-      position: relative;
+  &__add {
+    position: relative;
 
-      &__suggestions.selectable-dropdown.dropdown-menu {
-        position: absolute;
-        right: 0;
-        top: 100%;
-      }
+    &__suggestions.selectable-dropdown.dropdown-menu {
+      position: absolute;
+      right: 0;
+      top: 100%;
+    }
+  }
+
+  &__tags__tag {
+    span {
+      vertical-align: middle;
     }
 
-    &__tags__tag {
-      span {
-        vertical-align: middle;
+    &__delete.btn {
+      border: 0;
+      cursor: pointer;
+      font-size: 0.8rem;
+      line-height: 1;
+      padding: 0;
+
+      &.dark {
+        color: white;
       }
 
-      &__delete.btn {
-        border: 0;
-        cursor: pointer;
-        font-size: 0.8rem;
-        line-height: 1;
-        padding: 0;
+      &.light {
+        color: $text-muted;
+      }
 
-        &.dark {
-          color: white;
-        }
-
-        &.light {
-          color: $text-muted;
-        }
-
-        > svg:hover {
-          color: $danger;
-        }
+      > svg:hover {
+        color: $danger;
       }
     }
   }
+}
 </style>

--- a/src/components/DocumentTagsForm.vue
+++ b/src/components/DocumentTagsForm.vue
@@ -1,48 +1,48 @@
 <template>
   <div class="document-tags-form row no-gutters">
-    <div :class="{ 'col-md-4 mb-3': displayTags }" class="d-flex" v-if="displayForm">
-      <b-form @submit.prevent="addTag" class="document-tags-form__add">
+    <div v-if="displayForm" :class="{ 'col-md-4 mb-3': displayTags }" class="d-flex">
+      <b-form class="document-tags-form__add" @submit.prevent="addTag">
         <b-overlay :show="!isReady" spinner-small class="h-100">
           <b-input-group size="sm" class="h-100">
             <b-input-group-text slot="prepend">
               <fa icon="tag"></fa>
             </b-input-group-text>
             <b-form-input
+              ref="tag"
               v-model="tag"
-              @input="searchTags"
               required
               :placeholder="$t('document.tagsNew')"
               autocomplete="off"
               autofocus
-              ref="tag"
+              @input="searchTags"
             ></b-form-input>
           </b-input-group>
         </b-overlay>
         <selectable-dropdown
           :items="suggestions"
-          @input="tag = $event"
-          @click.native="addTag"
           :hide="!suggestions.length"
           class="document-tags-form__add__suggestions"
+          @input="tag = $event"
+          @click.native="addTag"
         ></selectable-dropdown>
       </b-form>
     </div>
-    <div class="col-md-8" v-if="displayTags">
+    <div v-if="displayTags" class="col-md-8">
       <ul class="document-tags-form__tags list-unstyled mb-0 mt-1">
         <li
-          class="document-tags-form__tags__tag badge badge-pill mr-2 mb-1"
-          :class="[mode === 'light' ? 'border badge-light' : 'badge-dark']"
           v-for="oneTag in tags"
           :key="oneTag.label"
+          class="document-tags-form__tags__tag badge badge-pill mr-2 mb-1"
+          :class="[mode === 'light' ? 'border badge-light' : 'badge-dark']"
         >
-          <span :title="generateTagTooltip(oneTag)" v-b-tooltip>
+          <span v-b-tooltip :title="generateTagTooltip(oneTag)">
             {{ oneTag.label }}
           </span>
           <confirm-button
+            v-if="!isCreatedByAdmin(oneTag)"
             class="document-tags-form__tags__tag__delete btn btn-sm"
             :class="mode"
             :confirmed="() => deleteTag(oneTag)"
-            v-if="!isCreatedByAdmin(oneTag)"
             :label="$t('document.tagConfirmation')"
             :no="$t('global.no')"
             :yes="$t('global.yes')"

--- a/src/components/DocumentThumbnail.vue
+++ b/src/components/DocumentThumbnail.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="document-thumbnail" :class="thumbnailClass" :style="thumbnailStyle">
-    <img :alt="thumbnailAlt" class="document-thumbnail__image" :src="thumbnailSrc" v-if="isActivated" />
-    <span class="document-thumbnail__placeholder" v-if="!loaded && document.contentTypeIcon">
+    <img v-if="isActivated" :alt="thumbnailAlt" class="document-thumbnail__image" :src="thumbnailSrc" />
+    <span v-if="!loaded && document.contentTypeIcon" class="document-thumbnail__placeholder">
       <fa :icon="document.contentTypeIcon"></fa>
     </span>
   </div>
@@ -97,6 +97,14 @@ export default {
       return window && 'IntersectionObserver' in window
     }
   },
+  async mounted() {
+    // This component can be deactivated globally
+    if (!this.isActivated) return
+    // This component can be lazy loaded
+    if (this.lazy && this.lazyLoadable) return this.bindObserver()
+    // Fetch directly
+    await this.fetchAndLoad()
+  },
   methods: {
     async fetchAsBase64() {
       return this.fetchPreviewAsBase64(this.thumbnailUrl)
@@ -139,14 +147,6 @@ export default {
       // Observe the component element
       this.observer.observe(this.$el)
     }
-  },
-  async mounted() {
-    // This component can be deactivated globally
-    if (!this.isActivated) return
-    // This component can be lazy loaded
-    if (this.lazy && this.lazyLoadable) return this.bindObserver()
-    // Fetch directly
-    await this.fetchAndLoad()
   }
 }
 </script>

--- a/src/components/DocumentThumbnail.vue
+++ b/src/components/DocumentThumbnail.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="document-thumbnail" :class="thumbnailClass" :style="thumbnailStyle">
-    <img :alt="thumbnailAlt"
-         class="document-thumbnail__image"
-         :src="thumbnailSrc"
-         v-if="isActivated">
+    <img :alt="thumbnailAlt" class="document-thumbnail__image" :src="thumbnailSrc" v-if="isActivated" />
     <span class="document-thumbnail__placeholder" v-if="!loaded && document.contentTypeIcon">
       <fa :icon="document.contentTypeIcon"></fa>
     </span>
@@ -61,7 +58,7 @@ export default {
       default: null
     }
   },
-  data () {
+  data() {
     return {
       loaded: false,
       errored: false,
@@ -70,7 +67,7 @@ export default {
     }
   },
   computed: {
-    thumbnailClass () {
+    thumbnailClass() {
       return {
         'document-thumbnail--crop': this.crop,
         'document-thumbnail--errored': this.errored,
@@ -79,32 +76,32 @@ export default {
         [`document-thumbnail--${this.size}`]: isNaN(this.size)
       }
     },
-    thumbnailStyle () {
+    thumbnailStyle() {
       return {
         '--estimated-ratio': this.ratio,
         '--estimated-height': isNaN(this.size) ? null : `${this.size}px`
       }
     },
-    thumbnailUrl () {
+    thumbnailUrl() {
       const { index, id, routing } = this.document
       const { page, size } = this
       return this.getPreviewUrl({ index, id, routing }, { page, size })
     },
-    thumbnailAlt () {
+    thumbnailAlt() {
       return `${this.document.basename} preview`
     },
-    isActivated () {
+    isActivated() {
       return !!this.$config.get('previewHost')
     },
-    lazyLoadable () {
+    lazyLoadable() {
       return window && 'IntersectionObserver' in window
     }
   },
   methods: {
-    async fetchAsBase64 () {
+    async fetchAsBase64() {
       return this.fetchPreviewAsBase64(this.thumbnailUrl)
     },
-    async fetchAndLoad () {
+    async fetchAndLoad() {
       try {
         if (!this.loaded && !this.errored) {
           this.$set(this, 'thumbnailSrc', await this.fetchAsBase64())
@@ -126,8 +123,8 @@ export default {
         this.$emit('errored')
       }
     },
-    bindObserver () {
-      this.observer = new IntersectionObserver(async entries => {
+    bindObserver() {
+      this.observer = new IntersectionObserver(async (entries) => {
         if (entries[0].isIntersecting) {
           /**
            * The thumbnail enters the viewport.
@@ -143,7 +140,7 @@ export default {
       this.observer.observe(this.$el)
     }
   },
-  async mounted () {
+  async mounted() {
     // This component can be deactivated globally
     if (!this.isActivated) return
     // This component can be lazy loaded
@@ -155,72 +152,78 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .document-thumbnail {
-    $heights: (xs: 80px, sm: 310px, md: 540px, lg: 720px, xl: 960px);
+.document-thumbnail {
+  $heights: (
+    xs: 80px,
+    sm: 310px,
+    md: 540px,
+    lg: 720px,
+    xl: 960px
+  );
 
-    @each $name, $value in $heights {
-      --height-#{$name}: #{$value};
-    }
+  @each $name, $value in $heights {
+    --height-#{$name}: #{$value};
+  }
 
-    background: $body-bg;
-    color: mix($body-bg, $text-muted, 70%);
-    max-width: 100%;
-    min-width: 80px;
-    overflow: hidden;
-    position: relative;
+  background: $body-bg;
+  color: mix($body-bg, $text-muted, 70%);
+  max-width: 100%;
+  min-width: 80px;
+  overflow: hidden;
+  position: relative;
 
-    &--crop {
-      height: 80px;
-      width: 80px;
-    }
+  &--crop {
+    height: 80px;
+    width: 80px;
+  }
 
-    &--loaded:not(&--errored) &__image {
-      opacity: 1;
-    }
+  &--loaded:not(&--errored) &__image {
+    opacity: 1;
+  }
 
-    &--estimated-size:not(&--loaded):not(&--errored) {
-      &:before {
-        content: "";
-        display: inline-block;
-        max-width: calc(var(--estimated-height) / var(--estimated-ratio));
-        padding-top: calc(100% * var(--estimated-ratio));
-        width: 100%;
-      }
-
-      .document-thumbnail__image {
-        position: absolute;
-      }
-    }
-
-    @each $name, $value in $heights {
-      &--estimated-size:not(&--loaded):not(&--errored).document-thumbnail--#{$name} &__image {
-        height: $value;
-        width: calc(#{$value} / var(--estimated-ratio));
-      }
-    }
-
-    &__image {
+  &--estimated-size:not(&--loaded):not(&--errored) {
+    &:before {
+      content: '';
       display: inline-block;
-      margin: auto;
-      max-width: 100%;
-      opacity: 0;
-      transition: opacity 300ms;
+      max-width: calc(var(--estimated-height) / var(--estimated-ratio));
+      padding-top: calc(100% * var(--estimated-ratio));
+      width: 100%;
     }
 
-    &--crop &__image {
-      left: 50%;
-      min-height: 100%;
-      min-width: 100%;
+    .document-thumbnail__image {
       position: absolute;
-      top: 50%;
-      transform: translate(-50%, -50%);
-    }
-
-    &__placeholder {
-      left: 50%;
-      position: absolute;
-      top: 50%;
-      transform: translate(-50%, -50%);
     }
   }
+
+  @each $name, $value in $heights {
+    &--estimated-size:not(&--loaded):not(&--errored).document-thumbnail--#{$name} &__image {
+      height: $value;
+      width: calc(#{$value} / var(--estimated-ratio));
+    }
+  }
+
+  &__image {
+    display: inline-block;
+    margin: auto;
+    max-width: 100%;
+    opacity: 0;
+    transition: opacity 300ms;
+  }
+
+  &--crop &__image {
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  &__placeholder {
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+}
 </style>

--- a/src/components/DocumentTranslatedContent.vue
+++ b/src/components/DocumentTranslatedContent.vue
@@ -5,8 +5,8 @@
         <div class="document-translated-content__translation__header px-3 py-2">
           <fa icon="globe" class="mr-2" />
           <abbr
-            :title="$t(`filter.lang.${document.source.language}`)"
             v-if="translation.source_language === document.source.language"
+            :title="$t(`filter.lang.${document.source.language}`)"
             >{{ $t('documentTranslatedContent.detected') }}</abbr
           >
           <span v-else>
@@ -52,6 +52,9 @@ import DocumentContent from '@/components/DocumentContent'
  */
 export default {
   name: 'DocumentTranslatedContent',
+  components: {
+    DocumentContent
+  },
   props: {
     /**
      * The selected document.
@@ -66,9 +69,6 @@ export default {
       type: String,
       default: ''
     }
-  },
-  components: {
-    DocumentContent
   },
   data() {
     return {

--- a/src/components/DocumentTranslatedContent.vue
+++ b/src/components/DocumentTranslatedContent.vue
@@ -76,6 +76,21 @@ export default {
       translations: []
     }
   },
+  computed: {
+    ...mapState('document', ['showTranslatedContent']),
+    targetLanguage() {
+      if (this.showTranslatedContent) {
+        return this.language
+      }
+      return null
+    },
+    hasTranslations() {
+      return !!this.translation
+    },
+    translation() {
+      return find(this.translations, { target_language: this.language })
+    }
+  },
   async mounted() {
     await this.loadAvailableTranslations()
   },
@@ -92,21 +107,6 @@ export default {
       const { index, id, routing } = this.document
       const data = await elasticsearch.getSource({ index, id, routing, _source })
       this.$set(this, 'translations', data.content_translated)
-    }
-  },
-  computed: {
-    ...mapState('document', ['showTranslatedContent']),
-    targetLanguage() {
-      if (this.showTranslatedContent) {
-        return this.language
-      }
-      return null
-    },
-    hasTranslations() {
-      return !!this.translation
-    },
-    translation() {
-      return find(this.translations, { target_language: this.language })
     }
   }
 }

--- a/src/components/DocumentTranslatedContent.vue
+++ b/src/components/DocumentTranslatedContent.vue
@@ -4,7 +4,11 @@
       <div class="document-translated-content__translation m-3">
         <div class="document-translated-content__translation__header px-3 py-2">
           <fa icon="globe" class="mr-2" />
-          <abbr :title="$t(`filter.lang.${document.source.language}`)" v-if="translation.source_language === document.source.language">{{ $t('documentTranslatedContent.detected') }}</abbr>
+          <abbr
+            :title="$t(`filter.lang.${document.source.language}`)"
+            v-if="translation.source_language === document.source.language"
+            >{{ $t('documentTranslatedContent.detected') }}</abbr
+          >
           <span v-else>
             {{ $t(`filter.lang.${translation.source_language}`) }}
           </span>
@@ -13,10 +17,22 @@
             {{ $t(`filter.lang.${language}`) }}
           </strong>
           <button class="btn btn-sm btn-link ml-3" @click="toggleTranslatedContent">
-            {{ $t(showTranslatedContent ? 'documentTranslatedContent.viewOriginal' : 'documentTranslatedContent.viewTranslated') }}
+            {{
+              $t(
+                showTranslatedContent
+                  ? 'documentTranslatedContent.viewOriginal'
+                  : 'documentTranslatedContent.viewTranslated'
+              )
+            }}
           </button>
         </div>
-        <document-content ref="content" class="document-translated-content__translation__header__content" :document="document" :q="q" :target-language="targetLanguage" />
+        <document-content
+          ref="content"
+          class="document-translated-content__translation__header__content"
+          :document="document"
+          :q="q"
+          :target-language="targetLanguage"
+        />
       </div>
     </template>
     <template v-else>
@@ -54,20 +70,20 @@ export default {
   components: {
     DocumentContent
   },
-  data () {
+  data() {
     return {
       language: 'ENGLISH',
       translations: []
     }
   },
-  async mounted () {
+  async mounted() {
     await this.loadAvailableTranslations()
   },
   methods: {
-    toggleTranslatedContent () {
+    toggleTranslatedContent() {
       this.$store.commit('document/toogleShowTransatedContent')
     },
-    async loadAvailableTranslations () {
+    async loadAvailableTranslations() {
       const _source = join([
         'content_translated.source_language',
         'content_translated.target_language',
@@ -80,16 +96,16 @@ export default {
   },
   computed: {
     ...mapState('document', ['showTranslatedContent']),
-    targetLanguage () {
+    targetLanguage() {
       if (this.showTranslatedContent) {
         return this.language
       }
       return null
     },
-    hasTranslations () {
+    hasTranslations() {
       return !!this.translation
     },
-    translation () {
+    translation() {
       return find(this.translations, { target_language: this.language })
     }
   }
@@ -97,22 +113,22 @@ export default {
 </script>
 
 <style lang="scss">
-  .document-translated-content {
-    &__translation {
-      box-shadow: 0 0 0 3px $translation-bg inset;
+.document-translated-content {
+  &__translation {
+    box-shadow: 0 0 0 3px $translation-bg inset;
 
-      .document-translated-content--original & {
-        box-shadow: none;
-
-        &__header {
-          background: transparent;
-        }
-      }
+    .document-translated-content--original & {
+      box-shadow: none;
 
       &__header {
-        background: $translation-bg;
-        color: rgba(darken($translation-bg, 70), 0.7);
+        background: transparent;
       }
     }
+
+    &__header {
+      background: $translation-bg;
+      color: rgba(darken($translation-bg, 70), 0.7);
+    }
   }
+}
 </style>

--- a/src/components/DocumentTypeCard.vue
+++ b/src/components/DocumentTypeCard.vue
@@ -4,7 +4,11 @@
     <div>
       <p class="m-0">
         {{ localizedDescription }}
-        <strong v-if="!document.hasStandardExtension" class="font-weight-bold" v-html="$t('search.nav.document.extensionWarning', { extension: document.standardExtension })"></strong>
+        <strong
+          v-if="!document.hasStandardExtension"
+          class="font-weight-bold"
+          v-html="$t('search.nav.document.extensionWarning', { extension: document.standardExtension })"
+        ></strong>
       </p>
       <p class="bg-warning mb-0 mt-2 p-2 text-dark" v-if="document.hasContentTypeWarning">
         <fa icon="exclamation-triangle" class="mr-1"></fa>
@@ -34,11 +38,11 @@ export default {
     DocumentThumbnail
   },
   computed: {
-    localizedDescription () {
+    localizedDescription() {
       const descriptions = this.document.contentTypeDescription
       return descriptions[this.$i18n.locale] || descriptions.en
     },
-    localizedContentTypeWarning () {
+    localizedContentTypeWarning() {
       const warnings = this.document.contentTypeWarning
       return warnings[this.$i18n.locale] || warnings.en
     }

--- a/src/components/DocumentTypeCard.vue
+++ b/src/components/DocumentTypeCard.vue
@@ -10,7 +10,7 @@
           v-html="$t('search.nav.document.extensionWarning', { extension: document.standardExtension })"
         ></strong>
       </p>
-      <p class="bg-warning mb-0 mt-2 p-2 text-dark" v-if="document.hasContentTypeWarning">
+      <p v-if="document.hasContentTypeWarning" class="bg-warning mb-0 mt-2 p-2 text-dark">
         <fa icon="exclamation-triangle" class="mr-1"></fa>
         {{ localizedContentTypeWarning }}
       </p>
@@ -26,6 +26,9 @@ import DocumentThumbnail from '@/components/DocumentThumbnail'
  */
 export default {
   name: 'DocumentTypeCard',
+  components: {
+    DocumentThumbnail
+  },
   props: {
     /**
      * The selected document.
@@ -33,9 +36,6 @@ export default {
     document: {
       type: Object
     }
-  },
-  components: {
-    DocumentThumbnail
   },
   computed: {
     localizedDescription() {

--- a/src/components/EllipseStatus.vue
+++ b/src/components/EllipseStatus.vue
@@ -150,7 +150,7 @@ export default {
       class="ellipse-status__badge mx-2 d-inline-flex"
       :class="{ 'ellipse-status__badge--has-error': hasError }"
     >
-      <b-badge v-b-modal:[errorModalId] v-if="hasError" :variant="statusAsVariant" class="p-0">
+      <b-badge v-if="hasError" v-b-modal:[errorModalId] :variant="statusAsVariant" class="p-0">
         <span class="d-inline-block p-1">
           {{ status }}
         </span>
@@ -165,7 +165,7 @@ export default {
         {{ status }}
       </b-badge>
     </span>
-    <b-modal body-class="ellipse-status__modal pb-0" hide-header ok-only :id="errorModalId" :size="errorModalSize">
+    <b-modal :id="errorModalId" body-class="ellipse-status__modal pb-0" hide-header ok-only :size="errorModalSize">
       <slot name="error" />
     </b-modal>
   </span>

--- a/src/components/EllipseStatus.vue
+++ b/src/components/EllipseStatus.vue
@@ -3,8 +3,8 @@ import { uniqueId } from 'lodash'
 import { toVariant, toVariantIcon, toVariantColor } from '@/utils/utils'
 
 /**
-   * Draw a badge depending on the status with an ellipse progress diagram.
-   */
+ * Draw a badge depending on the status with an ellipse progress diagram.
+ */
 export default {
   name: 'EllipseStatus',
   filters: {
@@ -14,103 +14,103 @@ export default {
   },
   props: {
     /**
-       * Status of the badge.
-       */
+     * Status of the badge.
+     */
     status: {
       type: String,
       default: 'warning'
     },
     /**
-       * Progress percentage. If none is specificed while the status is
-       * "running", the components passes to a "loading" state.
-       */
+     * Progress percentage. If none is specificed while the status is
+     * "running", the components passes to a "loading" state.
+     */
     progress: {
       type: Number,
       default: null
     },
     /**
-       * Dispaly the badge and the progress horizontaly.
-       */
+     * Dispaly the badge and the progress horizontaly.
+     */
     horizontal: {
       type: Boolean
     },
     /**
-       * Hide the badge (and show only the ellipse)
-       */
+     * Hide the badge (and show only the ellipse)
+     */
     noBadge: {
       type: Boolean
     },
     /**
-       * Default animation for "running" progress.
-       */
+     * Default animation for "running" progress.
+     */
     animation: {
       type: String,
       default: 'default 1000 0'
     },
     /**
-       * Size of the ellipse progress.
-       */
+     * Size of the ellipse progress.
+     */
     ellipseSize: {
       type: Number,
       default: 25
     },
     /**
-       * Thickness of the ellipse progress.
-       */
+     * Thickness of the ellipse progress.
+     */
     ellipseThickness: {
       type: Number,
       default: 2
     },
     /**
-       * Font size of the legend in the ellipse progress.
-       */
+     * Font size of the legend in the ellipse progress.
+     */
     ellipseSizeFontSize: {
       type: String,
       default: '0.5em'
     },
     /**
-       * Size of the error modal. Can be:  'sm', 'md', 'lg' (default), or 'xl'.
-       */
+     * Size of the error modal. Can be:  'sm', 'md', 'lg' (default), or 'xl'.
+     */
     errorModalSize: {
       type: String,
       default: 'lg',
-      validator: size => ['sm', 'md', 'lg', 'xl'].includes(size)
+      validator: (size) => ['sm', 'md', 'lg', 'xl'].includes(size)
     }
   },
   computed: {
-    emptyColor () {
+    emptyColor() {
       const style = getComputedStyle(document.body)
       return style.getPropertyValue('--light') || '#eee'
     },
-    statusAnimation () {
+    statusAnimation() {
       if (this.statusAsVariant === 'info') {
         return this.animation
       }
       return 'default 0 0'
     },
-    statusProgress () {
+    statusProgress() {
       if (this.statusAsVariant === 'info') {
         const rounded = Math.round(this.progress)
         return Math.max(Math.min(rounded, 100), 0)
       }
       return 100
     },
-    statusProgressAsPercentage () {
+    statusProgressAsPercentage() {
       return `${this.statusProgress}%`
     },
-    statusAsVariant () {
+    statusAsVariant() {
       return toVariant(this.status)
     },
-    loading () {
+    loading() {
       return this.statusAsVariant === 'info' && this.idle
     },
-    idle () {
+    idle() {
       return this.progress === null || this.progress <= 0 || this.progress >= 100
     },
-    hasError () {
+    hasError() {
       return 'error' in this.$slots
     },
-    errorModalId () {
+    errorModalId() {
       return uniqueId('ellipse-status-error-modal-')
     }
   }
@@ -129,25 +129,35 @@ export default {
       :color="status | toVariantColor"
       :empty-color="emptyColor"
       :animation="statusAnimation"
-      :loading="loading">
+      :loading="loading"
+    >
       <slot>
         <template v-if="statusAsVariant === 'info'">
           {{ statusProgressAsPercentage }}
         </template>
         <template v-else>
-          <fa class="ellipse-status__progress__icon"
-              fixed-width
-              :class="status | toVariant('dark', 'text-')"
-              :icon="status | toVariantIcon" />
+          <fa
+            class="ellipse-status__progress__icon"
+            fixed-width
+            :class="status | toVariant('dark', 'text-')"
+            :icon="status | toVariantIcon"
+          />
         </template>
       </slot>
     </vue-ellipse-progress>
-    <span v-if="!noBadge" class="ellipse-status__badge mx-2 d-inline-flex" :class="{ 'ellipse-status__badge--has-error': hasError }">
+    <span
+      v-if="!noBadge"
+      class="ellipse-status__badge mx-2 d-inline-flex"
+      :class="{ 'ellipse-status__badge--has-error': hasError }"
+    >
       <b-badge v-b-modal:[errorModalId] v-if="hasError" :variant="statusAsVariant" class="p-0">
         <span class="d-inline-block p-1">
           {{ status }}
         </span>
-        <span class="ellipse-status__badge__toggler bg-white d-inline-block p-1" :class="status | toVariant('dark', 'text-')">
+        <span
+          class="ellipse-status__badge__toggler bg-white d-inline-block p-1"
+          :class="status | toVariant('dark', 'text-')"
+        >
           <fa icon="external-link-alt" />
         </span>
       </b-badge>
@@ -155,41 +165,34 @@ export default {
         {{ status }}
       </b-badge>
     </span>
-    <b-modal body-class="ellipse-status__modal pb-0"
-             hide-header
-             ok-only
-             :id="errorModalId"
-             :size="errorModalSize">
+    <b-modal body-class="ellipse-status__modal pb-0" hide-header ok-only :id="errorModalId" :size="errorModalSize">
       <slot name="error" />
     </b-modal>
   </span>
 </template>
 
 <style lang="scss">
-  .ellipse-status {
+.ellipse-status {
+  &__progress {
+    position: relative;
 
-    &__progress {
-      position: relative;
-
-      &__icon {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%) scale(1.75);
-      }
+    &__icon {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%) scale(1.75);
     }
-
-    &__badge {
-
-      &--has-error {
-        cursor: pointer;
-      }
-
-      &__toggler {
-        box-shadow:0 0 0 1px currentColor inset;
-        border-radius: inherit;
-      }
-    }
-
   }
+
+  &__badge {
+    &--has-error {
+      cursor: pointer;
+    }
+
+    &__toggler {
+      box-shadow: 0 0 0 1px currentColor inset;
+      border-radius: inherit;
+    }
+  }
+}
 </style>

--- a/src/components/EmailString.vue
+++ b/src/components/EmailString.vue
@@ -2,18 +2,34 @@
   <component :is="tag" class="email-string">
     <span>
       {{ nameOrRawEmail }}
-      <b-popover :target="$el" triggers="hover focus" v-if="mounted" custom-class="email-string__popover" placement="bottom">
+      <b-popover
+        :target="$el"
+        triggers="hover focus"
+        v-if="mounted"
+        custom-class="email-string__popover"
+        placement="bottom"
+      >
         <template #title>
           <div class="pt-2">{{ nameWithoutEmail }}</div>
           <div class="text-muted small font-weight-normal py-2">{{ emailWithoutName || email }}</div>
         </template>
         <div class="text-right email-string__popover__content">
           <router-link :to="{ name: 'search', query: { q: qReceived, indices } }" class="btn btn-sm btn-primary">
-            <fa mask="square" icon="arrow-down" transform="shrink-3 up-2" class="email-string__popover__content__icon"></fa>
+            <fa
+              mask="square"
+              icon="arrow-down"
+              transform="shrink-3 up-2"
+              class="email-string__popover__content__icon"
+            ></fa>
             {{ $t('email.receivedLink') }}
           </router-link>
           <router-link :to="{ name: 'search', query: { q: qSent, indices } }" class="btn btn-sm btn-primary ml-1">
-            <fa mask="square" icon="arrow-up" transform="shrink-3 down-2" class="email-string__popover__content__icon"></fa>
+            <fa
+              mask="square"
+              icon="arrow-up"
+              transform="shrink-3 down-2"
+              class="email-string__popover__content__icon"
+            ></fa>
             {{ $t('email.sentLink') }}
           </router-link>
         </div>
@@ -47,34 +63,34 @@ export default {
       default: 'span'
     }
   },
-  data () {
+  data() {
     return {
       mounted: false
     }
   },
-  mounted () {
+  mounted() {
     this.$set(this, 'mounted', true)
   },
   computed: {
-    nameOrRawEmail () {
+    nameOrRawEmail() {
       return this.nameWithoutEmail || this.email
     },
-    nameWithoutEmail () {
+    nameWithoutEmail() {
       const matches = String(this.email).match(EMAIL_REGEX)
       return matches ? trim(matches[1]) : null
     },
-    emailWithoutName () {
+    emailWithoutName() {
       const matches = String(this.email).match(EMAIL_REGEX)
       return matches ? trim(matches[2]) : null
     },
-    indices () {
+    indices() {
       return this.$store.state.search.indices
     },
-    qReceived () {
+    qReceived() {
       const field = 'metadata.tika_metadata_message_to'
       return `${field}:"${this.emailWithoutName || this.email}"`
     },
-    qSent () {
+    qSent() {
       const field = 'metadata.tika_metadata_message_from'
       return `${field}:"${this.emailWithoutName || this.email}"`
     }
@@ -83,13 +99,11 @@ export default {
 </script>
 
 <style lang="scss">
-  .email-string {
-
-    &__popover {
-
-      &__content {
-        min-width: 250px;
-      }
+.email-string {
+  &__popover {
+    &__content {
+      min-width: 250px;
     }
   }
+}
 </style>

--- a/src/components/EmailString.vue
+++ b/src/components/EmailString.vue
@@ -3,9 +3,9 @@
     <span>
       {{ nameOrRawEmail }}
       <b-popover
+        v-if="mounted"
         :target="$el"
         triggers="hover focus"
-        v-if="mounted"
         custom-class="email-string__popover"
         placement="bottom"
       >
@@ -68,9 +68,6 @@ export default {
       mounted: false
     }
   },
-  mounted() {
-    this.$set(this, 'mounted', true)
-  },
   computed: {
     nameOrRawEmail() {
       return this.nameWithoutEmail || this.email
@@ -94,6 +91,9 @@ export default {
       const field = 'metadata.tika_metadata_message_from'
       return `${field}:"${this.emailWithoutName || this.email}"`
     }
+  },
+  mounted() {
+    this.$set(this, 'mounted', true)
   }
 }
 </script>

--- a/src/components/Extensions.vue
+++ b/src/components/Extensions.vue
@@ -18,17 +18,18 @@
                     <fa icon="link"></fa>
                   </span>
                 </div>
-                <b-form-input
-                  :state="isFormValid"
-                  placeholder="URL"
-                  type="url"
-                  v-model="url" />
+                <b-form-input :state="isFormValid" placeholder="URL" type="url" v-model="url" />
               </div>
               <div class="d-flex align-items-center">
                 <b-form-invalid-feedback class="text-secondary" :state="isFormValid">
                   {{ $t('global.enterCorrectUrl') }}
                 </b-form-invalid-feedback>
-                <b-btn variant="primary" class="ml-auto text-nowrap" @click="installExtensionFromUrl" :disabled="isFormValid !== true">
+                <b-btn
+                  variant="primary"
+                  class="ml-auto text-nowrap"
+                  @click="installExtensionFromUrl"
+                  :disabled="isFormValid !== true"
+                >
                   {{ $t('extensions.install') }}
                 </b-btn>
               </div>
@@ -36,11 +37,20 @@
           </b-modal>
         </div>
         <div class="extensions__search ml-auto">
-          <search-form-control :placeholder="$t('extensions.search')" v-model="searchTerm" @input="search"></search-form-control>
+          <search-form-control
+            :placeholder="$t('extensions.search')"
+            v-model="searchTerm"
+            @input="search"
+          ></search-form-control>
         </div>
       </div>
       <b-card-group deck>
-        <b-overlay :show="extension.show" v-for="extension in extensions" :key="extension.id" class="extensions__card m-3 d-flex">
+        <b-overlay
+          :show="extension.show"
+          v-for="extension in extensions"
+          :key="extension.id"
+          class="extensions__card m-3 d-flex"
+        >
           <b-card footer-border-variant="white" class="m-0">
             <b-card-text>
               <div class="d-flex">
@@ -53,36 +63,60 @@
                   </div>
                 </div>
                 <div class="d-flex flex-column text-nowrap pl-2">
-                  <b-btn class="extensions__card__uninstall-button mb-2" @click="uninstallExtension(extension.id)" v-if="extension.installed" variant="danger">
+                  <b-btn
+                    class="extensions__card__uninstall-button mb-2"
+                    @click="uninstallExtension(extension.id)"
+                    v-if="extension.installed"
+                    variant="danger"
+                  >
                     <fa icon="trash-alt"></fa>
                     {{ $t('extensions.uninstall') }}
                   </b-btn>
-                  <b-btn class="extensions__card__download-button mb-2" @click="installExtensionFromId(extension.id)" variant="primary" v-if="!extension.installed">
+                  <b-btn
+                    class="extensions__card__download-button mb-2"
+                    @click="installExtensionFromId(extension.id)"
+                    variant="primary"
+                    v-if="!extension.installed"
+                  >
                     <fa icon="cloud-download-alt"></fa>
                     {{ $t('extensions.install') }}
                   </b-btn>
-                  <b-btn class="extensions__card__update-button mb-2" @click="installExtensionFromId(extension.id)" variant="primary" v-if="extension.installed && isExtensionFromRegistry(extension) && extension.version !== extension.deliverableFromRegistry.version" size="sm">
+                  <b-btn
+                    class="extensions__card__update-button mb-2"
+                    @click="installExtensionFromId(extension.id)"
+                    variant="primary"
+                    v-if="
+                      extension.installed &&
+                      isExtensionFromRegistry(extension) &&
+                      extension.version !== extension.deliverableFromRegistry.version
+                    "
+                    size="sm"
+                  >
                     <fa icon="sync"></fa>
                     {{ $t('extensions.update') }}
                   </b-btn>
-                  <div v-if="extension.version && extension.installed" class="extensions__card__version text-muted text-center">
+                  <div
+                    v-if="extension.version && extension.installed"
+                    class="extensions__card__version text-muted text-center"
+                  >
                     {{ $t('extensions.version', { version: extension.version }) }}
                   </div>
                 </div>
               </div>
             </b-card-text>
-            <template v-slot:footer v-if="isExtensionFromRegistry(extension)">
+            <template #footer v-if="isExtensionFromRegistry(extension)">
               <div class="extensions__card__official-version text-truncate w-100">
-                <span class="font-weight-bold">
-                  {{ $t('extensions.officialVersion') }}:
-                </span>
+                <span class="font-weight-bold"> {{ $t('extensions.officialVersion') }}: </span>
                 {{ extension.deliverableFromRegistry.version }}
               </div>
               <div class="text-truncate w-100">
-                <span class="font-weight-bold">
-                  {{ $t('extensions.homePage') }}:
-                </span>
-                <a class="extensions__card__homepage" :href="extension.deliverableFromRegistry.homepage" target="_blank" v-if="extension.deliverableFromRegistry.homepage">
+                <span class="font-weight-bold"> {{ $t('extensions.homePage') }}: </span>
+                <a
+                  class="extensions__card__homepage"
+                  :href="extension.deliverableFromRegistry.homepage"
+                  target="_blank"
+                  v-if="extension.deliverableFromRegistry.homepage"
+                >
                   {{ extension.deliverableFromRegistry.homepage }}
                 </a>
               </div>
@@ -108,7 +142,7 @@ export default {
   components: {
     SearchFormControl
   },
-  data () {
+  data() {
     return {
       extensions: [],
       searchTerm: '',
@@ -116,7 +150,7 @@ export default {
       url: ''
     }
   },
-  mounted () {
+  mounted() {
     this.search()
   },
   filters: {
@@ -124,21 +158,25 @@ export default {
     startCase
   },
   methods: {
-    isExtensionFromRegistry (extension) {
+    isExtensionFromRegistry(extension) {
       return get(extension, 'deliverableFromRegistry', false)
     },
-    getExtensionName (extension) {
+    getExtensionName(extension) {
       return this.isExtensionFromRegistry(extension) ? extension.deliverableFromRegistry.name : extension.name
     },
-    getExtensionDescription (extension) {
-      return this.isExtensionFromRegistry(extension) ? extension.deliverableFromRegistry.description : extension.description
+    getExtensionDescription(extension) {
+      return this.isExtensionFromRegistry(extension)
+        ? extension.deliverableFromRegistry.description
+        : extension.description
     },
-    async search () {
+    async search() {
       const extensions = await this.$core.api.getExtensions(this.searchTerm)
-      map(extensions, extension => { extension.show = false })
+      map(extensions, (extension) => {
+        extension.show = false
+      })
       this.$set(this, 'extensions', extensions)
     },
-    async installExtensionFromId (extensionId) {
+    async installExtensionFromId(extensionId) {
       const extension = find(this.extensions, { id: extensionId })
       extension.show = true
       try {
@@ -150,7 +188,7 @@ export default {
       }
       extension.show = false
     },
-    async installExtensionFromUrl () {
+    async installExtensionFromUrl() {
       this.$set(this, 'isInstallingFromUrl', true)
       try {
         await this.$core.api.installExtensionFromUrl(this.url)
@@ -163,7 +201,7 @@ export default {
       this.$set(this, 'isInstallingFromUrl', false)
       this.$set(this, 'url', '')
     },
-    async uninstallExtension (extensionId) {
+    async uninstallExtension(extensionId) {
       const extension = find(this.extensions, { id: extensionId })
       extension.show = true
       try {
@@ -177,7 +215,7 @@ export default {
     }
   },
   computed: {
-    isFormValid () {
+    isFormValid() {
       return this.url === '' ? null : isUrl(this.url)
     }
   }

--- a/src/components/Extensions.vue
+++ b/src/components/Extensions.vue
@@ -18,7 +18,7 @@
                     <fa icon="link"></fa>
                   </span>
                 </div>
-                <b-form-input :state="isFormValid" placeholder="URL" type="url" v-model="url" />
+                <b-form-input v-model="url" :state="isFormValid" placeholder="URL" type="url" />
               </div>
               <div class="d-flex align-items-center">
                 <b-form-invalid-feedback class="text-secondary" :state="isFormValid">
@@ -27,8 +27,8 @@
                 <b-btn
                   variant="primary"
                   class="ml-auto text-nowrap"
-                  @click="installExtensionFromUrl"
                   :disabled="isFormValid !== true"
+                  @click="installExtensionFromUrl"
                 >
                   {{ $t('extensions.install') }}
                 </b-btn>
@@ -38,17 +38,17 @@
         </div>
         <div class="extensions__search ml-auto">
           <search-form-control
-            :placeholder="$t('extensions.search')"
             v-model="searchTerm"
+            :placeholder="$t('extensions.search')"
             @input="search"
           ></search-form-control>
         </div>
       </div>
       <b-card-group deck>
         <b-overlay
-          :show="extension.show"
           v-for="extension in extensions"
           :key="extension.id"
+          :show="extension.show"
           class="extensions__card m-3 d-flex"
         >
           <b-card footer-border-variant="white" class="m-0">
@@ -64,33 +64,33 @@
                 </div>
                 <div class="d-flex flex-column text-nowrap pl-2">
                   <b-btn
-                    class="extensions__card__uninstall-button mb-2"
-                    @click="uninstallExtension(extension.id)"
                     v-if="extension.installed"
+                    class="extensions__card__uninstall-button mb-2"
                     variant="danger"
+                    @click="uninstallExtension(extension.id)"
                   >
                     <fa icon="trash-alt"></fa>
                     {{ $t('extensions.uninstall') }}
                   </b-btn>
                   <b-btn
-                    class="extensions__card__download-button mb-2"
-                    @click="installExtensionFromId(extension.id)"
-                    variant="primary"
                     v-if="!extension.installed"
+                    class="extensions__card__download-button mb-2"
+                    variant="primary"
+                    @click="installExtensionFromId(extension.id)"
                   >
                     <fa icon="cloud-download-alt"></fa>
                     {{ $t('extensions.install') }}
                   </b-btn>
                   <b-btn
-                    class="extensions__card__update-button mb-2"
-                    @click="installExtensionFromId(extension.id)"
-                    variant="primary"
                     v-if="
                       extension.installed &&
                       isExtensionFromRegistry(extension) &&
                       extension.version !== extension.deliverableFromRegistry.version
                     "
+                    class="extensions__card__update-button mb-2"
+                    variant="primary"
                     size="sm"
+                    @click="installExtensionFromId(extension.id)"
                   >
                     <fa icon="sync"></fa>
                     {{ $t('extensions.update') }}
@@ -104,7 +104,7 @@
                 </div>
               </div>
             </b-card-text>
-            <template #footer v-if="isExtensionFromRegistry(extension)">
+            <template v-if="isExtensionFromRegistry(extension)" #footer>
               <div class="extensions__card__official-version text-truncate w-100">
                 <span class="font-weight-bold"> {{ $t('extensions.officialVersion') }}: </span>
                 {{ extension.deliverableFromRegistry.version }}
@@ -112,10 +112,10 @@
               <div class="text-truncate w-100">
                 <span class="font-weight-bold"> {{ $t('extensions.homePage') }}: </span>
                 <a
+                  v-if="extension.deliverableFromRegistry.homepage"
                   class="extensions__card__homepage"
                   :href="extension.deliverableFromRegistry.homepage"
                   target="_blank"
-                  v-if="extension.deliverableFromRegistry.homepage"
                 >
                   {{ extension.deliverableFromRegistry.homepage }}
                 </a>
@@ -142,6 +142,10 @@ export default {
   components: {
     SearchFormControl
   },
+  filters: {
+    camelCase,
+    startCase
+  },
   data() {
     return {
       extensions: [],
@@ -150,12 +154,13 @@ export default {
       url: ''
     }
   },
+  computed: {
+    isFormValid() {
+      return this.url === '' ? null : isUrl(this.url)
+    }
+  },
   mounted() {
     this.search()
-  },
-  filters: {
-    camelCase,
-    startCase
   },
   methods: {
     isExtensionFromRegistry(extension) {
@@ -212,11 +217,6 @@ export default {
         this.$bvToast.toast(this.$t('extensions.deleteError'), { noCloseButton: true, variant: 'danger' })
       }
       extension.show = false
-    }
-  },
-  computed: {
-    isFormValid() {
-      return this.url === '' ? null : isUrl(this.url)
     }
   }
 }

--- a/src/components/ExtractingForm.vue
+++ b/src/components/ExtractingForm.vue
@@ -79,7 +79,7 @@ export default {
       default: noop
     }
   },
-  data () {
+  data() {
     return {
       disabled: false
     }
@@ -88,7 +88,7 @@ export default {
     ...mapFields(['form.filter', 'form.ocr', 'form.path', 'form.language'])
   },
   methods: {
-    async submitExtract () {
+    async submitExtract() {
       this.disabled = true
       try {
         await this.$store.dispatch('indexing/submitExtract')
@@ -102,8 +102,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .extracting-form {
-    background: darken($primary, 20);
-    color: white;
-  }
+.extracting-form {
+  background: darken($primary, 20);
+  color: white;
+}
 </style>

--- a/src/components/ExtractingForm.vue
+++ b/src/components/ExtractingForm.vue
@@ -5,7 +5,7 @@
       <div class="ml-4 pl-3">
         <p class="font-weight-bold mb-0">Which folder do you want to index?</p>
         <p class="small mb-2">The entire Datashare folder will be indexed by default.</p>
-        <inline-directory-picker hide-folder-icon dark v-model="path" />
+        <inline-directory-picker v-model="path" hide-folder-icon dark />
       </div>
     </div>
     <div class="extracting-form__group mb-4">

--- a/src/components/ExtractingLanguageFormControl.vue
+++ b/src/components/ExtractingLanguageFormControl.vue
@@ -27,17 +27,17 @@ export default {
       type: Boolean
     }
   },
-  data () {
+  data() {
     return {
       textLanguages: [],
       ocrLanguages: []
     }
   },
-  async mounted () {
+  async mounted() {
     await this.loadLanguages()
   },
   methods: {
-    async loadLanguages () {
+    async loadLanguages() {
       this.$wait.start(this.waitIdentifier)
       this.textLanguages = await this.$core.api.textLanguages()
       this.ocrLanguages = await this.$core.api.ocrLanguages()
@@ -45,27 +45,27 @@ export default {
     }
   },
   computed: {
-    nullOption () {
+    nullOption() {
       return { value: null, text: this.$t('extractingLanguageFormControl.nullOption') }
     },
-    options () {
-      return this.textLanguages.map(language => {
+    options() {
+      return this.textLanguages.map((language) => {
         return { value: language.iso6392, text: this.$t(`filter.lang.${language.name}`) }
       })
     },
-    waitIdentifier () {
+    waitIdentifier() {
       return uniqueId('extracting-language-form-control-')
     },
-    isReady () {
+    isReady() {
       return !this.$wait.is(this.waitIdentifier)
     },
-    overlayVariant () {
+    overlayVariant() {
       return this.dark ? 'dark' : 'light'
     },
-    isOcrLanguageAvailable () {
+    isOcrLanguageAvailable() {
       return !!find(this.ocrLanguages, { iso6392: this.value })
     },
-    showOcrWarning () {
+    showOcrWarning() {
       return this.ocrWarning && this.value && !this.isOcrLanguageAvailable
     }
   }
@@ -74,7 +74,7 @@ export default {
 
 <template>
   <b-overlay rounded :show="!isReady" :variant="overlayVariant" spinner-small>
-    <b-form-select :value="value" @input="newValue => $emit('input', newValue)" :options="[nullOption, ...options]" />
+    <b-form-select :value="value" @input="(newValue) => $emit('input', newValue)" :options="[nullOption, ...options]" />
     <b-collapse :visible="showOcrWarning">
       <b-alert show variant="warning" class="mt-3" v-html="$t('extractingLanguageFormControl.ocrWarning')" />
     </b-collapse>

--- a/src/components/ExtractingLanguageFormControl.vue
+++ b/src/components/ExtractingLanguageFormControl.vue
@@ -33,17 +33,6 @@ export default {
       ocrLanguages: []
     }
   },
-  async mounted() {
-    await this.loadLanguages()
-  },
-  methods: {
-    async loadLanguages() {
-      this.$wait.start(this.waitIdentifier)
-      this.textLanguages = await this.$core.api.textLanguages()
-      this.ocrLanguages = await this.$core.api.ocrLanguages()
-      this.$wait.end(this.waitIdentifier)
-    }
-  },
   computed: {
     nullOption() {
       return { value: null, text: this.$t('extractingLanguageFormControl.nullOption') }
@@ -68,13 +57,24 @@ export default {
     showOcrWarning() {
       return this.ocrWarning && this.value && !this.isOcrLanguageAvailable
     }
+  },
+  async mounted() {
+    await this.loadLanguages()
+  },
+  methods: {
+    async loadLanguages() {
+      this.$wait.start(this.waitIdentifier)
+      this.textLanguages = await this.$core.api.textLanguages()
+      this.ocrLanguages = await this.$core.api.ocrLanguages()
+      this.$wait.end(this.waitIdentifier)
+    }
   }
 }
 </script>
 
 <template>
   <b-overlay rounded :show="!isReady" :variant="overlayVariant" spinner-small>
-    <b-form-select :value="value" @input="(newValue) => $emit('input', newValue)" :options="[nullOption, ...options]" />
+    <b-form-select :value="value" :options="[nullOption, ...options]" @input="(newValue) => $emit('input', newValue)" />
     <b-collapse :visible="showOcrWarning">
       <b-alert show variant="warning" class="mt-3" v-html="$t('extractingLanguageFormControl.ocrWarning')" />
     </b-collapse>

--- a/src/components/FiltersPanel.vue
+++ b/src/components/FiltersPanel.vue
@@ -83,12 +83,6 @@ export default {
       query: null
     }
   },
-  mounted() {
-    this.$root.$on('filter::async-search', this.openFilterSearch)
-    this.$root.$on('filter::add-filter-values', this.setFilterValue)
-    this.$root.$on('filter::search::reset-filters', this.resetFilterValues)
-    this.$root.$on('index::delete::all', this.refreshEachFilter)
-  },
   computed: {
     ...mapState('search', ['showFilters']),
     filters: {
@@ -97,6 +91,12 @@ export default {
         return this.$store.getters['search/instantiatedFilters']
       }
     }
+  },
+  mounted() {
+    this.$root.$on('filter::async-search', this.openFilterSearch)
+    this.$root.$on('filter::add-filter-values', this.setFilterValue)
+    this.$root.$on('filter::search::reset-filters', this.resetFilterValues)
+    this.$root.$on('index::delete::all', this.refreshEachFilter)
   },
   methods: {
     openFilterSearch(expandedFilter, query) {

--- a/src/components/FiltersPanel.vue
+++ b/src/components/FiltersPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="filters-panel" v-show="showFilters">
+  <div v-show="showFilters" class="filters-panel">
     <div class="filters-panel__sticky w-100">
       <hook name="filters-panel:before"></hook>
       <div class="filters-panel__sticky__toolbar">
@@ -9,10 +9,10 @@
             {{ $t('search.filtersTitle') }}
           </h5>
           <button
-            class="filters-panel__sticky__toolbar__toggler btn btn-link"
-            @click="hideFilters"
-            :title="$t('search.hideFilters')"
             v-b-tooltip
+            class="filters-panel__sticky__toolbar__toggler btn btn-link"
+            :title="$t('search.hideFilters')"
+            @click="hideFilters"
           >
             <fa icon="arrow-left" class="text-light"></fa>
             <span class="sr-only">
@@ -25,19 +25,19 @@
       <hook name="filters-panel.filters:before"></hook>
       <filter-project></filter-project>
       <component
+        :is="filter.component"
         v-for="filter in filters"
         :ref="filter.name"
         :key="filter.name"
-        :is="filter.component"
         v-bind="{ filter }"
       ></component>
       <hook name="filters-panel.filters:after"></hook>
       <hook name="filters-panel:after"></hook>
     </div>
     <b-modal
+      ref="openFilterSearch"
       hide-footer
       lazy
-      ref="openFilterSearch"
       :title="expandedFilter ? $t('filter.' + expandedFilter.name) : null"
     >
       <filter-search v-if="expandedFilter" :filter="expandedFilter" :model-query="query"></filter-search>
@@ -77,17 +77,17 @@ export default {
     FilterStarred,
     Hook
   },
-  mounted() {
-    this.$root.$on('filter::async-search', this.openFilterSearch)
-    this.$root.$on('filter::add-filter-values', this.setFilterValue)
-    this.$root.$on('filter::search::reset-filters', this.resetFilterValues)
-    this.$root.$on('index::delete::all', this.refreshEachFilter)
-  },
   data() {
     return {
       expandedFilter: null,
       query: null
     }
+  },
+  mounted() {
+    this.$root.$on('filter::async-search', this.openFilterSearch)
+    this.$root.$on('filter::add-filter-values', this.setFilterValue)
+    this.$root.$on('filter::search::reset-filters', this.resetFilterValues)
+    this.$root.$on('index::delete::all', this.refreshEachFilter)
   },
   computed: {
     ...mapState('search', ['showFilters']),

--- a/src/components/FiltersPanel.vue
+++ b/src/components/FiltersPanel.vue
@@ -8,7 +8,12 @@
           <h5 class="flex-grow-1 my-0 h6 text-uppercase text-muted">
             {{ $t('search.filtersTitle') }}
           </h5>
-          <button class="filters-panel__sticky__toolbar__toggler btn btn-link" @click="hideFilters" :title="$t('search.hideFilters')" v-b-tooltip>
+          <button
+            class="filters-panel__sticky__toolbar__toggler btn btn-link"
+            @click="hideFilters"
+            :title="$t('search.hideFilters')"
+            v-b-tooltip
+          >
             <fa icon="arrow-left" class="text-light"></fa>
             <span class="sr-only">
               {{ $t('search.hideFilters') }}
@@ -19,11 +24,22 @@
       </div>
       <hook name="filters-panel.filters:before"></hook>
       <filter-project></filter-project>
-      <component v-for="filter in filters" :ref="filter.name" :key="filter.name" :is="filter.component" v-bind="{ filter }"></component>
+      <component
+        v-for="filter in filters"
+        :ref="filter.name"
+        :key="filter.name"
+        :is="filter.component"
+        v-bind="{ filter }"
+      ></component>
       <hook name="filters-panel.filters:after"></hook>
       <hook name="filters-panel:after"></hook>
     </div>
-    <b-modal hide-footer lazy ref="openFilterSearch" :title="expandedFilter ? $t('filter.' + expandedFilter.name) : null">
+    <b-modal
+      hide-footer
+      lazy
+      ref="openFilterSearch"
+      :title="expandedFilter ? $t('filter.' + expandedFilter.name) : null"
+    >
       <filter-search v-if="expandedFilter" :filter="expandedFilter" :model-query="query"></filter-search>
     </b-modal>
   </div>
@@ -61,13 +77,13 @@ export default {
     FilterStarred,
     Hook
   },
-  mounted () {
+  mounted() {
     this.$root.$on('filter::async-search', this.openFilterSearch)
     this.$root.$on('filter::add-filter-values', this.setFilterValue)
     this.$root.$on('filter::search::reset-filters', this.resetFilterValues)
     this.$root.$on('index::delete::all', this.refreshEachFilter)
   },
-  data () {
+  data() {
     return {
       expandedFilter: null,
       query: null
@@ -77,30 +93,30 @@ export default {
     ...mapState('search', ['showFilters']),
     filters: {
       cache: false,
-      get () {
+      get() {
         return this.$store.getters['search/instantiatedFilters']
       }
     }
   },
   methods: {
-    openFilterSearch (expandedFilter, query) {
+    openFilterSearch(expandedFilter, query) {
       if (this.$refs.openFilterSearch) {
         this.$set(this, 'expandedFilter', expandedFilter)
         this.$set(this, 'query', query)
         this.$refs.openFilterSearch.show()
       }
     },
-    setFilterValue ({ name }, value) {
+    setFilterValue({ name }, value) {
       this.$store.commit('search/setFilterValue', { name, value })
     },
-    hideFilters () {
+    hideFilters() {
       this.$store.commit('search/toggleFilters')
     },
-    isFilterComponent (component) {
+    isFilterComponent(component) {
       return isArray(component) && !!get(component, '0.root', false)
     },
-    resetFilterValues (refresh = true) {
-      Object.values(this.$refs).forEach(component => {
+    resetFilterValues(refresh = true) {
+      Object.values(this.$refs).forEach((component) => {
         if (this.isFilterComponent(component)) {
           const filter = component[0]
           filter.root.query = ''
@@ -111,8 +127,8 @@ export default {
         }
       })
     },
-    refreshEachFilter () {
-      Object.values(this.$refs).forEach(component => {
+    refreshEachFilter() {
+      Object.values(this.$refs).forEach((component) => {
         if (this.isFilterComponent(component)) {
           component[0].root.aggregateWithLoading()
         }
@@ -124,66 +140,66 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @use "sass:math";
+@use 'sass:math';
 
-  .filters-panel {
-    $card-bg: darken($app-context-sidebar-bg, 5%);
-    $panel-color: $app-sidebar-color;
+.filters-panel {
+  $card-bg: darken($app-context-sidebar-bg, 5%);
+  $panel-color: $app-sidebar-color;
 
-    align-items: flex-start;
-    background: $app-context-sidebar-bg;
-    color: $panel-color;
-    display: flex;
-    min-height: 100vh;
-    padding-bottom: $spacer;
-    padding-right: $spacer;
+  align-items: flex-start;
+  background: $app-context-sidebar-bg;
+  color: $panel-color;
+  display: flex;
+  min-height: 100vh;
+  padding-bottom: $spacer;
+  padding-right: $spacer;
 
-    &__sticky {
-      width: 100%;
+  &__sticky {
+    width: 100%;
 
-      &__toolbar {
-        font-size: $font-size-sm;
-        line-height: $line-height-base * 1 - math.div(85 - 95, 95);
-        padding: $spacer 0 0 $spacer;
+    &__toolbar {
+      font-size: $font-size-sm;
+      line-height: $line-height-base * 1 - math.div(85 - 95, 95);
+      padding: $spacer 0 0 $spacer;
 
-        .custom-control-input:checked ~ .custom-control-label::before {
-          background-color: $tertiary;
-          border-color: $tertiary;
+      .custom-control-input:checked ~ .custom-control-label::before {
+        background-color: $tertiary;
+        border-color: $tertiary;
+      }
+    }
+
+    &:deep(.card) {
+      background: $card-bg;
+      border-width: 0;
+      color: $panel-color;
+      margin: $spacer 0 0 $spacer;
+
+      .card-header {
+        background: inherit;
+        border-radius: $card-border-radius;
+        border-width: 0;
+        color: rgba($panel-color, 0.6);
+        position: relative;
+        z-index: 10;
+
+        & > h6 {
+          background: transparent;
+          color: rgba($panel-color, 0.6);
+          cursor: pointer;
+          font-size: 0.9rem;
+          font-weight: bolder;
+          margin-bottom: 0;
+          padding-top: $spacer * 0.25;
         }
       }
 
-      &:deep(.card) {
-        background: $card-bg;
-        border-width: 0;
+      & > .list-group,
+      & > .card-body {
         color: $panel-color;
-        margin: $spacer 0 0 $spacer;
-
-        .card-header {
-          background: inherit;
-          border-radius: $card-border-radius;
-          border-width: 0;
-          color: rgba($panel-color, 0.6);
-          position: relative;
-          z-index: 10;
-
-          & > h6 {
-            background: transparent;
-            color: rgba($panel-color, 0.6);
-            cursor: pointer;
-            font-size: 0.9rem;
-            font-weight: bolder;
-            margin-bottom: 0;
-            padding-top: $spacer * .25;
-          }
-        }
-
-        & > .list-group,
-        & > .card-body {
-          color: $panel-color;
-          font-size: 0.8rem;
-          padding:0;
-        }
+        font-size: 0.8rem;
+        padding: 0;
       }
     }
   }
+}
 </style>

--- a/src/components/FindNamedEntitiesForm.vue
+++ b/src/components/FindNamedEntitiesForm.vue
@@ -1,6 +1,6 @@
 <template>
   <v-wait for="load ner pipelines">
-    <fa icon="circle-notch" slot="waiting" spin size="2x" class="d-flex mx-auto my-5 text-light" />
+    <fa slot="waiting" icon="circle-notch" spin size="2x" class="d-flex mx-auto my-5 text-light" />
     <form class="find-named-entities-form position-relative" @submit.prevent="submitFindNamedEntities">
       <fa icon="tags" class="position-absolute mt-1 ml-1" size="lg" />
       <div class="ml-4 pl-3">
@@ -13,13 +13,13 @@
           </p>
           <fieldset class="list-group">
             <div
-              class="list-group-item bg-transparent border-light"
               v-for="(translationReference, pip) in pipelines"
               :key="pip"
+              class="list-group-item bg-transparent border-light"
             >
-              <b-form-radio name="pipeline" v-model="pipeline" :value="pip">
+              <b-form-radio v-model="pipeline" name="pipeline" :value="pip">
                 {{ $t(`${translationReference}`) }}
-                <div class="font-italic small" v-if="pip === 'corenlp'">
+                <div v-if="pip === 'corenlp'" class="font-italic small">
                   {{ $t('indexing.default') }}
                 </div>
               </b-form-radio>
@@ -27,7 +27,7 @@
           </fieldset>
         </div>
       </div>
-      <div class="find-named-entities-form__offline form-group" v-if="$config.is('manageDocuments')">
+      <div v-if="$config.is('manageDocuments')" class="find-named-entities-form__offline form-group">
         <b-form-checkbox v-model="offline" switch>
           <div class="font-weight-bold ml-1">
             {{ $t('indexing.syncModelsLabel') }}
@@ -64,6 +64,10 @@ const { mapFields } = createHelpers({
  */
 export default {
   name: 'FindNamedEntitiesForm',
+  filters: {
+    lowerCase,
+    startCase
+  },
   mixins: [utils],
   props: {
     /**
@@ -74,10 +78,6 @@ export default {
       default: noop
     }
   },
-  filters: {
-    lowerCase,
-    startCase
-  },
   data() {
     return {
       pipelines: [],
@@ -86,6 +86,13 @@ export default {
   },
   computed: {
     ...mapFields(['form.offline', 'form.pipeline'])
+  },
+  async mounted() {
+    this.$wait.start('load ner pipelines')
+    let pipelines = await this.$store.dispatch('indexing/getNerPipelines')
+    pipelines = map(pipelines, lowerCase)
+    this.$set(this, 'pipelines', this.handlePipelinesTranslation(pipelines))
+    this.$wait.end('load ner pipelines')
   },
   methods: {
     async submitFindNamedEntities() {
@@ -104,13 +111,6 @@ export default {
       })
       return translationsMap
     }
-  },
-  async mounted() {
-    this.$wait.start('load ner pipelines')
-    let pipelines = await this.$store.dispatch('indexing/getNerPipelines')
-    pipelines = map(pipelines, lowerCase)
-    this.$set(this, 'pipelines', this.handlePipelinesTranslation(pipelines))
-    this.$wait.end('load ner pipelines')
   }
 }
 </script>

--- a/src/components/FindNamedEntitiesForm.vue
+++ b/src/components/FindNamedEntitiesForm.vue
@@ -12,12 +12,12 @@
             {{ $t('indexing.findNamedEntitiesSubheader') }}
           </p>
           <fieldset class="list-group">
-            <div class="list-group-item bg-transparent border-light"
-                            v-for="(translationReference, pip) in pipelines"
-                            :key="pip">
-              <b-form-radio name="pipeline"
-                            v-model="pipeline"
-                            :value="pip">
+            <div
+              class="list-group-item bg-transparent border-light"
+              v-for="(translationReference, pip) in pipelines"
+              :key="pip"
+            >
+              <b-form-radio name="pipeline" v-model="pipeline" :value="pip">
                 {{ $t(`${translationReference}`) }}
                 <div class="font-italic small" v-if="pip === 'corenlp'">
                   {{ $t('indexing.default') }}
@@ -78,20 +78,17 @@ export default {
     lowerCase,
     startCase
   },
-  data () {
+  data() {
     return {
       pipelines: [],
       disabled: false
     }
   },
   computed: {
-    ...mapFields([
-      'form.offline',
-      'form.pipeline'
-    ])
+    ...mapFields(['form.offline', 'form.pipeline'])
   },
   methods: {
-    async submitFindNamedEntities () {
+    async submitFindNamedEntities() {
       this.disabled = true
       try {
         await this.$store.dispatch('indexing/submitFindNamedEntities')
@@ -100,7 +97,7 @@ export default {
         this.finally()
       }
     },
-    handlePipelinesTranslation (pipelines) {
+    handlePipelinesTranslation(pipelines) {
       const translationsMap = {}
       pipelines.forEach((pip) => {
         translationsMap[pip] = `indexing.pipelineOptions.${pip}`
@@ -108,7 +105,7 @@ export default {
       return translationsMap
     }
   },
-  async mounted () {
+  async mounted() {
     this.$wait.start('load ner pipelines')
     let pipelines = await this.$store.dispatch('indexing/getNerPipelines')
     pipelines = map(pipelines, lowerCase)
@@ -116,21 +113,20 @@ export default {
     this.$wait.end('load ner pipelines')
   }
 }
-
 </script>
 
 <style lang="scss" scoped>
-  .find-named-entities-form {
-    background: darken($primary, 20);
-    color: white;
+.find-named-entities-form {
+  background: darken($primary, 20);
+  color: white;
 
-    &__header h4 {
-      font-size: 1.2em;
-      font-weight: bolder;
-    }
-
-    &__subheader {
-      font-style: italic;
-    }
+  &__header h4 {
+    font-size: 1.2em;
+    font-weight: bolder;
   }
+
+  &__subheader {
+    font-style: italic;
+  }
+}
 </style>

--- a/src/components/Hook.vue
+++ b/src/components/Hook.vue
@@ -27,27 +27,27 @@ export default {
     }
   },
   functional: true,
-  render (createElement, context) {
-    function filterHookedComponentsByTarget (targetName) {
+  render(createElement, context) {
+    function filterHookedComponentsByTarget(targetName) {
       const { $store } = context.parent
       return $store.getters['hooks/filterHookedComponentsByTarget'](targetName)
     }
 
-    function hookedComponents () {
+    function hookedComponents() {
       return filterHookedComponentsByTarget(context.props.name)
     }
 
-    function renderedComponents () {
+    function renderedComponents() {
       return hookedComponents().map(({ component }) => {
         return createElement(component, { props: context.props.bind })
       })
     }
 
-    function isDebug () {
+    function isDebug() {
       return context.parent.$config.is('hooksDebug')
     }
 
-    function debugTag () {
+    function debugTag() {
       return createElement(context.props.debugTag, {
         class: ['hook-debug'],
         attrs: {
@@ -57,7 +57,7 @@ export default {
       })
     }
 
-    function renderedComponentsWithDebug () {
+    function renderedComponentsWithDebug() {
       return [debugTag(), ...renderedComponents()]
     }
 
@@ -68,21 +68,21 @@ export default {
 </script>
 
 <style lang="scss">
-  .hook-debug {
-    position: relative;
-    white-space: nowrap;
-    height: 0;
-    width: 0;
+.hook-debug {
+  position: relative;
+  white-space: nowrap;
+  height: 0;
+  width: 0;
 
-    &:before {
-      content: attr(aria-hook) " → " attr(aria-count);
-      font-size: 0.8rem;
-      font-weight: bold;
-      color: $tertiary;
-      text-shadow: 0 0 0.5em black;
-      background: rgba(black, .7);
-      font-family: $font-family-monospace;
-      padding: 0.1em 0.3em;
-    }
+  &:before {
+    content: attr(aria-hook) ' → ' attr(aria-count);
+    font-size: 0.8rem;
+    font-weight: bold;
+    color: $tertiary;
+    text-shadow: 0 0 0.5em black;
+    background: rgba(black, 0.7);
+    font-family: $font-family-monospace;
+    padding: 0.1em 0.3em;
   }
+}
 </style>

--- a/src/components/Hook.vue
+++ b/src/components/Hook.vue
@@ -4,6 +4,7 @@
  */
 export default {
   name: 'Hook',
+  functional: true,
   props: {
     /**
      * Name of the hook (targeted by plugins).
@@ -26,7 +27,6 @@ export default {
       default: () => {}
     }
   },
-  functional: true,
   render(createElement, context) {
     function filterHookedComponentsByTarget(targetName) {
       const { $store } = context.parent

--- a/src/components/InlineDirectoryPicker.vue
+++ b/src/components/InlineDirectoryPicker.vue
@@ -114,22 +114,22 @@ export default {
   <div class="inline-directory-picker border rounded" :class="{ 'inline-directory-picker--dark': dark }">
     <b-overlay rounded :show="!isReady" :variant="overlayVariant" spinner-small>
       <div class="inline-directory-picker__header d-flex align-items-center p-2">
-        <fa class="inline-directory-picker__header__icon mr-3" icon="folder" fixed-width v-if="!hideFolderIcon" />
+        <fa v-if="!hideFolderIcon" class="inline-directory-picker__header__icon mr-3" icon="folder" fixed-width />
         <active-text-truncate
+          :key="directories.length"
           class="inline-directory-picker__header__list mr-1"
           direction="rtl"
-          :key="directories.length"
         >
           <div
-            class="inline-directory-picker__header__list__item"
             v-for="(directory, i) in directories"
             :key="directory"
+            class="inline-directory-picker__header__list__item"
             @click="selectAndBrowse(i)"
           >
             <b-btn
+              v-b-tooltip="{ delay: { show: 1e3, hide: 0 }, customClass: 'tooltip-lg' }"
               class="p-0"
               variant="link"
-              v-b-tooltip="{ delay: { show: 1e3, hide: 0 }, customClass: 'tooltip-lg' }"
               :title="directoryTitle(i)"
             >
               {{ basename(directory) }}

--- a/src/components/InlineDirectoryPicker.vue
+++ b/src/components/InlineDirectoryPicker.vue
@@ -18,7 +18,7 @@ export default {
       type: Boolean
     }
   },
-  data () {
+  data() {
     return {
       browse: false,
       browsingPath: null,
@@ -26,73 +26,78 @@ export default {
     }
   },
   computed: {
-    cannonicalDataDir () {
+    cannonicalDataDir() {
       return trimEnd(this.dataDir, '/')
     },
-    dataDir () {
+    dataDir() {
       return this.$config.get('dataDir')
     },
-    browsingTreeDirectories () {
+    browsingTreeDirectories() {
       return filter(get(this.browsingTree, 'contents', []), { type: 'directory' })
     },
-    directories () {
+    directories() {
       if (!this.path) {
         return ['Home']
       }
       return compact(['Home', ...this.pathWithoutDataDir.split('/')])
     },
-    pathWithoutDataDir () {
+    pathWithoutDataDir() {
       return trim(this.path.split(this.dataDir).pop(), '/')
     },
-    waitIdentifier () {
+    waitIdentifier() {
       return uniqueId('inline-directory-picker-')
     },
-    isReady () {
+    isReady() {
       return !this.$wait.is(this.waitIdentifier)
     },
-    browseBtnLabel () {
+    browseBtnLabel() {
       if (this.browse) {
         return this.$t('inlineDirectoryPicker.header.browseBtn.close')
       }
       return this.$t('inlineDirectoryPicker.header.browseBtn.browse')
     },
-    browseBtnVariant () {
+    browseBtnVariant() {
       return this.dark ? 'light' : 'dark'
     },
-    overlayVariant () {
+    overlayVariant() {
       return this.dark ? 'dark' : 'light'
     }
   },
   methods: {
-    basename (path) {
+    basename(path) {
       return trim(path.split('/').pop(), '/')
     },
-    directoryTitle (index) {
+    directoryTitle(index) {
       return [this.cannonicalDataDir, ...this.directories.slice(1, index + 1)].join('/')
     },
-    select (pathOrIndex, continueBrowsing = false) {
+    select(pathOrIndex, continueBrowsing = false) {
       this.browse = continueBrowsing
       if (isNaN(pathOrIndex)) {
         return this.selectPath(pathOrIndex)
       }
       return this.selectIndex(pathOrIndex)
     },
-    selectIndex (index) {
+    selectIndex(index) {
       const nonNullPath = this.path || this.cannonicalDataDir
-      const path = nonNullPath.split(this.cannonicalDataDir).pop().split('/').slice(0, index + 1).join('/')
+      const path = nonNullPath
+        .split(this.cannonicalDataDir)
+        .pop()
+        .split('/')
+        .slice(0, index + 1)
+        .join('/')
       return this.selectPath(this.cannonicalDataDir + path)
     },
-    selectPath (path) {
+    selectPath(path) {
       this.$emit('input', path)
       return path
     },
-    async selectAndBrowse (pathOrIndex) {
+    async selectAndBrowse(pathOrIndex) {
       this.select(pathOrIndex, true)
       // Browse only if we are already browsing
       await this.$nextTick()
       this.toggleBrowser(this.browse)
     },
-    async toggleBrowser (browse = null) {
+    async toggleBrowser(browse = null) {
       this.browse = browse ?? !this.browse
       if (this.browse) {
         this.$wait.start(this.waitIdentifier)
@@ -109,38 +114,49 @@ export default {
   <div class="inline-directory-picker border rounded" :class="{ 'inline-directory-picker--dark': dark }">
     <b-overlay rounded :show="!isReady" :variant="overlayVariant" spinner-small>
       <div class="inline-directory-picker__header d-flex align-items-center p-2">
-        <fa class="inline-directory-picker__header__icon mr-3"
-            icon="folder"
-            fixed-width
-            v-if="!hideFolderIcon" />
-        <active-text-truncate class="inline-directory-picker__header__list mr-1"
-                              direction="rtl"
-                              :key="directories.length">
-          <div class="inline-directory-picker__header__list__item"
-               v-for="(directory, i) in directories"
-               :key="directory"
-               @click="selectAndBrowse(i)">
-            <b-btn class="p-0"
-                   variant="link"
-                   v-b-tooltip="{ delay: { show: 1e3, hide: 0 }, customClass: 'tooltip-lg' }"
-                   :title="directoryTitle(i)">
+        <fa class="inline-directory-picker__header__icon mr-3" icon="folder" fixed-width v-if="!hideFolderIcon" />
+        <active-text-truncate
+          class="inline-directory-picker__header__list mr-1"
+          direction="rtl"
+          :key="directories.length"
+        >
+          <div
+            class="inline-directory-picker__header__list__item"
+            v-for="(directory, i) in directories"
+            :key="directory"
+            @click="selectAndBrowse(i)"
+          >
+            <b-btn
+              class="p-0"
+              variant="link"
+              v-b-tooltip="{ delay: { show: 1e3, hide: 0 }, customClass: 'tooltip-lg' }"
+              :title="directoryTitle(i)"
+            >
               {{ basename(directory) }}
             </b-btn>
           </div>
         </active-text-truncate>
-        <b-btn class="inline-directory-picker__header__browse py-0 ml-auto" size="sm" :variant="browseBtnVariant" @click="toggleBrowser()">
+        <b-btn
+          class="inline-directory-picker__header__browse py-0 ml-auto"
+          size="sm"
+          :variant="browseBtnVariant"
+          @click="toggleBrowser()"
+        >
           {{ browseBtnLabel }}
         </b-btn>
       </div>
       <b-collapse :visible="browse">
-        <ul v-if="browsingTreeDirectories.length"
-            class="inline-directory-picker__browser list-unstyled m-0 border-top">
-          <li v-for="directory in browsingTreeDirectories"
-              :key="directory.name"
-              class="inline-directory-picker__browser__item position-relative">
-            <a class="inline-directory-picker__browser__item__link d-block p-2 stretched-link"
-               href
-               @click.prevent="selectAndBrowse(directory.name, true)">
+        <ul v-if="browsingTreeDirectories.length" class="inline-directory-picker__browser list-unstyled m-0 border-top">
+          <li
+            v-for="directory in browsingTreeDirectories"
+            :key="directory.name"
+            class="inline-directory-picker__browser__item position-relative"
+          >
+            <a
+              class="inline-directory-picker__browser__item__link d-block p-2 stretched-link"
+              href
+              @click.prevent="selectAndBrowse(directory.name, true)"
+            >
               <fa icon="folder" fixed-width class="mr-3" />
               {{ basename(directory.name) }}
             </a>
@@ -155,52 +171,53 @@ export default {
 </template>
 
 <style lang="scss">
-  .inline-directory-picker {
-    &__header {
-      &__list {
-        & &__item {
-          margin-right: 0;
-          display: inline-flex;
+.inline-directory-picker {
+  &__header {
+    &__list {
+      & &__item {
+        margin-right: 0;
+        display: inline-flex;
 
-          &:not(:last-of-type):after {
-            content: "/";
-            margin: 0 $spacer-xxs;
-          }
-
-          .btn {
-            color: inherit;
-            opacity: $btn-disabled-opacity;
-          }
-
-          &:last-of-type .btn {
-            font-weight: bold;
-            opacity: 1;
-          }
+        &:not(:last-of-type):after {
+          content: '/';
+          margin: 0 $spacer-xxs;
         }
-      }
-    }
 
-    &__browser {
-      &__item {
-        &__link, &__link:hover {
+        .btn {
           color: inherit;
+          opacity: $btn-disabled-opacity;
         }
 
-        &__link:hover,
-        &--active &__link {
-          text-decoration: none;
-          background: $table-hover-bg;
-        }
-
-        .inline-directory-picker--dark &__link:hover,
-        .inline-directory-picker--dark &--active &__link {
-          background: $table-dark-hover-bg;
-        }
-
-        &__link:hover + &__browse {
-          display: block;
+        &:last-of-type .btn {
+          font-weight: bold;
+          opacity: 1;
         }
       }
     }
   }
+
+  &__browser {
+    &__item {
+      &__link,
+      &__link:hover {
+        color: inherit;
+      }
+
+      &__link:hover,
+      &--active &__link {
+        text-decoration: none;
+        background: $table-hover-bg;
+      }
+
+      .inline-directory-picker--dark &__link:hover,
+      .inline-directory-picker--dark &--active &__link {
+        background: $table-dark-hover-bg;
+      }
+
+      &__link:hover + &__browse {
+        display: block;
+      }
+    }
+  }
+}
 </style>

--- a/src/components/JsonFormatter.vue
+++ b/src/components/JsonFormatter.vue
@@ -39,10 +39,6 @@ export default {
       mounted: false
     }
   },
-  async mounted() {
-    await this.$nextTick()
-    this.mounted = true
-  },
   watch: {
     $props: {
       deep: true,
@@ -54,6 +50,10 @@ export default {
     mounted() {
       return this.render()
     }
+  },
+  async mounted() {
+    await this.$nextTick()
+    this.mounted = true
   },
   methods: {
     render() {

--- a/src/components/JsonFormatter.vue
+++ b/src/components/JsonFormatter.vue
@@ -33,13 +33,13 @@ export default {
       default: () => ({ hoverPreviewEnabled: true })
     }
   },
-  data () {
+  data() {
     return {
       formatter: null,
       mounted: false
     }
   },
-  async mounted () {
+  async mounted() {
     await this.$nextTick()
     this.mounted = true
   },
@@ -47,16 +47,16 @@ export default {
     $props: {
       deep: true,
       immediate: true,
-      handler () {
+      handler() {
         return this.render()
       }
     },
-    mounted () {
+    mounted() {
       return this.render()
     }
   },
   methods: {
-    render () {
+    render() {
       if (this.mounted) {
         const formatter = new JSONFormatter(this.json, this.open, this.config)
         this.$el.innerHTML = ''

--- a/src/components/LocalesMenu.vue
+++ b/src/components/LocalesMenu.vue
@@ -6,10 +6,21 @@
         {{ currentLocale.label }}
       </slot>
     </span>
-    <b-popover :target="uniqueId" triggers="click blur" custom-class="locales-menu__list popover-body-p-0" ref="popover">
+    <b-popover
+      :target="uniqueId"
+      triggers="click blur"
+      custom-class="locales-menu__list popover-body-p-0"
+      ref="popover"
+    >
       <div class="dropdown-menu show position-static border-0 px-2 bg-transparent">
-        <a href="#" class="dropdown-item" v-for="locale in locales" :key="locale.key"
-           @click.prevent="chooseLocale(locale.key)" :class="{ active: locale === currentLocale }">
+        <a
+          href="#"
+          class="dropdown-item"
+          v-for="locale in locales"
+          :key="locale.key"
+          @click.prevent="chooseLocale(locale.key)"
+          :class="{ active: locale === currentLocale }"
+        >
           {{ locale.label }}
         </a>
       </div>
@@ -42,38 +53,38 @@ export default {
       type: Boolean
     }
   },
-  data () {
+  data() {
     return {
       locales: settings.locales,
       loadedLocales: [settings.defaultLocale]
     }
   },
   computed: {
-    currentLocale () {
+    currentLocale() {
       const key = localStorage.getItem('locale') ? localStorage.getItem('locale') : this.$i18n.locale
       this.loadLocale(key)
       return find(this.locales, { key })
     },
-    uniqueId () {
+    uniqueId() {
       return uniqueId('locales-menu')
     }
   },
   methods: {
-    async chooseLocale (locale) {
+    async chooseLocale(locale) {
       await this.loadLocale(locale)
       if (this.$refs.popover) {
         this.$refs.popover.$emit('close')
       }
     },
-    setI18nLanguage (locale) {
+    setI18nLanguage(locale) {
       localStorage.setItem('locale', locale)
       this.$i18n.locale = locale
       return locale
     },
-    loadLocale (locale) {
+    loadLocale(locale) {
       if (this.$i18n.locale !== locale) {
         if (!this.loadedLocales.includes(locale)) {
-          return import(/* webpackChunkName: "[request]" */ '@/lang/' + locale + '.json').then(messages => {
+          return import(/* webpackChunkName: "[request]" */ '@/lang/' + locale + '.json').then((messages) => {
             this.$i18n.setLocaleMessage(locale, messages.default)
             this.loadedLocales.push(locale)
             return this.setI18nLanguage(locale)

--- a/src/components/LocalesMenu.vue
+++ b/src/components/LocalesMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-button class="locales-menu" :id="uniqueId" href="#" variant="none">
+  <b-button :id="uniqueId" class="locales-menu" href="#" variant="none">
     <span class="locales-menu__button">
       <slot v-bind="{ currentLocale, locales }">
         <fa icon="globe" class="mr-1"></fa>
@@ -7,19 +7,19 @@
       </slot>
     </span>
     <b-popover
+      ref="popover"
       :target="uniqueId"
       triggers="click blur"
       custom-class="locales-menu__list popover-body-p-0"
-      ref="popover"
     >
       <div class="dropdown-menu show position-static border-0 px-2 bg-transparent">
         <a
-          href="#"
-          class="dropdown-item"
           v-for="locale in locales"
           :key="locale.key"
-          @click.prevent="chooseLocale(locale.key)"
+          href="#"
+          class="dropdown-item"
           :class="{ active: locale === currentLocale }"
+          @click.prevent="chooseLocale(locale.key)"
         >
           {{ locale.label }}
         </a>

--- a/src/components/MountedDataLocation.vue
+++ b/src/components/MountedDataLocation.vue
@@ -2,7 +2,7 @@
   <div class="mounted-data-location d-flex align-items-center px-1">
     <div class="d-flex align-items-center flex-grow-1 mw-100" @click="showTreeView()">
       <fa icon="folder" class="ml-1 mr-2 text-muted mounted-data-location__icon"></fa>
-      <div class="flex-grow-1 text-monospace px-0 py-1 text-truncate mounted-data-location__value" :id="valueId">
+      <div :id="valueId" class="flex-grow-1 text-monospace px-0 py-1 text-truncate mounted-data-location__value">
         {{ dataDir }}
       </div>
     </div>
@@ -51,6 +51,14 @@ export default {
       path: null
     }
   },
+  computed: {
+    valueId() {
+      return uniqueId('mounted-data-location__value--')
+    },
+    dataDir() {
+      return this.$config.get('mountedDataDir') || this.$config.get('dataDir')
+    }
+  },
   methods: {
     async deleteAll() {
       try {
@@ -74,14 +82,6 @@ export default {
     showTreeView() {
       this.$set(this, 'path', this.dataDir)
       this.$bvModal.show('mounting-data-location-tree-view')
-    }
-  },
-  computed: {
-    valueId() {
-      return uniqueId('mounted-data-location__value--')
-    },
-    dataDir() {
-      return this.$config.get('mountedDataDir') || this.$config.get('dataDir')
     }
   }
 }

--- a/src/components/MountedDataLocation.vue
+++ b/src/components/MountedDataLocation.vue
@@ -12,14 +12,15 @@
       :description="$t('indexing.deleteIndexDescription')"
       :label="$t('indexing.deleteIndexLabel')"
       :no="$t('global.no')"
-      :yes="$t('global.yes')">
+      :yes="$t('global.yes')"
+    >
       <fa icon="trash-alt"></fa>
       <span class="sr-only">
         {{ $t('indexing.deleteIndexLabel') }}
       </span>
     </confirm-button>
     <b-popover :target="valueId" triggers="hover" placement="top" :boundary-padding="16 * 1.5">
-      <template v-slot:title>
+      <template #title>
         {{ $t('footer.homedir') }}
       </template>
       <div class="text-monospace">
@@ -45,13 +46,13 @@ export default {
   components: {
     TreeView
   },
-  data () {
+  data() {
     return {
       path: null
     }
   },
   methods: {
-    async deleteAll () {
+    async deleteAll() {
       try {
         await this.$store.dispatch('indexing/deleteAll')
         this.$root.$emit('index::delete::all')
@@ -70,16 +71,16 @@ export default {
         }
       }
     },
-    showTreeView () {
+    showTreeView() {
       this.$set(this, 'path', this.dataDir)
       this.$bvModal.show('mounting-data-location-tree-view')
     }
   },
   computed: {
-    valueId () {
+    valueId() {
       return uniqueId('mounted-data-location__value--')
     },
-    dataDir () {
+    dataDir() {
       return this.$config.get('mountedDataDir') || this.$config.get('dataDir')
     }
   }
@@ -87,14 +88,14 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .mounted-data-location {
-    border-radius: 1em;
-    background: rgba(black, 0.2);
-    cursor: pointer;
+.mounted-data-location {
+  border-radius: 1em;
+  background: rgba(black, 0.2);
+  cursor: pointer;
 
-    &:hover {
-      background: rgba(black, 0.5);
-      text-decoration: underline;
-    }
+  &:hover {
+    background: rgba(black, 0.5);
+    text-decoration: underline;
   }
+}
 </style>

--- a/src/components/NamedEntityInContext.vue
+++ b/src/components/NamedEntityInContext.vue
@@ -43,35 +43,6 @@ export default {
       default: 560
     }
   },
-  async mounted() {
-    await this.loadContent()
-    await this.$nextTick(this.scrollToFirstMark)
-  },
-  methods: {
-    async loadContent() {
-      if (!this.showContentTextLengthWarning && !this.isContentLoaded) {
-        this.$wait.start(this.waitIdentifier)
-        await this.$store.dispatch('document/getContent')
-        this.$wait.end(this.waitIdentifier)
-      }
-    },
-    highlight(content) {
-      const length = this.namedEntity.mention.length
-      const start = this.extractPrefix.length + this.firstOffset - this.extractOffsetStart
-      const ranges = [{ start, length }]
-      return Highlight.create({ content }).ranges(ranges)
-    },
-    scrollToFirstMark() {
-      const container = this.$el.querySelector('.named-entity-in-context__extract') || this.$el
-      const target = container.querySelector('mark')
-
-      if (target) {
-        container.style.overflow = 'auto'
-        VueScrollTo.scrollTo(target, 500, { container, offset: -75, force: true })
-        container.style.overflow = 'hidden'
-      }
-    }
-  },
   computed: {
     ...mapState('document', ['isContentLoaded', 'showContentTextLengthWarning']),
     content() {
@@ -108,6 +79,35 @@ export default {
     },
     waitIdentifier() {
       return 'load document content for named entity in context'
+    }
+  },
+  async mounted() {
+    await this.loadContent()
+    await this.$nextTick(this.scrollToFirstMark)
+  },
+  methods: {
+    async loadContent() {
+      if (!this.showContentTextLengthWarning && !this.isContentLoaded) {
+        this.$wait.start(this.waitIdentifier)
+        await this.$store.dispatch('document/getContent')
+        this.$wait.end(this.waitIdentifier)
+      }
+    },
+    highlight(content) {
+      const length = this.namedEntity.mention.length
+      const start = this.extractPrefix.length + this.firstOffset - this.extractOffsetStart
+      const ranges = [{ start, length }]
+      return Highlight.create({ content }).ranges(ranges)
+    },
+    scrollToFirstMark() {
+      const container = this.$el.querySelector('.named-entity-in-context__extract') || this.$el
+      const target = container.querySelector('mark')
+
+      if (target) {
+        container.style.overflow = 'auto'
+        VueScrollTo.scrollTo(target, 500, { container, offset: -75, force: true })
+        container.style.overflow = 'hidden'
+      }
     }
   }
 }

--- a/src/components/NamedEntityInContext.vue
+++ b/src/components/NamedEntityInContext.vue
@@ -4,7 +4,7 @@
       {{ $t('namedEntityInContext.none') }}
     </div>
     <div v-else-if="isInContext" class="named-entity-in-context__extract" v-html="extractInContext"></div>
-    <div v-else class="named-entity-in-context__meta" >
+    <div v-else class="named-entity-in-context__meta">
       {{ $t('namedEntityInContext.meta') }}
     </div>
   </b-overlay>
@@ -43,25 +43,25 @@ export default {
       default: 560
     }
   },
-  async mounted () {
+  async mounted() {
     await this.loadContent()
     await this.$nextTick(this.scrollToFirstMark)
   },
   methods: {
-    async loadContent () {
+    async loadContent() {
       if (!this.showContentTextLengthWarning && !this.isContentLoaded) {
         this.$wait.start(this.waitIdentifier)
         await this.$store.dispatch('document/getContent')
         this.$wait.end(this.waitIdentifier)
       }
     },
-    highlight (content) {
+    highlight(content) {
       const length = this.namedEntity.mention.length
       const start = this.extractPrefix.length + this.firstOffset - this.extractOffsetStart
       const ranges = [{ start, length }]
       return Highlight.create({ content }).ranges(ranges)
     },
-    scrollToFirstMark () {
+    scrollToFirstMark() {
       const container = this.$el.querySelector('.named-entity-in-context__extract') || this.$el
       const target = container.querySelector('mark')
 
@@ -74,39 +74,39 @@ export default {
   },
   computed: {
     ...mapState('document', ['isContentLoaded', 'showContentTextLengthWarning']),
-    content () {
+    content() {
       return toString(this.isContentLoaded ? this.document.content : '')
     },
-    isInContext () {
+    isInContext() {
       return !!without(this.namedEntity.offsets, -1).length
     },
-    extract () {
+    extract() {
       const substring = this.content.substring(this.extractOffsetStart, this.extractOffsetEnd)
       return [this.extractPrefix, trim(substring), this.extractSuffix].join('')
     },
-    extractInContext () {
+    extractInContext() {
       return this.document.nl2br(this.highlight(this.extract))
     },
-    extractOffsetStart () {
+    extractOffsetStart() {
       return Math.max(0, this.firstOffset - Math.floor(this.extractLength / 2))
     },
-    extractOffsetEnd () {
+    extractOffsetEnd() {
       const extraLength = Math.max(0, Math.floor(this.extractLength / 2) - this.extractOffsetStart)
       return this.firstOffset + extraLength + Math.floor(this.extractLength / 2)
     },
-    extractPrefix () {
+    extractPrefix() {
       return this.extractOffsetStart > 0 ? '...' : ''
     },
-    extractSuffix () {
+    extractSuffix() {
       return this.extractOffsetEnd < this.content.length ? '...' : ''
     },
-    extractNotAvailable () {
+    extractNotAvailable() {
       return this.showContentTextLengthWarning
     },
-    firstOffset () {
+    firstOffset() {
       return without(this.namedEntity.offsets, -1)[0]
     },
-    waitIdentifier () {
+    waitIdentifier() {
       return 'load document content for named entity in context'
     }
   }
@@ -114,48 +114,50 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .named-entity-in-context {
-    $gradient-height: $spacer * 1.5;
-    position: relative;
-    width: 440px;
-    max-width: 90vw;
-    overflow: hidden;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+.named-entity-in-context {
+  $gradient-height: $spacer * 1.5;
+  position: relative;
+  width: 440px;
+  max-width: 90vw;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
-    &__no-extract, &__extract {
-      text-align: center;
-      padding: $spacer;
-      font-style: italic;
+  &__no-extract,
+  &__extract {
+    text-align: center;
+    padding: $spacer;
+    font-style: italic;
+  }
+
+  &__extract {
+    padding: $gradient-height 0;
+    height: 150px;
+
+    mark {
+      font-weight: bold;
     }
 
-    &__extract {
-      padding: $gradient-height 0;
-      height: 150px;
+    &:before,
+    &:after {
+      content: '';
+      position: absolute;
+      left: 0;
+      right: 0;
+      height: $gradient-height;
+      z-index: 10;
+    }
 
-      mark {
-        font-weight: bold;
-      }
+    &:before {
+      top: 0;
+      @include gradient-y($popover-bg, rgba($popover-bg, 0));
+    }
 
-      &:before, &:after {
-        content: "";
-        position: absolute;
-        left: 0;
-        right: 0;
-        height: $gradient-height;
-        z-index: 10;
-      }
-
-      &:before {
-        top: 0;
-        @include gradient-y($popover-bg, rgba($popover-bg, 0));
-      }
-
-      &:after {
-        bottom: 0;
-        @include gradient-y(rgba($popover-bg, 0), $popover-bg);
-      }
+    &:after {
+      bottom: 0;
+      @include gradient-y(rgba($popover-bg, 0), $popover-bg);
     }
   }
+}
 </style>

--- a/src/components/PageHeader.vue
+++ b/src/components/PageHeader.vue
@@ -6,7 +6,7 @@
           <slot></slot>
         </div>
         <h3 class="page-header__title">
-          <page-icon :icon="icon" v-if="icon"></page-icon>
+          <page-icon v-if="icon" :icon="icon"></page-icon>
           <slot name="preTitle"></slot>
           {{ title }}
         </h3>
@@ -15,7 +15,7 @@
         </div>
       </div>
     </div>
-    <b-tabs v-model="tabIndex" class="page-header__tabs px-0" v-if="hasTabs" nav-wrapper-class="page-header__tabs__nav">
+    <b-tabs v-if="hasTabs" v-model="tabIndex" class="page-header__tabs px-0" nav-wrapper-class="page-header__tabs__nav">
       <slot name="tabs" />
     </b-tabs>
   </div>

--- a/src/components/PageHeader.vue
+++ b/src/components/PageHeader.vue
@@ -63,17 +63,17 @@ export default {
     }
   },
   computed: {
-    hasTabs () {
+    hasTabs() {
       return this.$slots.tabs
     },
     tabIndex: {
-      set (value) {
+      set(value) {
         /**
          * Called when more directories are loaded
          */
         this.$emit('update:tab', value)
       },
-      get () {
+      get() {
         return this.tab
       }
     }
@@ -82,56 +82,54 @@ export default {
 </script>
 
 <style lang="scss">
-  .page-header {
+.page-header {
+  &__tabs {
+    &__nav {
+      background: $white;
+      border-bottom: $border-color 1px solid;
 
-    &__tabs {
-
-      &__nav {
-        background: $white;
-        border-bottom: $border-color 1px solid;
-
-        .nav-tabs {
-          @include make-container();
-          @each $breakpoint, $container-max-width in  $container-max-widths {
-            @include media-breakpoint-up($breakpoint, $grid-breakpoints) {
-              max-width: $container-max-width;
-            }
+      .nav-tabs {
+        @include make-container();
+        @each $breakpoint, $container-max-width in $container-max-widths {
+          @include media-breakpoint-up($breakpoint, $grid-breakpoints) {
+            max-width: $container-max-width;
           }
+        }
 
-          border: 0;
-          padding: 0;
+        border: 0;
+        padding: 0;
 
-          .nav-link {
-            font-size: 1rem;
-            font-weight: bold;
-            border-radius: 0;
-            border-bottom: 0;
-            border-top: 0;
+        .nav-link {
+          font-size: 1rem;
+          font-weight: bold;
+          border-radius: 0;
+          border-bottom: 0;
+          border-top: 0;
 
-            &:hover:not(.active) {
-              border-color: transparent;
-            }
+          &:hover:not(.active) {
+            border-color: transparent;
           }
+        }
 
-          .nav-link.active {
-            background: $body-bg;
-            color: $dark;
-            position: relative;
-            overflow: hidden;
-            text-shadow: 0 -2px 2px $body-bg;
+        .nav-link.active {
+          background: $body-bg;
+          color: $dark;
+          position: relative;
+          overflow: hidden;
+          text-shadow: 0 -2px 2px $body-bg;
 
-            &:after {
-              content: "";
-              position: absolute;
-              top: 0;
-              left: 0;
-              right: 0;
-              border-top: 2px solid $secondary;
-              box-shadow: 0 0 10px 0 $secondary;
-            }
+          &:after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            border-top: 2px solid $secondary;
+            box-shadow: 0 0 10px 0 $secondary;
           }
         }
       }
     }
   }
+}
 </style>

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -1,39 +1,39 @@
 <template>
-  <div v-if="isDisplayedComputed" class="pagination" :id="id">
+  <div v-if="isDisplayedComputed" :id="id" class="pagination">
     <router-link
+      v-show="!noFirstPageLink"
+      v-b-tooltip="{ id, placement, trigger: 'hover' }"
       :to="firstPageLinkParameters()"
       :class="{ disabled: isFirstOrPreviousPageUnavailable() }"
       class="pagination__link pagination__first-page px-2"
-      v-b-tooltip="{ id, placement, trigger: 'hover' }"
-      v-show="!noFirstPageLink"
       :title="$t('pagination.firstPage')"
     >
       <fa icon="angle-double-left"></fa>
     </router-link>
     <router-link
+      v-b-tooltip="{ id, placement, trigger: 'hover' }"
       :to="previousPageLinkParameters()"
       :class="{ disabled: isFirstOrPreviousPageUnavailable() }"
       class="pagination__link pagination__previous-page px-2"
-      v-b-tooltip="{ id, placement, trigger: 'hover' }"
       :title="$t('pagination.previousPage')"
     >
       <fa icon="angle-left"></fa>
     </router-link>
     <router-link
+      v-b-tooltip="{ id, placement, trigger: 'hover' }"
       :to="nextPageLinkParameters()"
       :class="{ disabled: isNextOrLastPageUnavailable() }"
       class="pagination__link pagination__next-page px-2"
-      v-b-tooltip="{ id, placement, trigger: 'hover' }"
       :title="$t('pagination.nextPage')"
     >
       <fa icon="angle-right"></fa>
     </router-link>
     <router-link
+      v-show="!noLastPageLink"
+      v-b-tooltip="{ id, placement, trigger: 'hover' }"
       :to="lastPageLinkParameters()"
       :class="{ disabled: isNextOrLastPageUnavailable() }"
       class="pagination__link pagination__last-page px-2"
-      v-b-tooltip="{ id, placement, trigger: 'hover' }"
-      v-show="!noLastPageLink"
       :title="$t('pagination.lastPage')"
     >
       <fa icon="angle-double-right"></fa>

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -2,36 +2,40 @@
   <div v-if="isDisplayedComputed" class="pagination" :id="id">
     <router-link
       :to="firstPageLinkParameters()"
-      :class="{ 'disabled' : isFirstOrPreviousPageUnavailable() }"
+      :class="{ disabled: isFirstOrPreviousPageUnavailable() }"
       class="pagination__link pagination__first-page px-2"
       v-b-tooltip="{ id, placement, trigger: 'hover' }"
       v-show="!noFirstPageLink"
-      :title="$t('pagination.firstPage')">
+      :title="$t('pagination.firstPage')"
+    >
       <fa icon="angle-double-left"></fa>
     </router-link>
     <router-link
       :to="previousPageLinkParameters()"
-      :class="{ 'disabled' : isFirstOrPreviousPageUnavailable() }"
+      :class="{ disabled: isFirstOrPreviousPageUnavailable() }"
       class="pagination__link pagination__previous-page px-2"
       v-b-tooltip="{ id, placement, trigger: 'hover' }"
-      :title="$t('pagination.previousPage')">
+      :title="$t('pagination.previousPage')"
+    >
       <fa icon="angle-left"></fa>
     </router-link>
     <router-link
       :to="nextPageLinkParameters()"
-      :class="{ 'disabled' : isNextOrLastPageUnavailable() }"
+      :class="{ disabled: isNextOrLastPageUnavailable() }"
       class="pagination__link pagination__next-page px-2"
       v-b-tooltip="{ id, placement, trigger: 'hover' }"
-      :title="$t('pagination.nextPage')">
+      :title="$t('pagination.nextPage')"
+    >
       <fa icon="angle-right"></fa>
     </router-link>
     <router-link
       :to="lastPageLinkParameters()"
-      :class="{ 'disabled' : isNextOrLastPageUnavailable() }"
+      :class="{ disabled: isNextOrLastPageUnavailable() }"
       class="pagination__link pagination__last-page px-2"
       v-b-tooltip="{ id, placement, trigger: 'hover' }"
       v-show="!noLastPageLink"
-      :title="$t('pagination.lastPage')">
+      :title="$t('pagination.lastPage')"
+    >
       <fa icon="angle-double-right"></fa>
     </router-link>
   </div>
@@ -102,58 +106,58 @@ export default {
     }
   },
   computed: {
-    isDisplayedComputed () {
+    isDisplayedComputed() {
       return this.isDisplayed === noop ? this.total > this.size : this.isDisplayed()
     },
-    size () {
+    size() {
       return get(this.getToTemplate(), ['query', this.sizeAttr], 0)
     },
-    from () {
+    from() {
       return get(this.getToTemplate(), ['query', this.fromAttr], 0)
     },
-    nextFrom () {
+    nextFrom() {
       return this.from + this.size
     },
-    gap () {
+    gap() {
       return Number(this.total % this.size === 0)
     },
-    id () {
+    id() {
       return uniqueId('pagination')
     },
-    placement () {
+    placement() {
       return this.position === 'top' ? 'bottomleft' : 'topleft'
     }
   },
   methods: {
-    mergeWithQuery (query) {
+    mergeWithQuery(query) {
       const to = this.getToTemplate()
       to.query = Object.assign(to.query, query)
       return to
     },
-    firstPageLinkParameters () {
+    firstPageLinkParameters() {
       return this.mergeWithQuery({
         [this.fromAttr]: 0
       })
     },
-    previousPageLinkParameters () {
+    previousPageLinkParameters() {
       return this.mergeWithQuery({
         [this.fromAttr]: max([0, this.from - this.size])
       })
     },
-    nextPageLinkParameters () {
+    nextPageLinkParameters() {
       return this.mergeWithQuery({
         [this.fromAttr]: this.nextFrom < this.total ? this.nextFrom : this.from
       })
     },
-    lastPageLinkParameters () {
+    lastPageLinkParameters() {
       return this.mergeWithQuery({
         [this.fromAttr]: this.size * (floor(this.total / this.size) - this.gap)
       })
     },
-    isFirstOrPreviousPageUnavailable () {
+    isFirstOrPreviousPageUnavailable() {
       return this.from === 0
     },
-    isNextOrLastPageUnavailable () {
+    isNextOrLastPageUnavailable() {
       return this.from + this.size >= this.total
     }
   }
@@ -161,16 +165,16 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .pagination {
-    &__link,
-    &__link:hover {
-      color: $text-muted;
-      font-size: 1.1em;
+.pagination {
+  &__link,
+  &__link:hover {
+    color: $text-muted;
+    font-size: 1.1em;
 
-      &.disabled {
-        color: $gray-500;
-        cursor: inherit;
-      }
+    &.disabled {
+      color: $gray-500;
+      cursor: inherit;
     }
   }
+}
 </style>

--- a/src/components/Plugins.vue
+++ b/src/components/Plugins.vue
@@ -18,7 +18,7 @@
                     <fa icon="link" />
                   </span>
                 </div>
-                <b-form-input :state="isFormValid" class="b-form-control" placeholder="URL" type="url" v-model="url" />
+                <b-form-input v-model="url" :state="isFormValid" class="b-form-control" placeholder="URL" type="url" />
               </div>
               <div class="d-flex align-items-center">
                 <b-form-invalid-feedback class="text-secondary" :state="isFormValid">
@@ -27,8 +27,8 @@
                 <b-btn
                   variant="primary"
                   class="ml-auto text-nowrap"
-                  @click="installPluginFromUrl"
                   :disabled="isFormValid !== true"
+                  @click="installPluginFromUrl"
                 >
                   {{ $t('plugins.install') }}
                 </b-btn>
@@ -37,11 +37,11 @@
           </b-modal>
         </div>
         <div class="plugins__search ml-auto">
-          <search-form-control :placeholder="$t('plugins.search')" v-model="searchTerm" @input="search" />
+          <search-form-control v-model="searchTerm" :placeholder="$t('plugins.search')" @input="search" />
         </div>
       </div>
       <b-card-group deck>
-        <b-overlay :show="plugin.show" v-for="plugin in plugins" :key="plugin.id" class="plugins__card m-3 d-flex">
+        <b-overlay v-for="plugin in plugins" :key="plugin.id" :show="plugin.show" class="plugins__card m-3 d-flex">
           <b-card footer-border-variant="white" class="m-0">
             <b-card-text>
               <div class="d-flex">
@@ -55,33 +55,33 @@
                 </div>
                 <div class="d-flex flex-column text-nowrap pl-2">
                   <b-btn
-                    class="plugins__card__uninstall-button mb-2"
-                    @click="uninstallPlugin(plugin.id)"
                     v-if="plugin.installed"
+                    class="plugins__card__uninstall-button mb-2"
                     variant="danger"
+                    @click="uninstallPlugin(plugin.id)"
                   >
                     <fa icon="trash-alt"></fa>
                     {{ $t('plugins.uninstall') }}
                   </b-btn>
                   <b-btn
-                    class="plugins__card__download-button mb-2"
-                    @click="installPluginFromId(plugin.id)"
-                    variant="primary"
                     v-if="!plugin.installed"
+                    class="plugins__card__download-button mb-2"
+                    variant="primary"
+                    @click="installPluginFromId(plugin.id)"
                   >
                     <fa icon="cloud-download-alt"></fa>
                     {{ $t('plugins.install') }}
                   </b-btn>
                   <b-btn
-                    class="plugins__card__update-button mb-2"
-                    @click="installPluginFromId(plugin.id)"
-                    variant="primary"
                     v-if="
                       plugin.installed &&
                       isPluginFromRegistry(plugin) &&
                       plugin.version !== plugin.deliverableFromRegistry.version
                     "
+                    class="plugins__card__update-button mb-2"
+                    variant="primary"
                     size="sm"
+                    @click="installPluginFromId(plugin.id)"
                   >
                     <fa icon="sync"></fa>
                     {{ $t('plugins.update') }}
@@ -92,7 +92,7 @@
                 </div>
               </div>
             </b-card-text>
-            <template #footer v-if="isPluginFromRegistry(plugin)">
+            <template v-if="isPluginFromRegistry(plugin)" #footer>
               <div class="plugins__card__official-version text-truncate w-100">
                 <span class="font-weight-bold"> {{ $t('plugins.officialVersion') }}: </span>
                 {{ plugin.deliverableFromRegistry.version }}
@@ -100,10 +100,10 @@
               <div class="text-truncate w-100">
                 <span class="font-weight-bold"> {{ $t('plugins.homePage') }}: </span>
                 <a
+                  v-if="plugin.deliverableFromRegistry.homepage"
                   class="plugins__card__homepage"
                   :href="plugin.deliverableFromRegistry.homepage"
                   target="_blank"
-                  v-if="plugin.deliverableFromRegistry.homepage"
                 >
                   {{ plugin.deliverableFromRegistry.homepage }}
                 </a>
@@ -129,6 +129,10 @@ export default {
   components: {
     SearchFormControl
   },
+  filters: {
+    camelCase,
+    startCase
+  },
   data() {
     return {
       plugins: [],
@@ -137,12 +141,13 @@ export default {
       url: ''
     }
   },
+  computed: {
+    isFormValid() {
+      return this.url === '' ? null : isUrl(this.url)
+    }
+  },
   mounted() {
     this.search()
-  },
-  filters: {
-    camelCase,
-    startCase
   },
   methods: {
     isPluginFromRegistry(plugin) {
@@ -197,11 +202,6 @@ export default {
         this.$bvToast.toast(this.$t('plugins.deleteError'), { noCloseButton: true, variant: 'danger' })
       }
       plugin.show = false
-    }
-  },
-  computed: {
-    isFormValid() {
-      return this.url === '' ? null : isUrl(this.url)
     }
   }
 }

--- a/src/components/Plugins.vue
+++ b/src/components/Plugins.vue
@@ -18,18 +18,18 @@
                     <fa icon="link" />
                   </span>
                 </div>
-                <b-form-input
-                  :state="isFormValid"
-                  class="b-form-control"
-                  placeholder="URL"
-                  type="url"
-                  v-model="url" />
+                <b-form-input :state="isFormValid" class="b-form-control" placeholder="URL" type="url" v-model="url" />
               </div>
               <div class="d-flex align-items-center">
                 <b-form-invalid-feedback class="text-secondary" :state="isFormValid">
                   {{ $t('global.enterCorrectUrl') }}
                 </b-form-invalid-feedback>
-                <b-btn variant="primary" class="ml-auto text-nowrap" @click="installPluginFromUrl" :disabled="isFormValid !== true">
+                <b-btn
+                  variant="primary"
+                  class="ml-auto text-nowrap"
+                  @click="installPluginFromUrl"
+                  :disabled="isFormValid !== true"
+                >
                   {{ $t('plugins.install') }}
                 </b-btn>
               </div>
@@ -54,36 +54,57 @@
                   </div>
                 </div>
                 <div class="d-flex flex-column text-nowrap pl-2">
-                  <b-btn class="plugins__card__uninstall-button mb-2" @click="uninstallPlugin(plugin.id)" v-if="plugin.installed" variant="danger">
+                  <b-btn
+                    class="plugins__card__uninstall-button mb-2"
+                    @click="uninstallPlugin(plugin.id)"
+                    v-if="plugin.installed"
+                    variant="danger"
+                  >
                     <fa icon="trash-alt"></fa>
                     {{ $t('plugins.uninstall') }}
                   </b-btn>
-                  <b-btn class="plugins__card__download-button mb-2" @click="installPluginFromId(plugin.id)" variant="primary" v-if="!plugin.installed">
+                  <b-btn
+                    class="plugins__card__download-button mb-2"
+                    @click="installPluginFromId(plugin.id)"
+                    variant="primary"
+                    v-if="!plugin.installed"
+                  >
                     <fa icon="cloud-download-alt"></fa>
                     {{ $t('plugins.install') }}
                   </b-btn>
-                  <b-btn class="plugins__card__update-button mb-2" @click="installPluginFromId(plugin.id)" variant="primary" v-if="plugin.installed && isPluginFromRegistry(plugin) && plugin.version !== plugin.deliverableFromRegistry.version" size="sm">
+                  <b-btn
+                    class="plugins__card__update-button mb-2"
+                    @click="installPluginFromId(plugin.id)"
+                    variant="primary"
+                    v-if="
+                      plugin.installed &&
+                      isPluginFromRegistry(plugin) &&
+                      plugin.version !== plugin.deliverableFromRegistry.version
+                    "
+                    size="sm"
+                  >
                     <fa icon="sync"></fa>
                     {{ $t('plugins.update') }}
                   </b-btn>
                   <div v-if="plugin.version && plugin.installed" class="plugins__card__version text-muted text-center">
-                    {{ $t('plugins.version', { version: plugin.version  }) }}
+                    {{ $t('plugins.version', { version: plugin.version }) }}
                   </div>
                 </div>
               </div>
             </b-card-text>
-            <template v-slot:footer v-if="isPluginFromRegistry(plugin)" >
+            <template #footer v-if="isPluginFromRegistry(plugin)">
               <div class="plugins__card__official-version text-truncate w-100">
-                <span class="font-weight-bold">
-                  {{ $t('plugins.officialVersion') }}:
-                </span>
+                <span class="font-weight-bold"> {{ $t('plugins.officialVersion') }}: </span>
                 {{ plugin.deliverableFromRegistry.version }}
               </div>
               <div class="text-truncate w-100">
-                <span class="font-weight-bold">
-                  {{ $t('plugins.homePage') }}:
-                </span>
-                <a class="plugins__card__homepage" :href="plugin.deliverableFromRegistry.homepage" target="_blank" v-if="plugin.deliverableFromRegistry.homepage">
+                <span class="font-weight-bold"> {{ $t('plugins.homePage') }}: </span>
+                <a
+                  class="plugins__card__homepage"
+                  :href="plugin.deliverableFromRegistry.homepage"
+                  target="_blank"
+                  v-if="plugin.deliverableFromRegistry.homepage"
+                >
                   {{ plugin.deliverableFromRegistry.homepage }}
                 </a>
               </div>
@@ -108,7 +129,7 @@ export default {
   components: {
     SearchFormControl
   },
-  data () {
+  data() {
     return {
       plugins: [],
       searchTerm: '',
@@ -116,7 +137,7 @@ export default {
       url: ''
     }
   },
-  mounted () {
+  mounted() {
     this.search()
   },
   filters: {
@@ -124,21 +145,23 @@ export default {
     startCase
   },
   methods: {
-    isPluginFromRegistry (plugin) {
+    isPluginFromRegistry(plugin) {
       return get(plugin, 'deliverableFromRegistry', false)
     },
-    getPluginName (plugin) {
+    getPluginName(plugin) {
       return this.isPluginFromRegistry(plugin) ? plugin.deliverableFromRegistry.name : plugin.name
     },
-    getPluginDescription (plugin) {
+    getPluginDescription(plugin) {
       return this.isPluginFromRegistry(plugin) ? plugin.deliverableFromRegistry.description : plugin.description
     },
-    async search () {
+    async search() {
       const plugins = await this.$core.api.getPlugins(this.searchTerm)
-      map(plugins, plugin => { plugin.show = false })
+      map(plugins, (plugin) => {
+        plugin.show = false
+      })
       this.$set(this, 'plugins', plugins)
     },
-    async installPluginFromId (pluginId) {
+    async installPluginFromId(pluginId) {
       const plugin = find(this.plugins, { id: pluginId })
       plugin.show = true
       try {
@@ -150,7 +173,7 @@ export default {
       }
       plugin.show = false
     },
-    async installPluginFromUrl () {
+    async installPluginFromUrl() {
       this.$set(this, 'isInstallingFromUrl', true)
       try {
         await this.$core.api.installPluginFromUrl(this.url)
@@ -163,7 +186,7 @@ export default {
       this.$set(this, 'isInstallingFromUrl', false)
       this.$set(this, 'url', '')
     },
-    async uninstallPlugin (pluginId) {
+    async uninstallPlugin(pluginId) {
       const plugin = find(this.plugins, { id: pluginId })
       plugin.show = true
       try {
@@ -177,7 +200,7 @@ export default {
     }
   },
   computed: {
-    isFormValid () {
+    isFormValid() {
       return this.url === '' ? null : isUrl(this.url)
     }
   }

--- a/src/components/ProjectCards.vue
+++ b/src/components/ProjectCards.vue
@@ -2,7 +2,11 @@
   <div class="project-cards container-fluid p-0">
     <div class="row">
       <div class="col-4 mb-4" v-for="project in projects" :key="project">
-        <router-link :to="{ name: 'search', query: { indices: project, q: '*' } }" class="project-cards__item d-flex justify-content-start text-nowrap" :class="{ 'project-cards__item--active': isActive(project) }">
+        <router-link
+          :to="{ name: 'search', query: { indices: project, q: '*' } }"
+          class="project-cards__item d-flex justify-content-start text-nowrap"
+          :class="{ 'project-cards__item--active': isActive(project) }"
+        >
           <div class="project-cards__item__header py-2 px-3 bg-white text-secondary">
             <fa icon="book"></fa>
           </div>
@@ -16,24 +20,24 @@
 </template>
 
 <style lang="scss" scoped>
-  .project-cards {
-    &__item {
-      background: $primary;
-      border: darken($primary, 10%) 1px solid;
-      border-radius: $border-radius-sm;
+.project-cards {
+  &__item {
+    background: $primary;
+    border: darken($primary, 10%) 1px solid;
+    border-radius: $border-radius-sm;
+    color: white;
+    display: block;
+
+    &:hover {
+      background: darken($primary, 5);
       color: white;
-      display: block;
+    }
 
-      &:hover {
-        background: darken($primary, 5);
-        color: white;
-      }
-
-      &--active {
-        box-shadow: 0 0 0 2px $warning;
-      }
+    &--active {
+      box-shadow: 0 0 0 2px $warning;
     }
   }
+}
 </style>
 
 <script>
@@ -44,13 +48,13 @@ import { startCase } from 'lodash'
  */
 export default {
   methods: {
-    isActive (project) {
+    isActive(project) {
       return this.$store.state.search.indices.includes(project)
     },
     startCase
   },
   computed: {
-    projects () {
+    projects() {
       return this.$core.projects
     }
   }

--- a/src/components/ProjectCards.vue
+++ b/src/components/ProjectCards.vue
@@ -19,27 +19,6 @@
   </div>
 </template>
 
-<style lang="scss" scoped>
-.project-cards {
-  &__item {
-    background: $primary;
-    border: darken($primary, 10%) 1px solid;
-    border-radius: $border-radius-sm;
-    color: white;
-    display: block;
-
-    &:hover {
-      background: darken($primary, 5);
-      color: white;
-    }
-
-    &--active {
-      box-shadow: 0 0 0 2px $warning;
-    }
-  }
-}
-</style>
-
 <script>
 import { startCase } from 'lodash'
 
@@ -60,3 +39,24 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.project-cards {
+  &__item {
+    background: $primary;
+    border: darken($primary, 10%) 1px solid;
+    border-radius: $border-radius-sm;
+    color: white;
+    display: block;
+
+    &:hover {
+      background: darken($primary, 5);
+      color: white;
+    }
+
+    &--active {
+      box-shadow: 0 0 0 2px $warning;
+    }
+  }
+}
+</style>

--- a/src/components/ProjectCards.vue
+++ b/src/components/ProjectCards.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="project-cards container-fluid p-0">
     <div class="row">
-      <div class="col-4 mb-4" v-for="project in projects" :key="project">
+      <div v-for="project in projects" :key="project" class="col-4 mb-4">
         <router-link
           :to="{ name: 'search', query: { indices: project, q: '*' } }"
           class="project-cards__item d-flex justify-content-start text-nowrap"
@@ -47,16 +47,16 @@ import { startCase } from 'lodash'
  * List all the projects with cards linking to the search.
  */
 export default {
+  computed: {
+    projects() {
+      return this.$core.projects
+    }
+  },
   methods: {
     isActive(project) {
       return this.$store.state.search.indices.includes(project)
     },
     startCase
-  },
-  computed: {
-    projects() {
-      return this.$core.projects
-    }
   }
 }
 </script>

--- a/src/components/ProjectSelector.vue
+++ b/src/components/ProjectSelector.vue
@@ -1,16 +1,7 @@
 <template>
   <b-form-group class="mb-0">
-    <b-form-checkbox-group
-      :disabled="disabled"
-      :options="projectOptions"
-      v-if="multiple"
-      v-model="selectedProject" />
-    <b-form-select
-      :disabled="disabled"
-      :options="projectOptions"
-      :size="size"
-      v-else
-      v-model="selectedProject" />
+    <b-form-checkbox-group :disabled="disabled" :options="projectOptions" v-if="multiple" v-model="selectedProject" />
+    <b-form-select :disabled="disabled" :options="projectOptions" :size="size" v-else v-model="selectedProject" />
   </b-form-group>
 </template>
 
@@ -53,21 +44,21 @@ export default {
     }
   },
   computed: {
-    projects () {
+    projects() {
       return this.$core.projects
     },
-    projectOptions () {
-      return this.projects.map(value => {
+    projectOptions() {
+      return this.projects.map((value) => {
         const text = startCase(value)
         const disabled = this.multiple && isEqual(this.selectedProject, [value])
         return { disabled, text, value }
       })
     },
     selectedProject: {
-      get () {
+      get() {
         return this.multiple ? castArray(this.value) : this.value
       },
-      set (value) {
+      set(value) {
         this.$emit('input', value)
       }
     }

--- a/src/components/ProjectSelector.vue
+++ b/src/components/ProjectSelector.vue
@@ -1,7 +1,7 @@
 <template>
   <b-form-group class="mb-0">
-    <b-form-checkbox-group :disabled="disabled" :options="projectOptions" v-if="multiple" v-model="selectedProject" />
-    <b-form-select :disabled="disabled" :options="projectOptions" :size="size" v-else v-model="selectedProject" />
+    <b-form-checkbox-group v-if="multiple" v-model="selectedProject" :disabled="disabled" :options="projectOptions" />
+    <b-form-select v-else v-model="selectedProject" :disabled="disabled" :options="projectOptions" :size="size" />
   </b-form-group>
 </template>
 

--- a/src/components/QuickItemNav.vue
+++ b/src/components/QuickItemNav.vue
@@ -50,30 +50,6 @@ export default {
       default: null
     }
   },
-  methods: {
-    goToPreviousItem() {
-      this.setIndex(Math.max(0, this.index - 1))
-      /**
-       * Triggered when user click on the `previous` button.
-       */
-      this.$emit('previous')
-    },
-    goToNextItem() {
-      this.setIndex(Math.min(this.totalItems - 1, this.index + 1))
-      /**
-       * Triggered when user click on the `next` button.
-       */
-      this.$emit('next')
-    },
-    setIndex(index) {
-      if (index !== this.index) {
-        /**
-         * Triggered when the value of `index` changes.
-         */
-        this.$emit('input', index)
-      }
-    }
-  },
   computed: {
     isPreviousButtonEnable() {
       if (this.hasPreviousItem !== null) {
@@ -99,6 +75,30 @@ export default {
     nextTooltip() {
       return this.$t(`quickItemNav.next.${this.osTooltipKey}`)
     }
+  },
+  methods: {
+    goToPreviousItem() {
+      this.setIndex(Math.max(0, this.index - 1))
+      /**
+       * Triggered when user click on the `previous` button.
+       */
+      this.$emit('previous')
+    },
+    goToNextItem() {
+      this.setIndex(Math.min(this.totalItems - 1, this.index + 1))
+      /**
+       * Triggered when user click on the `next` button.
+       */
+      this.$emit('next')
+    },
+    setIndex(index) {
+      if (index !== this.index) {
+        /**
+         * Triggered when the value of `index` changes.
+         */
+        this.$emit('input', index)
+      }
+    }
   }
 }
 </script>
@@ -107,11 +107,11 @@ export default {
   <span class="quick-items-nav">
     <button
       id="previous-item-button"
+      v-shortkey="getKeys('goToPreviousItem')"
       class="btn btn-sm btn-link text-white py-0 quick-items-nav__previous"
+      :disabled="!isPreviousButtonEnable"
       @click="goToPreviousItem"
       @shortkey="getAction('goToPreviousItem')"
-      v-shortkey="getKeys('goToPreviousItem')"
-      :disabled="!isPreviousButtonEnable"
     >
       <fa icon="angle-left" class="mr-1"></fa>
       <span class="d-sm-none d-md-inline">
@@ -123,11 +123,11 @@ export default {
     </b-tooltip>
     <button
       id="next-item-button"
+      v-shortkey="getKeys('goToNextItem')"
       class="btn btn-sm btn-link text-white py-0 quick-items-nav__next"
+      :disabled="!isNextButtonEnable"
       @click="goToNextItem"
       @shortkey="getAction('goToNextItem')"
-      v-shortkey="getKeys('goToNextItem')"
-      :disabled="!isNextButtonEnable"
     >
       <span class="d-sm-none d-md-inline">
         {{ $t('quickItemNav.next.label') }}

--- a/src/components/QuickItemNav.vue
+++ b/src/components/QuickItemNav.vue
@@ -51,21 +51,21 @@ export default {
     }
   },
   methods: {
-    goToPreviousItem () {
+    goToPreviousItem() {
       this.setIndex(Math.max(0, this.index - 1))
       /**
        * Triggered when user click on the `previous` button.
        */
       this.$emit('previous')
     },
-    goToNextItem () {
+    goToNextItem() {
       this.setIndex(Math.min(this.totalItems - 1, this.index + 1))
       /**
        * Triggered when user click on the `next` button.
        */
       this.$emit('next')
     },
-    setIndex (index) {
+    setIndex(index) {
       if (index !== this.index) {
         /**
          * Triggered when the value of `index` changes.
@@ -75,28 +75,28 @@ export default {
     }
   },
   computed: {
-    isPreviousButtonEnable () {
+    isPreviousButtonEnable() {
       if (this.hasPreviousItem !== null) {
         return !!this.hasPreviousItem
       }
       return this.index > 0
     },
-    isNextButtonEnable () {
+    isNextButtonEnable() {
       if (this.hasNextItem !== null) {
         return !!this.hasNextItem
       }
       return this.index < this.totalItems - 1
     },
-    isMac () {
+    isMac() {
       return getShortkeyOS() === 'mac'
     },
-    osTooltipKey () {
+    osTooltipKey() {
       return this.isMac ? 'tooltipMac' : 'tooltipOthers'
     },
-    previousTooltip () {
+    previousTooltip() {
       return this.$t(`quickItemNav.previous.${this.osTooltipKey}`)
     },
-    nextTooltip () {
+    nextTooltip() {
       return this.$t(`quickItemNav.next.${this.osTooltipKey}`)
     }
   }
@@ -105,12 +105,14 @@ export default {
 
 <template>
   <span class="quick-items-nav">
-    <button id="previous-item-button"
-            class="btn btn-sm btn-link text-white py-0 quick-items-nav__previous"
-            @click="goToPreviousItem"
-            @shortkey="getAction('goToPreviousItem')"
-            v-shortkey="getKeys('goToPreviousItem')"
-            :disabled="!isPreviousButtonEnable" >
+    <button
+      id="previous-item-button"
+      class="btn btn-sm btn-link text-white py-0 quick-items-nav__previous"
+      @click="goToPreviousItem"
+      @shortkey="getAction('goToPreviousItem')"
+      v-shortkey="getKeys('goToPreviousItem')"
+      :disabled="!isPreviousButtonEnable"
+    >
       <fa icon="angle-left" class="mr-1"></fa>
       <span class="d-sm-none d-md-inline">
         {{ $t('quickItemNav.previous.label') }}
@@ -119,12 +121,14 @@ export default {
     <b-tooltip target="previous-item-button" triggers="hover">
       <span v-html="previousTooltip"></span>
     </b-tooltip>
-    <button id="next-item-button"
-            class="btn btn-sm btn-link text-white py-0 quick-items-nav__next"
-            @click="goToNextItem"
-            @shortkey="getAction('goToNextItem')"
-            v-shortkey="getKeys('goToNextItem')"
-            :disabled="!isNextButtonEnable">
+    <button
+      id="next-item-button"
+      class="btn btn-sm btn-link text-white py-0 quick-items-nav__next"
+      @click="goToNextItem"
+      @shortkey="getAction('goToNextItem')"
+      v-shortkey="getKeys('goToNextItem')"
+      :disabled="!isNextButtonEnable"
+    >
       <span class="d-sm-none d-md-inline">
         {{ $t('quickItemNav.next.label') }}
       </span>

--- a/src/components/ResetFiltersButton.vue
+++ b/src/components/ResetFiltersButton.vue
@@ -1,11 +1,13 @@
 <template>
-  <button class="btn"
-          :class="componentClasses"
-          @click="resetFiltersAndQuery"
-          v-show="!autoHiding || hasFiltersOrQuery"
-          :title="$t('search.clearFiltersDescription')"
-          v-b-tooltip
-          :disabled="!hasFiltersOrQuery">
+  <button
+    class="btn"
+    :class="componentClasses"
+    @click="resetFiltersAndQuery"
+    v-show="!autoHiding || hasFiltersOrQuery"
+    :title="$t('search.clearFiltersDescription')"
+    v-b-tooltip
+    :disabled="!hasFiltersOrQuery"
+  >
     <fa :icon="icon" v-if="!noIcon"></fa>
     <slot>
       {{ $t('search.clearFilters') }}
@@ -61,16 +63,16 @@ export default {
     }
   },
   computed: {
-    hasFilters () {
+    hasFilters() {
       return this.$store.getters['search/activeFilters'].length > 0
     },
-    hasQuery () {
+    hasQuery() {
       return this.$store.state.search.field !== settings.defaultSearchField || this.$store.state.search.query !== ''
     },
-    hasFiltersOrQuery () {
+    hasFiltersOrQuery() {
       return this.hasFilters || this.hasQuery
     },
-    componentClasses () {
+    componentClasses() {
       return {
         ['btn-' + this.size]: true,
         ['btn-' + this.variant]: true
@@ -78,7 +80,7 @@ export default {
     }
   },
   methods: {
-    resetFiltersAndQuery () {
+    resetFiltersAndQuery() {
       this.$store.commit('search/resetFilterValues')
       this.$store.commit('search/resetQuery')
       this.$root.$emit('bv::hide::popover')

--- a/src/components/ResetFiltersButton.vue
+++ b/src/components/ResetFiltersButton.vue
@@ -1,14 +1,14 @@
 <template>
   <button
+    v-show="!autoHiding || hasFiltersOrQuery"
+    v-b-tooltip
     class="btn"
     :class="componentClasses"
-    @click="resetFiltersAndQuery"
-    v-show="!autoHiding || hasFiltersOrQuery"
     :title="$t('search.clearFiltersDescription')"
-    v-b-tooltip
     :disabled="!hasFiltersOrQuery"
+    @click="resetFiltersAndQuery"
   >
-    <fa :icon="icon" v-if="!noIcon"></fa>
+    <fa v-if="!noIcon" :icon="icon"></fa>
     <slot>
       {{ $t('search.clearFilters') }}
     </slot>

--- a/src/components/RouteDocsLinks.vue
+++ b/src/components/RouteDocsLinks.vue
@@ -22,8 +22,8 @@
             <ul class="list-unstyled route-docs-links__item__outline">
               <li v-for="(heading, index) in meta.headings" :key="index">
                 <a
-                  href="#"
                   v-scroll-to="`#${heading.id}`"
+                  href="#"
                   class="route-docs-links__item__outline__heading"
                   :class="{ 'route-docs-links__item__outline__heading--last': index === meta.headings.length - 1 }"
                 >

--- a/src/components/RouteDocsLinks.vue
+++ b/src/components/RouteDocsLinks.vue
@@ -5,17 +5,29 @@
     </h5>
     <div class="card">
       <div class="list-group list-group-flush small">
-        <div v-for="meta in validRouteDocsMeta" v-bind:key="meta.resourcePath" class="route-docs-links__item" :class="{ 'route-docs-links__item--active': isActive(meta) }">
-          <router-link :to="{ name: 'docs', params: meta }" class="list-group-item list-group-item-action route-docs-links__item__link">
+        <div
+          v-for="meta in validRouteDocsMeta"
+          :key="meta.resourcePath"
+          class="route-docs-links__item"
+          :class="{ 'route-docs-links__item--active': isActive(meta) }"
+        >
+          <router-link
+            :to="{ name: 'docs', params: meta }"
+            class="list-group-item list-group-item-action route-docs-links__item__link"
+          >
             <fa icon="book" class="mr-2" />
             {{ meta.title }}
           </router-link>
           <slide-up-down :active="!!meta.headings.length && isActive(meta)">
             <ul class="list-unstyled route-docs-links__item__outline">
-              <li v-for="(heading, index) in meta.headings" v-bind:key="index">
-                <a href="#" v-scroll-to="`#${heading.id}`" class="route-docs-links__item__outline__heading" :class="{ 'route-docs-links__item__outline__heading--last': index === meta.headings.length -1}">
-                  <div class="text-truncate" v-html="heading.text">
-                  </div>
+              <li v-for="(heading, index) in meta.headings" :key="index">
+                <a
+                  href="#"
+                  v-scroll-to="`#${heading.id}`"
+                  class="route-docs-links__item__outline__heading"
+                  :class="{ 'route-docs-links__item__outline__heading--last': index === meta.headings.length - 1 }"
+                >
+                  <div class="text-truncate" v-html="heading.text"></div>
                 </a>
               </li>
             </ul>
@@ -37,7 +49,7 @@ export default {
   name: 'RouteDocsLinks',
   mixins: [docs],
   methods: {
-    isActive (meta = null) {
+    isActive(meta = null) {
       return meta && get(this, '$route.params.slug', null) === meta.slug
     }
   }
@@ -45,65 +57,66 @@ export default {
 </script>
 
 <style lang="scss">
-  .route-docs-links {
-    width: 100%;
+.route-docs-links {
+  width: 100%;
 
-    &__item {
-      padding-bottom: 0;
+  &__item {
+    padding-bottom: 0;
 
-      &__link.router-link-active,
-      &__link.router-link-active:hover,
-      &__link.router-link-active:focus,
-      &__outline {
-        color: $component-active-color;
-        background: $component-active-bg;
-        border: 0;
-        outline: none;
-      }
+    &__link.router-link-active,
+    &__link.router-link-active:hover,
+    &__link.router-link-active:focus,
+    &__outline {
+      color: $component-active-color;
+      background: $component-active-bg;
+      border: 0;
+      outline: none;
+    }
 
-      &__link {
-        z-index: 50;
+    &__link {
+      z-index: 50;
+      position: relative;
+    }
+
+    &__outline {
+      margin: 0;
+      z-index: 100;
+      position: relative;
+      padding-bottom: $list-group-item-padding-y;
+
+      &__heading {
+        padding: $list-group-item-padding-y * 0.2 $list-group-item-padding-x * 0.2;
+        margin-left: calc(#{$list-group-item-padding-x} + 1.2rem);
+        margin-right: $list-group-item-padding-x;
         position: relative;
-      }
+        display: block;
 
-      &__outline {
-        margin: 0;
-        z-index: 100;
-        position: relative;
-        padding-bottom: $list-group-item-padding-y;
+        &,
+        &:hover {
+          color: inherit;
+          text-decoration: none;
+        }
 
-        &__heading {
-          padding: $list-group-item-padding-y * 0.2 $list-group-item-padding-x * 0.2;
-          margin-left: calc(#{$list-group-item-padding-x} + 1.2rem);
-          margin-right: $list-group-item-padding-x;
-          position: relative;
-          display: block;
+        &:before {
+          content: '├─';
+          font-family: $font-family-monospace;
+          font-size: 1.5rem;
+          position: absolute;
+          right: 100%;
+          top: 50%;
+          transform: translateY(-50%);
+          width: $list-group-item-padding-x;
+          overflow: hidden;
+          height: 1.5rem;
+          line-height: 1.5rem;
+          color: mix($component-active-color, $component-active-bg);
+        }
 
-          &, &:hover {
-            color: inherit;
-            text-decoration: none;
-          }
-
-          &:before {
-            content: "├─";
-            font-family: $font-family-monospace;
-            font-size: 1.5rem;
-            position: absolute;
-            right: 100%;
-            top: 50%;
-            transform: translateY(-50%);
-            width: $list-group-item-padding-x;
-            overflow: hidden;
-            height: 1.5rem;
-            line-height: 1.5rem;
-            color: mix($component-active-color, $component-active-bg)
-          }
-
-          &--last:before {
-            content: "└─"
-          }
+        &--last:before {
+          content: '└─';
         }
       }
     }
   }
+}
 </style>

--- a/src/components/RouterLinkPopup.vue
+++ b/src/components/RouterLinkPopup.vue
@@ -32,14 +32,6 @@ export default {
       default: null
     }
   },
-  methods: {
-    open() {
-      instances[this.target] = window.open(this.href, this.target, this.features || this.defaultFeatures)
-      if (instances[this.target]) {
-        instances[this.target].focus()
-      }
-    }
-  },
   computed: {
     href() {
       const { href } = this.$router.resolve(this.to)
@@ -51,6 +43,14 @@ export default {
       const left = screen.width / 2 - width / 2
       const top = screen.height / 2 - height / 2
       return `width=${width},height=${height},left=${left},top=${top},resizable,scrollbars=yes,status=1`
+    }
+  },
+  methods: {
+    open() {
+      instances[this.target] = window.open(this.href, this.target, this.features || this.defaultFeatures)
+      if (instances[this.target]) {
+        instances[this.target].focus()
+      }
     }
   }
 }

--- a/src/components/RouterLinkPopup.vue
+++ b/src/components/RouterLinkPopup.vue
@@ -33,7 +33,7 @@ export default {
     }
   },
   methods: {
-    open () {
+    open() {
       instances[this.target] = window.open(this.href, this.target, this.features || this.defaultFeatures)
       if (instances[this.target]) {
         instances[this.target].focus()
@@ -41,15 +41,15 @@ export default {
     }
   },
   computed: {
-    href () {
+    href() {
       const { href } = this.$router.resolve(this.to)
       return href
     },
-    defaultFeatures () {
+    defaultFeatures() {
       const width = 880
       const height = window.outerHeight * 0.8
-      const left = (screen.width / 2) - (width / 2)
-      const top = (screen.height / 2) - (height / 2)
+      const left = screen.width / 2 - width / 2
+      const top = screen.height / 2 - height / 2
       return `width=${width},height=${height},left=${left},top=${top},resizable,scrollbars=yes,status=1`
     }
   }

--- a/src/components/ScrollTracker.vue
+++ b/src/components/ScrollTracker.vue
@@ -17,7 +17,7 @@ export default {
       default: 3000
     }
   },
-  data () {
+  data() {
     return {
       icon: faArrowUp,
       offset: 0,
@@ -27,54 +27,56 @@ export default {
       visible: false
     }
   },
-  mounted () {
+  mounted() {
     // Listen to scroll request from the root
     this.$root.$on('scroll-tracker:request', this.request)
   },
   methods: {
-    request (target, offset = 0, container = this.container) {
+    request(target, offset = 0, container = this.container) {
       this.target = target
       this.offset = offset
       this.container = container
       this.toggle(this.shouldBeVisible())
     },
-    scrollToTarget () {
+    scrollToTarget() {
       this.hide()
       VueScrollTo.scrollTo(this.target, 200, { offset: this.offset, container: this.container })
     },
-    toggle (toggler = !this.visible) {
+    toggle(toggler = !this.visible) {
       return toggler ? this.show() : this.hide()
     },
-    show () {
+    show() {
       this.icon = this.isTargetAbove() ? faArrowDown : faArrowUp
       this.visible = true
       this.setTimeout()
       // Hide the tracker on scroll
       window.addEventListener('scroll', this.hide)
     },
-    hide () {
+    hide() {
       this.visible = false
       // Remove the event listener
       window.removeEventListener('scroll', this.hide)
     },
-    setTimeout () {
+    setTimeout() {
       // Clear any existing timeout
       clearTimeout(this.timeoutHolder)
       // Hide the tracker after a delay
-      this.timeoutHolder = setTimeout(() => { this.$nextTick(this.hide) }, this.timeout)
+      this.timeoutHolder = setTimeout(() => {
+        this.$nextTick(this.hide)
+      }, this.timeout)
     },
-    shouldBeVisible () {
+    shouldBeVisible() {
       return !this.isTargetInView()
     },
-    isTargetInView () {
+    isTargetInView() {
       const { top } = this.targetBoundingClientRect()
       return top >= 0 && top < (window.innerHeight || document.documentElement.clientHeight)
     },
-    isTargetAbove () {
+    isTargetAbove() {
       const { top } = this.targetBoundingClientRect()
       return top > (window.innerHeight || document.documentElement.clientHeight)
     },
-    targetBoundingClientRect () {
+    targetBoundingClientRect() {
       if (this.target.nodeType > 0) {
         return this.target.getBoundingClientRect()
       } else {
@@ -94,37 +96,40 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  $scroll-tracker-size: 8rem;
+$scroll-tracker-size: 8rem;
 
-  a.scroll-tracker {
-    background: rgba(theme-color('dark'), 0.9);
-    border-radius: $scroll-tracker-size * 0.1;
-    bottom: 0;
+a.scroll-tracker {
+  background: rgba(theme-color('dark'), 0.9);
+  border-radius: $scroll-tracker-size * 0.1;
+  bottom: 0;
+  color: white;
+  cursor: pointer;
+  display: block;
+  font-size: $scroll-tracker-size * 0.6;
+  height: $scroll-tracker-size;
+  left: 50%;
+  line-height: $scroll-tracker-size;
+  margin: $spacer 0;
+  position: fixed;
+  text-align: center;
+  transform: translateX(-50%);
+  width: $scroll-tracker-size;
+  z-index: $zindex-tooltip;
+
+  &:hover,
+  &:active {
+    background: theme-color('darker');
     color: white;
-    cursor: pointer;
-    display: block;
-    font-size: $scroll-tracker-size * 0.6;
-    height: $scroll-tracker-size;
-    left: 50%;
-    line-height: $scroll-tracker-size;
-    margin: $spacer 0;
-    position: fixed;
-    text-align: center;
-    transform: translateX(-50%);
-    width: $scroll-tracker-size;
-    z-index: $zindex-tooltip;
-
-    &:hover, &:active {
-      background: theme-color('darker');
-      color: white;
-    }
-
-    &.fade-enter-active, &.fade-leave-active {
-      transition: .3s;
-    }
-
-    &.fade-enter, &.fade-leave-to {
-      opacity: 0;
-    }
   }
+
+  &.fade-enter-active,
+  &.fade-leave-active {
+    transition: 0.3s;
+  }
+
+  &.fade-enter,
+  &.fade-leave-to {
+    opacity: 0;
+  }
+}
 </style>

--- a/src/components/ScrollTracker.vue
+++ b/src/components/ScrollTracker.vue
@@ -89,7 +89,7 @@ export default {
 
 <template>
   <transition name="fade">
-    <a class="scroll-tracker" tabindex="0" v-show="visible" @click="scrollToTarget">
+    <a v-show="visible" class="scroll-tracker" tabindex="0" @click="scrollToTarget">
       <fa :icon="icon"></fa>
     </a>
   </transition>

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -1,5 +1,10 @@
 <template>
-  <form class="search-bar container-fluid" :id="uniqueId" @submit.prevent="submit" :class="{ 'search-bar--focused': focused, 'search-bar--animated': animated }">
+  <form
+    class="search-bar container-fluid"
+    :id="uniqueId"
+    @submit.prevent="submit"
+    :class="{ 'search-bar--focused': focused, 'search-bar--animated': animated }"
+  >
     <div class="d-flex align-items-center">
       <search-bar-input
         v-model="query"
@@ -14,17 +19,18 @@
           <search-bar-input-dropdown
             v-model="field"
             class="search-bar__field-options"
-            :fieldOptions="fieldOptions"
-            :fieldOptionsPath="fieldOptionsPath"
+            :field-options="fieldOptions"
+            :field-options-path="fieldOptionsPath"
           />
         </template>
         <template #suggestions>
-            <selectable-dropdown
+          <selectable-dropdown
             class="search-bar__suggestions dropdown-menu"
             ref="suggestions"
             :hide="!suggestions.length"
-            :items="suggestions">
-            <template v-slot:item-label="{ item }">
+            :items="suggestions"
+          >
+            <template #item-label="{ item }">
               <div class="d-flex">
                 <div class="flex-grow-1 text-truncate">
                   <span v-html="injectTermInQuery(item.key)"></span>
@@ -36,21 +42,27 @@
       </search-bar-input>
       <div class="px-0" v-if="settings">
         <shortkeys-modal class="d-none d-md-inline"></shortkeys-modal>
-        <b-btn v-b-tooltip.hover.bottomleft
-               :title="$t('userHistory.saveSearch')"
-               class="text-dark"
-               size="md"
-               variant="transparent"
-               @click="$refs['user-history-save-search-form'].show()">
-          <fa icon="save"/>
-          <b-modal body-class="p-0"
-                   hide-footer
-                   ref="user-history-save-search-form"
-                   size="md"
-                   :title="$t('userHistory.saveSearch')">
-            <user-history-save-search-form :indices="indices"
-                                           :uri="uri"
-                                           @submit="$refs['user-history-save-search-form'].hide()"/>
+        <b-btn
+          v-b-tooltip.hover.bottomleft
+          :title="$t('userHistory.saveSearch')"
+          class="text-dark"
+          size="md"
+          variant="transparent"
+          @click="$refs['user-history-save-search-form'].show()"
+        >
+          <fa icon="save" />
+          <b-modal
+            body-class="p-0"
+            hide-footer
+            ref="user-history-save-search-form"
+            size="md"
+            :title="$t('userHistory.saveSearch')"
+          >
+            <user-history-save-search-form
+              :indices="indices"
+              :uri="uri"
+              @submit="$refs['user-history-save-search-form'].hide()"
+            />
           </b-modal>
         </b-btn>
       </div>
@@ -70,9 +82,9 @@ import SearchBarInputDropdown from '@/components/SearchBarInputDropdown'
 import UserHistorySaveSearchForm from '@/components/UserHistorySaveSearchForm'
 import settings from '@/utils/settings'
 
-function escapeLuceneChars (str) {
+function escapeLuceneChars(str) {
   const escapable = [' ', '+', '-', '&&', '||', '!', '(', ')', '{', '}', '[', ']', '^', '~', '?', ':', '\\', '/']
-  return some(escapable, char => str.indexOf(char) > -1) ? JSON.stringify(str) : str
+  return some(escapable, (char) => str.indexOf(char) > -1) ? JSON.stringify(str) : str
 }
 
 /**
@@ -92,7 +104,9 @@ export default {
      */
     placeholder: {
       type: String,
-      default: function () { this.$t('search.placeholder') }
+      default: function () {
+        this.$t('search.placeholder')
+      }
     },
     /**
      * Display the shortcuts button.
@@ -105,8 +119,8 @@ export default {
      */
     fieldOptions: {
       type: Array,
-      default () {
-        return settings.searchFields.map(field => field.key)
+      default() {
+        return settings.searchFields.map((field) => field.key)
       }
     },
     /**
@@ -131,7 +145,7 @@ export default {
     UserHistorySaveSearchForm,
     SearchBarInputDropdown
   },
-  data () {
+  data() {
     return {
       field: this.$store.state.search.field,
       focused: false,
@@ -140,8 +154,8 @@ export default {
       suggestions: []
     }
   },
-  mounted () {
-    this.$store.subscribe(mutation => {
+  mounted() {
+    this.$store.subscribe((mutation) => {
       if (mutation.type === 'search/query') {
         this.$set(this, 'query', mutation.payload)
       }
@@ -151,7 +165,7 @@ export default {
     })
   },
   methods: {
-    submit () {
+    submit() {
       this.hideSuggestions()
       // Change the route after update the store with the new query
       this.$store.commit('search/field', this.field)
@@ -159,27 +173,27 @@ export default {
       this.$store.commit('search/from', 0)
       this.$router.push({ name: 'search', query: this.$store.getters['search/toRouteQueryWithStamp']() })
     },
-    async suggestTerms (candidates) {
+    async suggestTerms(candidates) {
       const query = this.query
       const index = this.$store.state.search.indices.join(',')
       const candidate = last(candidates)
       const fields = castArray(candidate.field === '<implicit>' ? settings.suggestedImplicitFields : candidate.field)
       const include = `.*${escapeRegExp(candidate.term).toLowerCase()}.*`
       const body = bodybuilder().size(0)
-      each(fields, field => {
+      each(fields, (field) => {
         body.aggregation('terms', field, { include }, field)
       })
       const preference = 'search-bar-suggestions'
       const response = await elasticsearch.search({ index, body: body.build(), preference })
       let suggestions = []
-      each(fields, field => {
+      each(fields, (field) => {
         suggestions = concat(suggestions, get(response, `aggregations.${field}.buckets`, []))
       })
       suggestions = orderBy(suggestions, ['doc_count'], ['desc'])
       // Return an object to check later if the promise result is still applicable
       return { query, suggestions }
     },
-    termCandidates (ast = null) {
+    termCandidates(ast = null) {
       try {
         // List of terms to return
         let terms = []
@@ -196,7 +210,7 @@ export default {
         return []
       }
     },
-    replaceLastTermCandidate (term, ast = null, highlight = true) {
+    replaceLastTermCandidate(term, ast = null, highlight = true) {
       // Parse the query by default
       ast = ast === null ? lucene.parse(this.query) : ast
       // Use recursive call for branches
@@ -209,7 +223,7 @@ export default {
       }
       return ast
     },
-    injectTermInQuery (term, ast = null, highlight = true) {
+    injectTermInQuery(term, ast = null, highlight = true) {
       try {
         ast = this.replaceLastTermCandidate(term, ast, highlight)
         return lucene.toString(ast)
@@ -217,7 +231,7 @@ export default {
         return this.query
       }
     },
-    selectTerm (term) {
+    selectTerm(term) {
       this.$set(this, 'query', term ? this.injectTermInQuery(term.key, null, false) : this.query)
     },
     searchTerms: throttle(async function () {
@@ -238,39 +252,39 @@ export default {
         this.hideSuggestions()
       }
     }, 200),
-    hideSuggestions () {
+    hideSuggestions() {
       this.$set(this, 'suggestions', [])
     },
-    hideSuggestionsAfterDelay () {
+    hideSuggestionsAfterDelay() {
       setTimeout(() => {
         this.$nextTick(this.hideSuggestions)
       }, 200)
     },
-    onBlur () {
+    onBlur() {
       this.focused = false
       this.hideSuggestionsAfterDelay()
     },
-    onInput () {
+    onInput() {
       this.searchTerms()
     },
-    onFocus () {
+    onFocus() {
       this.focused = true
       this.searchTerms()
     }
   },
   computed: {
-    indices () {
+    indices() {
       return this.$store.state.search.indices
     },
-    uniqueId () {
+    uniqueId() {
       return uniqueId('search-bar-')
     },
-    suggestionsAllowed () {
-      const terms = this.termCandidates().map(t => t.term)
+    suggestionsAllowed() {
+      const terms = this.termCandidates().map((t) => t.term)
       const lastTerm = last(terms) || ''
       return ['all', settings.suggestedImplicitFields].indexOf(this.field) > -1 && lastTerm.length > 4
     },
-    uri () {
+    uri() {
       return window.location.hash.substr(2)
     }
   }
@@ -278,34 +292,35 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .search-bar {
-
-    &--focused.search-bar--animated {
-      :deep(.input-group) {
-        filter: drop-shadow(0 0.3em .6em rgba(black, .2));
-        transition: transform 0.2s;
-        transform: translateY(-0.25em);
-      }
+.search-bar {
+  &--focused.search-bar--animated {
+    :deep(.input-group) {
+      filter: drop-shadow(0 0.3em 0.6em rgba(black, 0.2));
+      transition: transform 0.2s;
+      transform: translateY(-0.25em);
     }
+  }
 
-    & &__suggestions.dropdown-menu {
-      left: 0;
-      position: absolute !important;
-      right: 0;
-      top: 100%;
-    }
+  & &__suggestions.dropdown-menu {
+    left: 0;
+    position: absolute !important;
+    right: 0;
+    top: 100%;
+  }
 
-    &__suggestions {
-      box-shadow: $dropdown-box-shadow;
-      margin-top: $dropdown-spacer;
+  &__suggestions {
+    box-shadow: $dropdown-box-shadow;
+    margin-top: $dropdown-spacer;
 
-      & .dropdown-item {
-        cursor: pointer;
+    & .dropdown-item {
+      cursor: pointer;
 
-        &:active, &:focus, &.active {
-          color: white;
-        }
+      &:active,
+      &:focus,
+      &.active {
+        color: white;
       }
     }
   }
+}
 </style>

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -154,6 +154,22 @@ export default {
       suggestions: []
     }
   },
+  computed: {
+    indices() {
+      return this.$store.state.search.indices
+    },
+    uniqueId() {
+      return uniqueId('search-bar-')
+    },
+    suggestionsAllowed() {
+      const terms = this.termCandidates().map((t) => t.term)
+      const lastTerm = last(terms) || ''
+      return ['all', settings.suggestedImplicitFields].indexOf(this.field) > -1 && lastTerm.length > 4
+    },
+    uri() {
+      return window.location.hash.substr(2)
+    }
+  },
   mounted() {
     this.$store.subscribe((mutation) => {
       if (mutation.type === 'search/query') {
@@ -270,22 +286,6 @@ export default {
     onFocus() {
       this.focused = true
       this.searchTerms()
-    }
-  },
-  computed: {
-    indices() {
-      return this.$store.state.search.indices
-    },
-    uniqueId() {
-      return uniqueId('search-bar-')
-    },
-    suggestionsAllowed() {
-      const terms = this.termCandidates().map((t) => t.term)
-      const lastTerm = last(terms) || ''
-      return ['all', settings.suggestedImplicitFields].indexOf(this.field) > -1 && lastTerm.length > 4
-    },
-    uri() {
-      return window.location.hash.substr(2)
     }
   }
 }

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -1,9 +1,9 @@
 <template>
   <form
-    class="search-bar container-fluid"
     :id="uniqueId"
-    @submit.prevent="submit"
+    class="search-bar container-fluid"
     :class="{ 'search-bar--focused': focused, 'search-bar--animated': animated }"
+    @submit.prevent="submit"
   >
     <div class="d-flex align-items-center">
       <search-bar-input
@@ -25,8 +25,8 @@
         </template>
         <template #suggestions>
           <selectable-dropdown
-            class="search-bar__suggestions dropdown-menu"
             ref="suggestions"
+            class="search-bar__suggestions dropdown-menu"
             :hide="!suggestions.length"
             :items="suggestions"
           >
@@ -40,7 +40,7 @@
           </selectable-dropdown>
         </template>
       </search-bar-input>
-      <div class="px-0" v-if="settings">
+      <div v-if="settings" class="px-0">
         <shortkeys-modal class="d-none d-md-inline"></shortkeys-modal>
         <b-btn
           v-b-tooltip.hover.bottomleft
@@ -52,9 +52,9 @@
         >
           <fa icon="save" />
           <b-modal
+            ref="user-history-save-search-form"
             body-class="p-0"
             hide-footer
-            ref="user-history-save-search-form"
             size="md"
             :title="$t('userHistory.saveSearch')"
           >
@@ -92,6 +92,12 @@ function escapeLuceneChars(str) {
  */
 export default {
   name: 'SearchBar',
+  components: {
+    SearchBarInput,
+    ShortkeysModal,
+    UserHistorySaveSearchForm,
+    SearchBarInputDropdown
+  },
   props: {
     /**
      * Animate the focus on the search input.
@@ -138,12 +144,6 @@ export default {
       type: String,
       default: 'md'
     }
-  },
-  components: {
-    SearchBarInput,
-    ShortkeysModal,
-    UserHistorySaveSearchForm,
-    SearchBarInputDropdown
   },
   data() {
     return {

--- a/src/components/SearchBarInput.vue
+++ b/src/components/SearchBarInput.vue
@@ -11,11 +11,11 @@
     <div class="input-group-append">
       <router-link
         v-if="!hideTips"
+        v-b-tooltip.bottomleft
         :to="{ name: 'docs', params: { slug: 'all-search-with-operators' } }"
         class="search-bar-input__tips-addon input-group-text px-2"
         :class="{ 'search-bar-input__tips-addon--active': showTips }"
         :title="$t('search.tips')"
-        v-b-tooltip.bottomleft
       >
         <fa icon="question-circle" fixed-width />
       </router-link>
@@ -76,17 +76,6 @@ export default {
       type: Boolean
     }
   },
-  methods: {
-    onBlur() {
-      this.$emit('blur')
-    },
-    onInput() {
-      this.$emit('input')
-    },
-    onFocus() {
-      this.$emit('focus')
-    }
-  },
   computed: {
     value: {
       get() {
@@ -98,6 +87,17 @@ export default {
     },
     showTips() {
       return !this.hideTips && this.query?.length
+    }
+  },
+  methods: {
+    onBlur() {
+      this.$emit('blur')
+    },
+    onInput() {
+      this.$emit('input')
+    },
+    onFocus() {
+      this.$emit('focus')
     }
   }
 }

--- a/src/components/SearchBarInput.vue
+++ b/src/components/SearchBarInput.vue
@@ -6,16 +6,20 @@
       :placeholder="placeholder"
       @blur="onBlur"
       @input="onInput"
-      @focus="onFocus">
+      @focus="onFocus"
+    />
     <div class="input-group-append">
-        <router-link v-if="!hideTips" :to="{ name: 'docs', params: { slug: 'all-search-with-operators' } }"
-                     class="search-bar-input__tips-addon input-group-text px-2"
-                     :class="{ 'search-bar-input__tips-addon--active': showTips }"
-                     :title="$t('search.tips')" v-b-tooltip.bottomleft>
-          <fa icon="question-circle" fixed-width />
-        </router-link>
-      <slot name="fields">
-      </slot>
+      <router-link
+        v-if="!hideTips"
+        :to="{ name: 'docs', params: { slug: 'all-search-with-operators' } }"
+        class="search-bar-input__tips-addon input-group-text px-2"
+        :class="{ 'search-bar-input__tips-addon--active': showTips }"
+        :title="$t('search.tips')"
+        v-b-tooltip.bottomleft
+      >
+        <fa icon="question-circle" fixed-width />
+      </router-link>
+      <slot name="fields"> </slot>
       <button type="submit" class="btn btn-dark search-bar-input__submit" :disabled="disableSubmit">
         {{ $t('search.buttonLabel') }}
       </button>
@@ -25,7 +29,6 @@
 </template>
 
 <script>
-
 /**
  * The general search input group with field options.
  */
@@ -41,7 +44,9 @@ export default {
      */
     placeholder: {
       type: String,
-      default: function () { this.$t('search.placeholder') }
+      default: function () {
+        this.$t('search.placeholder')
+      }
     },
     /**
      * Search input query
@@ -72,26 +77,26 @@ export default {
     }
   },
   methods: {
-    onBlur () {
+    onBlur() {
       this.$emit('blur')
     },
-    onInput () {
+    onInput() {
       this.$emit('input')
     },
-    onFocus () {
+    onFocus() {
       this.$emit('focus')
     }
   },
   computed: {
     value: {
-      get () {
+      get() {
         return this.query
       },
-      set (value) {
+      set(value) {
         this.$emit('update', value)
       }
     },
-    showTips () {
+    showTips() {
       return !this.hideTips && this.query?.length
     }
   }
@@ -99,58 +104,58 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .search-bar-input {
-    .input-group {
-      filter: drop-shadow(0 0.3em .6em rgba(black, 0));
-      flex-wrap: nowrap;
-      white-space: nowrap;
+.search-bar-input {
+  .input-group {
+    filter: drop-shadow(0 0.3em 0.6em rgba(black, 0));
+    flex-wrap: nowrap;
+    white-space: nowrap;
+  }
+
+  .input-group-md &__input.form-control,
+  .input-group-lg &__input.form-control {
+    border-radius: 1.5em 0 0 1.5em;
+  }
+
+  &__input.form-control {
+    border-right: 0;
+
+    &:focus + .input-group-append .search-bar-input__field &:deep(.btn),
+    &:focus + .input-group-append .search-bar-input__tips-addon {
+      border-bottom-color: $input-focus-border-color;
+      border-top-color: $input-focus-border-color;
     }
 
-    .input-group-md &__input.form-control,
-    .input-group-lg &__input.form-control {
-      border-radius: 1.5em 0 0 1.5em;
-    }
-
-    &__input.form-control {
-      border-right: 0;
-
-      &:focus + .input-group-append .search-bar-input__field &:deep(.btn),
-      &:focus + .input-group-append .search-bar-input__tips-addon {
-        border-bottom-color: $input-focus-border-color;
-        border-top-color: $input-focus-border-color;
-      }
-
-      &:focus {
-        box-shadow: none;
-      }
-    }
-
-    &__tips-addon.input-group-text {
-      background: white;
-      border-left: 0;
-      border-right: 0;
-      box-shadow: $input-box-shadow;
-      color: transparent;
-      pointer-events: none;
-      transition: $input-transition, color .15s ease-in-out;
-    }
-
-    &__tips-addon--active.input-group-text {
-      color: $link-color;
-      pointer-events: all;
-    }
-
-    &__tips {
-      border-radius: 0 0 $input-border-radius $input-border-radius;
-      display: block;
-      font-size: 0.9rem;
-      padding: $spacer * 0.5 0 0;
-      z-index: 100;
-    }
-
-    &.input-group > .input-group-append > &__submit.btn {
-      border-bottom-right-radius: 1.5em;
-      border-top-right-radius: 1.5em;
+    &:focus {
+      box-shadow: none;
     }
   }
+
+  &__tips-addon.input-group-text {
+    background: white;
+    border-left: 0;
+    border-right: 0;
+    box-shadow: $input-box-shadow;
+    color: transparent;
+    pointer-events: none;
+    transition: $input-transition, color 0.15s ease-in-out;
+  }
+
+  &__tips-addon--active.input-group-text {
+    color: $link-color;
+    pointer-events: all;
+  }
+
+  &__tips {
+    border-radius: 0 0 $input-border-radius $input-border-radius;
+    display: block;
+    font-size: 0.9rem;
+    padding: $spacer * 0.5 0 0;
+    z-index: 100;
+  }
+
+  &.input-group > .input-group-append > &__submit.btn {
+    border-bottom-right-radius: 1.5em;
+    border-top-right-radius: 1.5em;
+  }
+}
 </style>

--- a/src/components/SearchBarInputDropdown.vue
+++ b/src/components/SearchBarInputDropdown.vue
@@ -1,12 +1,17 @@
 <template>
-  <b-dropdown :class="{ 'search-bar__field--selected': selectedField !== 'all' }" :text="$t(fieldOptionsPathValue + selectedField)"
-              class="search-bar-input-fields" right
-              variant="outline-light">
+  <b-dropdown
+    :class="{ 'search-bar__field--selected': selectedField !== 'all' }"
+    :text="$t(fieldOptionsPathValue + selectedField)"
+    class="search-bar-input-fields"
+    right
+    variant="outline-light"
+  >
     <b-dropdown-item
       v-for="key in fieldOptions"
       :key="key"
       class="search-bar-input-fields__option"
-      @click="selectedField = key">
+      @click="selectedField = key"
+    >
       {{ $t(fieldOptionsPathValue + key) }}
     </b-dropdown-item>
   </b-dropdown>
@@ -30,8 +35,8 @@ export default {
      */
     fieldOptions: {
       type: Array,
-      default () {
-        return settings.searchFields.map(field => field.key)
+      default() {
+        return settings.searchFields.map((field) => field.key)
       }
     },
     /**
@@ -50,14 +55,14 @@ export default {
     }
   },
   computed: {
-    fieldOptionsPathValue () {
+    fieldOptionsPathValue() {
       return `${this.fieldOptionsPath.join('.')}.`
     },
     selectedField: {
-      get () {
+      get() {
         return this.field
       },
-      set (value) {
+      set(value) {
         this.$emit('update', value)
       }
     }
@@ -66,40 +71,39 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .search-bar-input-fields {
-      background: $input-bg;
-      border-left: dashed 1px  $input-border-color;
-      font-size: inherit;
+.search-bar-input-fields {
+  background: $input-bg;
+  border-left: dashed 1px $input-border-color;
+  font-size: inherit;
 
-      &--selected:after {
-        bottom: 1px;
-        border: 2px solid $tertiary;
-        content: "";
-        left: 0;
-        position: absolute;
-        right: 1px;
-        top: 1px;
-      }
+  &--selected:after {
+    bottom: 1px;
+    border: 2px solid $tertiary;
+    content: '';
+    left: 0;
+    position: absolute;
+    right: 1px;
+    top: 1px;
+  }
 
-      &:deep(.btn) {
-        border: 1px solid $input-border-color;
-        border-left: 0;
-        box-shadow: $input-box-shadow;
-        color: $text-muted;
+  &:deep(.btn) {
+    border: 1px solid $input-border-color;
+    border-left: 0;
+    box-shadow: $input-box-shadow;
+    color: $text-muted;
 
-        .input-group-lg & {
-          font-size: 1.25rem;
-        }
-      }
+    .input-group-lg & {
+      font-size: 1.25rem;
+    }
+  }
 
-      &.show .btn.dropdown-toggle,
-      & .btn.dropdown-toggle:hover,
-      & .btn.dropdown-toggle:active {
-        background: transparent;
-        border: 1px solid $input-border-color;
-        border-left: 0;
-        box-shadow: $input-box-shadow;
-      }
+  &.show .btn.dropdown-toggle,
+  & .btn.dropdown-toggle:hover,
+  & .btn.dropdown-toggle:active {
+    background: transparent;
+    border: 1px solid $input-border-color;
+    border-left: 0;
+    box-shadow: $input-box-shadow;
+  }
 }
-
 </style>

--- a/src/components/SearchDocumentNavbar.vue
+++ b/src/components/SearchDocumentNavbar.vue
@@ -2,12 +2,12 @@
   <document-navbar class="search-document-navbar" :is-shrinked="isShrinked">
     <template #back>
       <router-link
+        v-b-tooltip.right="{ customClass: isShrinked ? 'ml-3' : 'd-none' }"
+        v-shortkey="getKeys('backToSearchResults')"
         class="document-navbar__back pr-1"
         :class="{ 'flex-grow-1': !isShrinked }"
         :to="{ name: 'search', query }"
         :title="$t('search.back')"
-        v-b-tooltip.right="{ customClass: isShrinked ? 'ml-3' : 'd-none' }"
-        v-shortkey="getKeys('backToSearchResults')"
         @shortkey.native="getAction('backToSearchResults')"
       >
         <fa icon="chevron-circle-left"></fa>
@@ -44,53 +44,17 @@ import shortkeys from '@/mixins/shortkeys'
  */
 export default {
   name: 'SearchDocumentNavbar',
-  mixins: [shortkeys],
   components: {
     DocumentNavbar,
     QuickItemNav
   },
+  mixins: [shortkeys],
   props: {
     /**
      * Shrink the layout of the navbar.
      */
     isShrinked: {
       type: Boolean
-    }
-  },
-  mounted() {
-    this.saveComponentHeight()
-  },
-  updated() {
-    this.saveComponentHeight()
-  },
-  methods: {
-    saveComponentHeight() {
-      const height = `${this.$el.offsetHeight}px`
-      // Save component height in a CSS variable after it's been update
-      this.$root.$el.style.setProperty('--search-document-navbar-height', height)
-    },
-    goToDocument(document) {
-      if (document) {
-        const params = document.routerParams
-        const query = { q: this.$store.state.search.query }
-        return this.$router.push({ name: 'document', params, query })
-      }
-    },
-    async goToPreviousDocument() {
-      if (this.navRequiresPreviousPage) {
-        await this.$store.dispatch('search/previousPage')
-        return this.goToDocument(this.lastDocument)
-      } else {
-        return this.goToDocument(this.previousDocument)
-      }
-    },
-    async goToNextDocument() {
-      if (this.navRequiresNextPage) {
-        await this.$store.dispatch('search/nextPage')
-        return this.goToDocument(this.firstDocument)
-      } else {
-        return this.goToDocument(this.nextDocument)
-      }
     }
   },
   computed: {
@@ -141,6 +105,42 @@ export default {
     },
     nextDocument() {
       return this.response.hits[this.documentIndex + 1]
+    }
+  },
+  mounted() {
+    this.saveComponentHeight()
+  },
+  updated() {
+    this.saveComponentHeight()
+  },
+  methods: {
+    saveComponentHeight() {
+      const height = `${this.$el.offsetHeight}px`
+      // Save component height in a CSS variable after it's been update
+      this.$root.$el.style.setProperty('--search-document-navbar-height', height)
+    },
+    goToDocument(document) {
+      if (document) {
+        const params = document.routerParams
+        const query = { q: this.$store.state.search.query }
+        return this.$router.push({ name: 'document', params, query })
+      }
+    },
+    async goToPreviousDocument() {
+      if (this.navRequiresPreviousPage) {
+        await this.$store.dispatch('search/previousPage')
+        return this.goToDocument(this.lastDocument)
+      } else {
+        return this.goToDocument(this.previousDocument)
+      }
+    },
+    async goToNextDocument() {
+      if (this.navRequiresNextPage) {
+        await this.$store.dispatch('search/nextPage')
+        return this.goToDocument(this.firstDocument)
+      } else {
+        return this.goToDocument(this.nextDocument)
+      }
     }
   }
 }

--- a/src/components/SearchDocumentNavbar.vue
+++ b/src/components/SearchDocumentNavbar.vue
@@ -8,7 +8,8 @@
         :title="$t('search.back')"
         v-b-tooltip.right="{ customClass: isShrinked ? 'ml-3' : 'd-none' }"
         v-shortkey="getKeys('backToSearchResults')"
-        @shortkey.native="getAction('backToSearchResults')">
+        @shortkey.native="getAction('backToSearchResults')"
+      >
         <fa icon="chevron-circle-left"></fa>
         <transition name="slide-x">
           <span v-if="!isShrinked" class="document-navbar__back__label ml-2">
@@ -18,11 +19,13 @@
       </router-link>
     </template>
     <template #nav>
-      <quick-item-nav v-if="documentIndex > -1"
-                      :has-previous-item="hasPreviousDocument"
-                      :has-next-item="hasNextDocument"
-                      @previous="goToPreviousDocument"
-                      @next="goToNextDocument" />
+      <quick-item-nav
+        v-if="documentIndex > -1"
+        :has-previous-item="hasPreviousDocument"
+        :has-next-item="hasNextDocument"
+        @previous="goToPreviousDocument"
+        @next="goToNextDocument"
+      />
     </template>
   </document-navbar>
 </template>
@@ -54,26 +57,26 @@ export default {
       type: Boolean
     }
   },
-  mounted () {
+  mounted() {
     this.saveComponentHeight()
   },
-  updated () {
+  updated() {
     this.saveComponentHeight()
   },
   methods: {
-    saveComponentHeight () {
+    saveComponentHeight() {
       const height = `${this.$el.offsetHeight}px`
       // Save component height in a CSS variable after it's been update
       this.$root.$el.style.setProperty('--search-document-navbar-height', height)
     },
-    goToDocument (document) {
+    goToDocument(document) {
       if (document) {
         const params = document.routerParams
         const query = { q: this.$store.state.search.query }
         return this.$router.push({ name: 'document', params, query })
       }
     },
-    async goToPreviousDocument () {
+    async goToPreviousDocument() {
       if (this.navRequiresPreviousPage) {
         await this.$store.dispatch('search/previousPage')
         return this.goToDocument(this.lastDocument)
@@ -81,7 +84,7 @@ export default {
         return this.goToDocument(this.previousDocument)
       }
     },
-    async goToNextDocument () {
+    async goToNextDocument() {
       if (this.navRequiresNextPage) {
         await this.$store.dispatch('search/nextPage')
         return this.goToDocument(this.firstDocument)
@@ -91,52 +94,52 @@ export default {
     }
   },
   computed: {
-    doc () {
+    doc() {
       return this.$store.state.document.doc
     },
-    response () {
+    response() {
       return this.$store.state.search.response
     },
-    query () {
+    query() {
       return this.$store.getters['search/toRouteQuery']()
     },
-    documentIndex () {
+    documentIndex() {
       return this.doc ? findIndex(this.response.hits, { id: this.doc.id }) : -1
     },
-    navRequiresPreviousPage () {
+    navRequiresPreviousPage() {
       return this.isFirstDocument && !this.isFirstPage
     },
-    navRequiresNextPage () {
+    navRequiresNextPage() {
       return this.isLastDocument && !this.isLastPage
     },
-    isFirstDocument () {
+    isFirstDocument() {
       return this.documentIndex === 0
     },
-    isLastDocument () {
+    isLastDocument() {
       return this.documentIndex === this.response.hits.length - 1
     },
-    firstDocument () {
+    firstDocument() {
       return first(this.response.hits)
     },
-    lastDocument () {
+    lastDocument() {
       return last(this.response.hits)
     },
-    isFirstPage () {
+    isFirstPage() {
       return this.$store.state.search.from === 0
     },
-    isLastPage () {
+    isLastPage() {
       return this.$store.state.search.from + this.$store.state.search.size >= this.$store.state.search.response.total
     },
-    hasPreviousDocument () {
+    hasPreviousDocument() {
       return !this.isFirstDocument || !this.isFirstPage
     },
-    hasNextDocument () {
+    hasNextDocument() {
       return !this.isLastDocument || !this.isLastPage
     },
-    previousDocument () {
+    previousDocument() {
       return this.response.hits[this.documentIndex - 1]
     },
-    nextDocument () {
+    nextDocument() {
       return this.response.hits[this.documentIndex + 1]
     }
   }

--- a/src/components/SearchFormControl.vue
+++ b/src/components/SearchFormControl.vue
@@ -85,9 +85,9 @@ export default {
       <b-form-input
         :autofocus="autofocus"
         class="search-form-control__input"
-        @input="$emit('input', $event)"
         :placeholder="placeholder"
         :value="value"
+        @input="$emit('input', $event)"
       ></b-form-input>
       <b-input-group-append class="search-form-control__addon search-form-control__addon--append">
         <b-button variant="light" class="search-form-control__addon__submit" type="submit">

--- a/src/components/SearchFormControl.vue
+++ b/src/components/SearchFormControl.vue
@@ -66,7 +66,7 @@ export default {
     }
   },
   computed: {
-    searchFormClassAttr () {
+    searchFormClassAttr() {
       return {
         'search-form-control--fill-submit': this.fillSubmit,
         'search-form-control--show-submit-label': this.showSubmitLabel,
@@ -82,12 +82,14 @@ export default {
 <template>
   <b-form @submit.prevent="$emit('submit', value)">
     <b-input-group size="sm" class="search-form-control" :class="searchFormClassAttr">
-      <b-form-input :autofocus="autofocus"
-                    class="search-form-control__input"
-                    @input="$emit('input', $event)"
-                    :placeholder="placeholder"
-                    :value="value"></b-form-input>
-      <b-input-group-append  class="search-form-control__addon search-form-control__addon--append">
+      <b-form-input
+        :autofocus="autofocus"
+        class="search-form-control__input"
+        @input="$emit('input', $event)"
+        :placeholder="placeholder"
+        :value="value"
+      ></b-form-input>
+      <b-input-group-append class="search-form-control__addon search-form-control__addon--append">
         <b-button variant="light" class="search-form-control__addon__submit" type="submit">
           <template v-if="!noIcon">
             <fa v-if="loading" icon="circle-notch" spin fixed-width></fa>
@@ -103,70 +105,69 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  .search-form-control {
-    position: relative;
+.search-form-control {
+  position: relative;
 
-    &__input:focus {
-      border-right: 0;
-      box-shadow: none;
+  &__input:focus {
+    border-right: 0;
+    box-shadow: none;
+  }
+
+  &__input:focus + &__addon &__addon__submit {
+    border-color: $input-focus-border-color;
+  }
+
+  &__input:focus + &__addon:after {
+    box-shadow: $input-focus-box-shadow;
+    border-radius: $input-border-radius;
+  }
+
+  &--rounded &__input {
+    border-bottom-left-radius: $rounded-pill;
+    border-top-left-radius: $rounded-pill;
+  }
+
+  &--rounded &__input:focus + &__addon:after {
+    border-radius: $rounded-pill;
+  }
+
+  &__addon {
+    &:after {
+      bottom: 0;
+      box-shadow: 0 0 0 $input-btn-focus-width transparent;
+      content: '';
+      left: 0;
+      pointer-events: none;
+      position: absolute;
+      right: 0;
+      top: 0;
+      transition: $input-transition;
+      z-index: 0;
     }
 
-    &__input:focus + &__addon &__addon__submit {
-      border-color: $input-focus-border-color;
+    & &__submit:last-of-type {
+      background: $input-bg;
+      border-color: $input-border-color;
+      border-left: 0;
+      transition: $input-transition;
     }
+  }
 
-    &__input:focus + &__addon:after {
-      box-shadow: $input-focus-box-shadow;
-      border-radius: $input-border-radius;
-    }
-
-    &--rounded &__input {
-      border-bottom-left-radius: $rounded-pill;
-      border-top-left-radius: $rounded-pill;
-    }
-
-    &--rounded &__input:focus + &__addon:after {
+  &--rounded &__addon {
+    &:after {
       border-radius: $rounded-pill;
     }
 
-    &__addon {
-
-      &:after {
-        bottom: 0;
-        box-shadow: 0 0 0 $input-btn-focus-width transparent;
-        content: "";
-        left: 0;
-        pointer-events: none;
-        position: absolute;
-        right: 0;
-        top: 0;
-        transition: $input-transition;
-        z-index: 0;
-      }
-
-      & &__submit:last-of-type {
-        background: $input-bg;
-        border-color: $input-border-color;
-        border-left: 0;
-        transition: $input-transition;
-      }
-    }
-
-    &--rounded &__addon {
-      &:after {
-        border-radius: $rounded-pill;
-      }
-
-      &__submit:last-of-type {
-        border-bottom-right-radius: $rounded-pill;
-        border-top-right-radius: $rounded-pill;
-      }
-    }
-
-    &--fill-submit &__addon__submit.btn {
-      @include gradient-bg($primary);
-      border-color: $primary;
-      color: color-yiq($primary);
+    &__submit:last-of-type {
+      border-bottom-right-radius: $rounded-pill;
+      border-top-right-radius: $rounded-pill;
     }
   }
+
+  &--fill-submit &__addon__submit.btn {
+    @include gradient-bg($primary);
+    border-color: $primary;
+    color: color-yiq($primary);
+  }
+}
 </style>

--- a/src/components/SearchLayoutSelector.vue
+++ b/src/components/SearchLayoutSelector.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="search-layout-selector btn-group">
     <button
+      v-b-tooltip
       class="btn search-layout-selector__button"
       :class="{ 'search-layout-selector__button--active': layout === 'list' }"
-      @click="layout = 'list'"
       :title="$t('search.layout.list')"
-      v-b-tooltip
+      @click="layout = 'list'"
     >
       <fa icon="th-list" fa-fw></fa>
       <span class="sr-only">
@@ -13,11 +13,11 @@
       </span>
     </button>
     <button
+      v-b-tooltip
       class="btn search-layout-selector__button"
       :class="{ 'search-layout-selector__button--active': layout === 'grid' }"
-      @click="layout = 'grid'"
       :title="$t('search.layout.grid')"
-      v-b-tooltip
+      @click="layout = 'grid'"
     >
       <fa icon="th" fa-fw></fa>
       <span class="sr-only">
@@ -25,11 +25,11 @@
       </span>
     </button>
     <button
+      v-b-tooltip
       class="btn search-layout-selector__button"
       :class="{ 'search-layout-selector__button--active': layout === 'table' }"
-      @click="layout = 'table'"
       :title="$t('search.layout.table')"
-      v-b-tooltip
+      @click="layout = 'table'"
     >
       <fa icon="table" fa-fw></fa>
       <span class="sr-only">

--- a/src/components/SearchLayoutSelector.vue
+++ b/src/components/SearchLayoutSelector.vue
@@ -1,30 +1,36 @@
 <template>
   <div class="search-layout-selector btn-group">
-    <button class="btn search-layout-selector__button"
-            :class="{ 'search-layout-selector__button--active': layout === 'list' }"
-            @click="layout = 'list'"
-            :title="$t('search.layout.list')"
-            v-b-tooltip>
+    <button
+      class="btn search-layout-selector__button"
+      :class="{ 'search-layout-selector__button--active': layout === 'list' }"
+      @click="layout = 'list'"
+      :title="$t('search.layout.list')"
+      v-b-tooltip
+    >
       <fa icon="th-list" fa-fw></fa>
       <span class="sr-only">
         {{ $t('search.layout.list') }}
       </span>
     </button>
-    <button class="btn search-layout-selector__button"
-            :class="{ 'search-layout-selector__button--active': layout === 'grid' }"
-            @click="layout = 'grid'"
-            :title="$t('search.layout.grid')"
-            v-b-tooltip>
+    <button
+      class="btn search-layout-selector__button"
+      :class="{ 'search-layout-selector__button--active': layout === 'grid' }"
+      @click="layout = 'grid'"
+      :title="$t('search.layout.grid')"
+      v-b-tooltip
+    >
       <fa icon="th" fa-fw></fa>
       <span class="sr-only">
         {{ $t('search.layout.grid') }}
       </span>
     </button>
-    <button class="btn search-layout-selector__button"
-            :class="{ 'search-layout-selector__button--active': layout === 'table' }"
-            @click="layout = 'table'"
-            :title="$t('search.layout.table')"
-            v-b-tooltip>
+    <button
+      class="btn search-layout-selector__button"
+      :class="{ 'search-layout-selector__button--active': layout === 'table' }"
+      @click="layout = 'table'"
+      :title="$t('search.layout.table')"
+      v-b-tooltip
+    >
       <fa icon="table" fa-fw></fa>
       <span class="sr-only">
         {{ $t('search.layout.table') }}
@@ -41,10 +47,10 @@ export default {
   name: 'SearchLayoutSelector',
   computed: {
     layout: {
-      get () {
+      get() {
         return this.$store.state.search.layout
       },
-      set (layout) {
+      set(layout) {
         this.$root.$emit('bv::hide::tooltip')
         return this.$store.commit('search/layout', layout)
       }
@@ -54,14 +60,14 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .search-layout-selector {
-    &__button.btn {
-      background: white;
-    }
-
-    &__button--active.btn {
-      background: $tertiary;
-      color: $component-active-color;
-    }
+.search-layout-selector {
+  &__button.btn {
+    background: white;
   }
+
+  &__button--active.btn {
+    background: $tertiary;
+    color: $component-active-color;
+  }
+}
 </style>

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -11,11 +11,14 @@ import { mapState } from 'vuex'
 export default {
   name: 'SearchResults',
   computed: {
-    component () {
+    component() {
       switch (this.layout) {
-      case 'grid': return () => import('@/components/SearchResultsGrid')
-      case 'table': return () => import('@/components/SearchResultsTable')
-      default: return () => import('@/components/SearchResultsList')
+        case 'grid':
+          return () => import('@/components/SearchResultsGrid')
+        case 'table':
+          return () => import('@/components/SearchResultsTable')
+        default:
+          return () => import('@/components/SearchResultsList')
       }
     },
     ...mapState('search', ['layout'])

--- a/src/components/SearchResultsGrid.vue
+++ b/src/components/SearchResultsGrid.vue
@@ -3,19 +3,34 @@
     <div v-if="hasResults">
       <search-results-header position="top" class="p-0 mb-3" />
       <div class="search-results-grid__items">
-        <div v-for="document in response.hits" :key="document.id" class="search-results-grid__items__item d-flex flex-column border rounded">
-          <document-actions :document="document" class="search-results-grid__items__item__actions m-2" :is-download-allowed="isDownloadAllowed(document)" />
-          <router-link class="flex-grow-1 search-results-grid__items__item__thumbnail"
-                       :to="{ name: 'document', params: document.routerParams, query: { q: query } }">
+        <div
+          v-for="document in response.hits"
+          :key="document.id"
+          class="search-results-grid__items__item d-flex flex-column border rounded"
+        >
+          <document-actions
+            :document="document"
+            class="search-results-grid__items__item__actions m-2"
+            :is-download-allowed="isDownloadAllowed(document)"
+          />
+          <router-link
+            class="flex-grow-1 search-results-grid__items__item__thumbnail"
+            :to="{ name: 'document', params: document.routerParams, query: { q: query } }"
+          >
             <document-thumbnail :document="document" size="md" />
           </router-link>
-          <router-link class="search-results-grid__items__item__title py-2 px-3 small"
-                       :to="{ name: 'document', params: document.routerParams }"
-                       :title="document.slicedNameToString" v-b-tooltip>
-            <document-sliced-name active-text-truncate
-                                  show-subject
-                                  text-truncate-rtl-attachments
-                                  :document="document" />
+          <router-link
+            class="search-results-grid__items__item__title py-2 px-3 small"
+            :to="{ name: 'document', params: document.routerParams }"
+            :title="document.slicedNameToString"
+            v-b-tooltip
+          >
+            <document-sliced-name
+              active-text-truncate
+              show-subject
+              text-truncate-rtl-attachments
+              :document="document"
+            />
           </router-link>
         </div>
       </div>
@@ -54,15 +69,18 @@ export default {
   },
   computed: {
     ...mapState('search', ['query', 'response']),
-    hasResults () {
+    hasResults() {
       return this.response.hits.length > 0
     },
-    hasFilters () {
-      return this.$store.getters['search/activeFilters'].length > 0 || this.$store.state.search.field !== settings.defaultSearchField
+    hasFilters() {
+      return (
+        this.$store.getters['search/activeFilters'].length > 0 ||
+        this.$store.state.search.field !== settings.defaultSearchField
+      )
     }
   },
   methods: {
-    isDownloadAllowed ({ index }) {
+    isDownloadAllowed({ index }) {
       return !!this.$store.state.downloads.allowedFor[index]
     }
   }
@@ -70,107 +88,107 @@ export default {
 </script>
 
 <style lang="scss">
-  .search-results-grid {
-    padding: 0 0 $spacer;
+.search-results-grid {
+  padding: 0 0 $spacer;
 
-    &__items {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
-      grid-auto-rows: 1fr;
-      grid-gap: $spacer;
+  &__items {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+    grid-auto-rows: 1fr;
+    grid-gap: $spacer;
 
-      &:before {
-        content: '';
-        width: 0;
-        padding-bottom: 100%;
-        grid-row: 1 / 1;
-        grid-column: 1 / 1;
-      }
+    &:before {
+      content: '';
+      width: 0;
+      padding-bottom: 100%;
+      grid-row: 1 / 1;
+      grid-column: 1 / 1;
+    }
 
-      *:first-child {
-         grid-row: 1 / 1;
-         grid-column: 1 / 1;
-      }
+    *:first-child {
+      grid-row: 1 / 1;
+      grid-column: 1 / 1;
+    }
 
-      &__item {
+    &__item {
+      background: white;
+      position: relative;
+
+      &:hover .document-actions {
         background: white;
-        position: relative;
 
-        &:hover .document-actions {
-          background: white;
-
-          & > *{
-            visibility: visible;
-          }
+        & > * {
+          visibility: visible;
         }
+      }
 
-        .document-actions {
+      .document-actions {
+        background: transparent;
+        z-index: 10;
+        position: absolute;
+        left: 0;
+        top: 0;
+
+        & > * {
           background: transparent;
-          z-index: 10;
+          visibility: hidden;
+        }
+
+        &__star.starred {
+          border-color: transparent;
+          box-shadow: none;
+          visibility: visible;
+
+          path {
+            stroke: white;
+            stroke-width: 3em;
+          }
+        }
+      }
+
+      &__thumbnail {
+        position: relative;
+        overflow: hidden;
+
+        &.router-link-active:after {
+          content: '';
           position: absolute;
-          left: 0;
           top: 0;
-
-          & > * {
-            background: transparent;
-            visibility: hidden;
-          }
-
-          &__star.starred {
-            border-color: transparent;
-            box-shadow: none;
-            visibility: visible;
-
-            path {
-              stroke: white;
-              stroke-width: 3em;
-            }
-          }
+          left: 0;
+          right: 0;
+          bottom: 0;
+          border: 2px solid $secondary;
+          border-bottom: 0;
         }
 
-        &__thumbnail {
-          position: relative;
-          overflow: hidden;
-
-          &.router-link-active:after {
-            content: "";
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            border: 2px solid $secondary;
-            border-bottom: 0;
-          }
-
-          .document-thumbnail {
-            position: absolute;
-            left: 50%;
-            top: 50%;
-            transform: translate(-50%, -50%);
-            min-width: 100%;
-            min-height: 100%;
-          }
+        .document-thumbnail {
+          position: absolute;
+          left: 50%;
+          top: 50%;
+          transform: translate(-50%, -50%);
+          min-width: 100%;
+          min-height: 100%;
         }
+      }
 
-        &__title {
-          display: flex;
-          align-items: center;
-        }
+      &__title {
+        display: flex;
+        align-items: center;
+      }
 
-        &__title.router-link-active {
-          background: $secondary;
-          color: white;
-        }
+      &__title.router-link-active {
+        background: $secondary;
+        color: white;
+      }
 
-        &__title:visited:not(.router-link-active) {
-          color: mix(#609, white, 50%);
-        }
+      &__title:visited:not(.router-link-active) {
+        color: mix(#609, white, 50%);
+      }
 
-        &__title:hover {
-          text-decoration: none;
-        }
+      &__title:hover {
+        text-decoration: none;
       }
     }
   }
+}
 </style>

--- a/src/components/SearchResultsGrid.vue
+++ b/src/components/SearchResultsGrid.vue
@@ -20,10 +20,10 @@
             <document-thumbnail :document="document" size="md" />
           </router-link>
           <router-link
+            v-b-tooltip
             class="search-results-grid__items__item__title py-2 px-3 small"
             :to="{ name: 'document', params: document.routerParams }"
             :title="document.slicedNameToString"
-            v-b-tooltip
           >
             <document-sliced-name
               active-text-truncate

--- a/src/components/SearchResultsHeader.vue
+++ b/src/components/SearchResultsHeader.vue
@@ -1,33 +1,41 @@
 <template>
-  <div class="search-results-header"
-       :class="{ 'search-results-header--bordered': bordered, [`search-results-header--${position}`]: true }">
+  <div
+    class="search-results-header"
+    :class="{ 'search-results-header--bordered': bordered, [`search-results-header--${position}`]: true }"
+  >
     <div class="search-results-header__settings d-flex align-items-center">
       <b-btn-group class="flex-grow-1" v-if="!noProgress">
-        <b-dropdown class="search-results-header__settings__sort"
-                    menu-class="search-results-header__settings__sort__dropdown"
-                    toggle-class="text-decoration-none py-2 px-2 border search-results-header__settings__sort__toggler"
-                    size="sm"
-                    variant="link">
-          <template v-slot:button-content>
+        <b-dropdown
+          class="search-results-header__settings__sort"
+          menu-class="search-results-header__settings__sort__dropdown"
+          toggle-class="text-decoration-none py-2 px-2 border search-results-header__settings__sort__toggler"
+          size="sm"
+          variant="link"
+        >
+          <template #button-content>
             {{ $t('search.results.sort.sortLabel') }}
           </template>
           <b-dropdown-header>
             {{ $t('search.settings.sortBy') }}
           </b-dropdown-header>
-          <b-dropdown-item :active="selectedSort === sort"
-                           @click="selectSort(selectedSort)"
-                           :key="selectedSort"
-                           v-for="selectedSort in sorts">
+          <b-dropdown-item
+            :active="selectedSort === sort"
+            @click="selectSort(selectedSort)"
+            :key="selectedSort"
+            v-for="selectedSort in sorts"
+          >
             {{ $t('search.results.sort.' + selectedSort) }}
           </b-dropdown-item>
         </b-dropdown>
-        <b-dropdown class="search-results-header__settings__size mr-2"
-                    menu-class="search-results-header__settings__size__dropdown pt-0"
-                    size="sm"
-                    toggle-class="text-decoration-none py-1 px-2 border search-results-header__settings__size__toggler"
-                    variant="link">
-          <template v-slot:button-content>
-            <span class="search-results-header__settings__size__toggler__slot" >
+        <b-dropdown
+          class="search-results-header__settings__size mr-2"
+          menu-class="search-results-header__settings__size__dropdown pt-0"
+          size="sm"
+          toggle-class="text-decoration-none py-1 px-2 border search-results-header__settings__size__toggler"
+          variant="link"
+        >
+          <template #button-content>
+            <span class="search-results-header__settings__size__toggler__slot">
               {{ firstDocument }} – {{ lastDocument }}
             </span>
             <span class="search-results-header__settings__size__toggler__hits text-muted" :title="nbDocuments">
@@ -37,23 +45,26 @@
           <b-dropdown-header>
             {{ $t('search.settings.resultsPerPage') }}
           </b-dropdown-header>
-          <b-dropdown-item :active="selectedSize === size"
-                           :key="selectedSize"
-                           @click="selectSize(selectedSize)"
-                           v-for="selectedSize in sizes">
+          <b-dropdown-item
+            :active="selectedSize === size"
+            :key="selectedSize"
+            @click="selectSize(selectedSize)"
+            v-for="selectedSize in sizes"
+          >
             <div class="d-flex align-items-center">
-              <span>
-                {{ selectedSize }} {{ $t('search.results.perPage') }}
-              </span>
+              <span> {{ selectedSize }} {{ $t('search.results.perPage') }} </span>
             </div>
           </b-dropdown-item>
         </b-dropdown>
       </b-btn-group>
-      <confirm-button v-if="response.total > 0" class="search-results-header__settings__btn-download btn btn-link text-nowrap "
-                      :confirmed="batchDownload"
-                      :label="batchDownloadLabel"
-                      :yes="$t('global.yes')"
-                      :no="$t('global.no')">
+      <confirm-button
+        v-if="response.total > 0"
+        class="search-results-header__settings__btn-download btn btn-link text-nowrap"
+        :confirmed="batchDownload"
+        :label="batchDownloadLabel"
+        :yes="$t('global.yes')"
+        :no="$t('global.no')"
+      >
         <fa icon="download"></fa>
         <span v-if="!noLabels" class="ml-2 d-none d-md-inline">
           {{ $t('search.results.batchDownload') }}
@@ -65,7 +76,8 @@
         :is-displayed="isDisplayed"
         :no-last-page-link="searchWindowTooLarge"
         :position="position"
-        :total="response.total" />
+        :total="response.total"
+      />
     </div>
     <div class="search-results-header__applied-search-filters" v-if="position === 'top' && !noFilters">
       <applied-search-filters />
@@ -100,7 +112,7 @@ export default {
     position: {
       type: String,
       default: 'top',
-      validator: value => ['top', 'bottom'].indexOf(value) >= -1
+      validator: (value) => ['top', 'bottom'].indexOf(value) >= -1
     },
     /**
      * Use borders
@@ -128,7 +140,7 @@ export default {
       default: false
     }
   },
-  data () {
+  data() {
     return {
       batchDownloadMaxNbFiles: this.$config.get('batchDownloadMaxNbFiles'),
       batchDownloadMaxSize: this.$config.get('batchDownloadMaxSize'),
@@ -148,83 +160,93 @@ export default {
   },
   computed: {
     ...mapState('search', ['from', 'response', 'size', 'sort']),
-    firstDocument () {
+    firstDocument() {
       return this.lastDocument === 0 ? 0 : this.from + 1
     },
-    lastDocument () {
+    lastDocument() {
       return min([this.response.total, this.from + this.size])
     },
-    searchWindowTooLarge () {
-      return (this.response.total + this.size) >= this.$config.get('search.maxWindowSize', 1e4)
+    searchWindowTooLarge() {
+      return this.response.total + this.size >= this.$config.get('search.maxWindowSize', 1e4)
     },
-    sumContentLength () {
+    sumContentLength() {
       let totalLength = 0
-      this.response.hits.forEach(doc => {
+      this.response.hits.forEach((doc) => {
         if (doc.contentLength >= 0) {
           totalLength += doc.contentLength
         }
       })
       return totalLength
     },
-    batchDownloadLabel () {
+    batchDownloadLabel() {
       let label = ''
       if (this.batchDownloadMaxNbFiles !== undefined && this.response.total > this.batchDownloadMaxNbFiles) {
-        label += `${this.$tc('search.results.warningNumber', this.batchDownloadMaxNbFiles, { number: this.$n(this.batchDownloadMaxNbFiles) })} `
+        label += `${this.$tc('search.results.warningNumber', this.batchDownloadMaxNbFiles, {
+          number: this.$n(this.batchDownloadMaxNbFiles)
+        })} `
       }
       if (this.batchDownloadMaxSize !== undefined && this.sumContentLength > byteSize(this.batchDownloadMaxSize)) {
-        label += `${this.$tc('search.results.warningSize', this.batchDownloadMaxSize, { size: this.batchDownloadMaxSize })} `
+        label += `${this.$tc('search.results.warningSize', this.batchDownloadMaxSize, {
+          size: this.batchDownloadMaxSize
+        })} `
       }
       return label === ''
-        ? `${this.$tc('search.results.batchDownloadSubmit', this.response.total, { total: this.$n(this.response.total) })} ${this.$t('global.confirmLabel')}`
+        ? `${this.$tc('search.results.batchDownloadSubmit', this.response.total, {
+            total: this.$n(this.response.total)
+          })} ${this.$t('global.confirmLabel')}`
         : `${label} ${this.$t('search.results.warningConfirm')}`
     },
-    nbDocuments () {
-      return `${this.$t('search.results.on')} ${this.$tc('search.results.results', this.response.total, { total: this.$n(this.response.total) })}`
+    nbDocuments() {
+      return `${this.$t('search.results.on')} ${this.$tc('search.results.results', this.response.total, {
+        total: this.$n(this.response.total)
+      })}`
     },
-    uriFromStore () {
+    uriFromStore() {
       const from = 0
       const query = { ...this.$store.getters['search/toRouteQuery'](), from }
-      const { route: { fullPath } } = this.$router.resolve({ name: 'search', query })
+      const {
+        route: { fullPath }
+      } = this.$router.resolve({ name: 'search', query })
       return fullPath
     }
   },
-  mounted () {
+  mounted() {
     // Force page to scroll top at each load
     // Specially for pagination
     document.body.scrollTop = document.documentElement.scrollTop = 0
   },
   methods: {
-    getToTemplate () {
+    getToTemplate() {
       return { name: 'search', query: cloneDeep(this.$store.getters['search/toRouteQuery']()) }
     },
-    isDisplayed () {
+    isDisplayed() {
       return this.response.total > this.size
     },
-    selectSize (size) {
+    selectSize(size) {
       // Store new search size into store
       this.$store.commit('search/size', size)
       // Change the route
       this.refreshRouteAndSearch()
     },
-    selectSort (sort) {
+    selectSort(sort) {
       // Store new search sort into store
       this.$store.commit('search/sort', sort)
       // Change the route
       this.refreshRouteAndSearch()
     },
-    refreshRouteAndSearch () {
+    refreshRouteAndSearch() {
       this.refreshRoute()
       this.refreshSearch()
     },
-    refreshRoute () {
+    refreshRoute() {
       const name = 'search'
       const query = this.$store.getters['search/toRouteQuery']()
       this.$router.push({ name, query }).catch(() => {})
     },
-    refreshSearch () {
+    refreshSearch() {
       this.$store.dispatch('search/query')
     },
-    batchDownload () {
+    batchDownload() {
       const uri = this.uriFromStore
       this.$store.dispatch('search/runBatchDownload', uri)
       const to = { name: 'batch-download' }
@@ -238,68 +260,70 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .search-results-header {
-    padding: 0.5 * $spacer 0;
+.search-results-header {
+  padding: 0.5 * $spacer 0;
 
-    &--bordered {
-      &.search-results-header--top {
-        border-bottom: 1px solid $gray-200;
-      }
-      &.search-results-header--bottom {
-        border-top: 1px solid $gray-200;
-      }
+  &--bordered {
+    &.search-results-header--top {
+      border-bottom: 1px solid $gray-200;
     }
-
-    &__settings {
-      color: $text-muted;
-      font-size: 0.95em;
-
-      &__size, &__sort {
-        &__toggler {
-          font-size: $font-size-sm;
-          line-height: inherit;
-        }
-      }
-
-      &__size  {
-        &:deep(&__toggler) {
-          display: flex;
-          align-items: center;
-          gap: 0.5em;
-          width :172px;
-        }
-
-        &:deep(&__toogler__hits) {
-          text-overflow: ellipsis;
-          white-space: nowrap;
-          overflow: hidden;
-        }
-      }
+    &.search-results-header--bottom {
+      border-top: 1px solid $gray-200;
     }
+  }
 
-    .search-results-header__settings__size__dropdown,
-    .search-results-header__settings__sort__dropdown {
-      min-width: 100%;
-      padding-top: 0;
+  &__settings {
+    color: $text-muted;
+    font-size: 0.95em;
 
-      .dropdown-header {
-        background: $gray-100;
-        border-bottom: 1px solid $border-color;
-        color: $body-color;
-        font-weight: bold;
-      }
-
-      .dropdown-item, .dropdown-header {
-        font-size: inherit;
+    &__size,
+    &__sort {
+      &__toggler {
+        font-size: $font-size-sm;
         line-height: inherit;
-        padding: 0.25rem 0.75rem;
+      }
+    }
 
-        &.active .text-muted,
-        &:focus .text-muted {
-          color: white !important;
-          opacity: 0.6;
-        }
+    &__size {
+      &:deep(&__toggler) {
+        display: flex;
+        align-items: center;
+        gap: 0.5em;
+        width: 172px;
+      }
+
+      &:deep(&__toogler__hits) {
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
       }
     }
   }
+
+  .search-results-header__settings__size__dropdown,
+  .search-results-header__settings__sort__dropdown {
+    min-width: 100%;
+    padding-top: 0;
+
+    .dropdown-header {
+      background: $gray-100;
+      border-bottom: 1px solid $border-color;
+      color: $body-color;
+      font-weight: bold;
+    }
+
+    .dropdown-item,
+    .dropdown-header {
+      font-size: inherit;
+      line-height: inherit;
+      padding: 0.25rem 0.75rem;
+
+      &.active .text-muted,
+      &:focus .text-muted {
+        color: white !important;
+        opacity: 0.6;
+      }
+    }
+  }
+}
 </style>

--- a/src/components/SearchResultsHeader.vue
+++ b/src/components/SearchResultsHeader.vue
@@ -4,7 +4,7 @@
     :class="{ 'search-results-header--bordered': bordered, [`search-results-header--${position}`]: true }"
   >
     <div class="search-results-header__settings d-flex align-items-center">
-      <b-btn-group class="flex-grow-1" v-if="!noProgress">
+      <b-btn-group v-if="!noProgress" class="flex-grow-1">
         <b-dropdown
           class="search-results-header__settings__sort"
           menu-class="search-results-header__settings__sort__dropdown"
@@ -19,10 +19,10 @@
             {{ $t('search.settings.sortBy') }}
           </b-dropdown-header>
           <b-dropdown-item
+            v-for="selectedSort in sorts"
+            :key="selectedSort"
             :active="selectedSort === sort"
             @click="selectSort(selectedSort)"
-            :key="selectedSort"
-            v-for="selectedSort in sorts"
           >
             {{ $t('search.results.sort.' + selectedSort) }}
           </b-dropdown-item>
@@ -46,10 +46,10 @@
             {{ $t('search.settings.resultsPerPage') }}
           </b-dropdown-header>
           <b-dropdown-item
-            :active="selectedSize === size"
-            :key="selectedSize"
-            @click="selectSize(selectedSize)"
             v-for="selectedSize in sizes"
+            :key="selectedSize"
+            :active="selectedSize === size"
+            @click="selectSize(selectedSize)"
           >
             <div class="d-flex align-items-center">
               <span> {{ selectedSize }} {{ $t('search.results.perPage') }} </span>
@@ -79,7 +79,7 @@
         :total="response.total"
       />
     </div>
-    <div class="search-results-header__applied-search-filters" v-if="position === 'top' && !noFilters">
+    <div v-if="position === 'top' && !noFilters" class="search-results-header__applied-search-filters">
       <applied-search-filters />
     </div>
   </div>

--- a/src/components/SearchResultsList.vue
+++ b/src/components/SearchResultsList.vue
@@ -3,17 +3,24 @@
     <div v-if="hasResults">
       <search-results-header position="top" no-labels bordered class="px-3"></search-results-header>
       <div class="search-results-list__items">
-        <div v-for="document in response.hits" :key="document.id" :data-document-id="document.id" class="search-results-list__items__item mw-100">
+        <div
+          v-for="document in response.hits"
+          :key="document.id"
+          :data-document-id="document.id"
+          class="search-results-list__items__item mw-100"
+        >
           <search-results-list-link
             class="search-results-list__items__item__link"
-            :document="document"></search-results-list-link>
+            :document="document"
+          ></search-results-list-link>
           <div>
             <document-actions
               class="search-results-list__items__item__actions"
               :document="document"
               :is-download-allowed="isDownloadAllowed(document)"
               tooltips-placement="right"
-              vertical></document-actions>
+              vertical
+            ></document-actions>
           </div>
         </div>
       </div>
@@ -49,7 +56,7 @@ export default {
     SearchResultsListLink
   },
   watch: {
-    $route (to, from) {
+    $route(to, from) {
       if (to.name === 'document') {
         const documentId = to.params.id
         const searchListItems = [...this.$el.querySelectorAll('.search-results-list__items__item')]
@@ -65,15 +72,18 @@ export default {
   },
   computed: {
     ...mapState('search', ['query', 'response']),
-    hasResults () {
+    hasResults() {
       return this.response.hits.length > 0
     },
-    hasFilters () {
-      return this.$store.getters['search/activeFilters'].length > 0 || this.$store.state.search.field !== settings.defaultSearchField
+    hasFilters() {
+      return (
+        this.$store.getters['search/activeFilters'].length > 0 ||
+        this.$store.state.search.field !== settings.defaultSearchField
+      )
     }
   },
   methods: {
-    isDownloadAllowed ({ index }) {
+    isDownloadAllowed({ index }) {
       return !!this.$store.state.downloads.allowedFor[index]
     }
   }
@@ -81,80 +91,83 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @use "sass:math";
+@use 'sass:math';
 
-  .search-results-list {
-    background: white;
-    border-radius: $card-border-radius;
+.search-results-list {
+  background: white;
+  border-radius: $card-border-radius;
 
-    &__toolbar {
-      background: $tertiary;
-      color: white;
-      font-size: 0.85rem;
-      line-height: $line-height-base * (1 - math.div(85 - 95, 95));
-      padding: 0.5rem 0;
+  &__toolbar {
+    background: $tertiary;
+    color: white;
+    font-size: 0.85rem;
+    line-height: $line-height-base * (1 - math.div(85 - 95, 95));
+    padding: 0.5rem 0;
 
-      &.slide-up-enter-active, &.slide-up-leave-active {
-        transition: .3s;
-      }
-
-      &.slide-up-enter, &.slide-up-leave-to {
-        // Works with only one row
-        margin-top: calc(#{-1em * $line-height-base} - #{$spacer * 1});
-        opacity: 0;
-      }
-
-      .nav-link {
-        color: mix($tertiary, text-contrast($tertiary), .7)
-      }
+    &.slide-up-enter-active,
+    &.slide-up-leave-active {
+      transition: 0.3s;
     }
 
-    &__items {
-      &__item {
-        flex-direction: row;
-        display: flex;
-        flex-wrap: nowrap;
-        max-width: 100%;
-        overflow: hidden;
+    &.slide-up-enter,
+    &.slide-up-leave-to {
+      // Works with only one row
+      margin-top: calc(#{-1em * $line-height-base} - #{$spacer * 1});
+      opacity: 0;
+    }
 
-        &:hover, &:hover &__link {
-          background: $table-hover-bg;
-          text-decoration: none;
+    .nav-link {
+      color: mix($tertiary, text-contrast($tertiary), 0.7);
+    }
+  }
+
+  &__items {
+    &__item {
+      flex-direction: row;
+      display: flex;
+      flex-wrap: nowrap;
+      max-width: 100%;
+      overflow: hidden;
+
+      &:hover,
+      &:hover &__link {
+        background: $table-hover-bg;
+        text-decoration: none;
+      }
+
+      &__actions {
+        margin: $spacer;
+        visibility: hidden;
+
+        &:deep(.btn) {
+          font-size: 0.9rem;
+          padding: $spacer * 0.1 $spacer * 0.25;
+          transition: none;
         }
 
-        &__actions {
-          margin: $spacer;
-          visibility: hidden;
-
-          &:deep(.btn) {
-            font-size: 0.9rem;
-            padding: $spacer * 0.10 $spacer * 0.25;
-            transition: none;
+        &:deep(.document-actions__star) {
+          &.starred {
+            border-color: transparent;
+            box-shadow: none;
+            visibility: visible;
           }
-
-          &:deep(.document-actions__star) {
-            &.starred {
-              border-color: transparent;
-              box-shadow: none;
-              visibility: visible;
-            }
-          }
         }
+      }
 
-        &:hover &__actions {
-          visibility: visible;
+      &:hover &__actions {
+        visibility: visible;
 
-          &:deep(.btn) {
-            background: white;
-            border-color: $primary;
-          }
+        &:deep(.btn) {
+          background: white;
+          border-color: $primary;
         }
+      }
 
-        &__link {
-          flex-grow: 1;
-          min-width: 0;
-        }
+      &__link {
+        flex-grow: 1;
+        min-width: 0;
       }
     }
   }
+}
 </style>

--- a/src/components/SearchResultsList.vue
+++ b/src/components/SearchResultsList.vue
@@ -55,6 +55,18 @@ export default {
     SearchResultsHeader,
     SearchResultsListLink
   },
+  computed: {
+    ...mapState('search', ['query', 'response']),
+    hasResults() {
+      return this.response.hits.length > 0
+    },
+    hasFilters() {
+      return (
+        this.$store.getters['search/activeFilters'].length > 0 ||
+        this.$store.state.search.field !== settings.defaultSearchField
+      )
+    }
+  },
   watch: {
     $route(to, from) {
       if (to.name === 'document') {
@@ -68,18 +80,6 @@ export default {
 
         target.scrollIntoView({ behavior: 'instant', block: 'nearest' })
       }
-    }
-  },
-  computed: {
-    ...mapState('search', ['query', 'response']),
-    hasResults() {
-      return this.response.hits.length > 0
-    },
-    hasFilters() {
-      return (
-        this.$store.getters['search/activeFilters'].length > 0 ||
-        this.$store.state.search.field !== settings.defaultSearchField
-      )
     }
   },
   methods: {

--- a/src/components/SearchResultsListLink.vue
+++ b/src/components/SearchResultsListLink.vue
@@ -43,6 +43,9 @@ export default {
     DocumentSlicedName,
     DocumentThumbnail
   },
+  filters: {
+    startCase
+  },
   mixins: [ner],
   props: {
     /**
@@ -74,9 +77,6 @@ export default {
     showIndex() {
       return this.indices.length > 1 && !this.location.startsWith(`./${this.index}`)
     }
-  },
-  filters: {
-    startCase
   },
   methods: {}
 }

--- a/src/components/SearchResultsListLink.vue
+++ b/src/components/SearchResultsListLink.vue
@@ -11,15 +11,15 @@
       <active-text-truncate class="search-results-list-link__location">
         <span class="d-inline-flex align-items-center">
           <fa icon="folder" class="mr-1" />
-          <b-badge variant="light" class="mr-2" v-if="showIndex">
+          <b-badge v-if="showIndex" variant="light" class="mr-2">
             {{ document.index | startCase }}
           </b-badge>
           {{ location }}
         </span>
       </active-text-truncate>
       <div
-        class="search-results-list-link__fragments"
         v-if="document.highlight"
+        class="search-results-list-link__fragments"
         v-html="document.highlight.content.join(' [...] ')"
       ></div>
     </div>
@@ -39,6 +39,10 @@ import ner from '@/mixins/ner'
  */
 export default {
   name: 'SearchResultsLink',
+  components: {
+    DocumentSlicedName,
+    DocumentThumbnail
+  },
   mixins: [ner],
   props: {
     /**
@@ -47,10 +51,6 @@ export default {
     document: {
       type: Object
     }
-  },
-  components: {
-    DocumentSlicedName,
-    DocumentThumbnail
   },
   computed: {
     ...mapState('search', ['indices', 'query']),

--- a/src/components/SearchResultsListLink.vue
+++ b/src/components/SearchResultsListLink.vue
@@ -1,6 +1,8 @@
 <template>
-  <router-link class="search-results-list-link d-flex align-self-stretch flex-nowrap"
-               :to="{ name: 'document', params, query: { q: query } }">
+  <router-link
+    class="search-results-list-link d-flex align-self-stretch flex-nowrap"
+    :to="{ name: 'document', params, query: { q: query } }"
+  >
     <document-thumbnail :document="document" class="search-results-list-link__thumbnail" crop lazy />
     <div class="search-results-list-link__wrapper">
       <span class="search-results-list-link__basename d-block">
@@ -15,9 +17,11 @@
           {{ location }}
         </span>
       </active-text-truncate>
-      <div class="search-results-list-link__fragments"
-           v-if="document.highlight"
-           v-html="document.highlight.content.join(' [...] ')"></div>
+      <div
+        class="search-results-list-link__fragments"
+        v-if="document.highlight"
+        v-html="document.highlight.content.join(' [...] ')"
+      ></div>
     </div>
   </router-link>
 </template>
@@ -50,95 +54,93 @@ export default {
   },
   computed: {
     ...mapState('search', ['indices', 'query']),
-    folder () {
+    folder() {
       const parts = this.document.get('_source.path', '').split('/')
       parts.splice(-1, 1)
       return parts.join('/') + '/'
     },
-    location () {
+    location() {
       return '.' + this.folder.split(this.$config.get('dataDir', process.env.VUE_APP_DATA_PREFIX)).pop()
     },
-    folderParams () {
+    folderParams() {
       return { q: `path:${this.folder}*` }
     },
-    params () {
+    params() {
       return this.document.routerParams
     },
-    index () {
+    index() {
       return this.document.index
     },
-    showIndex () {
+    showIndex() {
       return this.indices.length > 1 && !this.location.startsWith(`./${this.index}`)
     }
   },
   filters: {
     startCase
   },
-  methods: {
-
-  }
+  methods: {}
 }
 </script>
 <style lang="scss" scoped>
-  .search-results-list-link {
-    display: block;
+.search-results-list-link {
+  display: block;
 
-    &:visited:not(.router-link-active) &__basename {
-      color: mix(#609, white, 50%);
-    }
-
-    &.router-link-active,
-    &.router-link-active:active,
-    &.router-link-active:focus,
-    &:active,
-    &:focus {
-      outline: 0;
-      position: relative;
-
-      &:before {
-        border-left: 2px solid $secondary;
-        bottom: 0;
-        box-shadow: 0 0 10px 0 $secondary;
-        content: "";
-        left: 0;
-        position: absolute;
-        top: 0;
-      }
-    }
-
-    &:active:before, &:focus:before {
-      border-left: 2px solid $text-muted;
-      box-shadow: 0 0 10px 0 $gray-500;
-    }
-
-    &__thumbnail {
-      margin: $spacer;
-      margin-right: 0;
-    }
-
-    &__wrapper {
-      margin: $spacer;
-      min-width: 0;
-      flex-grow: 1;
-    }
-
-    &__basename {
-      font-size: $font-size-base;
-      margin: 0;
-      word-break: break-all;
-    }
-
-    &__location {
-      color: $text-muted;
-      display: block;
-      font-size: $font-size-sm;
-    }
-
-    &__fragments {
-      color: $body-color;
-      font-size: $font-size-sm;
-      margin-top: $spacer * 0.5;
-    }
-
+  &:visited:not(.router-link-active) &__basename {
+    color: mix(#609, white, 50%);
   }
+
+  &.router-link-active,
+  &.router-link-active:active,
+  &.router-link-active:focus,
+  &:active,
+  &:focus {
+    outline: 0;
+    position: relative;
+
+    &:before {
+      border-left: 2px solid $secondary;
+      bottom: 0;
+      box-shadow: 0 0 10px 0 $secondary;
+      content: '';
+      left: 0;
+      position: absolute;
+      top: 0;
+    }
+  }
+
+  &:active:before,
+  &:focus:before {
+    border-left: 2px solid $text-muted;
+    box-shadow: 0 0 10px 0 $gray-500;
+  }
+
+  &__thumbnail {
+    margin: $spacer;
+    margin-right: 0;
+  }
+
+  &__wrapper {
+    margin: $spacer;
+    min-width: 0;
+    flex-grow: 1;
+  }
+
+  &__basename {
+    font-size: $font-size-base;
+    margin: 0;
+    word-break: break-all;
+  }
+
+  &__location {
+    color: $text-muted;
+    display: block;
+    font-size: $font-size-sm;
+  }
+
+  &__fragments {
+    color: $body-color;
+    font-size: $font-size-sm;
+    margin-top: $spacer * 0.5;
+  }
+}
 </style>

--- a/src/components/SearchResultsTable.vue
+++ b/src/components/SearchResultsTable.vue
@@ -8,10 +8,10 @@
         >
           <b-list-group horizontal>
             <b-list-group-item
-              class="search-results-table__actions__action py-2"
-              button
               v-for="action in actions"
               :key="action.id"
+              class="search-results-table__actions__action py-2"
+              button
               @click="onClick(action.id)"
             >
               <fa v-if="action.icon" :icon="action.icon" :class="action.iconClass"></fa>
@@ -34,7 +34,6 @@
         hover
         selectable
         responsive
-        @row-selected="onRowSelected"
         :items="itemsProvider"
         :fields="fields"
         :busy="$wait.waiting('load results table')"
@@ -44,6 +43,7 @@
         thead-tr-class="text-nowrap"
         :sort-by.sync="sortBy"
         :sort-desc.sync="sortDesc"
+        @row-selected="onRowSelected"
       >
         <template #cell(relevance)="{ item, rowSelected }">
           <fa
@@ -70,7 +70,7 @@
           </router-link>
         </template>
         <template #cell(highlight)="{ value }">
-          <span v-html="value" class="text-truncate text-muted"></span>
+          <span class="text-truncate text-muted" v-html="value"></span>
         </template>
         <template #cell(contentLength)="{ value }">
           {{ humanSize(value) }}

--- a/src/components/SearchResultsTable.vue
+++ b/src/components/SearchResultsTable.vue
@@ -119,6 +119,9 @@ export default {
     DocumentTagsForm,
     SearchResultsHeader
   },
+  filters: {
+    startCase
+  },
   data() {
     return {
       selected: []
@@ -230,9 +233,6 @@ export default {
         }
       ]
     }
-  },
-  filters: {
-    startCase
   },
   methods: {
     onRowSelected(items) {

--- a/src/components/SearchResultsTable.vue
+++ b/src/components/SearchResultsTable.vue
@@ -2,16 +2,30 @@
   <div class="search-results-table">
     <div v-if="hasResults">
       <div class="d-flex mb-2">
-        <div v-if="selected.length" class="d-inline-flex search-results-table__actions mr-2 align-self-start align-items-center">
+        <div
+          v-if="selected.length"
+          class="d-inline-flex search-results-table__actions mr-2 align-self-start align-items-center"
+        >
           <b-list-group horizontal>
-            <b-list-group-item class="search-results-table__actions__action py-2" button v-for="action in actions" :key="action.id" @click="onClick(action.id)">
+            <b-list-group-item
+              class="search-results-table__actions__action py-2"
+              button
+              v-for="action in actions"
+              :key="action.id"
+              @click="onClick(action.id)"
+            >
               <fa v-if="action.icon" :icon="action.icon" :class="action.iconClass"></fa>
               {{ action.label }}
             </b-list-group-item>
           </b-list-group>
           <document-tags-form class="search-results-table__actions__action mx-2" :document="selected" display-form />
         </div>
-        <search-results-header position="top" class="flex-grow-1 align-self-center py-0" :no-progress="!!selected.length" :no-filters="!!selected.length" />
+        <search-results-header
+          position="top"
+          class="flex-grow-1 align-self-center py-0"
+          :no-progress="!!selected.length"
+          :no-filters="!!selected.length"
+        />
       </div>
       <b-table
         ref="selectableTable"
@@ -29,29 +43,45 @@
         tbody-tr-class="search-results-table__items__row"
         thead-tr-class="text-nowrap"
         :sort-by.sync="sortBy"
-        :sort-desc.sync="sortDesc">
-        <template v-slot:cell(relevance)="{ item, rowSelected }">
-          <fa v-if="item.contentTypeIcon" :icon="item.contentTypeIcon" fixed-width class="search-results-table__items__row__icon"></fa>
-          <fa :icon="['far', rowSelected ? 'check-square' : 'square']" fixed-width class="search-results-table__items__row__checkbox"></fa>
+        :sort-desc.sync="sortDesc"
+      >
+        <template #cell(relevance)="{ item, rowSelected }">
+          <fa
+            v-if="item.contentTypeIcon"
+            :icon="item.contentTypeIcon"
+            fixed-width
+            class="search-results-table__items__row__icon"
+          ></fa>
+          <fa
+            :icon="['far', rowSelected ? 'check-square' : 'square']"
+            fixed-width
+            class="search-results-table__items__row__checkbox"
+          ></fa>
         </template>
-        <template v-slot:cell(index)="{ item }">
+        <template #cell(index)="{ item }">
           <b-badge variant="light">{{ item.index | startCase }}</b-badge>
         </template>
-        <template v-slot:cell(path)="{ item }">
+        <template #cell(path)="{ item }">
           <router-link
             :to="{ name: 'document', params: item.routerParams, query: { q: query } }"
-            class="search-results-table__items__row__title">
+            class="search-results-table__items__row__title"
+          >
             <document-sliced-name :document="item" active-text-truncate show-subject />
           </router-link>
         </template>
-        <template v-slot:cell(highlight)="{ value }">
+        <template #cell(highlight)="{ value }">
           <span v-html="value" class="text-truncate text-muted"></span>
         </template>
-        <template v-slot:cell(contentLength)="{ value }">
+        <template #cell(contentLength)="{ value }">
           {{ humanSize(value) }}
         </template>
-        <template v-slot:cell(actions)="{ item }">
-          <document-actions :document="item" class="float-right btn-group-sm" :is-download-allowed="isDownloadAllowed(item)" tooltips-placement="rightbottom"></document-actions>
+        <template #cell(actions)="{ item }">
+          <document-actions
+            :document="item"
+            class="float-right btn-group-sm"
+            :is-download-allowed="isDownloadAllowed(item)"
+            tooltips-placement="rightbottom"
+          ></document-actions>
         </template>
       </b-table>
       <search-results-header position="bottom" />
@@ -89,59 +119,66 @@ export default {
     DocumentTagsForm,
     SearchResultsHeader
   },
-  data () {
+  data() {
     return {
       selected: []
     }
   },
   computed: {
     ...mapState('search', ['indices', 'query', 'response']),
-    isAllSelected () {
+    isAllSelected() {
       return this.response.hits.length === this.selected.length
     },
-    actions () {
-      return [{
-        id: 'selectAll',
-        label: this.isAllSelected ? this.$t('document.unselectAll') : this.$t('document.selectAll'),
-        icon: ['far', this.isAllSelected ? 'check-square' : 'square']
-      }, {
-        id: 'star',
-        label: this.$t('document.starButton'),
-        icon: ['fa', 'star']
-      }, {
-        id: 'unstar',
-        label: this.$t('document.unstarButton'),
-        icon: ['far', 'star']
-      }]
+    actions() {
+      return [
+        {
+          id: 'selectAll',
+          label: this.isAllSelected ? this.$t('document.unselectAll') : this.$t('document.selectAll'),
+          icon: ['far', this.isAllSelected ? 'check-square' : 'square']
+        },
+        {
+          id: 'star',
+          label: this.$t('document.starButton'),
+          icon: ['fa', 'star']
+        },
+        {
+          id: 'unstar',
+          label: this.$t('document.unstarButton'),
+          icon: ['far', 'star']
+        }
+      ]
     },
-    hasResults () {
+    hasResults() {
       return this.response.hits.length > 0
     },
-    hasFilters () {
-      return this.$store.getters['search/activeFilters'].length > 0 || this.$store.state.search.field !== settings.defaultSearchField
+    hasFilters() {
+      return (
+        this.$store.getters['search/activeFilters'].length > 0 ||
+        this.$store.state.search.field !== settings.defaultSearchField
+      )
     },
-    defaultSortField () {
+    defaultSortField() {
       return this.fields[0]
     },
     sortBy: {
-      get () {
+      get() {
         const { field } = this.$store.getters['search/sortBy']
         const { key } = find(this.fields, { sortBy: field }) || this.defaultSortField
         return key
       },
-      set () {
+      set() {
         return null
       }
     },
     sortDesc: {
-      get () {
+      get() {
         return this.$store.getters['search/sortBy'].desc
       },
-      set () {
+      set() {
         return null
       }
     },
-    fields () {
+    fields() {
       return [
         {
           key: 'relevance',
@@ -158,13 +195,17 @@ export default {
           key: 'path',
           sortBy: 'path',
           sortable: true,
-          label: this.$t('document.document') + (this.$store.getters['search/sortBy'].field === 'path' ? ` (${this.$t('search.results.sortedByPath')})` : ''),
+          label:
+            this.$t('document.document') +
+            (this.$store.getters['search/sortBy'].field === 'path'
+              ? ` (${this.$t('search.results.sortedByPath')})`
+              : ''),
           class: 'pl-0'
         },
         {
           key: 'highlight',
           headerTitle: 'highlight',
-          formatter: value => value?.content?.join(' [...] ') || ''
+          formatter: (value) => value?.content?.join(' [...] ') || ''
         },
         {
           key: 'creationDateHumanShort',
@@ -194,35 +235,35 @@ export default {
     startCase
   },
   methods: {
-    onRowSelected (items) {
+    onRowSelected(items) {
       this.$set(this, 'selected', items)
     },
-    async onClick (actionId) {
+    async onClick(actionId) {
       this.$wait.start('load results table')
       switch (actionId) {
-      case 'selectAll':
-        if (this.isAllSelected) {
-          this.$refs.selectableTable.clearSelected()
-          this.$bvToast.toast(this.$t('document.unselected'), { noCloseButton: true, variant: 'success' })
-        } else {
-          this.$refs.selectableTable.selectAllRows()
-          this.$bvToast.toast(this.$t('document.selected'), { noCloseButton: true, variant: 'success' })
-        }
-        break
-      case 'star':
-        await this.$store.dispatch('starred/starDocuments', this.selected)
-        this.$bvToast.toast(this.$t('document.starred'), { noCloseButton: true, variant: 'success' })
-        break
-      case 'unstar':
-        await this.$store.dispatch('starred/unstarDocuments', this.selected)
-        this.$bvToast.toast(this.$t('document.unstarred'), { noCloseButton: true, variant: 'success' })
-        break
-      default:
-        break
+        case 'selectAll':
+          if (this.isAllSelected) {
+            this.$refs.selectableTable.clearSelected()
+            this.$bvToast.toast(this.$t('document.unselected'), { noCloseButton: true, variant: 'success' })
+          } else {
+            this.$refs.selectableTable.selectAllRows()
+            this.$bvToast.toast(this.$t('document.selected'), { noCloseButton: true, variant: 'success' })
+          }
+          break
+        case 'star':
+          await this.$store.dispatch('starred/starDocuments', this.selected)
+          this.$bvToast.toast(this.$t('document.starred'), { noCloseButton: true, variant: 'success' })
+          break
+        case 'unstar':
+          await this.$store.dispatch('starred/unstarDocuments', this.selected)
+          this.$bvToast.toast(this.$t('document.unstarred'), { noCloseButton: true, variant: 'success' })
+          break
+        default:
+          break
       }
       this.$wait.end('load results table')
     },
-    async itemsProvider ({ sortBy, sortDesc }) {
+    async itemsProvider({ sortBy, sortDesc }) {
       // Refresh response only if sortBy or sortDesc are different from the state
       if (sortBy !== this.sortBy || sortDesc !== this.sortDesc) {
         // Find the table field for the sorting key (or use the first by default)
@@ -236,11 +277,11 @@ export default {
       }
       return this.response.hits
     },
-    humanSize (value) {
+    humanSize(value) {
       const size = humanSize(value)
       return size === 'unknown' ? this.$t('document.unknown') : size
     },
-    isDownloadAllowed ({ index }) {
+    isDownloadAllowed({ index }) {
       return !!this.$store.state.downloads.allowedFor[index]
     }
   }
@@ -248,85 +289,86 @@ export default {
 </script>
 
 <style lang="scss">
-  .search-results-table {
-    padding: 0 0 $spacer;
+.search-results-table {
+  padding: 0 0 $spacer;
 
-    &__items {
-      .table.b-table > thead > tr > th.fit {
-        background-position: right 0.10rem center;
+  &__items {
+    .table.b-table > thead > tr > th.fit {
+      background-position: right 0.1rem center;
+      padding-right: 0.85em;
+    }
+
+    &__row {
+      &__title {
+        display: flex;
+
+        &:visited:not(.router-link-active) {
+          color: mix(#609, white, 50%);
+        }
+      }
+
+      td.fit {
         padding-right: 0.85em;
       }
 
-      &__row {
-        &__title {
-          display: flex;
-
-          &:visited:not(.router-link-active) {
-            color: mix(#609, white, 50%);
-          }
-        }
-
-        td.fit {
-          padding-right: 0.85em;
-        }
-
-        table tbody tr &__title:hover {
-          text-decoration: none;
-        }
-
-        table tbody tr:not(.b-table-row-selected):not(:hover) &__checkbox,
-        table tbody tr.b-table-row-selected &__icon,
-        table tbody tr:hover &__icon {
-          display: none;
-        }
-
-        table tbody tr &__checkbox,
-        table tbody tr &__icon {
-          color: $link-color;
-        }
-
-        table tbody tr &__actions {
-          padding: 0;
-          vertical-align: middle;
-        }
-
-        td .text-truncate {
-          display: block;
-          max-width: 20vw;
-
-          .document-sliced-name {
-            display: inline-block;
-          }
-        }
-      }
-    }
-
-    &__actions {
-      background: $body-bg;
-      font-size: $font-size-sm;
-
-      &__action.document-tags-form {
-        align-self: stretch;
-        display: inline-flex;
-
-        & > div, input.form-control {
-          align-self: stretch;
-          height: 100%;
-        }
+      table tbody tr &__title:hover {
+        text-decoration: none;
       }
 
-      &__action.list-group-item-action {
-        color: $primary;
-        width: auto;
+      table tbody tr:not(.b-table-row-selected):not(:hover) &__checkbox,
+      table tbody tr.b-table-row-selected &__icon,
+      table tbody tr:hover &__icon {
+        display: none;
+      }
 
-        svg {
-          margin-right: .5em;
-        }
+      table tbody tr &__checkbox,
+      table tbody tr &__icon {
+        color: $link-color;
+      }
 
-        &:hover {
-          color: theme-color('dark');
+      table tbody tr &__actions {
+        padding: 0;
+        vertical-align: middle;
+      }
+
+      td .text-truncate {
+        display: block;
+        max-width: 20vw;
+
+        .document-sliced-name {
+          display: inline-block;
         }
       }
     }
   }
+
+  &__actions {
+    background: $body-bg;
+    font-size: $font-size-sm;
+
+    &__action.document-tags-form {
+      align-self: stretch;
+      display: inline-flex;
+
+      & > div,
+      input.form-control {
+        align-self: stretch;
+        height: 100%;
+      }
+    }
+
+    &__action.list-group-item-action {
+      color: $primary;
+      width: auto;
+
+      svg {
+        margin-right: 0.5em;
+      }
+
+      &:hover {
+        color: theme-color('dark');
+      }
+    }
+  }
+}
 </style>

--- a/src/components/ServerSettings.vue
+++ b/src/components/ServerSettings.vue
@@ -10,8 +10,9 @@
               label-cols-xs="12"
               label-cols-sm="4"
               label-cols-lg="3"
-              v-for="(_, name) in settings">
-              <template v-slot:label>
+              v-for="(_, name) in settings"
+            >
+              <template #label>
                 <span :class="{ 'font-weight-bold': fieldChanged(name) }" class="d-flex align-items-top">
                   <span class="flex-grow-1 pb-1" :title="name">
                     {{ name | sentenceCase | capitalizeKnownAcronyms }}
@@ -57,28 +58,31 @@ export default {
   name: 'ServerSettings',
   mixins: [utils],
   filters: {
-    sentenceCase (str) {
+    sentenceCase(str) {
       const result = str.replace(/([A-Z])/g, ' $1')
       return result.charAt(0).toUpperCase() + result.slice(1)
     },
-    capitalizeKnownAcronyms (str) {
-      return str.split(' ').map(word => {
-        const knownAcronyms = KNOWN_ACRONYMS.map(a => a.toUpperCase())
-        const index = knownAcronyms.indexOf(word.toUpperCase())
-        if (index > -1) {
-          return KNOWN_ACRONYMS[index]
-        }
-        return word
-      }).join(' ')
+    capitalizeKnownAcronyms(str) {
+      return str
+        .split(' ')
+        .map((word) => {
+          const knownAcronyms = KNOWN_ACRONYMS.map((a) => a.toUpperCase())
+          const index = knownAcronyms.indexOf(word.toUpperCase())
+          if (index > -1) {
+            return KNOWN_ACRONYMS[index]
+          }
+          return word
+        })
+        .join(' ')
     }
   },
-  data () {
+  data() {
     return {
       master: {},
       settings: {}
     }
   },
-  async mounted () {
+  async mounted() {
     this.$wait.start('load server settings')
     const master = await this.$store.dispatch('settings/getSettings')
     this.$set(this, 'master', master)
@@ -86,13 +90,13 @@ export default {
     this.$wait.end('load server settings')
   },
   methods: {
-    fieldChanged (field) {
+    fieldChanged(field) {
       return this.settings[field] !== this.master[field]
     },
-    restore (field) {
+    restore(field) {
       this.$set(this.settings, field, this.master[field])
     },
-    async onSubmit () {
+    async onSubmit() {
       try {
         await this.$store.dispatch('settings/onSubmit', this.settings)
         this.$config.merge(this.settings)

--- a/src/components/ServerSettings.vue
+++ b/src/components/ServerSettings.vue
@@ -3,14 +3,14 @@
     <div v-if="!isServer">
       <div class="container my-4">
         <v-wait for="load server settings">
-          <fa icon="circle-notch" spin size="2x" class="d-flex mx-auto mt-5" slot="waiting"></fa>
+          <fa slot="waiting" icon="circle-notch" spin size="2x" class="d-flex mx-auto mt-5"></fa>
           <b-form @submit.prevent="onSubmit">
             <b-form-group
+              v-for="(_, name) in settings"
               :key="name"
               label-cols-xs="12"
               label-cols-sm="4"
               label-cols-lg="3"
-              v-for="(_, name) in settings"
             >
               <template #label>
                 <span :class="{ 'font-weight-bold': fieldChanged(name) }" class="d-flex align-items-top">
@@ -18,7 +18,7 @@
                     {{ name | sentenceCase | capitalizeKnownAcronyms }}
                   </span>
                   <span>
-                    <b-btn variant="link text-muted" size="sm py-0" v-if="fieldChanged(name)" @click="restore(name)">
+                    <b-btn v-if="fieldChanged(name)" variant="link text-muted" size="sm py-0" @click="restore(name)">
                       <fa icon="undo"></fa>
                     </b-btn>
                   </span>
@@ -56,7 +56,6 @@ const KNOWN_ACRONYMS = ['URI', 'URL', 'NLP', 'OCR', 'TCP', 'API', 'TTL', 'OAuth'
  */
 export default {
   name: 'ServerSettings',
-  mixins: [utils],
   filters: {
     sentenceCase(str) {
       const result = str.replace(/([A-Z])/g, ' $1')
@@ -76,6 +75,7 @@ export default {
         .join(' ')
     }
   },
+  mixins: [utils],
   data() {
     return {
       master: {},

--- a/src/components/ShortkeysModal.vue
+++ b/src/components/ShortkeysModal.vue
@@ -1,12 +1,12 @@
 <template>
   <span class="shortkeys-modal">
     <b-button
+      v-b-modal.shortkeys
+      v-b-tooltip.hover.bottomleft
       class="text-dark"
       variant="transparent"
       size="md"
-      v-b-modal.shortkeys
       :title="$t('shortkeys.title')"
-      v-b-tooltip.hover.bottomleft
     >
       <fa icon="keyboard" />
       <span class="sr-only">
@@ -17,7 +17,7 @@
       <div v-for="(shortkey, index) in shortkeys" :key="index" class="shortkeys-modal__shortkey mb-1">
         <b-link :href="shortkey.link" target="_blank" class="shortkeys-modal__shortkey__link row no-gutters w-100 mb-1">
           <div class="col-sm-1 pr-2">
-            <fa :icon="shortkey.icon" v-if="shortkey.icon" fixed-width></fa>
+            <fa v-if="shortkey.icon" :icon="shortkey.icon" fixed-width></fa>
           </div>
           <div class="col-sm-7 pr-2">
             {{ getLabel(shortkey) }}
@@ -44,14 +44,14 @@ import { getShortkeyOS } from '@/utils/utils'
  */
 export default {
   name: 'ShortkeysModal',
-  data() {
-    return {
-      shortkeys: []
-    }
-  },
   filters: {
     shortkey(values) {
       return join(map(values, capitalize), '+')
+    }
+  },
+  data() {
+    return {
+      shortkeys: []
     }
   },
   computed: {

--- a/src/components/ShortkeysModal.vue
+++ b/src/components/ShortkeysModal.vue
@@ -1,7 +1,13 @@
 <template>
   <span class="shortkeys-modal">
-    <b-button class="text-dark" variant="transparent" size="md" v-b-modal.shortkeys :title="$t('shortkeys.title')"
-              v-b-tooltip.hover.bottomleft>
+    <b-button
+      class="text-dark"
+      variant="transparent"
+      size="md"
+      v-b-modal.shortkeys
+      :title="$t('shortkeys.title')"
+      v-b-tooltip.hover.bottomleft
+    >
       <fa icon="keyboard" />
       <span class="sr-only">
         {{ $t('shortkeys.title') }}
@@ -38,23 +44,23 @@ import { getShortkeyOS } from '@/utils/utils'
  */
 export default {
   name: 'ShortkeysModal',
-  data () {
+  data() {
     return {
       shortkeys: []
     }
   },
   filters: {
-    shortkey (values) {
+    shortkey(values) {
       return join(map(values, capitalize), '+')
     }
   },
   computed: {
     getShortkeyOS
   },
-  created () {
+  created() {
     const currentPage = get(this, '$route.name', '')
-    map(shortkeys, action => {
-      map(action, shortkey => {
+    map(shortkeys, (action) => {
+      map(action, (shortkey) => {
         // Filter only shortkeys of the current page
         if (shortkey.page !== currentPage) return
         // Check if multiple keys
@@ -62,7 +68,11 @@ export default {
           this.shortkeys.push(shortkey)
         } else {
           map(shortkey.keys.default, (_, action) => {
-            const newShortkey = { action, keys: { default: shortkey.keys.default[action], mac: shortkey.keys.mac[action] }, link: shortkey.link }
+            const newShortkey = {
+              action,
+              keys: { default: shortkey.keys.default[action], mac: shortkey.keys.mac[action] },
+              link: shortkey.link
+            }
             const label = get(shortkey, ['label', action], false)
             if (label) newShortkey.label = label
             const icon = get(shortkey, ['icon', action], false)
@@ -74,7 +84,7 @@ export default {
     })
   },
   methods: {
-    getLabel (shortkey) {
+    getLabel(shortkey) {
       const label = get(shortkey, 'label', get(shortkey, 'action', ''))
       return this.$te(label) ? this.$t(label) : label
     }
@@ -83,21 +93,21 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .shortkeys-modal__shortkey {
-    border-bottom: 1px solid lighten($text-muted, 40);
+.shortkeys-modal__shortkey {
+  border-bottom: 1px solid lighten($text-muted, 40);
 
-    &:last-child {
-      border-bottom: none;
-    }
+  &:last-child {
+    border-bottom: none;
+  }
 
-    &__link {
-      color: inherit;
-      display: inline-flex;
+  &__link {
+    color: inherit;
+    display: inline-flex;
+    text-decoration: none;
+
+    &:hover {
       text-decoration: none;
-
-      &:hover {
-        text-decoration: none;
-      }
     }
   }
+}
 </style>

--- a/src/components/TasksList.vue
+++ b/src/components/TasksList.vue
@@ -1,13 +1,15 @@
 <template>
   <div class="tasks-list">
-    <b-table :fields="tasksFields"
-             :items="sortedTasks"
-             responsive
-             striped
-             show-empty
-             thead-tr-class="text-nowrap"
-             tbody-tr-class="tasks-list__tasks__item"
-             class="card border-top-0 tasks-list__tasks">
+    <b-table
+      :fields="tasksFields"
+      :items="sortedTasks"
+      responsive
+      striped
+      show-empty
+      thead-tr-class="text-nowrap"
+      tbody-tr-class="tasks-list__tasks__item"
+      class="card border-top-0 tasks-list__tasks"
+    >
       <template #empty>
         <slot name="empty">
           <p class="text-center m-0" v-html="$t('tasksList.empty')"></p>
@@ -27,10 +29,13 @@
             {{ item.name | taskToId }}
           </b-badge>
           <template v-if="item.state === 'RUNNING' && stoppable">
-            <span class="px-1">
-              –
-            </span>
-            <b-btn variant="link" size="sm" @click="stopTask(item.name)" class="tasks-list__tasks__item__stop text-danger p-0">
+            <span class="px-1"> – </span>
+            <b-btn
+              variant="link"
+              size="sm"
+              @click="stopTask(item.name)"
+              class="tasks-list__tasks__item__stop text-danger p-0"
+            >
               {{ $t('tasksList.stop') }}
             </b-btn>
           </template>
@@ -43,7 +48,7 @@
         </div>
       </template>
       <template #table-colgroup="{ fields }">
-        <col v-for="{ key } in fields" :key="key" :style="{ width: key === 'state' ? '140px' : 'auto' }">
+        <col v-for="{ key } in fields" :key="key" :style="{ width: key === 'state' ? '140px' : 'auto' }" />
       </template>
     </b-table>
   </div>
@@ -61,8 +66,8 @@ export default {
   },
   props: {
     /**
-      * Object of tasks passed from the parent
-      */
+     * Object of tasks passed from the parent
+     */
     tasks: {
       type: Array
     },
@@ -74,42 +79,46 @@ export default {
     }
   },
   filters: {
-    taskToName (taskName) {
+    taskToName(taskName) {
       return taskName.split('.').pop().split('@').shift()
     },
-    taskToId (taskName) {
+    taskToId(taskName) {
       return taskName.split('@').pop()
     }
   },
   computed: {
-    sortedTasks () {
+    sortedTasks() {
       // Move running tasks on top
       const states = ['RUNNING']
       return sortBy(this.tasks, ({ state }) => -states.indexOf(state))
     },
-    tasksFields () {
+    tasksFields() {
       return this.tasks.length ? ['state', 'name'] : []
     },
-    isZipEncrypted () {
+    isZipEncrypted() {
       return this.$config.get('batchDownloadEncrypt')
     }
   },
   methods: {
-    isBatchDownloadEncrypted (item) {
+    isBatchDownloadEncrypted(item) {
       return item.name.includes('BatchDownload') && item.properties.batchDownload.encrypted
     },
-    hasZipSize (item) {
-      return item.name.includes('BatchDownload') && item.state !== 'ERROR' && item.properties.batchDownload.zipSize !== undefined
+    hasZipSize(item) {
+      return (
+        item.name.includes('BatchDownload') &&
+        item.state !== 'ERROR' &&
+        item.properties.batchDownload.zipSize !== undefined
+      )
     },
-    async stopPendingTasks () {
+    async stopPendingTasks() {
       await this.$store.dispatch('indexing/stopPendingTasks')
       await this.$store.dispatch('indexing/getTasks')
     },
-    async stopTask (name) {
+    async stopTask(name) {
       await this.$store.dispatch('indexing/stopTask', name)
       await this.$store.dispatch('indexing/getTasks')
     },
-    async deleteDoneTasks () {
+    async deleteDoneTasks() {
       await this.$store.dispatch('indexing/deleteDoneTasks')
       await this.$store.dispatch('indexing/getTasks')
     },

--- a/src/components/TasksList.vue
+++ b/src/components/TasksList.vue
@@ -33,8 +33,8 @@
             <b-btn
               variant="link"
               size="sm"
-              @click="stopTask(item.name)"
               class="tasks-list__tasks__item__stop text-danger p-0"
+              @click="stopTask(item.name)"
             >
               {{ $t('tasksList.stop') }}
             </b-btn>
@@ -64,6 +64,14 @@ export default {
   components: {
     EllipseStatus
   },
+  filters: {
+    taskToName(taskName) {
+      return taskName.split('.').pop().split('@').shift()
+    },
+    taskToId(taskName) {
+      return taskName.split('@').pop()
+    }
+  },
   props: {
     /**
      * Object of tasks passed from the parent
@@ -76,14 +84,6 @@ export default {
      */
     stoppable: {
       type: Boolean
-    }
-  },
-  filters: {
-    taskToName(taskName) {
-      return taskName.split('.').pop().split('@').shift()
-    },
-    taskToId(taskName) {
-      return taskName.split('@').pop()
     }
   },
   computed: {

--- a/src/components/TreeBreadcrumb.vue
+++ b/src/components/TreeBreadcrumb.vue
@@ -13,9 +13,9 @@
       ...
     </li>
     <li
-      class="list-inline-item tree-breadcrumb__item"
       v-for="directory in tree.slice(-maxDirectories)"
       :key="directory"
+      class="list-inline-item tree-breadcrumb__item"
     >
       <a href @click.prevent="$emit('input', directory)">{{ directory | basename }}</a>
     </li>
@@ -31,6 +31,9 @@ import { basename } from 'path'
  */
 export default {
   name: 'TreeBreadcrumb',
+  filters: {
+    basename
+  },
   model: {
     prop: 'path',
     event: 'input'
@@ -70,9 +73,6 @@ export default {
       type: Boolean,
       default: false
     }
-  },
-  filters: {
-    basename
   },
   computed: {
     fullTree() {

--- a/src/components/TreeBreadcrumb.vue
+++ b/src/components/TreeBreadcrumb.vue
@@ -6,10 +6,17 @@
         <span v-if="datadirLabel" class="ml-1">{{ $t('treeView.datadir') }}</span>
       </a>
     </li>
-    <li v-if="treeWithoutDataDir.length > maxDirectories" class="list-inline-item tree-breadcrumb__item tree-breadcrumb__item--abbr">
+    <li
+      v-if="treeWithoutDataDir.length > maxDirectories"
+      class="list-inline-item tree-breadcrumb__item tree-breadcrumb__item--abbr"
+    >
       ...
     </li>
-    <li class="list-inline-item tree-breadcrumb__item" v-for="directory in tree.slice(-maxDirectories)" :key="directory">
+    <li
+      class="list-inline-item tree-breadcrumb__item"
+      v-for="directory in tree.slice(-maxDirectories)"
+      :key="directory"
+    >
       <a href @click.prevent="$emit('input', directory)">{{ directory | basename }}</a>
     </li>
   </ul>
@@ -68,21 +75,25 @@ export default {
     basename
   },
   computed: {
-    fullTree () {
-      return reduce(this.path.split('/'), (tree, d) => {
-        if (d !== '') {
-          tree.push([last(tree), basename(d)].join('/'))
-        }
-        return tree
-      }, [])
+    fullTree() {
+      return reduce(
+        this.path.split('/'),
+        (tree, d) => {
+          if (d !== '') {
+            tree.push([last(tree), basename(d)].join('/'))
+          }
+          return tree
+        },
+        []
+      )
     },
-    treeWithoutDataDir () {
-      return filter(this.fullTree, d => d.length > this.dataDir.length)
+    treeWithoutDataDir() {
+      return filter(this.fullTree, (d) => d.length > this.dataDir.length)
     },
-    tree () {
+    tree() {
       return this.noDatadir ? this.treeWithoutDataDir : this.fullTree
     },
-    dataDir () {
+    dataDir() {
       return this.$config.get('mountedDataDir') || this.$config.get('dataDir')
     }
   }
@@ -90,21 +101,21 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .tree-breadcrumb {
-    &__item.list-inline-item {
-      margin-right: $spacer * 0.10;
-      padding: 0;
+.tree-breadcrumb {
+  &__item.list-inline-item {
+    margin-right: $spacer * 0.1;
+    padding: 0;
 
-      &:not(:last-child):after {
-        content: "/";
-        color: $text-muted;
-        margin-left: $spacer * 0.10;
-      }
+    &:not(:last-child):after {
+      content: '/';
+      color: $text-muted;
+      margin-left: $spacer * 0.1;
+    }
 
-      &:last-child a {
-        color: inherit;
-        font-weight: bold;
-      }
+    &:last-child a {
+      color: inherit;
+      font-weight: bold;
     }
   }
+}
 </style>

--- a/src/components/TreeView.vue
+++ b/src/components/TreeView.vue
@@ -2,14 +2,24 @@
   <div class="tree-view" :class="{ 'tree-view--compact': compact }">
     <b-collapse :visible="!noHeader">
       <div class="tree-view__header d-flex flex-row text-nowrap">
-        <tree-breadcrumb :path="path" @input="$emit('input', $event)" :max-directories="compact ? 2 : 5" no-datadir datadir-label></tree-breadcrumb>
+        <tree-breadcrumb
+          :path="path"
+          @input="$emit('input', $event)"
+          :max-directories="compact ? 2 : 5"
+          no-datadir
+          datadir-label
+        ></tree-breadcrumb>
         <transition name="fade">
           <div v-if="!$wait.waiting('loading tree view data')">
             <span v-if="size" class="tree-view__header__size">
               <fa icon="weight"></fa>
               {{ humanSize(total, false, $t('human.size')) }}
             </span>
-            <span :title="$tc('treeView.hits', hits, { hits })" class="tree-view__header__hits ml-2 badge badge-light badge-pill" v-if="count">
+            <span
+              :title="$tc('treeView.hits', hits, { hits })"
+              class="tree-view__header__hits ml-2 badge badge-light badge-pill"
+              v-if="count"
+            >
               {{ humanNumber(hits, $t('human.number')) }} {{ $tc('treeView.docs', hits) }}
             </span>
           </div>
@@ -25,8 +35,15 @@
         <slot name="above"></slot>
         <b-form-checkbox-group v-model="selected">
           <ul class="list-group list-group-flush tree-view__directories">
-            <li v-if="hits && selectable" class="list-group-item d-flex flex-row align-items-center text-muted tree-view__directories__item">
-              <b-form-checkbox :value="path" class="tree-view__directories__item__checkbox" :id="allDirectoriesInputId" />
+            <li
+              v-if="hits && selectable"
+              class="list-group-item d-flex flex-row align-items-center text-muted tree-view__directories__item"
+            >
+              <b-form-checkbox
+                :value="path"
+                class="tree-view__directories__item__checkbox"
+                :id="allDirectoriesInputId"
+              />
               <label class="flex-grow-1 m-0 text-light" :for="allDirectoriesInputId">
                 {{ $t('treeView.all') }} <em class="text-muted">({{ $t('treeView.includingIndividualDocuments') }})</em>
               </label>
@@ -34,23 +51,35 @@
                 <span v-if="compact">
                   {{ $n(hits) }}
                 </span>
-                <span v-else>
-                  {{ humanNumber(hits) }} {{ $tc('treeView.docs', hits) }}
-                </span>
+                <span v-else> {{ humanNumber(hits) }} {{ $tc('treeView.docs', hits) }} </span>
               </div>
             </li>
-            <li v-for="directory in directories" :key="directory.key" class="list-group-item d-flex flex-row align-items-center tree-view__directories__item">
-              <b-form-checkbox :value="directory.key" v-if="selectable" class="tree-view__directories__item__checkbox"></b-form-checkbox>
+            <li
+              v-for="directory in directories"
+              :key="directory.key"
+              class="list-group-item d-flex flex-row align-items-center tree-view__directories__item"
+            >
+              <b-form-checkbox
+                :value="directory.key"
+                v-if="selectable"
+                class="tree-view__directories__item__checkbox"
+              ></b-form-checkbox>
               <a class="flex-grow-1" href @click.prevent="$emit('input', directory.key)">
                 {{ directory.key | basename }}
               </a>
-              <div class="font-weight-bold ml-2" :title="$n(directory.contentLength.value)" v-if="size && directory.contentLength">
-                {{ humanSize(directory.contentLength.value, false, $t('human.size'))  }}
+              <div
+                class="font-weight-bold ml-2"
+                :title="$n(directory.contentLength.value)"
+                v-if="size && directory.contentLength"
+              >
+                {{ humanSize(directory.contentLength.value, false, $t('human.size')) }}
               </div>
-              <span :title="$tc('treeView.hits', directory.doc_count, { hits: $n(directory.doc_count) })" class="ml-2 badge badge-light badge-pill" v-if="count">
-                <span v-if="!directory.doc_count">
-                  -
-                </span>
+              <span
+                :title="$tc('treeView.hits', directory.doc_count, { hits: $n(directory.doc_count) })"
+                class="ml-2 badge badge-light badge-pill"
+                v-if="count"
+              >
+                <span v-if="!directory.doc_count"> - </span>
                 <span v-else-if="compact">
                   {{ $n(directory.doc_count) }}
                 </span>
@@ -58,9 +87,16 @@
                   {{ humanNumber(directory.doc_count) }} {{ $tc('treeView.docs', directory.doc_count) }}
                 </span>
               </span>
-              <span class="tree-view__directories__item__bar" v-if="!noBars" :style="{ width: totalPercentage(directory.contentLength.value) }"></span>
+              <span
+                class="tree-view__directories__item__bar"
+                v-if="!noBars"
+                :style="{ width: totalPercentage(directory.contentLength.value) }"
+              ></span>
             </li>
-            <li v-if="!selectable && !directories.length" class="list-group-item tree-view__directories__item tree-view__directories__item--no-folders text-muted text-center">
+            <li
+              v-if="!selectable && !directories.length"
+              class="list-group-item tree-view__directories__item tree-view__directories__item--no-folders text-muted text-center"
+            >
               {{ $t('widget.noFolders') }}
             </li>
           </ul>
@@ -182,7 +218,7 @@ export default {
     sortBy: {
       type: String,
       default: 'contentLength',
-      validator: order => includes(['_count', '_key', 'contentLength'], order)
+      validator: (order) => includes(['_count', '_key', 'contentLength'], order)
     },
     /**
      * Order to sort by (asc or desc)
@@ -190,7 +226,7 @@ export default {
     sortByOrder: {
       type: String,
       default: 'desc',
-      validator: order => includes(['asc', 'desc'], order)
+      validator: (order) => includes(['asc', 'desc'], order)
     },
     /**
      * If the true, the document count and size of each directory will include
@@ -204,7 +240,7 @@ export default {
     InfiniteLoading,
     TreeBreadcrumb
   },
-  data () {
+  data() {
     return {
       pages: [],
       tree: [],
@@ -212,20 +248,20 @@ export default {
       allDirectoriesInputId: uniqueId('all-directories-input-')
     }
   },
-  async created () {
+  async created() {
     await this.loadDataWithSpinner({ clearPages: true })
   },
   watch: {
-    path () {
+    path() {
       return this.reloadDataWithSpinner()
     },
-    sortBy () {
+    sortBy() {
       return this.reloadDataWithSpinner()
     },
-    sortByOrder () {
+    sortByOrder() {
       return this.reloadDataWithSpinner()
     },
-    directories () {
+    directories() {
       /**
        * Called when more directories are loaded
        */
@@ -236,48 +272,48 @@ export default {
     basename
   },
   computed: {
-    lastPage () {
+    lastPage() {
       return this.pages[this.pages.length - 1]
     },
-    lastPageDirectories () {
+    lastPageDirectories() {
       return get(this.lastPage, 'aggregations.byDirname.buckets', [])
     },
-    offset () {
+    offset() {
       return get(this, 'directories.length', 0)
     },
-    nextOffset () {
+    nextOffset() {
       return this.offset + this.bucketsSize
     },
-    bucketsSize () {
+    bucketsSize() {
       return 50
     },
-    order () {
+    order() {
       return { [this.sortBy]: this.sortByOrder }
     },
-    treeChildren () {
+    treeChildren() {
       return filter(get(this.tree, 'contents', []), { type: 'directory' })
     },
-    treeAsPagesBuckets () {
+    treeAsPagesBuckets() {
       return this.treeChildren
-        .filter(dir => dir.type === 'directory')
-        .map(dir => ({ key: dir.name, contentLength: 0, doc_count: 0 }))
+        .filter((dir) => dir.type === 'directory')
+        .map((dir) => ({ key: dir.name, contentLength: 0, doc_count: 0 }))
     },
-    pagesBuckets () {
-      return this.pages.map(p => get(p, 'aggregations.byDirname.buckets', []))
+    pagesBuckets() {
+      return this.pages.map((p) => get(p, 'aggregations.byDirname.buckets', []))
     },
-    flattenPagesBuckets () {
+    flattenPagesBuckets() {
       return flatten(this.pagesBuckets)
     },
-    directories () {
-      return uniqBy([...this.flattenPagesBuckets, ...this.treeAsPagesBuckets], dir => dir.key)
+    directories() {
+      return uniqBy([...this.flattenPagesBuckets, ...this.treeAsPagesBuckets], (dir) => dir.key)
     },
-    hits () {
+    hits() {
       return get(this, 'lastPage.hits.total.value', 0)
     },
-    total () {
+    total() {
       return get(this, 'lastPage.aggregations.totalContentLength.value', -1)
     },
-    aggregationOptions () {
+    aggregationOptions() {
       return {
         include: this.suffixPathTokens('/.*').join('|'),
         exclude: this.suffixPathTokens('/.*/.*').join('|'),
@@ -285,13 +321,13 @@ export default {
         order: this.order
       }
     },
-    reachedTheEnd () {
+    reachedTheEnd() {
       return this.lastPageDirectories.length < this.bucketsSize
     },
-    useInfiniteScroll () {
+    useInfiniteScroll() {
       return this.infiniteScroll && this.offset > 0 && !this.reachedTheEnd
     },
-    pathTokens () {
+    pathTokens() {
       /**
        * @deprecated Since 9.4.2, the dirname field is tokenized using the
        * "lowercase" filter. To ensure retro-compatibility, we apply lookup for
@@ -301,16 +337,16 @@ export default {
       return uniq([this.path, this.path.toLowerCase()])
     },
     selected: {
-      get () {
+      get() {
         return this.selectedPaths
       },
-      set (paths) {
+      set(paths) {
         const diff = difference(paths, this.selectedPaths)
         // True if the current path just has been selected.
         // This is equivalent to select "all.
         if (diff.includes(this.path)) {
           paths = this.pathsWihtoutSiblings(paths)
-        // True if a sibling directory is selected, not the current path
+          // True if a sibling directory is selected, not the current path
         } else if (diff.length && paths.includes(this.path)) {
           paths = this.pathsWithoutCurrent(paths)
         }
@@ -321,10 +357,10 @@ export default {
   methods: {
     humanSize,
     humanNumber,
-    suffixPathTokens (suffix = '') {
-      return this.pathTokens.map(token => `${token}${suffix}`)
+    suffixPathTokens(suffix = '') {
+      return this.pathTokens.map((token) => `${token}${suffix}`)
     },
-    selectPaths (paths) {
+    selectPaths(paths) {
       /**
        * The selectedPaths are updated (deprecated event).
        *
@@ -339,61 +375,63 @@ export default {
        */
       this.$emit('update:selectedPaths', paths)
     },
-    pathsWihtoutSiblings (paths) {
-      return filter(paths, path => {
+    pathsWihtoutSiblings(paths) {
+      return filter(paths, (path) => {
         return path === this.path || !path.startsWith(this.path)
       })
     },
-    pathsWithoutCurrent (paths) {
-      return filter(paths, path => {
+    pathsWithoutCurrent(paths) {
+      return filter(paths, (path) => {
         return path && path !== this.path
       })
     },
-    totalPercentage (value) {
+    totalPercentage(value) {
       if (this.total > 0) {
-        return round(value / this.total * 100, 2) + '%'
+        return round((value / this.total) * 100, 2) + '%'
       } else {
         return '0%'
       }
     },
-    bodybuilderBase ({ from = 0, size = 100 } = {}) {
+    bodybuilderBase({ from = 0, size = 100 } = {}) {
       const body = bodybuilder().size(0).rawOption('track_total_hits', true)
       // Only the extraction level is an optional query
       if (!this.includeChildrenDocuments) {
         body.andQuery('match', 'extractionLevel', 0)
       }
       return body
-        .andQuery('bool', bool => {
+        .andQuery('bool', (bool) => {
           // Add all path tokens in a "should" statement
-          this.pathTokens.forEach(t => bool.orQuery('term', 'dirname.tree', t))
+          this.pathTokens.forEach((t) => bool.orQuery('term', 'dirname.tree', t))
           return bool
         })
         .andQuery('match', 'type', 'Document')
-        .agg('terms', 'dirname.tree', this.aggregationOptions, 'byDirname', b => {
-          return b
-            .agg('sum', 'contentLength', 'contentLength')
-            .agg('bucket_sort', {
+        .agg('terms', 'dirname.tree', this.aggregationOptions, 'byDirname', (b) => {
+          return b.agg('sum', 'contentLength', 'contentLength').agg(
+            'bucket_sort',
+            {
               size,
               from
-            }, 'bucket_truncate')
+            },
+            'bucket_truncate'
+          )
         })
         .agg('sum', 'contentLength', 'totalContentLength')
     },
-    async nextLoadData ($infiniteLoadingState) {
+    async nextLoadData($infiniteLoadingState) {
       await this.loadData()
       // Did we reach the end?
       const method = this.reachedTheEnd ? 'complete' : 'loaded'
       // Call the right method (with "noop" as safety net in case the method can't be found)
       return get($infiniteLoadingState, method, noop)()
     },
-    async reloadDataWithSpinner () {
+    async reloadDataWithSpinner() {
       await this.loadDataWithSpinner({ clearPages: true })
       this.$set(this, 'infiniteScrollId', uniqueId())
     },
     loadDataWithSpinner: waitFor('loading tree view data', function (...args) {
       return this.loadData(...args)
     }),
-    async loadData ({ clearPages = false } = {}) {
+    async loadData({ clearPages = false } = {}) {
       const index = this.projects.join(',')
       const from = clearPages ? 0 : this.offset
       const size = this.bucketsSize
@@ -405,10 +443,10 @@ export default {
       // Add the result as a page
       this.pages.push(res)
     },
-    clearPages () {
+    clearPages() {
       return this.pages.splice(0, this.pages.length)
     },
-    async clearPagesAndLoadTree () {
+    async clearPagesAndLoadTree() {
       this.clearPages()
       // Only load the tree if we clear out the pages
       // and entirely load the folder. This way we avoid
@@ -422,7 +460,7 @@ export default {
         await this.loadTree()
       }
     },
-    async loadTree () {
+    async loadTree() {
       this.tree = await this.$core.api.tree(this.path)
     }
   }
@@ -430,83 +468,82 @@ export default {
 </script>
 
 <style lang="scss">
-  @keyframes slidingBar {
-    0% {
-      transform: translateX(-100%);
-    }
-    100% {
-      transform: translateX(0%);
+@keyframes slidingBar {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(0%);
+  }
+}
+
+.tree-view {
+  overflow: hidden;
+
+  .fade-enter-active,
+  .fade-leave-active {
+    transition: opacity 0.5s;
+  }
+  .fade-enter,
+  .fade-leave-to {
+    opacity: 0;
+  }
+
+  &__spinner {
+    padding: $spacer * 3;
+
+    .tree-view--compact & {
+      padding: $spacer;
     }
   }
 
-  .tree-view {
-      overflow: hidden;
+  &__header {
+    padding: $list-group-item-padding-y $list-group-item-padding-x;
+    color: inherit;
 
-      .fade-enter-active,
-      .fade-leave-active {
-        transition: opacity .5s;
-      }
-      .fade-enter,
-      .fade-leave-to {
-        opacity: 0;
-      }
-
-      &__spinner {
-        padding: $spacer * 3;
-
-        .tree-view--compact & {
-          padding: $spacer;
-        }
-      }
-
-      &__header {
-        padding: $list-group-item-padding-y $list-group-item-padding-x;
-        color: inherit;
-
-        .tree-view--compact & {
-          padding: $spacer * 0.5;
-        }
-      }
-
-      &__directories {
-
-        &__item {
-          position: relative;
-
-          .tree-view & &__checkbox {
-            margin: 0;
-            margin-right: $spacer * 0.5;
-          }
-
-          .tree-view--compact & &__checkbox {
-            margin: 0;
-            margin-right: $spacer * 0.25;
-          }
-
-          .tree-view--compact & {
-            padding: $spacer * 0.25 $spacer * 0.5;
-
-            &--no-folders {
-              padding: 0.5rem;
-            }
-          }
-
-          &__bar {
-            animation: slidingBar 200ms forwards;
-            background: $primary;
-            bottom: 0;
-            height: 3px;
-            left: 0;
-            position: absolute;
-            transform: translateX(-100%);
-          }
-
-          @for $i from 0 through 100 {
-            &:nth-child(#{$i}) &__bar {
-              animation-delay: $i * 50ms;
-            }
-          }
-        }
-      }
+    .tree-view--compact & {
+      padding: $spacer * 0.5;
+    }
   }
+
+  &__directories {
+    &__item {
+      position: relative;
+
+      .tree-view & &__checkbox {
+        margin: 0;
+        margin-right: $spacer * 0.5;
+      }
+
+      .tree-view--compact & &__checkbox {
+        margin: 0;
+        margin-right: $spacer * 0.25;
+      }
+
+      .tree-view--compact & {
+        padding: $spacer * 0.25 $spacer * 0.5;
+
+        &--no-folders {
+          padding: 0.5rem;
+        }
+      }
+
+      &__bar {
+        animation: slidingBar 200ms forwards;
+        background: $primary;
+        bottom: 0;
+        height: 3px;
+        left: 0;
+        position: absolute;
+        transform: translateX(-100%);
+      }
+
+      @for $i from 0 through 100 {
+        &:nth-child(#{$i}) &__bar {
+          animation-delay: $i * 50ms;
+        }
+      }
+    }
+  }
+}
 </style>

--- a/src/components/UserDisplay.vue
+++ b/src/components/UserDisplay.vue
@@ -167,7 +167,7 @@ export default {
         <template #waiting>
           {{ username }}
         </template>
-        <template>
+        <template #default>
           {{ transformedUsername }}
         </template>
       </v-wait>

--- a/src/components/UserDisplay.vue
+++ b/src/components/UserDisplay.vue
@@ -84,19 +84,6 @@ export default {
       transformedUsername: null
     }
   },
-  watch: {
-    username() {
-      return this.applyPipelines()
-    }
-  },
-  created() {
-    this.$store.subscribe(({ type }) => {
-      if (type.startsWith('pipelines/')) {
-        return this.applyPipelines()
-      }
-    })
-    return this.applyPipelinesWithLoader()
-  },
   computed: {
     ...mapGetters('pipelines', {
       applyPipelineChain: 'applyPipelineChainByCategory'
@@ -127,6 +114,19 @@ export default {
     loader() {
       return `load-username-${this.username}`
     }
+  },
+  watch: {
+    username() {
+      return this.applyPipelines()
+    }
+  },
+  created() {
+    this.$store.subscribe(({ type }) => {
+      if (type.startsWith('pipelines/')) {
+        return this.applyPipelines()
+      }
+    })
+    return this.applyPipelinesWithLoader()
   },
   methods: {
     async applyPipelinesWithLoader() {

--- a/src/components/UserDisplay.vue
+++ b/src/components/UserDisplay.vue
@@ -84,6 +84,11 @@ export default {
       transformedUsername: null
     }
   },
+  watch: {
+    username() {
+      return this.applyPipelines()
+    }
+  },
   created() {
     this.$store.subscribe(({ type }) => {
       if (type.startsWith('pipelines/')) {
@@ -91,11 +96,6 @@ export default {
       }
     })
     return this.applyPipelinesWithLoader()
-  },
-  watch: {
-    username() {
-      return this.applyPipelines()
-    }
   },
   computed: {
     ...mapGetters('pipelines', {

--- a/src/components/UserDisplay.vue
+++ b/src/components/UserDisplay.vue
@@ -77,14 +77,14 @@ export default {
       default: 'user-display-username'
     }
   },
-  data () {
+  data() {
     return {
       transformedAvatar: null,
       transformedLink: null,
       transformedUsername: null
     }
   },
-  created () {
+  created() {
     this.$store.subscribe(({ type }) => {
       if (type.startsWith('pipelines/')) {
         return this.applyPipelines()
@@ -93,7 +93,7 @@ export default {
     return this.applyPipelinesWithLoader()
   },
   watch: {
-    username () {
+    username() {
       return this.applyPipelines()
     }
   },
@@ -101,51 +101,51 @@ export default {
     ...mapGetters('pipelines', {
       applyPipelineChain: 'applyPipelineChainByCategory'
     }),
-    avatarAlt () {
+    avatarAlt() {
       return `${this.username} avatar`
     },
-    avatarSrc () {
+    avatarSrc() {
       return this.transformedAvatar
     },
-    avatarFallback () {
+    avatarFallback() {
       const icon = faIcon(faUserCircle)
       const svg = icon.html[0].split('currentColor').join(this.fallbackAvatarColor)
       const base64 = window.btoa(svg)
       return `data:image/svg+xml;base64,${base64}`
     },
-    userDisplayStyle () {
+    userDisplayStyle() {
       return {
         '--avatar-height': this.avatarHeight
       }
     },
-    usernameTag () {
+    usernameTag() {
       return !this.hideLink && this.transformedLink !== null ? 'a' : 'span'
     },
-    showAvatar () {
+    showAvatar() {
       return !this.hideAvatar && this.avatarSrc
     },
-    loader () {
+    loader() {
       return `load-username-${this.username}`
     }
   },
   methods: {
-    async applyPipelinesWithLoader () {
+    async applyPipelinesWithLoader() {
       this.$wait.start(this.loader)
       await this.applyPipelines()
       this.$wait.end(this.loader)
     },
-    async applyPipelines () {
+    async applyPipelines() {
       this.transformedAvatar = await this.applyAvatarPipeline()
       this.transformedLink = await this.applyLinkPipeline()
       this.transformedUsername = await this.applyUsernamePipeline()
     },
-    applyAvatarPipeline () {
+    applyAvatarPipeline() {
       return this.applyPipelineChain(this.avatarPipeline)(this.avatarFallback, this.username)
     },
-    applyUsernamePipeline () {
+    applyUsernamePipeline() {
       return this.applyPipelineChain(this.usernamePipeline)(this.username, this.$core.auth)
     },
-    applyLinkPipeline () {
+    applyLinkPipeline() {
       return this.applyPipelineChain(this.linkPipeline)(this.linkFallback, this.username)
     }
   }
@@ -153,29 +153,34 @@ export default {
 </script>
 
 <template>
-    <component :is="tag" class="user-display d-inline-flex align-items-center" :style="userDisplayStyle">
-      <template v-if="showAvatar">
-        <img class="user-display__avatar mr-2 rounded-circle" :src="avatarSrc" :alt="avatarAlt"/>
-      </template>
-      <component :is="usernameTag" :href="transformedLink" class="user-display__username" :class="{ 'user-display__username--loading': $wait.is(loader) }">
-        <v-wait :for="loader" class="d-inline">
-          <template #waiting>
-            {{ username }}
-          </template>
-          <template>
-            {{ transformedUsername }}
-          </template>
-        </v-wait>
-      </component>
+  <component :is="tag" class="user-display d-inline-flex align-items-center" :style="userDisplayStyle">
+    <template v-if="showAvatar">
+      <img class="user-display__avatar mr-2 rounded-circle" :src="avatarSrc" :alt="avatarAlt" />
+    </template>
+    <component
+      :is="usernameTag"
+      :href="transformedLink"
+      class="user-display__username"
+      :class="{ 'user-display__username--loading': $wait.is(loader) }"
+    >
+      <v-wait :for="loader" class="d-inline">
+        <template #waiting>
+          {{ username }}
+        </template>
+        <template>
+          {{ transformedUsername }}
+        </template>
+      </v-wait>
     </component>
+  </component>
 </template>
 
 <style lang="scss">
-  .user-display {
-    --avatar-height: 1.75em;
+.user-display {
+  --avatar-height: 1.75em;
 
-    &__avatar {
-      height: var(--avatar-height);
-    }
+  &__avatar {
+    height: var(--avatar-height);
   }
+}
 </style>

--- a/src/components/UserHistorySaveSearchForm.vue
+++ b/src/components/UserHistorySaveSearchForm.vue
@@ -37,21 +37,6 @@ export default {
       name: ''
     }
   },
-  methods: {
-    async saveSearch() {
-      try {
-        await this.$core.api.addHistoryEvent(this.indices, 'SEARCH', this.name, this.uriFromStore)
-        const { href } = this.$router.resolve({ name: 'search-history' })
-        const toastParams = { href, noCloseButton: true, variant: 'success' }
-        this.$root.$bvToast.toast(this.$t('userHistory.submitSuccess'), toastParams)
-      } catch (_) {
-        const toastParams = { noCloseButton: true, variant: 'danger' }
-        this.$root.$bvToast.toast(this.$t('userHistory.submitError'), toastParams)
-      } finally {
-        this.$emit('submit')
-      }
-    }
-  },
   computed: {
     uriFromStore() {
       const from = 0
@@ -66,6 +51,21 @@ export default {
         route: { path }
       } = this.$router.resolve({ name: 'search-history' })
       return `/#${path}`
+    }
+  },
+  methods: {
+    async saveSearch() {
+      try {
+        await this.$core.api.addHistoryEvent(this.indices, 'SEARCH', this.name, this.uriFromStore)
+        const { href } = this.$router.resolve({ name: 'search-history' })
+        const toastParams = { href, noCloseButton: true, variant: 'success' }
+        this.$root.$bvToast.toast(this.$t('userHistory.submitSuccess'), toastParams)
+      } catch (_) {
+        const toastParams = { noCloseButton: true, variant: 'danger' }
+        this.$root.$bvToast.toast(this.$t('userHistory.submitError'), toastParams)
+      } finally {
+        this.$emit('submit')
+      }
     }
   }
 }

--- a/src/components/UserHistorySaveSearchForm.vue
+++ b/src/components/UserHistorySaveSearchForm.vue
@@ -2,14 +2,14 @@
   <b-form @submit.prevent="saveSearch">
     <div class="w-100 border-top">
       <div class="card-body pb-1">
-        <b-form-group label-size="sm" :label="`${ $t('userHistory.name') } *`">
+        <b-form-group label-size="sm" :label="`${$t('userHistory.name')} *`">
           <b-form-input v-model="name" type="text" required />
         </b-form-group>
         <p v-html="$t('userHistorySaveSearchForm.description', { searchHistoryPath })"></p>
       </div>
       <div class="card-footer">
         <div class="d-flex justify-content-end align-items-center">
-          <b-btn type="submit"  variant="primary">
+          <b-btn type="submit" variant="primary">
             {{ $t('global.submit') }}
           </b-btn>
         </div>
@@ -19,7 +19,6 @@
 </template>
 
 <script>
-
 /**
  * A form to save the search in user history
  */
@@ -33,13 +32,13 @@ export default {
       type: [String, Array]
     }
   },
-  data () {
+  data() {
     return {
       name: ''
     }
   },
   methods: {
-    async saveSearch () {
+    async saveSearch() {
       try {
         await this.$core.api.addHistoryEvent(this.indices, 'SEARCH', this.name, this.uriFromStore)
         const { href } = this.$router.resolve({ name: 'search-history' })
@@ -54,14 +53,18 @@ export default {
     }
   },
   computed: {
-    uriFromStore () {
+    uriFromStore() {
       const from = 0
       const query = { ...this.$store.getters['search/toRouteQuery'](), from }
-      const { route: { fullPath } } = this.$router.resolve({ name: 'search', query })
+      const {
+        route: { fullPath }
+      } = this.$router.resolve({ name: 'search', query })
       return fullPath
     },
-    searchHistoryPath () {
-      const { route: { path } } = this.$router.resolve({ name: 'search-history' })
+    searchHistoryPath() {
+      const {
+        route: { path }
+      } = this.$router.resolve({ name: 'search-history' })
       return `/#${path}`
     }
   }

--- a/src/components/VersionNumber.vue
+++ b/src/components/VersionNumber.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
-    <div class="version-number d-inline-block" ref="appFooterVersion">
-      <fa icon="bolt" class="mr-1" v-if="!noIcon"></fa>
+    <div ref="appFooterVersion" class="version-number d-inline-block">
+      <fa v-if="!noIcon" icon="bolt" class="mr-1"></fa>
       {{ label }} {{ serverVersion }}
     </div>
-    <b-tooltip :target="() => this.$refs.appFooterVersion" :placement="tooltipPlacement">
+    <b-tooltip :target="() => $refs.appFooterVersion" :placement="tooltipPlacement">
       <div class="version-number__tooltip">
         <div class="d-flex text-left align-items-center version-number__tooltip__client">
           <div class="text-muted w-100">
@@ -58,14 +58,19 @@ export default {
       default: 'Version'
     }
   },
-  mounted() {
-    this.setVersion()
-  },
   data() {
     return {
       serverHash: null,
       serverVersion: null
     }
+  },
+  computed: {
+    clientHash() {
+      return process.env.VUE_APP_GIT_HASH.substring(0, 7)
+    }
+  },
+  mounted() {
+    this.setVersion()
   },
   methods: {
     async fetchVersion() {
@@ -75,11 +80,6 @@ export default {
       const version = await this.fetchVersion()
       this.$set(this, 'serverHash', version['git.commit.id.abbrev'])
       this.$set(this, 'serverVersion', version['git.build.version'])
-    }
-  },
-  computed: {
-    clientHash() {
-      return process.env.VUE_APP_GIT_HASH.substring(0, 7)
     }
   }
 }

--- a/src/components/VersionNumber.vue
+++ b/src/components/VersionNumber.vue
@@ -30,7 +30,6 @@
 </template>
 
 <script>
-
 /**
  * Display Datashare's version number.
  */
@@ -59,27 +58,27 @@ export default {
       default: 'Version'
     }
   },
-  mounted () {
+  mounted() {
     this.setVersion()
   },
-  data () {
+  data() {
     return {
       serverHash: null,
       serverVersion: null
     }
   },
   methods: {
-    async fetchVersion () {
+    async fetchVersion() {
       return this.$core.api.getVersion()
     },
-    async setVersion () {
+    async setVersion() {
       const version = await this.fetchVersion()
       this.$set(this, 'serverHash', version['git.commit.id.abbrev'])
       this.$set(this, 'serverVersion', version['git.build.version'])
     }
   },
   computed: {
-    clientHash () {
+    clientHash() {
       return process.env.VUE_APP_GIT_HASH.substring(0, 7)
     }
   }

--- a/src/components/document/DocumentNavbar.vue
+++ b/src/components/document/DocumentNavbar.vue
@@ -101,6 +101,14 @@ export default {
     UserDisplay
   },
   mixins: [utils],
+  props: {
+    /**
+     * Shrink the layout of the navbar.
+     */
+    isShrinked: {
+      type: Boolean
+    }
+  },
   computed: {
     ...mapState('document', ['doc', 'isRecommended', 'recommendedBy']),
     query() {
@@ -116,14 +124,6 @@ export default {
     },
     markAsRecommendedVariant() {
       return this.isRecommended ? 'success' : 'light'
-    }
-  },
-  props: {
-    /**
-     * Shrink the layout of the navbar.
-     */
-    isShrinked: {
-      type: Boolean
     }
   },
   mounted() {

--- a/src/components/document/DocumentNavbar.vue
+++ b/src/components/document/DocumentNavbar.vue
@@ -9,8 +9,8 @@
         <b-btn
           v-if="isShrinked"
           class="document-navbar__title text-left font-weight-bold flex-grow-1 px-2 text-white py-0 text-truncate"
-          @click="scrollToTop"
           variant="link"
+          @click="scrollToTop"
         >
           {{ doc.title }}
         </b-btn>
@@ -21,19 +21,19 @@
       <b-btn
         class="mx-2 px-2 py-0 document-navbar__recommended-by"
         size="sm"
-        @click="toggleAsRecommended"
         :data-recommended-label="$t('search.nav.markAsRecommended')"
         :data-unrecommended-label="$t('search.nav.unmarkAsRecommended')"
         :variant="markAsRecommendedVariant"
+        @click="toggleAsRecommended"
       >
         {{ markAsRecommendedLabel }}
       </b-btn>
       <template v-if="isServer">
         <b-badge
+          id="popover-recommended-by"
           pill
           :variant="markAsRecommendedVariant"
           class="mr-2 document-navbar__recommended-by-number"
-          id="popover-recommended-by"
         >
           {{ recommendedBy.length }}
         </b-badge>
@@ -49,9 +49,9 @@
         </b-popover>
       </template>
       <b-btn
+        id="popover-document-share"
         variant="link"
         class="text-white py-0 px-2 px-2 py-0 document-navbar__share"
-        id="popover-document-share"
         size="sm"
       >
         <fa icon="share-alt"></fa>
@@ -96,11 +96,11 @@ import utils from '@/mixins/utils'
  */
 export default {
   name: 'SearchDocumentNavbar',
-  mixins: [utils],
   components: {
     DocumentActions,
     UserDisplay
   },
+  mixins: [utils],
   computed: {
     ...mapState('document', ['doc', 'isRecommended', 'recommendedBy']),
     query() {

--- a/src/components/document/DocumentNavbar.vue
+++ b/src/components/document/DocumentNavbar.vue
@@ -1,25 +1,45 @@
 <template>
-  <div class="document-navbar px-3 py-2 bg-dark text-white text-nowrap" :class="{ 'document-navbar--shrinked': isShrinked }">
+  <div
+    class="document-navbar px-3 py-2 bg-dark text-white text-nowrap"
+    :class="{ 'document-navbar--shrinked': isShrinked }"
+  >
     <slot name="back" />
     <slot name="title">
       <transition name="slide-x">
-        <b-btn v-if="isShrinked" class="document-navbar__title text-left font-weight-bold flex-grow-1 px-2 text-white py-0 text-truncate" @click="scrollToTop" variant="link">
+        <b-btn
+          v-if="isShrinked"
+          class="document-navbar__title text-left font-weight-bold flex-grow-1 px-2 text-white py-0 text-truncate"
+          @click="scrollToTop"
+          variant="link"
+        >
           {{ doc.title }}
         </b-btn>
       </transition>
     </slot>
     <div v-if="doc" class="ml-auto d-flex align-items-center">
       <slot name="nav" />
-      <b-btn class="mx-2 px-2 py-0 document-navbar__recommended-by" size="sm" @click="toggleAsRecommended" :data-recommended-label="$t('search.nav.markAsRecommended')" :data-unrecommended-label="$t('search.nav.unmarkAsRecommended')" :variant="markAsRecommendedVariant">
+      <b-btn
+        class="mx-2 px-2 py-0 document-navbar__recommended-by"
+        size="sm"
+        @click="toggleAsRecommended"
+        :data-recommended-label="$t('search.nav.markAsRecommended')"
+        :data-unrecommended-label="$t('search.nav.unmarkAsRecommended')"
+        :variant="markAsRecommendedVariant"
+      >
         {{ markAsRecommendedLabel }}
       </b-btn>
       <template v-if="isServer">
-        <b-badge pill :variant="markAsRecommendedVariant" class="mr-2 document-navbar__recommended-by-number" id="popover-recommended-by">
+        <b-badge
+          pill
+          :variant="markAsRecommendedVariant"
+          class="mr-2 document-navbar__recommended-by-number"
+          id="popover-recommended-by"
+        >
           {{ recommendedBy.length }}
         </b-badge>
         <b-popover target="popover-recommended-by" triggers="hover" placement="bottom">
           <div>
-            {{ $tc('search.nav.markAsRecommendedBy',  recommendedBy.length, { count: recommendedBy.length }) }}
+            {{ $tc('search.nav.markAsRecommendedBy', recommendedBy.length, { count: recommendedBy.length }) }}
           </div>
           <ul class="mb-0 mt-2 list-unstyled">
             <li v-for="user in recommendedBy" :key="user">
@@ -28,20 +48,22 @@
           </ul>
         </b-popover>
       </template>
-      <b-btn variant="link" class="text-white py-0 px-2 px-2 py-0 document-navbar__share" id="popover-document-share" size="sm">
+      <b-btn
+        variant="link"
+        class="text-white py-0 px-2 px-2 py-0 document-navbar__share"
+        id="popover-document-share"
+        size="sm"
+      >
         <fa icon="share-alt"></fa>
       </b-btn>
-      <b-popover target="popover-document-share"
-                 triggers="click blur"
-                 placement="bottom"
-                 custom-class="popover-body-p-0 popover-body-overflow-hidden w-100"
-                 @show="$root.$emit('bv::hide::tooltip')">
-        <advanced-link-form
-          card
-          no-fade
-          :title="doc.slicedNameToString"
-          :value="1"
-          :link="documentLink" />
+      <b-popover
+        target="popover-document-share"
+        triggers="click blur"
+        placement="bottom"
+        custom-class="popover-body-p-0 popover-body-overflow-hidden w-100"
+        @show="$root.$emit('bv::hide::tooltip')"
+      >
+        <advanced-link-form card no-fade :title="doc.slicedNameToString" :value="1" :link="documentLink" />
       </b-popover>
       <b-tooltip target="popover-document-share" triggers="hover">
         {{ $t('search.nav.share') }}
@@ -56,7 +78,8 @@
         display-download-without-metadata
         no-btn-group
         popup-btn-class="btn btn-link text-white py-0 px-2"
-        star-btn-class="btn btn-link text-white py-0 px-2" />
+        star-btn-class="btn btn-link text-white py-0 px-2"
+      />
     </div>
   </div>
 </template>
@@ -80,18 +103,18 @@ export default {
   },
   computed: {
     ...mapState('document', ['doc', 'isRecommended', 'recommendedBy']),
-    query () {
+    query() {
       return this.$store.getters['search/toRouteQuery']()
     },
-    documentLink () {
+    documentLink() {
       const route = this.$router.resolve({ name: 'document-standalone', params: this.doc.routerParams })
       const { protocol, host, pathname } = window.location
       return [protocol, '//', host, pathname, route.href].join('')
     },
-    markAsRecommendedLabel () {
+    markAsRecommendedLabel() {
       return this.isRecommended ? this.$t('search.nav.unmarkAsRecommended') : this.$t('search.nav.markAsRecommended')
     },
-    markAsRecommendedVariant () {
+    markAsRecommendedVariant() {
       return this.isRecommended ? 'success' : 'light'
     }
   },
@@ -103,29 +126,29 @@ export default {
       type: Boolean
     }
   },
-  mounted () {
+  mounted() {
     this.saveComponentHeight()
   },
-  updated () {
+  updated() {
     this.saveComponentHeight()
   },
   methods: {
-    back () {
+    back() {
       this.$router.push({ name: 'search', query: this.query })
     },
-    isDownloadAllowed ({ index }) {
+    isDownloadAllowed({ index }) {
       return !!this.$store.state.downloads.allowedFor[index]
     },
-    saveComponentHeight () {
+    saveComponentHeight() {
       const height = `${this.$el.offsetHeight}px`
       // Save component height in a CSS variable after it's been update
       this.$root.$el.style.setProperty('--document-navbar-height', height)
     },
-    async toggleAsRecommended () {
+    async toggleAsRecommended() {
       await this.$store.dispatch('document/toggleAsRecommended', await this.$core.auth.getUsername())
       await this.$store.dispatch('recommended/fetchIndicesRecommendations')
     },
-    scrollToTop () {
+    scrollToTop() {
       document.getElementById('search__body__document__wrapper').scrollTop = 0
     }
   }
@@ -133,76 +156,79 @@ export default {
 </script>
 
 <style lang="scss">
-  .document-navbar {
-    align-items: center;
-    display: flex;
+.document-navbar {
+  align-items: center;
+  display: flex;
+  margin: 0;
+
+  @media (max-width: $document-float-breakpoint-width) {
+    border-radius: 0;
     margin: 0;
+  }
 
-    @media (max-width: $document-float-breakpoint-width) {
-      border-radius: 0;
-      margin: 0;
+  &__back,
+  &__back:hover {
+    color: inherit;
+    display: inline;
+    font-size: $font-size-sm;
+  }
+
+  &__back .svg-inline--fa {
+    transition: 500ms transform;
+  }
+
+  &--shrinked &__back .svg-inline--fa {
+    transform: scale(1.3);
+  }
+
+  &__back__label {
+    position: absolute;
+  }
+
+  &__title,
+  &__back__label {
+    display: inline-block;
+
+    &.slide-x-enter-active,
+    &.slide-x-leave-active {
+      transition: 500ms;
     }
 
-    &__back, &__back:hover {
-      color: inherit;
-      display: inline;
-      font-size: $font-size-sm;
+    &.slide-x-enter {
+      opacity: 0;
+      transform: translateY(100%);
     }
 
-    &__back .svg-inline--fa {
-      transition: 500ms transform;
-    }
-
-    &--shrinked &__back .svg-inline--fa {
-      transform: scale(1.3)
-    }
-
-    &__back__label {
-      position: absolute;
-    }
-
-    &__title, &__back__label {
-      display: inline-block;
-
-      &.slide-x-enter-active,
-      &.slide-x-leave-active {
-        transition: 500ms;
-      }
-
-      &.slide-x-enter {
-        opacity: 0;
-        transform: translateY(100%);
-      }
-
-      &.slide-x-leave-to {
-        opacity: 0;
-        transform: translateY(-100%);
-      }
-    }
-
-    &__recommended-by {
-      position: relative;
-
-      &:before, &:after{
-        color: transparent;
-        display: block;
-        height: 0;
-        overflow: hidden;
-        text-overflow: -999999px;
-        visibility: hidden;
-      }
-
-      &:before {
-        content: attr(data-unrecommended-label);
-      }
-
-      &:after {
-        content: attr(data-recommended-label);
-      }
-    }
-
-    &__nav .btn {
-      cursor: pointer;
+    &.slide-x-leave-to {
+      opacity: 0;
+      transform: translateY(-100%);
     }
   }
+
+  &__recommended-by {
+    position: relative;
+
+    &:before,
+    &:after {
+      color: transparent;
+      display: block;
+      height: 0;
+      overflow: hidden;
+      text-overflow: -999999px;
+      visibility: hidden;
+    }
+
+    &:before {
+      content: attr(data-unrecommended-label);
+    }
+
+    &:after {
+      content: attr(data-recommended-label);
+    }
+  }
+
+  &__nav .btn {
+    cursor: pointer;
+  }
+}
 </style>

--- a/src/components/document/DocumentNotes.vue
+++ b/src/components/document/DocumentNotes.vue
@@ -22,7 +22,7 @@ export default {
       type: String
     }
   },
-  data () {
+  data() {
     return {
       notes: []
     }
@@ -31,12 +31,12 @@ export default {
     ...mapState('search', ['index'])
   },
   methods: {
-    async retrieveNotes (project, path) {
+    async retrieveNotes(project, path) {
       const notes = await this.$store.dispatch('documentNotes/retrieveNotes', { project, path })
       this.$set(this, 'notes', notes)
     }
   },
-  mounted () {
+  mounted() {
     this.retrieveNotes(this.index, this.path)
   }
 }

--- a/src/components/document/DocumentNotes.vue
+++ b/src/components/document/DocumentNotes.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="m-3" v-if="notes.length">
+  <div v-if="notes.length" class="m-3">
     <b-alert v-for="note in notes" :key="note.note" :variant="note.variant || 'warning'" show>
       {{ note.note }}
     </b-alert>
@@ -30,14 +30,14 @@ export default {
   computed: {
     ...mapState('search', ['index'])
   },
+  mounted() {
+    this.retrieveNotes(this.index, this.path)
+  },
   methods: {
     async retrieveNotes(project, path) {
       const notes = await this.$store.dispatch('documentNotes/retrieveNotes', { project, path })
       this.$set(this, 'notes', notes)
     }
-  },
-  mounted() {
-    this.retrieveNotes(this.index, this.path)
   }
 }
 </script>

--- a/src/components/document/DocumentTabDetails.vue
+++ b/src/components/document/DocumentTabDetails.vue
@@ -7,7 +7,7 @@
       <p class="text-muted">
         {{ $t('document.tagsVisibility') }}
       </p>
-      <document-tags-form :document="document" :tags="tags" :displayTags="true" :displayForm="true" />
+      <document-tags-form :document="document" :tags="tags" :display-tags="true" :display-form="true" />
     </div>
     <div class="document__content__shortcuts mb-3">
       <h5 class="mb-3">
@@ -35,15 +35,27 @@
       <p class="text-muted">
         {{ $t('document.detailsInfo') }}
       </p>
-      <div class="row document__content__details__children mx-2">
-      </div>
+      <div class="row document__content__details__children mx-2"></div>
       <div class="row document__content__details__item" v-for="field in filteredCanonicalFields" :key="field.name">
         <div class="col-sm-4 pr-0 font-weight-bold d-flex justify-content-between">
           <div class="text-truncate mr-1 w-100" :title="field.name">
             {{ field.label }}
           </div>
           <div class="mr-auto document__content__details__item__search">
-            <router-link :to="field.to || { name: 'search', query: { q: document.valueAsQueryParam(field.name, field.rawValue !== undefined ? field.rawValue : field.value), indices } }">
+            <router-link
+              :to="
+                field.to || {
+                  name: 'search',
+                  query: {
+                    q: document.valueAsQueryParam(
+                      field.name,
+                      field.rawValue !== undefined ? field.rawValue : field.value
+                    ),
+                    indices
+                  }
+                }
+              "
+            >
               <fa icon="search" />
             </router-link>
           </div>
@@ -119,41 +131,41 @@ export default {
   filters: {
     startCase
   },
-  data () {
+  data() {
     return {
       metadataVisible: false
     }
   },
   computed: {
     ...mapState('document', ['tags']),
-    documentPath () {
+    documentPath() {
       if (this.$config.get('mountedDataDir')) {
         return this.document.source.path.replace(this.$config.get('dataDir'), this.$config.get('mountedDataDir'))
       } else {
         return this.document.source.path
       }
     },
-    documentDirname () {
+    documentDirname() {
       if (this.$config.get('mountedDataDir')) {
         return this.document.source.dirname.replace(this.$config.get('dataDir'), this.$config.get('mountedDataDir'))
       } else {
         return this.document.source.dirname
       }
     },
-    index () {
+    index() {
       return this.document.index
     },
-    indices () {
+    indices() {
       return uniq([this.index, ...this.$store.state.search.indices]).join(',')
     },
-    metaFieldsNames () {
+    metaFieldsNames() {
       if (this.metadataVisible) {
-        return filter(this.document.metas, name => map(this.canonicalFields, 'name').indexOf(name) === -1)
+        return filter(this.document.metas, (name) => map(this.canonicalFields, 'name').indexOf(name) === -1)
       } else {
         return []
       }
     },
-    canonicalFields () {
+    canonicalFields() {
       return [
         {
           name: '_id',
@@ -259,23 +271,23 @@ export default {
         }
       ]
     },
-    filteredCanonicalFields () {
-      return filter(this.canonicalFields, field => field.value)
+    filteredCanonicalFields() {
+      return filter(this.canonicalFields, (field) => field.value)
     },
-    searchChildrenDocumentParams () {
+    searchChildrenDocumentParams() {
       const index = this.index
       const q = `_routing:${this.document.id}`
       const query = { q, index }
       return { name: 'search', query }
     },
-    searchDirnameDocumentParams () {
+    searchDirnameDocumentParams() {
       const index = this.index
       const q = `dirname:"${this.documentDirname}"`
       const query = { q, index }
       return { name: 'search', query }
     }
   },
-  async created () {
+  async created() {
     await this.$store.dispatch('document/getTags')
   },
   methods: {
@@ -286,35 +298,31 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .tab-pane {
-    & div {
-      word-wrap: break-word;
-    }
+.tab-pane {
+  & div {
+    word-wrap: break-word;
   }
+}
 
-  .document {
+.document {
+  &__content {
+    &__details {
+      &__item {
+        padding: $spacer * 0.3 0;
 
-    &__content {
-
-      &__details {
-
-        &__item {
-          padding: $spacer * 0.3 0;
-
-          &__search {
-            display: none;
-          }
-
-          &:hover &__search {
-            display: block;
-          }
+        &__search {
+          display: none;
         }
 
-        &__item:nth-child(even) {
-          background: #f3f3f3;
+        &:hover &__search {
+          display: block;
         }
+      }
+
+      &__item:nth-child(even) {
+        background: #f3f3f3;
       }
     }
   }
-
+}
 </style>

--- a/src/components/document/DocumentTabDetails.vue
+++ b/src/components/document/DocumentTabDetails.vue
@@ -36,7 +36,7 @@
         {{ $t('document.detailsInfo') }}
       </p>
       <div class="row document__content__details__children mx-2"></div>
-      <div class="row document__content__details__item" v-for="field in filteredCanonicalFields" :key="field.name">
+      <div v-for="field in filteredCanonicalFields" :key="field.name" class="row document__content__details__item">
         <div class="col-sm-4 pr-0 font-weight-bold d-flex justify-content-between">
           <div class="text-truncate mr-1 w-100" :title="field.name">
             {{ field.label }}
@@ -73,7 +73,7 @@
           </div>
         </div>
       </div>
-      <div class="row document__content__details__item" v-for="name in metaFieldsNames" :key="name">
+      <div v-for="name in metaFieldsNames" :key="name" class="row document__content__details__item">
         <div class="col-sm-4 pr-0 font-weight-bold d-flex justify-content-between">
           <div class="text-truncate mr-1 w-100" :title="name">
             <var>{{ document.shortMetaName(name) | startCase }}</var>
@@ -91,7 +91,7 @@
         </div>
       </div>
       <div class="text-center mt-4">
-        <button @click="metadataVisible = !metadataVisible" class="btn btn-outline-primary btn-sm">
+        <button class="btn btn-outline-primary btn-sm" @click="metadataVisible = !metadataVisible">
           {{ $t(metadataVisible ? 'document.showLessDetails' : 'document.showMoreDetails') }}
         </button>
       </div>
@@ -111,6 +111,12 @@ import { getDocumentTypeLabel, getExtractionLevelTranslationKey } from '@/utils/
  */
 export default {
   name: 'DocumentTabDetails',
+  components: {
+    DocumentTagsForm
+  },
+  filters: {
+    startCase
+  },
   props: {
     /**
      * The selected document
@@ -124,12 +130,6 @@ export default {
     parentDocument: {
       type: Object
     }
-  },
-  components: {
-    DocumentTagsForm
-  },
-  filters: {
-    startCase
   },
   data() {
     return {

--- a/src/components/document/DocumentTabExtractedText.vue
+++ b/src/components/document/DocumentTabExtractedText.vue
@@ -20,6 +20,11 @@ import DocumentTranslatedContent from '@/components/DocumentTranslatedContent'
  */
 export default {
   name: 'DocumentTabExtractedText',
+  components: {
+    DocumentNotes,
+    DocumentThread,
+    DocumentTranslatedContent
+  },
   props: {
     /**
      * The selected document
@@ -34,11 +39,6 @@ export default {
       type: String,
       default: ''
     }
-  },
-  components: {
-    DocumentNotes,
-    DocumentThread,
-    DocumentTranslatedContent
   }
 }
 </script>

--- a/src/components/document/DocumentTabNamedEntities.vue
+++ b/src/components/document/DocumentTabNamedEntities.vue
@@ -1,6 +1,6 @@
 <template>
   <v-wait for="load first page of named entities">
-    <fa icon="circle-notch" spin size="2x" class="d-flex mx-auto mt-5" slot="waiting"></fa>
+    <fa slot="waiting" icon="circle-notch" spin size="2x" class="d-flex mx-auto mt-5"></fa>
     <div class="p-3">
       <div class="document__named-entities__toolbox">
         <search-form-control
@@ -25,9 +25,9 @@
       <div v-else-if="!isLoadingNamedEntities" class="document__named-entitie">
         <div v-for="(hits, category) in namedEntitiesByCategories" :key="category" class="s border-bottom pb-4 mb-4">
           <div
+            v-if="categoryIsNotEmpty(category)"
             class="mb-2 d-flex align-items-center"
             :class="getCategoryClass(category, 'text-')"
-            v-if="categoryIsNotEmpty(category)"
           >
             <fa :icon="getCategoryIcon(category)" class="mr-2" />
             {{ $t('filter.namedEntity' + capitalize(category)) }}
@@ -38,11 +38,11 @@
           </div>
           <span v-for="(ne, index) in hits" :key="index" class="d-inline-block">
             <b-badge
+              :id="`named-entity-${ne.id}`"
               class="p-1 text-uppercase text-black border"
               pill
               variant="light"
               :class="getCategoryClass(category, 'border-')"
-              :id="`named-entity-${ne.id}`"
             >
               {{ ne.source.mentionNorm }}
             </b-badge>
@@ -52,7 +52,7 @@
               <template #title>
                 <div class="d-flex">
                   <div class="text-muted" v-html="$t('namedEntityInContext.title', ne.source)"></div>
-                  <div class="ml-auto pl-2" v-if="ne.offsets.length > 1">
+                  <div v-if="ne.offsets.length > 1" class="ml-auto pl-2">
                     {{ $tc('document.namedEntitiesOccurences', ne.offsets.length, { count: ne.offsets.length }) }}
                   </div>
                 </div>
@@ -60,7 +60,7 @@
             </b-popover>
           </span>
           <v-wait :for="`load_more_data_${category}`">
-            <fa icon="circle-notch" spin size="2x" class="d-flex mx-auto mt-3" slot="waiting" />
+            <fa slot="waiting" icon="circle-notch" spin size="2x" class="d-flex mx-auto mt-3" />
             <div v-if="categoryHasNextPage(category)" class="mt-3 text-center">
               <b-btn
                 class="document__named-entities__more"
@@ -92,6 +92,11 @@ import utils from '@/mixins/utils'
  */
 export default {
   name: 'DocumentTabNamedEntities',
+  components: {
+    NamedEntityInContext,
+    SearchFormControl
+  },
+  mixins: [ner, utils],
   props: {
     /**
      * The selected document
@@ -104,11 +109,6 @@ export default {
     return {
       filterToken: null
     }
-  },
-  mixins: [ner, utils],
-  components: {
-    NamedEntityInContext,
-    SearchFormControl
   },
   watch: {
     filterToken(filterToken) {

--- a/src/components/document/DocumentTabNamedEntities.vue
+++ b/src/components/document/DocumentTabNamedEntities.vue
@@ -3,22 +3,32 @@
     <fa icon="circle-notch" spin size="2x" class="d-flex mx-auto mt-5" slot="waiting"></fa>
     <div class="p-3">
       <div class="document__named-entities__toolbox">
-        <search-form-control v-model="filterToken"
-                             :loading="$wait.is('load named entities')"
-                             class="document__named-entities__toolbox__filter"
-                             :placeholder="$t('document.namedEntityFilter')"></search-form-control>
+        <search-form-control
+          v-model="filterToken"
+          :loading="$wait.is('load named entities')"
+          class="document__named-entities__toolbox__filter"
+          :placeholder="$t('document.namedEntityFilter')"
+        ></search-form-control>
       </div>
-      <div v-if="$config.is('manageDocuments') && !document.hasNerTags"
-           class="document__named-entities document__named-entities--not--searched">
+      <div
+        v-if="$config.is('manageDocuments') && !document.hasNerTags"
+        class="document__named-entities document__named-entities--not--searched"
+      >
         <div v-html="$t('document.namedEntitiesNotSearched', { indexing_link: '#/indexing' })"></div>
       </div>
-      <div v-else-if="!hasNamedEntities && !isLoadingNamedEntities"
-           class="document__named-entities document__named-entities--not--found">
+      <div
+        v-else-if="!hasNamedEntities && !isLoadingNamedEntities"
+        class="document__named-entities document__named-entities--not--found"
+      >
         {{ $t('document.namedEntitiesNotFound') }}
       </div>
       <div v-else-if="!isLoadingNamedEntities" class="document__named-entitie">
         <div v-for="(hits, category) in namedEntitiesByCategories" :key="category" class="s border-bottom pb-4 mb-4">
-          <div class="mb-2 d-flex align-items-center" :class="getCategoryClass(category, 'text-')" v-if="categoryIsNotEmpty(category)">
+          <div
+            class="mb-2 d-flex align-items-center"
+            :class="getCategoryClass(category, 'text-')"
+            v-if="categoryIsNotEmpty(category)"
+          >
             <fa :icon="getCategoryIcon(category)" class="mr-2" />
             {{ $t('filter.namedEntity' + capitalize(category)) }}
             <i>({{ getCategoryTotal(category) }})</i>
@@ -27,11 +37,13 @@
             </div>
           </div>
           <span v-for="(ne, index) in hits" :key="index" class="d-inline-block">
-            <b-badge class="p-1 text-uppercase text-black border"
-                      pill
-                      variant="light"
-                      :class="getCategoryClass(category, 'border-')"
-                      :id="`named-entity-${ne.id}`">
+            <b-badge
+              class="p-1 text-uppercase text-black border"
+              pill
+              variant="light"
+              :class="getCategoryClass(category, 'border-')"
+              :id="`named-entity-${ne.id}`"
+            >
               {{ ne.source.mentionNorm }}
             </b-badge>
             <span>&nbsp;</span>
@@ -50,10 +62,12 @@
           <v-wait :for="`load_more_data_${category}`">
             <fa icon="circle-notch" spin size="2x" class="d-flex mx-auto mt-3" slot="waiting" />
             <div v-if="categoryHasNextPage(category)" class="mt-3 text-center">
-              <b-btn class="document__named-entities__more"
-                     size="sm"
-                     variant="link"
-                     @click.prevent="getNextPageInCategory(category)">
+              <b-btn
+                class="document__named-entities__more"
+                size="sm"
+                variant="link"
+                @click.prevent="getNextPageInCategory(category)"
+              >
                 {{ $t('document.namedEntitiesShowMore.showMore' + capitalize(category)) }}
               </b-btn>
             </div>
@@ -80,13 +94,13 @@ export default {
   name: 'DocumentTabNamedEntities',
   props: {
     /**
-    * The selected document
-    */
+     * The selected document
+     */
     document: {
       type: Object
     }
   },
-  data () {
+  data() {
     return {
       filterToken: null
     }
@@ -97,7 +111,7 @@ export default {
     SearchFormControl
   },
   watch: {
-    filterToken (filterToken) {
+    filterToken(filterToken) {
       // No throttle when the filter token is empty
       if (!filterToken) {
         return this.getFirstPageInAllCategories()
@@ -107,43 +121,45 @@ export default {
   },
   computed: {
     ...mapState('document', ['isLoadingNamedEntities', 'namedEntitiesPaginatedByCategories']),
-    hasNamedEntities () {
-      return sumBy(this.categories, category => this.getCategoryTotal(category))
+    hasNamedEntities() {
+      return sumBy(this.categories, (category) => this.getCategoryTotal(category))
     },
-    namedEntitiesByCategories () {
-      const namedEntitiesByCategories = mapValues(this.namedEntitiesPaginatedByCategories, pages => {
-        return flatten(pages.map(page => page.hits))
+    namedEntitiesByCategories() {
+      const namedEntitiesByCategories = mapValues(this.namedEntitiesPaginatedByCategories, (pages) => {
+        return flatten(pages.map((page) => page.hits))
       })
-      return pickBy(namedEntitiesByCategories, hits => !!hits.length)
+      return pickBy(namedEntitiesByCategories, (hits) => !!hits.length)
     },
-    categories () {
+    categories() {
       return this.$store.getters['document/categories']
     },
-    getFirstPageInAllCategoriesWithThrottle () {
+    getFirstPageInAllCategoriesWithThrottle() {
       return throttle(this.getFirstPageInAllCategories, 1000)
     }
   },
-  mounted () {
+  mounted() {
     this.getFirstPageInAllCategories('load first page of named entities')
   },
   methods: {
-    hitsAsCsv (hits = []) {
+    hitsAsCsv(hits = []) {
       const csvHeader = ['named entity', 'occurences'].join(',')
-      const csvBody = hits.map(({ source }) => {
-        return [source.mentionNorm, source.offsets.length].join(',')
-      }).join('\n')
+      const csvBody = hits
+        .map(({ source }) => {
+          return [source.mentionNorm, source.offsets.length].join(',')
+        })
+        .join('\n')
       return [csvHeader, csvBody].join('\n')
     },
-    getCategoryTotal (category) {
+    getCategoryTotal(category) {
       return get(this, ['namedEntitiesPaginatedByCategories', category, 0, 'total'], 0)
     },
-    categoryIsNotEmpty (category) {
+    categoryIsNotEmpty(category) {
       return !!this.getCategoryTotal(category)
     },
-    categoryHasNextPage (category) {
+    categoryHasNextPage(category) {
       return this.getCategoryTotal(category) > this.$store.getters['document/countNamedEntitiesInCategory'](category)
     },
-    async getNextPageInCategory (category) {
+    async getNextPageInCategory(category) {
       // Don't load named entities if they are already loading
       if (!this.isLoadingNamedEntities) {
         this.$wait.start(`load_more_data_${category}`)
@@ -152,7 +168,7 @@ export default {
         this.$wait.end(`load_more_data_${category}`)
       }
     },
-    async getFirstPageInAllCategories (waitIdentifier = 'load named entities') {
+    async getFirstPageInAllCategories(waitIdentifier = 'load named entities') {
       this.$wait.start(waitIdentifier)
       const filterToken = this.filterToken
       await this.$store.dispatch('document/getFirstPageForNamedEntityInAllCategories', { filterToken })
@@ -164,18 +180,18 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .document__named-entities {
-    &__toolbox {
-      background: $lighter;
-      display: flex;
-      margin: 0 0 $spacer;
-      padding: $spacer-xs $spacer;
+.document__named-entities {
+  &__toolbox {
+    background: $lighter;
+    display: flex;
+    margin: 0 0 $spacer;
+    padding: $spacer-xs $spacer;
 
-      &__filter {
-        margin-left: auto;
-        max-width: 300px;
-        width: 100%;
-      }
+    &__filter {
+      margin-left: auto;
+      max-width: 300px;
+      width: 100%;
     }
   }
+}
 </style>

--- a/src/components/document/DocumentTabNamedEntities.vue
+++ b/src/components/document/DocumentTabNamedEntities.vue
@@ -110,15 +110,6 @@ export default {
       filterToken: null
     }
   },
-  watch: {
-    filterToken(filterToken) {
-      // No throttle when the filter token is empty
-      if (!filterToken) {
-        return this.getFirstPageInAllCategories()
-      }
-      return this.getFirstPageInAllCategoriesWithThrottle()
-    }
-  },
   computed: {
     ...mapState('document', ['isLoadingNamedEntities', 'namedEntitiesPaginatedByCategories']),
     hasNamedEntities() {
@@ -135,6 +126,15 @@ export default {
     },
     getFirstPageInAllCategoriesWithThrottle() {
       return throttle(this.getFirstPageInAllCategories, 1000)
+    }
+  },
+  watch: {
+    filterToken(filterToken) {
+      // No throttle when the filter token is empty
+      if (!filterToken) {
+        return this.getFirstPageInAllCategories()
+      }
+      return this.getFirstPageInAllCategoriesWithThrottle()
     }
   },
   mounted() {

--- a/src/components/document/DocumentTabPreview.vue
+++ b/src/components/document/DocumentTabPreview.vue
@@ -34,7 +34,7 @@ export default {
       type: Object
     }
   },
-  data () {
+  data() {
     return {
       paginatedTypes: [
         'application/pdf',
@@ -46,30 +46,30 @@ export default {
     }
   },
   methods: {
-    importPreviewComponent () {
+    importPreviewComponent() {
       return import('@/components/document/viewers/' + this.previewComponent + '.vue')
     }
   },
   computed: {
-    isPaginated () {
+    isPaginated() {
       return this.paginatedTypes.indexOf(this.document.contentType) > -1
     },
-    previewComponent () {
+    previewComponent() {
       switch (true) {
-      case this.document.isJson:
-        return 'JsonViewer'
-      case this.isPaginated:
-        return 'PaginatedViewer'
-      case this.document.isTiff:
-        return 'TiffViewer'
-      case this.document.isSpreadsheet && this.hasFeature('SERVER_RENDERING_SPREADSHEET'):
-        return 'SpreadsheetViewer'
-      case this.document.isSpreadsheet:
-        return 'LegacySpreadsheetViewer'
-      case this.document.isImage:
-        return 'ImageViewer'
-      default:
-        return null
+        case this.document.isJson:
+          return 'JsonViewer'
+        case this.isPaginated:
+          return 'PaginatedViewer'
+        case this.document.isTiff:
+          return 'TiffViewer'
+        case this.document.isSpreadsheet && this.hasFeature('SERVER_RENDERING_SPREADSHEET'):
+          return 'SpreadsheetViewer'
+        case this.document.isSpreadsheet:
+          return 'LegacySpreadsheetViewer'
+        case this.document.isImage:
+          return 'ImageViewer'
+        default:
+          return null
       }
     }
   }

--- a/src/components/document/DocumentTabPreview.vue
+++ b/src/components/document/DocumentTabPreview.vue
@@ -45,11 +45,6 @@ export default {
       ]
     }
   },
-  methods: {
-    importPreviewComponent() {
-      return import('@/components/document/viewers/' + this.previewComponent + '.vue')
-    }
-  },
   computed: {
     isPaginated() {
       return this.paginatedTypes.indexOf(this.document.contentType) > -1
@@ -71,6 +66,11 @@ export default {
         default:
           return null
       }
+    }
+  },
+  methods: {
+    importPreviewComponent() {
+      return import('@/components/document/viewers/' + this.previewComponent + '.vue')
     }
   }
 }

--- a/src/components/document/viewers/ImageViewer.vue
+++ b/src/components/document/viewers/ImageViewer.vue
@@ -22,7 +22,7 @@ export default {
 </script>
 
 <style>
-  .image-viewer img {
-    max-width: 100%;
-  }
+.image-viewer img {
+  max-width: 100%;
+}
 </style>

--- a/src/components/document/viewers/JsonViewer.vue
+++ b/src/components/document/viewers/JsonViewer.vue
@@ -13,10 +13,10 @@ import datashareSourceMixin from '@/mixins/datashareSourceMixin'
  */
 export default {
   name: 'JsonViewer',
-  mixins: [datashareSourceMixin],
   components: {
     JsonFormatter
   },
+  mixins: [datashareSourceMixin],
   props: {
     /**
      * The selected document

--- a/src/components/document/viewers/JsonViewer.vue
+++ b/src/components/document/viewers/JsonViewer.vue
@@ -25,27 +25,27 @@ export default {
       type: Object
     }
   },
-  data () {
+  data() {
     return {
       source: null
     }
   },
-  async mounted () {
+  async mounted() {
     this.source = await this.getSource(this.document)
   }
 }
 </script>
 
 <style lang="scss">
-  .json-viewer {
-    max-width: 100%;
-    overflow: auto;
+.json-viewer {
+  max-width: 100%;
+  overflow: auto;
 
-    &__formatter > * {
-      bottom: $spacer;
-      left: $spacer;
-      right: $spacer;
-      top: $spacer;
-    }
+  &__formatter > * {
+    bottom: $spacer;
+    left: $spacer;
+    right: $spacer;
+    top: $spacer;
   }
+}
 </style>

--- a/src/components/document/viewers/LegacySpreadsheetViewer.vue
+++ b/src/components/document/viewers/LegacySpreadsheetViewer.vue
@@ -8,8 +8,8 @@
         <div
           v-for="page in Object.keys(doc.sheets).length"
           :key="page"
-          @click="doc.active = Object.keys(doc.sheets)[page - 1]"
           class="mr-2 my-2 d-flex legacy-spreadsheet-viewer__header__thumbnails"
+          @click="doc.active = Object.keys(doc.sheets)[page - 1]"
         >
           <span class="d-flex align-items-center">{{ page }}</span>
           <div
@@ -19,10 +19,10 @@
         </div>
       </div>
       <div class="legacy-spreadsheet-viewer__preview">
-        <div class="legacy-spreadsheet-viewer__preview__header" v-if="doc.active">
+        <div v-if="doc.active" class="legacy-spreadsheet-viewer__preview__header">
           <b-form-select
-            class="input-sm"
             v-model="doc.active"
+            class="input-sm"
             :options="Object.keys(doc.sheets)"
             @change="displaySheet"
           />
@@ -48,6 +48,7 @@ import datashareSourceMixin from '@/mixins/datashareSourceMixin'
  */
 export default {
   name: 'LegacySpreadsheetViewer',
+  mixins: [datashareSourceMixin],
   props: {
     /**
      * The selected document
@@ -57,7 +58,6 @@ export default {
       default: () => ({})
     }
   },
-  mixins: [datashareSourceMixin],
   data() {
     return {
       message: this.$t('document.generatingPreview'),

--- a/src/components/document/viewers/LegacySpreadsheetViewer.vue
+++ b/src/components/document/viewers/LegacySpreadsheetViewer.vue
@@ -5,14 +5,27 @@
         <div class="text-center mb-4">
           {{ Object.keys(doc.sheets).indexOf(doc.active) + 1 }} / {{ Object.keys(doc.sheets).length }}
         </div>
-        <div v-for="page in Object.keys(doc.sheets).length" :key="page" @click="doc.active = Object.keys(doc.sheets)[page - 1]" class="mr-2 my-2 d-flex legacy-spreadsheet-viewer__header__thumbnails">
+        <div
+          v-for="page in Object.keys(doc.sheets).length"
+          :key="page"
+          @click="doc.active = Object.keys(doc.sheets)[page - 1]"
+          class="mr-2 my-2 d-flex legacy-spreadsheet-viewer__header__thumbnails"
+        >
           <span class="d-flex align-items-center">{{ page }}</span>
-          <div class="small ml-1 img-thumbnail text-truncate" v-html="displaySheet(Object.keys(doc.sheets)[page - 1])" />
+          <div
+            class="small ml-1 img-thumbnail text-truncate"
+            v-html="displaySheet(Object.keys(doc.sheets)[page - 1])"
+          />
         </div>
       </div>
       <div class="legacy-spreadsheet-viewer__preview">
         <div class="legacy-spreadsheet-viewer__preview__header" v-if="doc.active">
-          <b-form-select class="input-sm" v-model="doc.active" :options="Object.keys(doc.sheets)" @change="displaySheet" />
+          <b-form-select
+            class="input-sm"
+            v-model="doc.active"
+            :options="Object.keys(doc.sheets)"
+            @change="displaySheet"
+          />
         </div>
         <div class="legacy-spreadsheet-viewer__preview__content">
           <div v-html="displaySheet(doc.active)" />
@@ -45,7 +58,7 @@ export default {
     }
   },
   mixins: [datashareSourceMixin],
-  data () {
+  data() {
     return {
       message: this.$t('document.generatingPreview'),
       doc: {
@@ -54,36 +67,37 @@ export default {
       }
     }
   },
-  mounted () {
+  mounted() {
     this.getWorkbook()
   },
   methods: {
-    getWorkbook () {
-      return this.xlsx().then(workbook => {
-        this.doc.sheets = workbook
-        this.doc.active = Object.keys(workbook)[0]
-      }).catch(err => {
-        this.message = err.message
-      })
-    },
-    xlsx () {
-      return this.getSource(this.document, { responseType: 'arraybuffer' })
-        .then(arrayBuffer => {
-          let arr = ''
-          const data = new Uint8Array(arrayBuffer)
-          for (let i = 0; i !== data.length; ++i) {
-            arr += String.fromCharCode(data[i])
-          }
-          const workbook = read(arr, { type: 'binary' })
-          const result = {}
-          workbook.SheetNames.forEach(function (sheetname) {
-            const roa = utils.sheet_to_html(workbook.Sheets[sheetname])
-            if (roa.length > 0) result[sheetname] = roa
-          })
-          return result
+    getWorkbook() {
+      return this.xlsx()
+        .then((workbook) => {
+          this.doc.sheets = workbook
+          this.doc.active = Object.keys(workbook)[0]
+        })
+        .catch((err) => {
+          this.message = err.message
         })
     },
-    displaySheet (value) {
+    xlsx() {
+      return this.getSource(this.document, { responseType: 'arraybuffer' }).then((arrayBuffer) => {
+        let arr = ''
+        const data = new Uint8Array(arrayBuffer)
+        for (let i = 0; i !== data.length; ++i) {
+          arr += String.fromCharCode(data[i])
+        }
+        const workbook = read(arr, { type: 'binary' })
+        const result = {}
+        workbook.SheetNames.forEach(function (sheetname) {
+          const roa = utils.sheet_to_html(workbook.Sheets[sheetname])
+          if (roa.length > 0) result[sheetname] = roa
+        })
+        return result
+      })
+    },
+    displaySheet(value) {
       return this.doc.sheets[value]
     }
   }

--- a/src/components/document/viewers/PaginatedViewer.vue
+++ b/src/components/document/viewers/PaginatedViewer.vue
@@ -4,31 +4,44 @@
       {{ $t('document.fetching') }}
     </div>
     <div class="paginated-viewer paginated-viewer--pdf p-3 flex-grow-1" v-if="document.isPdf">
-      <iframe class="paginated-viewer__iframe border shadow" :src="document.inlineFullUrl" width="100%" height="100%"  frameborder="0" allowfullscreen></iframe>
+      <iframe
+        class="paginated-viewer__iframe border shadow"
+        :src="document.inlineFullUrl"
+        width="100%"
+        height="100%"
+        frameborder="0"
+        allowfullscreen
+      ></iframe>
     </div>
     <div class="paginated-viewer paginated-viewer--previewable d-flex flex-grow-1" v-else-if="isPreviewable">
       <div class="paginated-viewer__thumbnails">
         <div class="text-center p-2 d-flex align-items-center paginated-viewer__thumbnails__select">
-          <select class="form-control form-control-sm" v-model.number="active" @change="scrollToPageAndThumbnail(active)">
+          <select
+            class="form-control form-control-sm"
+            v-model.number="active"
+            @change="scrollToPageAndThumbnail(active)"
+          >
             <option v-for="page in pagesRange" :key="page" :value="page">
               {{ page + 1 }}
             </option>
           </select>
-          <span class="w-100">
-            / {{ meta.pages }}
-          </span>
+          <span class="w-100"> / {{ meta.pages }} </span>
         </div>
         <div class="paginated-viewer__thumbnails__items">
-          <div v-for="page in pagesRange"
-              @click="setActiveAndScrollToPage(page)"
-               class="paginated-viewer__thumbnails__items__item m-2"
-              :class="{ 'paginated-viewer__thumbnails__items__item--active': active === page }"
-              :key="`thumbnail-${page}`">
-            <document-thumbnail class="border-0"
-                                :document="document"
-                                :page="page"
-                                :ratio="ratio"
-                                size="150"></document-thumbnail>
+          <div
+            v-for="page in pagesRange"
+            @click="setActiveAndScrollToPage(page)"
+            class="paginated-viewer__thumbnails__items__item m-2"
+            :class="{ 'paginated-viewer__thumbnails__items__item--active': active === page }"
+            :key="`thumbnail-${page}`"
+          >
+            <document-thumbnail
+              class="border-0"
+              :document="document"
+              :page="page"
+              :ratio="ratio"
+              size="150"
+            ></document-thumbnail>
             <span class="paginated-viewer__thumbnails__items__item__page">
               {{ page + 1 }}
             </span>
@@ -37,13 +50,15 @@
       </div>
       <div class="paginated-viewer__preview flex-grow-1 p-2">
         <div v-for="page in pagesRange" :key="page" class="paginated-viewer__preview__page m-3" :data-page="page + 1">
-          <document-thumbnail :document="document"
-                              @enter="setActiveAndScrollToThumbnail(page)"
-                              @errored.once="errored = true"
-                              lazy
-                              :page="page"
-                              :ratio="ratio"
-                              :size="1200"></document-thumbnail>
+          <document-thumbnail
+            :document="document"
+            @enter="setActiveAndScrollToThumbnail(page)"
+            @errored.once="errored = true"
+            lazy
+            :page="page"
+            :ratio="ratio"
+            :size="1200"
+          ></document-thumbnail>
         </div>
       </div>
     </div>
@@ -77,7 +92,7 @@ export default {
   components: {
     DocumentThumbnail
   },
-  data () {
+  data() {
     return {
       active: 0,
       errored: false,
@@ -90,7 +105,7 @@ export default {
       }
     }
   },
-  async mounted () {
+  async mounted() {
     if (this.hasPreviewHost) {
       await this.waitFor(async () => {
         try {
@@ -103,7 +118,7 @@ export default {
     }
   },
   methods: {
-    async waitFor (callback) {
+    async waitFor(callback) {
       try {
         this.$wait.start(this.loader)
         this.$Progress.start()
@@ -113,7 +128,7 @@ export default {
         this.$wait.end(this.loader)
       }
     },
-    async fetchSize () {
+    async fetchSize() {
       const url = this.getPreviewUrl(this.document, { size: 150 })
       const base64 = await this.fetchPreviewAsBase64(url)
       return new Promise((resolve, reject) => {
@@ -123,49 +138,49 @@ export default {
         image.src = base64
       })
     },
-    async fetchMeta () {
+    async fetchMeta() {
       const url = this.getPreviewMetaUrl(this.document)
       const { data } = await axios({ url, ...this.metaOptions })
       return data
     },
-    setActiveAndScrollToThumbnail (page) {
+    setActiveAndScrollToThumbnail(page) {
       this.active = page
       this.scrollToThumbnail(page)
     },
-    setActiveAndScrollToPage (page) {
+    setActiveAndScrollToPage(page) {
       this.active = page
       this.scrollToPage(page)
     },
-    scrollToThumbnail (page) {
+    scrollToThumbnail(page) {
       const thumbnails = this.$el.querySelectorAll('.paginated-viewer__thumbnails__items__item')
       const target = thumbnails[page]
       target.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
     },
-    scrollToPage (page) {
+    scrollToPage(page) {
       const previews = this.$el.querySelectorAll('.paginated-viewer__preview__page')
       const target = previews[page]
       target.scrollIntoView({ behavior: 'instant', block: 'nearest' })
     },
-    scrollToPageAndThumbnail (page) {
+    scrollToPageAndThumbnail(page) {
       this.scrollToPage(page)
       this.scrollToThumbnail(page)
     }
   },
   computed: {
-    hasPreviewHost () {
+    hasPreviewHost() {
       return !!this.$config.get('previewHost')
     },
-    ratio () {
+    ratio() {
       try {
         return this.size.height / this.size.width
       } catch (_) {
         return 1
       }
     },
-    pagesRange () {
+    pagesRange() {
       return range(this.meta.pages)
     },
-    metaOptions () {
+    metaOptions() {
       return {
         method: 'GET',
         cache: 'default',
@@ -174,10 +189,10 @@ export default {
         }
       }
     },
-    loader () {
+    loader() {
       return uniqueId('paginated-viewer-load-data-')
     },
-    isPreviewable () {
+    isPreviewable() {
       return this.hasPreviewHost && get(this, 'meta.previewable', false) && !this.errored
     }
   }
@@ -185,93 +200,93 @@ export default {
 </script>
 
 <style lang="scss">
-  .paginated-viewer {
+.paginated-viewer {
+  &__thumbnails {
+    width: 150px;
+    position: sticky;
+    top: 0;
+    display: flex;
+    flex-direction: column;
+    background: $light;
+    max-height: calc(100vh - var(--search-document-navbar-height));
 
-    &__thumbnails {
-      width: 150px;
-      position: sticky;
-      top: 0;
-      display: flex;
-      flex-direction: column;
-      background: $light;
-      max-height: calc(100vh - var(--search-document-navbar-height));
-
-      .document-standalone & {
-        max-height: 100vh;
-      }
-
-      &__items {
-        height: 100%;
-        overflow: auto;
-
-        &__item {
-          border: 1px solid $border-color;
-          cursor: pointer;
-          position: relative;
-
-          .document-thumbnail__image {
-            max-width: 100%;
-            width: 100%;
-          }
-
-          &:hover {
-            border-color: $primary;
-            box-shadow: 0 0 0 0.1em rgba($primary, .2);
-          }
-
-          &--active, &--active:hover {
-            border-color: $secondary;
-          }
-
-          &--active &__page {
-            background: $secondary;
-            color: white;
-          }
-
-          &__page {
-            background: $light;
-            border: 1px solid $border-color;
-            border-bottom: 0;
-            border-right: 0;
-            bottom: 0;
-            font-size: 0.8em;
-            font-weight: bold;
-            padding: 0.2em 0.4em;
-            position: absolute;
-            right: 0;
-          }
-        }
-      }
+    .document-standalone & {
+      max-height: 100vh;
     }
 
-    &__preview {
-      text-align: center;
+    &__items {
+      height: 100%;
+      overflow: auto;
 
-      &__page {
+      &__item {
+        border: 1px solid $border-color;
+        cursor: pointer;
         position: relative;
 
-        &:after {
-          content: attr(data-page);
+        .document-thumbnail__image {
+          max-width: 100%;
+          width: 100%;
+        }
+
+        &:hover {
+          border-color: $primary;
+          box-shadow: 0 0 0 0.1em rgba($primary, 0.2);
+        }
+
+        &--active,
+        &--active:hover {
+          border-color: $secondary;
+        }
+
+        &--active &__page {
+          background: $secondary;
+          color: white;
+        }
+
+        &__page {
           background: $light;
           border: 1px solid $border-color;
+          border-bottom: 0;
+          border-right: 0;
           bottom: 0;
-          font-size: 0.8rem;
+          font-size: 0.8em;
           font-weight: bold;
           padding: 0.2em 0.4em;
           position: absolute;
           right: 0;
         }
-
-        .document-thumbnail {
-          background: transparent;
-
-          &__image, &:before {
-            border: $border-color 1px solid;
-            background: $body-bg;
-          }
-        }
       }
-
     }
   }
+
+  &__preview {
+    text-align: center;
+
+    &__page {
+      position: relative;
+
+      &:after {
+        content: attr(data-page);
+        background: $light;
+        border: 1px solid $border-color;
+        bottom: 0;
+        font-size: 0.8rem;
+        font-weight: bold;
+        padding: 0.2em 0.4em;
+        position: absolute;
+        right: 0;
+      }
+
+      .document-thumbnail {
+        background: transparent;
+
+        &__image,
+        &:before {
+          border: $border-color 1px solid;
+          background: $body-bg;
+        }
+      }
+    }
+  }
+}
 </style>

--- a/src/components/document/viewers/SpreadsheetViewer.vue
+++ b/src/components/document/viewers/SpreadsheetViewer.vue
@@ -109,21 +109,6 @@ export default {
       meta: null
     }
   },
-  async mounted() {
-    this.$wait.start('load spreadsheet')
-    this.$Progress.start()
-    const response = await fetch(this.contentUrl, this.contentOptions)
-    const meta = await response.json()
-    this.$set(this, 'meta', meta)
-    this.$set(this, 'activeSheetIndex', 0)
-    this.$Progress.finish()
-    this.$wait.end('load spreadsheet')
-  },
-  methods: {
-    debounceFilterInput: debounce(function ({ target: { value } }) {
-      this.$set(this, 'filter', value)
-    }, 500)
-  },
   computed: {
     tableVars() {
       return {
@@ -200,6 +185,21 @@ export default {
         return ['ctrl', 'f']
       }
     }
+  },
+  async mounted() {
+    this.$wait.start('load spreadsheet')
+    this.$Progress.start()
+    const response = await fetch(this.contentUrl, this.contentOptions)
+    const meta = await response.json()
+    this.$set(this, 'meta', meta)
+    this.$set(this, 'activeSheetIndex', 0)
+    this.$Progress.finish()
+    this.$wait.end('load spreadsheet')
+  },
+  methods: {
+    debounceFilterInput: debounce(function ({ target: { value } }) {
+      this.$set(this, 'filter', value)
+    }, 500)
   }
 }
 </script>

--- a/src/components/document/viewers/SpreadsheetViewer.vue
+++ b/src/components/document/viewers/SpreadsheetViewer.vue
@@ -17,13 +17,13 @@
         >
           <div class="input-group justify-content-end">
             <input
+              v-shortkey.focus="getShortcut"
               type="search"
               class="form-control"
-              @input="debounceFilterInput"
               :placeholder="$t('document.spreadsheet.findInSpreadsheet')"
-              v-shortkey.focus="getShortcut"
+              @input="debounceFilterInput"
             />
-            <div class="input-group-append" v-if="filter">
+            <div v-if="filter" class="input-group-append">
               <div class="input-group-text">
                 {{ $tc('document.spreadsheet.filtered.rows', filteredItems.length) }}
               </div>
@@ -37,12 +37,12 @@
           :min-item-size="54"
           class="spreadsheet-viewer__content__table__scroller border-left border mb-3"
         >
-          <template #before v-if="fieldsInFirstItem">
+          <template v-if="fieldsInFirstItem" #before>
             <div class="spreadsheet-viewer__content__table__item row no-gutters border-bottom">
               <div
                 v-for="field in fields"
-                class="spreadsheet-viewer__content__table__item__col col border-right overflow-hidden"
                 :key="field"
+                class="spreadsheet-viewer__content__table__item__col col border-right overflow-hidden"
               >
                 <div class="p-2">
                   {{ field }}
@@ -55,8 +55,8 @@
               <div class="spreadsheet-viewer__content__table__item row no-gutters border-bottom">
                 <div
                   v-for="(col, i) in item.cols"
-                  class="spreadsheet-viewer__content__table__item__col col border-right overflow-hidden"
                   :key="i"
+                  class="spreadsheet-viewer__content__table__item__col col border-right overflow-hidden"
                 >
                   <div class="p-2">
                     {{ col }}
@@ -67,8 +67,8 @@
           </template>
         </dynamic-scroller>
       </div>
-      <b-tabs v-model="activeSheetIndex" pills class="mx-3 mb-3" v-if="nonEmptySheets.length > 1">
-        <b-tab :title="sheet" v-for="(sheet, i) in nonEmptySheets" :key="i"></b-tab>
+      <b-tabs v-if="nonEmptySheets.length > 1" v-model="activeSheetIndex" pills class="mx-3 mb-3">
+        <b-tab v-for="(sheet, i) in nonEmptySheets" :key="i" :title="sheet"></b-tab>
       </b-tabs>
     </div>
   </v-wait>
@@ -88,6 +88,11 @@ import { getShortkeyOS } from '@/utils/utils'
  */
 export default {
   name: 'SpreadsheetViewer',
+  components: {
+    DynamicScroller,
+    DynamicScrollerItem
+  },
+  mixins: [shortkeys],
   props: {
     /**
      * The selected document
@@ -95,11 +100,6 @@ export default {
     document: {
       type: Object
     }
-  },
-  mixins: [shortkeys],
-  components: {
-    DynamicScroller,
-    DynamicScrollerItem
   },
   data() {
     return {

--- a/src/components/document/viewers/SpreadsheetViewer.vue
+++ b/src/components/document/viewers/SpreadsheetViewer.vue
@@ -11,11 +11,18 @@
         <b-form-checkbox v-model="fieldsInFirstItem" switch class="ml-3">
           {{ $t('document.spreadsheet.fieldsInFirstItem') }}
         </b-form-checkbox>
-        <div class="spreadsheet-viewer__content__toolbox__filter pl-3 text-right flex-grow-1"
-             :class="{ 'spreadsheet-viewer__content__toolbox__filter--filtered': filter }">
+        <div
+          class="spreadsheet-viewer__content__toolbox__filter pl-3 text-right flex-grow-1"
+          :class="{ 'spreadsheet-viewer__content__toolbox__filter--filtered': filter }"
+        >
           <div class="input-group justify-content-end">
-            <input type="search" class="form-control" @input="debounceFilterInput"
-                   :placeholder="$t('document.spreadsheet.findInSpreadsheet')" v-shortkey.focus="getShortcut">
+            <input
+              type="search"
+              class="form-control"
+              @input="debounceFilterInput"
+              :placeholder="$t('document.spreadsheet.findInSpreadsheet')"
+              v-shortkey.focus="getShortcut"
+            />
             <div class="input-group-append" v-if="filter">
               <div class="input-group-text">
                 {{ $tc('document.spreadsheet.filtered.rows', filteredItems.length) }}
@@ -25,23 +32,32 @@
         </div>
       </div>
       <div class="spreadsheet-viewer__content__table mx-3 small flex-grow-1" :style="tableVars">
-        <dynamic-scroller :items="scrollerItems" :min-item-size="54"
-                          class="spreadsheet-viewer__content__table__scroller border-left border mb-3">
+        <dynamic-scroller
+          :items="scrollerItems"
+          :min-item-size="54"
+          class="spreadsheet-viewer__content__table__scroller border-left border mb-3"
+        >
           <template #before v-if="fieldsInFirstItem">
             <div class="spreadsheet-viewer__content__table__item row no-gutters border-bottom">
-              <div v-for="field in fields"
-                   class="spreadsheet-viewer__content__table__item__col col border-right overflow-hidden" :key="field">
+              <div
+                v-for="field in fields"
+                class="spreadsheet-viewer__content__table__item__col col border-right overflow-hidden"
+                :key="field"
+              >
                 <div class="p-2">
                   {{ field }}
                 </div>
               </div>
             </div>
           </template>
-          <template v-slot="{ item, index, active }">
+          <template #default="{ item, index, active }">
             <dynamic-scroller-item :item="item" :active="active" :data-index="index" :size-dependencies="item.cols">
               <div class="spreadsheet-viewer__content__table__item row no-gutters border-bottom">
-                <div v-for="(col, i) in item.cols"
-                     class="spreadsheet-viewer__content__table__item__col col border-right overflow-hidden" :key="i">
+                <div
+                  v-for="(col, i) in item.cols"
+                  class="spreadsheet-viewer__content__table__item__col col border-right overflow-hidden"
+                  :key="i"
+                >
                   <div class="p-2">
                     {{ col }}
                   </div>
@@ -51,7 +67,7 @@
           </template>
         </dynamic-scroller>
       </div>
-      <b-tabs v-model="activeSheetIndex" pills class=" mx-3 mb-3" v-if="nonEmptySheets.length > 1">
+      <b-tabs v-model="activeSheetIndex" pills class="mx-3 mb-3" v-if="nonEmptySheets.length > 1">
         <b-tab :title="sheet" v-for="(sheet, i) in nonEmptySheets" :key="i"></b-tab>
       </b-tabs>
     </div>
@@ -85,7 +101,7 @@ export default {
     DynamicScroller,
     DynamicScrollerItem
   },
-  data () {
+  data() {
     return {
       activeSheetIndex: 0,
       fieldsInFirstItem: false,
@@ -93,7 +109,7 @@ export default {
       meta: null
     }
   },
-  async mounted () {
+  async mounted() {
     this.$wait.start('load spreadsheet')
     this.$Progress.start()
     const response = await fetch(this.contentUrl, this.contentOptions)
@@ -109,15 +125,17 @@ export default {
     }, 500)
   },
   computed: {
-    tableVars () {
+    tableVars() {
       return {
         '--table-wrapper-width': Math.max(100, (5 + this.firstItem.length) * 10) + '%'
       }
     },
-    contentUrl () {
-      return `${this.$config.get('previewHost')}/api/v1/thumbnail/${this.document.index}/${this.document.id}.json?include-content=1&routing=${this.document.routing}`
+    contentUrl() {
+      return `${this.$config.get('previewHost')}/api/v1/thumbnail/${this.document.index}/${
+        this.document.id
+      }.json?include-content=1&routing=${this.document.routing}`
     },
-    contentOptions () {
+    contentOptions() {
       return {
         method: 'GET',
         cache: 'default',
@@ -126,56 +144,56 @@ export default {
         }
       }
     },
-    sessionIdHeaderValue () {
+    sessionIdHeaderValue() {
       return getCookie(process.env.VUE_APP_DS_COOKIE_NAME)
     },
-    sessionIdHeaderName () {
+    sessionIdHeaderName() {
       let dsCookieName = kebabCase(process.env.VUE_APP_DS_COOKIE_NAME)
       dsCookieName = dsCookieName.split('-').map(startCase).join('-')
       return `x-${dsCookieName}`
     },
-    isPreviewable () {
+    isPreviewable() {
       return this.meta && this.meta.previewable && this.meta.content
     },
-    activeSheet () {
+    activeSheet() {
       return this.nonEmptySheets[this.activeSheetIndex]
     },
-    sheets () {
+    sheets() {
       return sortBy(Object.keys(get(this, 'meta.content', {})))
     },
-    nonEmptySheets () {
-      return filter(this.sheets, sheet => {
+    nonEmptySheets() {
+      return filter(this.sheets, (sheet) => {
         const rows = get(this, `meta.content.${sheet}`, [])
-        return filter(rows, row => row.length).length
+        return filter(rows, (row) => row.length).length
       })
     },
-    filteredItems () {
+    filteredItems() {
       if (this.filter === '') return this.items
       return this.fuse.search(this.filter)
     },
-    items () {
+    items() {
       const items = get(this, `meta.content.${this.activeSheet}`, [])
       // Skip first item
-      return (this.fieldsInFirstItem ? items.slice(1) : items)
+      return this.fieldsInFirstItem ? items.slice(1) : items
     },
-    firstItem () {
+    firstItem() {
       return first(get(this, `meta.content.${this.activeSheet}`, [])) || []
     },
-    scrollerItems () {
+    scrollerItems() {
       return this.filteredItems.map((cols, id) => ({ id, cols }))
     },
-    fields () {
+    fields() {
       if (this.fieldsInFirstItem) {
         return this.firstItem
       }
       return null
     },
-    fuse () {
+    fuse() {
       const keys = range(this.firstItem.length).map(String)
       const options = { distance: 100, keys, shouldSort: true, threshold: 0.1 }
       return new Fuse(this.items, options)
     },
-    getShortcut () {
+    getShortcut() {
       if (getShortkeyOS() === 'mac') {
         return ['meta', 'f']
       } else {
@@ -187,74 +205,74 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @import '~node_modules/vue-virtual-scroller/dist/vue-virtual-scroller.css';
+@import '~node_modules/vue-virtual-scroller/dist/vue-virtual-scroller.css';
 
-  .spreadsheet-viewer {
-    &__content {
-      &__toolbox {
-        background: $light;
-        box-shadow: 0 -1 * $spacer 0 0 white;
-        margin: $spacer $grid-gutter-width * 0.5;
+.spreadsheet-viewer {
+  &__content {
+    &__toolbox {
+      background: $light;
+      box-shadow: 0 -1 * $spacer 0 0 white;
+      margin: $spacer $grid-gutter-width * 0.5;
 
-        &__filter {
-          margin-left: auto;
-          max-width: 300px;
+      &__filter {
+        margin-left: auto;
+        max-width: 300px;
 
-          &--filtered input.form-control {
-            border-right: 0;
+        &--filtered input.form-control {
+          border-right: 0;
 
-            &:focus + .input-group-append .input-group-text {
-              border-color: $input-focus-border-color;
-            }
+          &:focus + .input-group-append .input-group-text {
+            border-color: $input-focus-border-color;
           }
+        }
 
-          input.form-control {
-            border-radius: 1.5em;
-            width: 100%;
-          }
+        input.form-control {
+          border-radius: 1.5em;
+          width: 100%;
+        }
 
-          .input-group-text {
-            background: $input-bg;
-            border-radius: 0 1.5em 1.5em 0;
-            color: $text-muted;
-            font-size: 0.8rem;
-            margin-left: -1px;
-            transition: $input-transition;
-          }
+        .input-group-text {
+          background: $input-bg;
+          border-radius: 0 1.5em 1.5em 0;
+          color: $text-muted;
+          font-size: 0.8rem;
+          margin-left: -1px;
+          transition: $input-transition;
+        }
+      }
+    }
+
+    &__table {
+      position: relative;
+
+      &__item {
+        &__col.border-right:last-child {
+          border-right: 0 !important;
         }
       }
 
-      &__table {
-        position: relative;
+      &__scroller {
+        bottom: 0;
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
 
-        &__item {
-          &__col.border-right:last-child {
-            border-right: 0 !important;
-          }
+        .vue-recycle-scroller__slot,
+        .vue-recycle-scroller__item-wrapper {
+          width: var(--table-wrapper-width) !important;
         }
 
-        &__scroller {
-          bottom: 0;
-          left: 0;
-          position: absolute;
-          right: 0;
+        .vue-recycle-scroller__slot:first-child {
+          background: $light;
+          border-bottom: 1px solid $border-color;
+          font-weight: bold;
+          position: sticky;
           top: 0;
-
-          .vue-recycle-scroller__slot,
-          .vue-recycle-scroller__item-wrapper {
-            width: var(--table-wrapper-width) !important;
-          }
-
-          .vue-recycle-scroller__slot:first-child {
-            background: $light;
-            border-bottom: 1px solid $border-color;
-            font-weight: bold;
-            position: sticky;
-            top: 0;
-            z-index: 10;
-          }
+          z-index: 10;
         }
       }
     }
   }
+}
 </style>

--- a/src/components/document/viewers/TiffViewer.vue
+++ b/src/components/document/viewers/TiffViewer.vue
@@ -3,7 +3,7 @@
     <template v-if="pages.length">
       <div class="tiff-viewer__thumbnails bg-light p-3">
         <div class="text-center mb-4">{{ active }} / {{ pages.length }}</div>
-        <div class="tiff-viewer__thumbnails__item mb-3" v-for="page in pages.length" :key="page" @click="active = page">
+        <div v-for="page in pages.length" :key="page" class="tiff-viewer__thumbnails__item mb-3" @click="active = page">
           <img class="ml-1 img-responsive" :width="thumbWidth" :height="thumbWidth" :src="getPage(page)" />
           <div class="tiff-viewer__thumbnails__item__page text-center small">
             <span class="badge badge-dark">{{ page }}</span>
@@ -44,6 +44,7 @@ import datashareSourceMixin from '@/mixins/datashareSourceMixin'
  */
 export default {
   name: 'TiffViewer',
+  mixins: [datashareSourceMixin],
   props: {
     /**
      * The selected document
@@ -52,7 +53,6 @@ export default {
       type: Object
     }
   },
-  mixins: [datashareSourceMixin],
   data() {
     return {
       error: null,

--- a/src/components/document/viewers/TiffViewer.vue
+++ b/src/components/document/viewers/TiffViewer.vue
@@ -53,7 +53,7 @@ export default {
     }
   },
   mixins: [datashareSourceMixin],
-  data () {
+  data() {
     return {
       error: null,
       maxWidth: 750,
@@ -63,10 +63,10 @@ export default {
       pages: []
     }
   },
-  created () {
+  created() {
     Tiff.initialize({ TOTAL_MEMORY: 16777216 * 10 })
   },
-  async mounted () {
+  async mounted() {
     try {
       this.tiff = await this.getTiff()
       for (const page of range(1, this.tiff.countDirectory() + 1)) {
@@ -77,32 +77,32 @@ export default {
     }
   },
   methods: {
-    getPage (page = this.active) {
+    getPage(page = this.active) {
       if (this.pages[page - 1]) {
         return this.pages[page - 1].toDataURL()
       }
     },
-    renderPage (page = this.active) {
+    renderPage(page = this.active) {
       this.tiff.setDirectory(page - 1)
       return this.tiff.toCanvas()
     },
-    async getTiff () {
+    async getTiff() {
       const r = await this.$core.api.getSource(this.document, { responseType: 'blob' })
       const buffer = await r.arrayBuffer()
       return new Tiff({ buffer })
     },
-    async rotateActivePage (page, direction = 1) {
+    async rotateActivePage(page, direction = 1) {
       const canvas = await this.rotate(this.pages[page - 1], direction)
       this.$set(this.pages, page - 1, canvas)
     },
-    rotate (canvas, direction = 1) {
+    rotate(canvas, direction = 1) {
       const ctx = canvas.getContext('2d')
       const cw = canvas.width
       const ch = canvas.height
       // Store current data to a temporary image
       let img = new Image()
       // Create a promise to return when the image is rotated
-      const promise = new Promise(resolve => {
+      const promise = new Promise((resolve) => {
         img.onload = () => {
           // Reset the canvas with new dimensions
           canvas.width = ch
@@ -111,10 +111,10 @@ export default {
           ctx.translate(ch / 2, cw / 2)
           // Clockwise rotation
           if (direction === 1) {
-            ctx.rotate(90 * Math.PI / 180)
+            ctx.rotate((90 * Math.PI) / 180)
             // Counterclockwise rotation
           } else {
-            ctx.rotate(-90 * Math.PI / 180)
+            ctx.rotate((-90 * Math.PI) / 180)
           }
           // Draw the previows image, now rotated
           ctx.drawImage(img, cw / -2, ch / -2)
@@ -140,8 +140,7 @@ export default {
       cursor: pointer;
 
       &:hover {
-        box-shadow: 0 0 0 1px $input-focus-border-color,
-                    0 0 $spacer * 0.5 0 $input-focus-border-color;
+        box-shadow: 0 0 0 1px $input-focus-border-color, 0 0 $spacer * 0.5 0 $input-focus-border-color;
       }
 
       &__page {

--- a/src/components/filter/FilterBoilerplate.vue
+++ b/src/components/filter/FilterBoilerplate.vue
@@ -1,13 +1,15 @@
 <template>
-  <div class="filter card"
-      :class="{
-        'filter--reversed': isReversed,
-        'filter--hide-show-more': hideShowMore,
-        'filter--hide-search': hideSearch,
-        'filter--hide-header': hideHeader,
-        'filter--has-values': hasValues,
-        'filter--dark': dark
-      }">
+  <div
+    class="filter card"
+    :class="{
+      'filter--reversed': isReversed,
+      'filter--hide-show-more': hideShowMore,
+      'filter--hide-search': hideSearch,
+      'filter--hide-header': hideHeader,
+      'filter--has-values': hasValues,
+      'filter--dark': dark
+    }"
+  >
     <hook :name="`filter.${filter.name}.header:before`" :bind="{ filter }"></hook>
     <slot name="header" v-if="!hideHeader">
       <div class="card-header px-2 d-flex filter__header" @click="toggleItems">
@@ -30,21 +32,25 @@
       <div class="list-group list-group-flush filter__items">
         <hook :name="`filter.${filter.name}.search:before`" :bind="{ filter, query: query }"></hook>
         <slot name="search" v-if="!hideSearch && filter.isSearchable">
-          <search-form-control class="filter__items__search"
-                               :placeholder="$t('search.searchIn') + ' ' + $t('filter.' + filter.name) + '...'"
-                               :rounded="false"
-                               @submit.prevent="openFilterSearch"
-                               v-model="query"></search-form-control>
+          <search-form-control
+            class="filter__items__search"
+            :placeholder="$t('search.searchIn') + ' ' + $t('filter.' + filter.name) + '...'"
+            :rounded="false"
+            @submit.prevent="openFilterSearch"
+            v-model="query"
+          ></search-form-control>
         </slot>
         <hook :name="`filter.${filter.name}.search:after`" :bind="{ filter, query: query }"></hook>
-        <slot :items="items"
-              name="items"
-              :options="options"
-              :query="query"
-              :selected="selected"
-              :sort-by="sortBy"
-              :sort-by-order="sortByOrder"
-              :total-count="totalCount">
+        <slot
+          :items="items"
+          name="items"
+          :options="options"
+          :query="query"
+          :selected="selected"
+          :sort-by="sortBy"
+          :sort-by-order="sortByOrder"
+          :total-count="totalCount"
+        >
           <b-form-checkbox v-model="isAllSelected" class="filter__items__all mb-0" :disabled="isAllSelected">
             <slot name="all" v-bind="{ total }">
               <span class="d-flex">
@@ -58,10 +64,12 @@
             </slot>
           </b-form-checkbox>
           <slot name="items-group" :items="items" :options="options" :selected="selected">
-            <b-form-checkbox-group class="list-group-item p-0 border-0"
-                                   @input="changeSelectedValues"
-                                   stacked
-                                   v-model="selected">
+            <b-form-checkbox-group
+              class="list-group-item p-0 border-0"
+              @input="changeSelectedValues"
+              stacked
+              v-model="selected"
+            >
               <template v-for="{ value, item, label } of options">
                 <slot name="item" :item="item" :label="label" :value="value" :selected="selected">
                   <b-form-checkbox :value="value" class="filter__items__item">
@@ -93,25 +101,40 @@
           <span slot="no-results"></span>
         </infinite-loading>
       </div>
-      <filter-footer @contextualize-filter="toggleContextualizeFilter"
-                     :filter="filter"
-                     :hide-contextualize="hideContextualize"
-                     :hide-exclude="hideExclude"
-                     :hide-show-more="hideShowMore"
-                     :hide-sort="hideSort"
-                     :sort-by-options.sync="sortByOptions"
-                     :sort-by-order.sync="sortByOrder"
-                     :sort-by.sync="sortBy"
-                     @open-filter-search="openFilterSearch"
-                     @toggle-filter="toggleFilter"
-                     v-if="!hideFooter" />
+      <filter-footer
+        @contextualize-filter="toggleContextualizeFilter"
+        :filter="filter"
+        :hide-contextualize="hideContextualize"
+        :hide-exclude="hideExclude"
+        :hide-show-more="hideShowMore"
+        :hide-sort="hideSort"
+        :sort-by-options.sync="sortByOptions"
+        :sort-by-order.sync="sortByOrder"
+        :sort-by.sync="sortBy"
+        @open-filter-search="openFilterSearch"
+        @toggle-filter="toggleFilter"
+        v-if="!hideFooter"
+      />
     </b-collapse>
   </div>
 </template>
 
 <script>
 import {
-  compact, concat, escapeRegExp, findIndex, flatten, get, map, noop, pick, setWith, sumBy, throttle, toLower, uniqueId
+  compact,
+  concat,
+  escapeRegExp,
+  findIndex,
+  flatten,
+  get,
+  map,
+  noop,
+  pick,
+  setWith,
+  sumBy,
+  throttle,
+  toLower,
+  uniqueId
 } from 'lodash'
 import InfiniteLoading from 'vue-infinite-loading'
 
@@ -200,7 +223,7 @@ export default {
       default: true
     }
   },
-  data () {
+  data() {
     return {
       collapseItems: this.collapsedIfNoValues && !this.hasValues,
       infiniteId: uniqueId(),
@@ -214,10 +237,10 @@ export default {
     }
   },
   watch: {
-    modelQuery () {
+    modelQuery() {
       this.$set(this, 'query', this.modelQuery)
     },
-    query () {
+    query() {
       this.$set(this, 'infiniteId', uniqueId())
       this.aggregateWithThrottle({ clearPages: true })
       // Emit an event to update the model value only if it changed
@@ -225,17 +248,17 @@ export default {
         this.$emit('update:modelQuery', this.query)
       }
     },
-    collapseItems () {
+    collapseItems() {
       this.initialize()
     },
-    sortBy () {
+    sortBy() {
       this.clearInfiniteScroll()
     },
-    sortByOrder () {
+    sortByOrder() {
       this.clearInfiniteScroll()
     }
   },
-  async mounted () {
+  async mounted() {
     await this.$nextTick()
     this.mounted = true
     // Listen for event to refresh the filter
@@ -248,7 +271,7 @@ export default {
         return
       }
       // Collects all indexes of the deleted item in the components loaded pages
-      const itemIndexes = this.pages.map(page => {
+      const itemIndexes = this.pages.map((page) => {
         return findIndex(this.getPageItems(page), { key })
       })
       // Iterate on the list of indexes for each page
@@ -265,8 +288,8 @@ export default {
         // update the doc count
         if (item.doc_count > 1) {
           item.doc_count--
-        // The item as only one occurrence, meaning it must be
-        // deleted from the page's items.
+          // The item as only one occurrence, meaning it must be
+          // deleted from the page's items.
         } else {
           get(this.pages, [pageIndex, ...this.pageItemsPath]).splice(itemIndex, 1)
         }
@@ -276,26 +299,26 @@ export default {
     this.initialize()
   },
   computed: {
-    waitIdentifier () {
+    waitIdentifier() {
       return `items for ${this.filter.name} on ${this.$options.name}`
     },
-    isReady () {
+    isReady() {
       return !this.$wait.is(this.waitIdentifier)
     },
-    isGlobal () {
+    isGlobal() {
       return !this.filter.contextualized
     },
-    getFilter () {
+    getFilter() {
       return this.getFilterByName(this.filter.name)
     },
-    pageItemsPath () {
+    pageItemsPath() {
       return ['aggregations', this.filter.key, 'buckets']
     },
-    queryTokens () {
+    queryTokens() {
       return [escapeRegExp(this.query.toLowerCase())]
     },
-    options () {
-      return map(this.itemsWithExcludedValues, item => {
+    options() {
+      return map(this.itemsWithExcludedValues, (item) => {
         return {
           item,
           value: item.key.toString(),
@@ -303,80 +326,80 @@ export default {
         }
       })
     },
-    items () {
+    items() {
       return flatten(this.pages.map(this.getPageItems))
     },
-    itemsWithExcludedValues () {
+    itemsWithExcludedValues() {
       const pages = concat([this.excludedItemsPage], this.pages)
       return flatten(pages.map(this.getPageItems))
     },
-    lastPage () {
+    lastPage() {
       return this.pages[this.pages.length - 1]
     },
-    lastPageItems () {
+    lastPageItems() {
       return get(this.lastPage, this.pageItemsPath, [])
     },
-    excludedItemsPage () {
+    excludedItemsPage() {
       if (!this.isGlobal && this.getFilter && this.getFilter.reverse) {
-        const values = this.getFilter.values.map(key => ({ key, doc_count: 0 }))
+        const values = this.getFilter.values.map((key) => ({ key, doc_count: 0 }))
         return setWith({}, this.pageItemsPath.join('.'), values, Object)
       }
       return []
     },
-    calculatedCount () {
+    calculatedCount() {
       return this.totalCount || 0
     },
-    totalCount () {
+    totalCount() {
       return sumBy(this.items, 'doc_count')
     },
-    total () {
+    total() {
       return get(this, 'lastPage.total', 0)
     },
-    headerIcon () {
+    headerIcon() {
       return this.collapseItems ? 'plus' : 'minus'
     },
-    showResults () {
+    showResults() {
       return (this.isReady || this.offset > 0) && !this.collapseItems
     },
-    hasResults () {
+    hasResults() {
       return this.isReady && this.items.length > 0
     },
-    noResults () {
+    noResults() {
       return this.isReady && this.items.length === 0
     },
-    noMatches () {
+    noMatches() {
       return this.isReady && this.items.length === 0
     },
-    useInfiniteScroll () {
+    useInfiniteScroll() {
       return this.infiniteScroll && this.offset > 0 && this.items.length >= this.size
     },
-    fromElasticSearch () {
+    fromElasticSearch() {
       return get(this, 'filter.fromElasticSearch', false)
     },
-    aggregateWithThrottle () {
+    aggregateWithThrottle() {
       return throttle(this.aggregateWithLoading, 700)
     },
-    offset () {
+    offset() {
       return get(this, 'items.length', 0)
     },
-    nextOffset () {
+    nextOffset() {
       return this.offset + this.size
     },
-    size () {
+    size() {
       return settings.filter.bucketSize
     },
-    hasFilterQuery () {
+    hasFilterQuery() {
       // The filter has a query if:
       //   * it is searchable
       //   * the query is not empty
       //   * it has an "alternativeSearch" function to generate query tokens
       return this.filter.isSearchable && this.query !== '' && this.filter.alternativeSearch
     },
-    aggregationInclude () {
+    aggregationInclude() {
       const alternativeSearch = compact(this.filter.alternativeSearch(toLower(this.query)))
       return '.*(' + concat(alternativeSearch, this.queryTokens).join('|') + ').*'
     },
-    aggregationOptions () {
+    aggregationOptions() {
       // The "size" attribute must be as big as the number of displayed buckets
       let options = { size: this.nextOffset, order: this.order }
       // Merge the options object with the filter's query
@@ -385,39 +408,39 @@ export default {
       }
       return options
     },
-    order () {
+    order() {
       return { [this.sortBy]: this.sortByOrder }
     },
     selected: {
-      get () {
+      get() {
         return this.getFilterValuesByName(this.filter.name)
       },
-      set (key) {
+      set(key) {
         this.setFilterValue(this.filter, { key })
       }
     },
     isAllSelected: {
-      get () {
+      get() {
         return this.selected.length === 0
       },
-      set (checked) {
+      set(checked) {
         if (checked) {
           this.$set(this, 'selected', [])
         }
       }
     },
-    isReversed () {
+    isReversed() {
       return this.$store.getters['search/isFilterReversed'](this.filter.name)
     },
     hasValues: {
       cache: false,
-      get () {
+      get() {
         return this.$store.getters['search/hasFilterValues'](this.filter.name)
       }
     }
   },
   methods: {
-    initialize () {
+    initialize() {
       if (!this.collapseItems && this.offset === 0) {
         // Are we using an "offline" components?
         this.aggregateWithLoading()
@@ -430,19 +453,23 @@ export default {
         //
         // When they are contextualized, every filter with selected values will
         // be present in the list of watched values.
-        const unwatch = this.$store.watch(this.watchedForUpdate, () => {
-          // It's important to clear pages to ensure the filter is loading
-          // pages from the start and not adding new pages.
-          this.aggregateWithLoading({ clearPages: true })
-        }, { deep: true })
+        const unwatch = this.$store.watch(
+          this.watchedForUpdate,
+          () => {
+            // It's important to clear pages to ensure the filter is loading
+            // pages from the start and not adding new pages.
+            this.aggregateWithLoading({ clearPages: true })
+          },
+          { deep: true }
+        )
         this.$set(this, 'unwatch', unwatch)
       }
     },
-    clearInfiniteScroll () {
+    clearInfiniteScroll() {
       this.$set(this, 'infiniteId', uniqueId())
       this.aggregateWithThrottle({ clearPages: true })
     },
-    openFilterSearch () {
+    openFilterSearch() {
       /**
        * Triggered at the root level when user starts to search in the filter values.
        */
@@ -452,13 +479,13 @@ export default {
        */
       this.$emit('async-search', this.filter, this.query)
     },
-    async aggregateWithLoading (...args) {
+    async aggregateWithLoading(...args) {
       this.$wait.start(this.waitIdentifier)
       const page = await this.aggregate(...args)
       this.$wait.end(this.waitIdentifier)
       return page
     },
-    async aggregate ({ clearPages = false } = {}) {
+    async aggregate({ clearPages = false } = {}) {
       /**
        * Triggered when a filter received instruction to be load data
        */
@@ -479,41 +506,41 @@ export default {
       this.pages.push(page)
       return page
     },
-    async nextAggregate ($infiniteLoadingState) {
+    async nextAggregate($infiniteLoadingState) {
       await this.aggregateWithLoading()
       // Did we reach the end?
       const method = this.lastPageItems.length < this.size ? 'complete' : 'loaded'
       // Call the right method (with "noop" as safety net in case the method can't be found)
       return get($infiniteLoadingState, method, noop)()
     },
-    toggleItems () {
+    toggleItems() {
       this.collapseItems = !this.collapseItems
     },
-    getPageItems (page) {
+    getPageItems(page) {
       return get(page, this.pageItemsPath, [])
     },
-    hasValue (item) {
+    hasValue(item) {
       return this.$store.getters['search/hasFilterValue'](this.filter.itemParam(item))
     },
-    removeValue (item) {
+    removeValue(item) {
       this.$store.commit('search/removeFilterValue', this.filter.itemParam(item))
       this.refreshRouteAndSearch()
     },
-    addValue (item) {
+    addValue(item) {
       this.$store.commit('search/addFilterValue', this.filter.itemParam(item))
       this.refreshRouteAndSearch()
     },
-    setValue (item) {
+    setValue(item) {
       this.setFilterValue(this.filter, item)
       this.refreshRouteAndSearch()
     },
-    toggleFilter () {
+    toggleFilter() {
       this.refreshRouteAndSearch()
     },
-    toggleContextualizeFilter () {
+    toggleContextualizeFilter() {
       this.clearInfiniteScroll()
     },
-    watchedForUpdate () {
+    watchedForUpdate() {
       const { search } = this.$store.state
       if (this.filter.contextualized) {
         // This will allow to watch change on the search only when
@@ -523,110 +550,110 @@ export default {
         return pick(search, ['indices'])
       }
     },
-    resetFilterValues (refresh = true) {
+    resetFilterValues(refresh = true) {
       this.$set(this, 'selected', [])
       this.$store.commit('search/includeFilter', this.filter.name)
       this.$emit('reset-filter-values', this.filter, refresh)
     },
-    changeSelectedValues ($ev) {
+    changeSelectedValues($ev) {
       this.$root.$emit('filter::add-filter-values', this.filter, this.selected)
       this.$store.commit('search/from', 0)
       this.$emit('add-filter-values', this.filter, this.selected)
       this.refreshRouteAndSearch()
     }
   },
-  beforeDestroy () {
+  beforeDestroy() {
     this.unwatch()
   }
 }
 </script>
 
 <style lang="scss">
-  .filter {
-    .content-placeholder .content-placeholder__wrapper__row__box {
-      background: darken($app-context-sidebar-bg, 5%);
-    }
+.filter {
+  .content-placeholder .content-placeholder__wrapper__row__box {
+    background: darken($app-context-sidebar-bg, 5%);
+  }
 
-    &__header {
-      &__icon {
-        cursor: pointer;
-      }
+  &__header {
+    &__icon {
+      cursor: pointer;
     }
+  }
 
-    .custom-checkbox {
+  .custom-checkbox {
+    display: block;
+    margin: 0.5rem;
+
+    label {
       display: block;
-      margin: 0.5rem;
+      padding-top: 0.2rem;
 
-      label {
-        display: block;
-        padding-top: 0.2rem;
-
-        & > span {
-          display: flex;
-          flex-direction: row;
-        }
-      }
-
-      input:checked + label {
-        font-weight: bold;
+      & > span {
+        display: flex;
+        flex-direction: row;
       }
     }
 
-    &.filter--reversed {
-      .filter__items__item:not(.filter__items__all) input:checked + label {
-        text-decoration: line-through;
-      }
+    input:checked + label {
+      font-weight: bold;
+    }
+  }
+
+  &.filter--reversed {
+    .filter__items__item:not(.filter__items__all) input:checked + label {
+      text-decoration: line-through;
+    }
+  }
+
+  &.filter--has-values {
+    box-shadow: 0 0 0 2px $tertiary, 0 0 10px 0 rgba($tertiary, 0.2);
+  }
+
+  &__items {
+    font-size: 0.8rem;
+    max-height: 300px;
+    overflow: auto;
+
+    .list-group-item {
+      background: inherit;
+      color: inherit;
     }
 
-    &.filter--has-values {
-      box-shadow: 0 0 0 2px $tertiary, 0 0 10px 0 rgba($tertiary, .2);
+    &__all + .list-group-item:empty {
+      margin-bottom: $spacer * 0.5;
     }
 
-    &__items {
-      font-size: 0.8rem;
-      max-height: 300px;
-      overflow: auto;
+    &__item .custom-checkbox {
+      margin-bottom: 0;
+    }
 
-      .list-group-item {
-        background: inherit;
+    &__search {
+      margin: 0 0.5rem;
+    }
+
+    .filter--dark &__search {
+      color: $light;
+
+      .search-form-control__input,
+      .search-form-control__addon__submit:last-of-type {
+        background: #000;
         color: inherit;
       }
 
-      &__all + .list-group-item:empty {
-        margin-bottom: $spacer * 0.5;
-      }
-
-      &__item .custom-checkbox {
-        margin-bottom: 0;
-      }
-
-      &__search {
-        margin: 0 0.5rem;
-      }
-
-      .filter--dark &__search {
-        color: $light;
-
-        .search-form-control__input,
-        .search-form-control__addon__submit:last-of-type {
-          background: #000;
-          color: inherit;
-        }
-
-        .search-form-control__input:not(:focus),
-        .search-form-control__addon__submit:last-of-type {
-          border-color: #000;
-        }
-      }
-
-      & &__display {
-        cursor: pointer;
-        font-size: 0.8rem;
-        font-weight: bolder;
-        margin: 0;
-        padding: 0 2.25rem 0.5rem;
-        text-align: center;
+      .search-form-control__input:not(:focus),
+      .search-form-control__addon__submit:last-of-type {
+        border-color: #000;
       }
     }
+
+    & &__display {
+      cursor: pointer;
+      font-size: 0.8rem;
+      font-weight: bolder;
+      margin: 0;
+      padding: 0 2.25rem 0.5rem;
+      text-align: center;
+    }
   }
+}
 </style>

--- a/src/components/filter/FilterBoilerplate.vue
+++ b/src/components/filter/FilterBoilerplate.vue
@@ -17,11 +17,9 @@
           <span v-if="filter.icon" class="filter__items__item__icon pl-0 pr-1">
             <fa :icon="filter.icon" fixed-width></fa>
           </span>
-          <template>
-            <slot name="title">
-              {{ $t(`filter.${filter.name}`) }}
-            </slot>
-          </template>
+          <slot name="title">
+            {{ $t(`filter.${filter.name}`) }}
+          </slot>
         </h6>
         <fa v-if="isReady" :icon="headerIcon" class="float-right filter__header__icon"></fa>
         <fa v-else icon="circle-notch" spin class="float-right"></fa>
@@ -102,6 +100,7 @@
         </infinite-loading>
       </div>
       <filter-footer
+        v-if="!hideFooter"
         :filter="filter"
         :hide-contextualize="hideContextualize"
         :hide-exclude="hideExclude"
@@ -109,7 +108,6 @@
         :hide-sort="hideSort"
         :sort-by-options.sync="sortByOptions"
         :sort-by-order.sync="sortByOrder"
-        v-if="!hideFooter"
         :sort-by.sync="sortBy"
         @contextualize-filter="toggleContextualizeFilter"
         @open-filter-search="openFilterSearch"

--- a/src/components/filter/FilterFooter.vue
+++ b/src/components/filter/FilterFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="filter__footer d-flex align-items-center text-nowrap p-1" v-if="!hideFooter">
+  <div v-if="!hideFooter" class="filter__footer d-flex align-items-center text-nowrap p-1">
     <filter-sort-by-dropdown
       v-if="!hideSort"
       :sort-by="sortBy"

--- a/src/components/filter/FilterFooter.vue
+++ b/src/components/filter/FilterFooter.vue
@@ -1,28 +1,36 @@
 <template>
   <div class="filter__footer d-flex align-items-center text-nowrap p-1" v-if="!hideFooter">
-    <filter-sort-by-dropdown v-if="!hideSort"
-                            :sort-by="sortBy"
-                            :sort-by-order="sortByOrder"
-                            :sort-by-options="sortByOptions"
-                            @update:sortBy="$emit('update:sortBy', $event)"
-                            @update:sortByOrder="$emit('update:sortByOrder', $event)" />
-    <button v-if="shouldDisplayShowMore"
-            class="filter__footer__action filter__footer__action--expand btn btn-link btn-sm"
-            @click="openFilterSearch">
+    <filter-sort-by-dropdown
+      v-if="!hideSort"
+      :sort-by="sortBy"
+      :sort-by-order="sortByOrder"
+      :sort-by-options="sortByOptions"
+      @update:sortBy="$emit('update:sortBy', $event)"
+      @update:sortByOrder="$emit('update:sortByOrder', $event)"
+    />
+    <button
+      v-if="shouldDisplayShowMore"
+      class="filter__footer__action filter__footer__action--expand btn btn-link btn-sm"
+      @click="openFilterSearch"
+    >
       <fa icon="expand-alt" fixed-width />
       {{ $t('filter.showMore') }}
     </button>
     <span class="mx-auto"></span>
-    <b-form-checkbox v-if="!hideExclude"
-                     v-model="isReversed"
-                     size="sm"
-                     class="filter__footer__action filter__footer__action--invert">
+    <b-form-checkbox
+      v-if="!hideExclude"
+      v-model="isReversed"
+      size="sm"
+      class="filter__footer__action filter__footer__action--invert"
+    >
       {{ $t('filter.invert') }}
     </b-form-checkbox>
-    <b-form-checkbox v-if="!hideContextualize"
-                     v-model="isContextualized"
-                     size="sm"
-                     class="filter__footer__action filter__footer__action--contextualize">
+    <b-form-checkbox
+      v-if="!hideContextualize"
+      v-model="isContextualized"
+      size="sm"
+      class="filter__footer__action filter__footer__action--contextualize"
+    >
       {{ $t('filter.contextualize') }}
     </b-form-checkbox>
   </div>
@@ -71,17 +79,17 @@ export default {
     }
   },
   computed: {
-    hideFooter () {
+    hideFooter() {
       return this.hideExclude && this.hideSort && this.hideContextualize && !this.shouldDisplayShowMore
     },
-    shouldDisplayShowMore () {
+    shouldDisplayShowMore() {
       return !this.hideShowMore
     },
     isReversed: {
-      get () {
+      get() {
         return this.$store.getters['search/isFilterReversed'](this.filter.name)
       },
-      set (toggler) {
+      set(toggler) {
         // Change the store so it's reflected everywhere
         this.toggleFilter(toggler)
         /**
@@ -91,10 +99,10 @@ export default {
       }
     },
     isContextualized: {
-      get () {
+      get() {
         return this.$store.getters['search/isFilterContextualized'](this.filter.name)
       },
-      set (toggler) {
+      set(toggler) {
         // Change the store so it's reflected everywhere
         this.toggleContextualizedFilter(toggler)
         /**
@@ -105,20 +113,20 @@ export default {
     }
   },
   methods: {
-    openFilterSearch () {
+    openFilterSearch() {
       /**
        * Triggered when user starts to search in the filter values.
        */
       this.$emit('open-filter-search', this.filter, this.query)
     },
-    toggleContextualizedFilter (toggler) {
+    toggleContextualizedFilter(toggler) {
       if (toggler) {
         this.$store.commit('search/contextualizeFilter', this.filter.name)
       } else {
         this.$store.commit('search/decontextualizeFilter', this.filter.name)
       }
     },
-    toggleFilter (toggler) {
+    toggleFilter(toggler) {
       if (toggler) {
         this.$store.commit('search/excludeFilter', this.filter.name)
       } else {
@@ -130,39 +138,39 @@ export default {
 </script>
 
 <style lang="scss">
-  .filter__footer {
+.filter__footer {
+  .filter--has-values & {
+    background: $tertiary;
+    color: #000;
+  }
 
-    .filter--has-values & {
-      background: $tertiary;
-      color: #000;
+  &__action {
+    color: inherit;
+
+    &.btn {
+      padding: 0.2em;
     }
 
-    &__action {
+    .filter__footer > &.custom-checkbox {
+      margin: 0 0.2em;
+
+      label {
+        padding-top: 0;
+        display: inline-block;
+        margin-bottom: 0;
+      }
+
+      .filter--has-values & .custom-control-input:checked ~ .custom-control-label::before {
+        background: #000;
+        border-color: #000;
+        color: #fff;
+      }
+    }
+
+    &:hover,
+    &:active {
       color: inherit;
-
-      &.btn {
-        padding: 0.2em;
-      }
-
-      .filter__footer > &.custom-checkbox {
-        margin: 0 .2em;
-
-        label {
-          padding-top: 0;
-          display: inline-block;
-          margin-bottom: 0;
-        }
-
-        .filter--has-values & .custom-control-input:checked ~ .custom-control-label::before {
-          background: #000;
-          border-color: #000;
-          color: #fff;
-        }
-      }
-
-      &:hover, &:active {
-        color: inherit;
-      }
     }
   }
+}
 </style>

--- a/src/components/filter/FilterSearch.vue
+++ b/src/components/filter/FilterSearch.vue
@@ -2,17 +2,17 @@
   <div class="filter-search">
     <div class="card">
       <component
-        class="border-0"
-        ref="filterComponent"
         :is="filter.component"
+        ref="filterComponent"
         :key="filter.name"
+        class="border-0"
         :collapsed-if-no-values="false"
         :dark="false"
         :model-query="modelQuery"
-        @add-filter-values="onAddedFilterValues"
         hide-header
         hide-show-more
         v-bind="{ filter }"
+        @add-filter-values="onAddedFilterValues"
       ></component>
     </div>
   </div>

--- a/src/components/filter/FilterSearch.vue
+++ b/src/components/filter/FilterSearch.vue
@@ -1,17 +1,19 @@
 <template>
   <div class="filter-search">
     <div class="card">
-      <component class="border-0"
-                 ref="filterComponent"
-                 :is="filter.component"
-                 :key="filter.name"
-                 :collapsed-if-no-values="false"
-                 :dark="false"
-                 :model-query="modelQuery"
-                 @add-filter-values="onAddedFilterValues"
-                 hide-header
-                 hide-show-more
-                 v-bind="{ filter }"></component>
+      <component
+        class="border-0"
+        ref="filterComponent"
+        :is="filter.component"
+        :key="filter.name"
+        :collapsed-if-no-values="false"
+        :dark="false"
+        :model-query="modelQuery"
+        @add-filter-values="onAddedFilterValues"
+        hide-header
+        hide-show-more
+        v-bind="{ filter }"
+      ></component>
     </div>
   </div>
 </template>
@@ -49,7 +51,7 @@ export default {
     }
   },
   methods: {
-    onAddedFilterValues (component) {
+    onAddedFilterValues(component) {
       /**
        * A value is selected for a specific component
        */
@@ -60,17 +62,15 @@ export default {
 </script>
 
 <style lang="scss">
-  .filter-search {
+.filter-search {
+  .filter {
+    &__items {
+      max-height: calc(100vh - 300px);
 
-    .filter {
-
-      &__items {
-        max-height: calc(100vh - 300px);
-
-        &__search {
-          margin-top: 0.5rem;
-        }
+      &__search {
+        margin-top: 0.5rem;
       }
     }
   }
+}
 </style>

--- a/src/components/filter/FilterSortByDropdown.vue
+++ b/src/components/filter/FilterSortByDropdown.vue
@@ -11,10 +11,10 @@
       {{ $t('filter.sortByDropdown.toggler') }}
     </template>
     <b-dropdown-item
-      v-for="({ sortBy, sortByOrder, label }, $index) in sortByOptionsWithLabels"
+      v-for="({ sortByOption, sortByOptionOrder, label }, $index) in sortByOptionsWithLabels"
       :key="$index"
-      :active="isOptionActive({ sortBy, sortByOrder })"
-      @click="selectOption({ sortBy, sortByOrder })"
+      :active="isOptionActive({ sortByOption, sortByOptionOrder })"
+      @click="selectOption({ sortByOption, sortByOptionOrder })"
     >
       {{ label }}
     </b-dropdown-item>

--- a/src/components/filter/FilterSortByDropdown.vue
+++ b/src/components/filter/FilterSortByDropdown.vue
@@ -11,10 +11,10 @@
       {{ $t('filter.sortByDropdown.toggler') }}
     </template>
     <b-dropdown-item
-      v-for="({ sortByOption, sortByOptionOrder, label }, $index) in sortByOptionsWithLabels"
+      v-for="({ sortByFromFilter, sortByOrderFromFilter, label }, $index) in sortByOptionsWithLabels"
       :key="$index"
-      :active="isOptionActive({ sortByOption, sortByOptionOrder })"
-      @click="selectOption({ sortByOption, sortByOptionOrder })"
+      :active="isOptionActive({ sortByFromFilter, sortByOrderFromFilter })"
+      @click="selectOption({ sortByFromFilter, sortByOrderFromFilter })"
     >
       {{ label }}
     </b-dropdown-item>
@@ -49,21 +49,21 @@ export default {
       return this.sortByOptions.map(({ sortBy, sortByOrder }) => {
         const key = `filter.sortByDropdown.options.${sortBy}.${sortByOrder}`
         const label = this.$t(key)
-        return { label, sortBy, sortByOrder }
+        return { label, sortByFromFilter: sortBy, sortByOrderFromFilter: sortByOrder }
       })
     }
   },
   methods: {
-    selectOption({ sortBy, sortByOrder }) {
-      if (sortBy !== this.sortBy) {
-        this.$emit('update:sortBy', sortBy)
+    selectOption({ sortByFromFilter, sortByOrderFromFilter }) {
+      if (sortByFromFilter !== this.sortBy) {
+        this.$emit('update:sortBy', sortByFromFilter)
       }
-      if (sortByOrder !== this.sortByOrder) {
-        this.$emit('update:sortByOrder', sortByOrder)
+      if (sortByOrderFromFilter !== this.sortByOrder) {
+        this.$emit('update:sortByOrder', sortByOrderFromFilter)
       }
     },
-    isOptionActive({ sortBy, sortByOrder }) {
-      return this.sortBy === sortBy && this.sortByOrder === sortByOrder
+    isOptionActive({ sortByFromFilter, sortByOrderFromFilter }) {
+      return this.sortBy === sortByFromFilter && this.sortByOrder === sortByOrderFromFilter
     }
   }
 }

--- a/src/components/filter/FilterSortByDropdown.vue
+++ b/src/components/filter/FilterSortByDropdown.vue
@@ -1,13 +1,21 @@
 <template>
-  <b-dropdown dropup no-caret size="sm" variant="link" toggle-class="filter__footer__action filter__footer__action--sort">
-    <template v-slot:button-content>
+  <b-dropdown
+    dropup
+    no-caret
+    size="sm"
+    variant="link"
+    toggle-class="filter__footer__action filter__footer__action--sort"
+  >
+    <template #button-content>
       <fa icon="caret-up" fixed-width />
       {{ $t('filter.sortByDropdown.toggler') }}
     </template>
-    <b-dropdown-item v-for="({ sortBy, sortByOrder, label }, $index) in sortByOptionsWithLabels"
-                    :key="$index"
-                    :active="isOptionActive({ sortBy, sortByOrder })"
-                    @click="selectOption({ sortBy, sortByOrder })">
+    <b-dropdown-item
+      v-for="({ sortBy, sortByOrder, label }, $index) in sortByOptionsWithLabels"
+      :key="$index"
+      :active="isOptionActive({ sortBy, sortByOrder })"
+      @click="selectOption({ sortBy, sortByOrder })"
+    >
       {{ label }}
     </b-dropdown-item>
   </b-dropdown>
@@ -37,7 +45,7 @@ export default {
     }
   },
   computed: {
-    sortByOptionsWithLabels () {
+    sortByOptionsWithLabels() {
       return this.sortByOptions.map(({ sortBy, sortByOrder }) => {
         const key = `filter.sortByDropdown.options.${sortBy}.${sortByOrder}`
         const label = this.$t(key)
@@ -46,7 +54,7 @@ export default {
     }
   },
   methods: {
-    selectOption ({ sortBy, sortByOrder }) {
+    selectOption({ sortBy, sortByOrder }) {
       if (sortBy !== this.sortBy) {
         this.$emit('update:sortBy', sortBy)
       }
@@ -54,7 +62,7 @@ export default {
         this.$emit('update:sortByOrder', sortByOrder)
       }
     },
-    isOptionActive ({ sortBy, sortByOrder }) {
+    isOptionActive({ sortBy, sortByOrder }) {
       return this.sortBy === sortBy && this.sortByOrder === sortByOrder
     }
   }

--- a/src/components/filter/types/FilterAbstract.vue
+++ b/src/components/filter/types/FilterAbstract.vue
@@ -1,8 +1,9 @@
 <template>
   <filter-boilerplate
-    @add-filter-values="value => $emit('add-filter-values', value)"
+    @add-filter-values="(value) => $emit('add-filter-values', value)"
     ref="filter"
-    v-bind="$props"></filter-boilerplate>
+    v-bind="$props"
+  ></filter-boilerplate>
 </template>
 
 <script>
@@ -24,27 +25,31 @@ export default {
     // Temporary import of the props from FilterBoilerplate
     ...FilterBoilerplate.props
   },
-  async mounted () {
+  async mounted() {
     await this.$nextTick()
     this.mounted = true
   },
   computed: {
-    root () {
+    root() {
       return get(this, '$refs.filter', {})
     }
   },
   methods: {
     // Returns all props without the givens keys
-    propsWithout (...keys) {
+    propsWithout(...keys) {
       keys = flatten(keys).map(camelCase)
-      return reduce(this.$props, (props, value, key) => {
-        if (keys.indexOf(key) === -1) {
-          props[key] = value
-        }
-        return props
-      }, {})
+      return reduce(
+        this.$props,
+        (props, value, key) => {
+          if (keys.indexOf(key) === -1) {
+            props[key] = value
+          }
+          return props
+        },
+        {}
+      )
     },
-    async bindOnRoot (...args) {
+    async bindOnRoot(...args) {
       if (!this.mounted) {
         await this.$nextTick()
       }

--- a/src/components/filter/types/FilterAbstract.vue
+++ b/src/components/filter/types/FilterAbstract.vue
@@ -1,8 +1,8 @@
 <template>
   <filter-boilerplate
-    @add-filter-values="(value) => $emit('add-filter-values', value)"
     ref="filter"
     v-bind="$props"
+    @add-filter-values="(value) => $emit('add-filter-values', value)"
   ></filter-boilerplate>
 </template>
 
@@ -17,22 +17,22 @@ import filters from '@/mixins/filters'
  */
 export default {
   name: 'FilterAbstract',
-  mixins: [filters],
   components: {
     FilterBoilerplate
   },
+  mixins: [filters],
   props: {
     // Temporary import of the props from FilterBoilerplate
     ...FilterBoilerplate.props
-  },
-  async mounted() {
-    await this.$nextTick()
-    this.mounted = true
   },
   computed: {
     root() {
       return get(this, '$refs.filter', {})
     }
+  },
+  async mounted() {
+    await this.$nextTick()
+    this.mounted = true
   },
   methods: {
     // Returns all props without the givens keys

--- a/src/components/filter/types/FilterDateRange.vue
+++ b/src/components/filter/types/FilterDateRange.vue
@@ -1,7 +1,7 @@
 <template>
   <filter-boilerplate
-    class="filter--date-range"
     ref="filter"
+    class="filter--date-range"
     v-bind="$props"
     hide-show-more
     hide-contextualize
@@ -10,17 +10,17 @@
     <template #items>
       <div class="m-2">
         <date-picker
+          :key="locale"
+          v-model="selectedDate"
           class="date-picker"
           is-range
           is-dark
           is-expanded
           color="yellow"
-          v-model="selectedDate"
           show-caps
           :model-config="{ type: 'number' }"
           :attributes="attributes"
           :locale="locale"
-          :key="locale"
         >
         </date-picker>
       </div>
@@ -41,11 +41,11 @@ import min from 'lodash/min'
  */
 export default {
   name: 'FilterDateRange',
-  extends: FilterAbstract,
   components: {
     DatePicker,
     FilterBoilerplate
   },
+  extends: FilterAbstract,
   computed: {
     attributes() {
       return [

--- a/src/components/filter/types/FilterDateRange.vue
+++ b/src/components/filter/types/FilterDateRange.vue
@@ -1,10 +1,12 @@
 <template>
-  <filter-boilerplate class="filter--date-range"
-                      ref="filter"
-                      v-bind="$props"
-                      hide-show-more
-                      hide-contextualize
-                      hide-sort>
+  <filter-boilerplate
+    class="filter--date-range"
+    ref="filter"
+    v-bind="$props"
+    hide-show-more
+    hide-contextualize
+    hide-sort
+  >
     <template #items>
       <div class="m-2">
         <date-picker
@@ -18,7 +20,8 @@
           :model-config="{ type: 'number' }"
           :attributes="attributes"
           :locale="locale"
-          :key="locale">
+          :key="locale"
+        >
         </date-picker>
       </div>
     </template>
@@ -44,7 +47,7 @@ export default {
     FilterBoilerplate
   },
   computed: {
-    attributes () {
+    attributes() {
       return [
         {
           key: 'today',
@@ -56,11 +59,11 @@ export default {
         }
       ]
     },
-    locale () {
+    locale() {
       return this.$i18n.locale
     },
     selectedDate: {
-      get () {
+      get() {
         const values = this.getFilterValuesByName(this.filter.name) || []
         if (values.length < 2) {
           return null
@@ -69,7 +72,7 @@ export default {
         const end = max(values)
         return { start, end }
       },
-      set (range) {
+      set(range) {
         if (range === null) {
           return this.setFilterValue(this.filter, { key: [] })
         }
@@ -112,7 +115,7 @@ export default {
           .vc-highlight-base-start,
           .vc-highlight-base-middle,
           .vc-highlight-base-end {
-            background-color: rgba($tertiary, .4);
+            background-color: rgba($tertiary, 0.4);
           }
 
           .vc-rounded-full {
@@ -123,7 +126,7 @@ export default {
       }
 
       .vc-day-content:hover {
-        background-color: rgba($tertiary, .1);
+        background-color: rgba($tertiary, 0.1);
       }
     }
   }

--- a/src/components/filter/types/FilterNamedEntity.vue
+++ b/src/components/filter/types/FilterNamedEntity.vue
@@ -1,5 +1,5 @@
 <template>
-  <filter-boilerplate v-bind="$props" class="filter--named-entity" ref="filter">
+  <filter-boilerplate v-bind="$props" ref="filter" class="filter--named-entity">
     <template #title>
       <span class="col-2 filter__items__item__icon pl-0 pr-1" :class="getCategoryClass(filter.category, 'text-')">
         <fa :icon="getCategoryIcon(filter.category)" fixed-width></fa>
@@ -22,8 +22,8 @@
           </span>
         </b-form-checkbox>
         <confirm-button
-          class="align-self-start btn btn-link btn-sm p-0 mr-2 mt-1 filter__items__item__delete"
           v-if="$config.is('manageDocuments')"
+          class="align-self-start btn btn-link btn-sm p-0 mr-2 mt-1 filter__items__item__delete"
           :confirmed="() => deleteNamedEntitiesByMentionNorm(value)"
           :label="$t('filter.deleteNamedEntity')"
           :yes="$t('global.yes')"
@@ -47,10 +47,10 @@ import utils from '@/mixins/utils'
  */
 export default {
   name: 'FilterNamedEntity',
-  extends: FilterAbstract,
   components: {
     FilterBoilerplate
   },
+  extends: FilterAbstract,
   mixins: [ner, utils],
   methods: {
     async deleteNamedEntitiesByMentionNorm(mentionNorm) {

--- a/src/components/filter/types/FilterNamedEntity.vue
+++ b/src/components/filter/types/FilterNamedEntity.vue
@@ -13,7 +13,10 @@
             <span class="filter__items__item__label px-1 flex-grow-1">
               {{ value }}
             </span>
-            <span class="filter__items__item__count badge badge-pill badge-light align-self-start" :class="{ hideOnHover : $config.is('manageDocuments') }">
+            <span
+              class="filter__items__item__count badge badge-pill badge-light align-self-start"
+              :class="{ hideOnHover: $config.is('manageDocuments') }"
+            >
               {{ $n(item.doc_count) }}
             </span>
           </span>
@@ -24,7 +27,8 @@
           :confirmed="() => deleteNamedEntitiesByMentionNorm(value)"
           :label="$t('filter.deleteNamedEntity')"
           :yes="$t('global.yes')"
-          :no="$t('global.no')">
+          :no="$t('global.no')"
+        >
           <fa icon="trash-alt"></fa>
         </confirm-button>
       </div>
@@ -49,7 +53,7 @@ export default {
   },
   mixins: [ner, utils],
   methods: {
-    async deleteNamedEntitiesByMentionNorm (mentionNorm) {
+    async deleteNamedEntitiesByMentionNorm(mentionNorm) {
       const promises = []
       for (const index in this.$store.state.search.indices) {
         promises.push(this.$core.api.deleteNamedEntitiesByMentionNorm(index, mentionNorm))
@@ -63,20 +67,20 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .filter--named-entity {
-    .filter__items__item {
-      &__delete:not([aria-describedby]) {
-        display: none;
-      }
+.filter--named-entity {
+  .filter__items__item {
+    &__delete:not([aria-describedby]) {
+      display: none;
+    }
 
-      &:hover .filter__items__item__delete {
-        color: inherit;
-        display: block;
-      }
+    &:hover .filter__items__item__delete {
+      color: inherit;
+      display: block;
+    }
 
-      &:hover .hideOnHover {
-        display: none;
-      }
+    &:hover .hideOnHover {
+      display: none;
     }
   }
+}
 </style>

--- a/src/components/filter/types/FilterPath.vue
+++ b/src/components/filter/types/FilterPath.vue
@@ -3,18 +3,19 @@
     <template #items="{ sortBy, sortByOrder }">
       <div class="filter__tree-view">
         <tree-view
-                  :projects="projects"
-                  :selectedPaths.sync="selectedPaths"
-                  :pre-body-build="preBodyBuild"
-                  :sort-by="sortBy"
-                  :sort-by-order="sortByOrder"
-                  compact
-                  count
-                  include-children-documents
-                  no-bars
-                  ref="treeView"
-                  selectable
-                  v-model="path" />
+          :projects="projects"
+          :selected-paths.sync="selectedPaths"
+          :pre-body-build="preBodyBuild"
+          :sort-by="sortBy"
+          :sort-by-order="sortByOrder"
+          compact
+          count
+          include-children-documents
+          no-bars
+          ref="treeView"
+          selectable
+          v-model="path"
+        />
       </div>
     </template>
   </filter-boilerplate>
@@ -37,17 +38,17 @@ export default {
     FilterBoilerplate,
     TreeView
   },
-  data () {
+  data() {
     return {
       key: null,
       path: null
     }
   },
-  created () {
+  created() {
     this.$set(this, 'path', this.dataDir)
   },
   watch: {
-    projects (value, previousValue) {
+    projects(value, previousValue) {
       if (!isEqual(value, previousValue)) {
         this.$set(this, 'path', this.dataDir)
         this.setFilterValue(this.filter, { key: [] })
@@ -55,17 +56,17 @@ export default {
     }
   },
   computed: {
-    dataDir () {
+    dataDir() {
       return this.$config.get('mountedDataDir') || this.$config.get('dataDir')
     },
-    filterValues () {
+    filterValues() {
       return this.getFilterByName(this.filter.name).values
     },
     selectedPaths: {
-      get () {
+      get() {
         return this.filterValues
       },
-      set (key) {
+      set(key) {
         if (!isEqual(key, this.filterValues)) {
           this.setFilterValue(this.filter, { key })
           this.$store.commit('search/from', 0)
@@ -73,21 +74,21 @@ export default {
         }
       }
     },
-    projects () {
+    projects() {
       return this.$store.state.search.indices
     },
-    instantiatedFilters () {
+    instantiatedFilters() {
       return this.$store.getters['search/instantiatedFilters']
     },
-    isContextualized () {
+    isContextualized() {
       return this.$store.getters['search/isFilterContextualized'](this.filter.name)
     }
   },
   methods: {
-    preBodyBuild (body) {
+    preBodyBuild(body) {
       if (this.isContextualized) {
         // Add every filter to the search body
-        this.instantiatedFilters.forEach(filter => filter.addFilter(body))
+        this.instantiatedFilters.forEach((filter) => filter.addFilter(body))
         // Add query to the search body
         elasticsearch.addQueryToFilter(this.$store.state.search.query || '*', body)
       }
@@ -98,26 +99,27 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .filter {
-    &__tree-view :deep(.tree-view) {
-      .tree-view__header {
-        background: $light;
-        border-radius: $border-radius-sm;
-        color: $body-color;
-        margin: 0.5rem;
+.filter {
+  &__tree-view :deep(.tree-view) {
+    .tree-view__header {
+      background: $light;
+      border-radius: $border-radius-sm;
+      color: $body-color;
+      margin: 0.5rem;
 
-        &__hits, &__size {
-          display: none;
-        }
+      &__hits,
+      &__size {
+        display: none;
       }
+    }
 
-      .filter--dark & .list-group-item {
-        border-bottom: 0;
+    .filter--dark & .list-group-item {
+      border-bottom: 0;
 
-        a {
-          color: $light;
-        }
+      a {
+        color: $light;
       }
     }
   }
+}
 </style>

--- a/src/components/filter/types/FilterPath.vue
+++ b/src/components/filter/types/FilterPath.vue
@@ -3,6 +3,8 @@
     <template #items="{ sortBy, sortByOrder }">
       <div class="filter__tree-view">
         <tree-view
+          ref="treeView"
+          v-model="path"
           :projects="projects"
           :selected-paths.sync="selectedPaths"
           :pre-body-build="preBodyBuild"
@@ -12,9 +14,7 @@
           count
           include-children-documents
           no-bars
-          ref="treeView"
           selectable
-          v-model="path"
         />
       </div>
     </template>
@@ -33,26 +33,15 @@ import TreeView from '@/components/TreeView'
  */
 export default {
   name: 'FilterPath',
-  extends: FilterAbstract,
   components: {
     FilterBoilerplate,
     TreeView
   },
+  extends: FilterAbstract,
   data() {
     return {
       key: null,
       path: null
-    }
-  },
-  created() {
-    this.$set(this, 'path', this.dataDir)
-  },
-  watch: {
-    projects(value, previousValue) {
-      if (!isEqual(value, previousValue)) {
-        this.$set(this, 'path', this.dataDir)
-        this.setFilterValue(this.filter, { key: [] })
-      }
     }
   },
   computed: {
@@ -83,6 +72,17 @@ export default {
     isContextualized() {
       return this.$store.getters['search/isFilterContextualized'](this.filter.name)
     }
+  },
+  watch: {
+    projects(value, previousValue) {
+      if (!isEqual(value, previousValue)) {
+        this.$set(this, 'path', this.dataDir)
+        this.setFilterValue(this.filter, { key: [] })
+      }
+    }
+  },
+  created() {
+    this.$set(this, 'path', this.dataDir)
   },
   methods: {
     preBodyBuild(body) {

--- a/src/components/filter/types/FilterProject.vue
+++ b/src/components/filter/types/FilterProject.vue
@@ -10,11 +10,7 @@
       </h6>
     </div>
     <slide-up-down class="list-group list-group-flush filter__items" :active="!collapseItems">
-      <project-selector
-        @input="select"
-        class="border-0"
-        multiple
-        v-model="selectedProject" />
+      <project-selector @input="select" class="border-0" multiple v-model="selectedProject" />
     </slide-up-down>
   </div>
 </template>
@@ -33,13 +29,13 @@ export default {
   components: {
     ProjectSelector
   },
-  data () {
+  data() {
     return {
       collapseItems: false
     }
   },
   computed: {
-    projects () {
+    projects() {
       const defaultProject = this.$config.get('defaultProject')
       const projects = this.$config.get('groups_by_applications.datashare', [])
       return compact(uniq([...projects, defaultProject]).sort())
@@ -54,20 +50,20 @@ export default {
         }
       }
     },
-    headerIcon () {
+    headerIcon() {
       return this.collapseItems ? 'plus' : 'minus'
     },
-    showSelector () {
+    showSelector() {
       return this.isServer || this.projects.length > 1
     }
   },
-  async created () {
+  async created() {
     await this.$store.dispatch('starred/fetchIndicesStarredDocuments')
     await this.$store.dispatch('recommended/fetchIndicesRecommendations')
     await this.$store.dispatch('downloads/fetchIndicesStatus')
   },
   methods: {
-    async select (projects) {
+    async select(projects) {
       this.$store.commit('search/indices', projects)
       this.$store.commit('search/isReady', false)
       await this.$store.dispatch('starred/fetchIndicesStarredDocuments')
@@ -75,19 +71,19 @@ export default {
       await this.$store.dispatch('downloads/fetchIndicesStatus')
       this.refreshRouteAndSearch()
     },
-    toggleItems () {
+    toggleItems() {
       this.collapseItems = !this.collapseItems
     },
-    refreshRouteAndSearch () {
+    refreshRouteAndSearch() {
       this.refreshRoute()
       this.refreshSearch()
     },
-    refreshRoute () {
+    refreshRoute() {
       const name = 'search'
       const query = this.$store.getters['search/toRouteQuery']()
       this.$router.push({ name, query }).catch(() => {})
     },
-    refreshSearch () {
+    refreshSearch() {
       this.$store.dispatch('search/query')
     }
   }
@@ -95,15 +91,15 @@ export default {
 </script>
 
 <style scoped lang="scss">
- .filter {
-    & :deep.custom-control-label span {
-      padding: 0 $spacer-xxs;
-    }
+.filter {
+  & :deep.custom-control-label span {
+    padding: 0 $spacer-xxs;
+  }
 
-    & :deep.custom-control-input[disabled]:checked ~ .custom-control-label,
-    & :deep.custom-control-input:disabled:checked ~ .custom-control-label {
-      color: inherit;
-      font-weight: bold;
-    }
- }
+  & :deep.custom-control-input[disabled]:checked ~ .custom-control-label,
+  & :deep.custom-control-input:disabled:checked ~ .custom-control-label {
+    color: inherit;
+    font-weight: bold;
+  }
+}
 </style>

--- a/src/components/filter/types/FilterProject.vue
+++ b/src/components/filter/types/FilterProject.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="filter card" v-if="showSelector">
+  <div v-if="showSelector" class="filter card">
     <div class="card-header px-2">
-      <h6 @click="toggleItems" class="pt-0">
+      <h6 class="pt-0" @click="toggleItems">
         <span class="filter__items__item__icon pl-0 pr-1">
           <fa icon="book" fixed-width />
         </span>
@@ -10,7 +10,7 @@
       </h6>
     </div>
     <slide-up-down class="list-group list-group-flush filter__items" :active="!collapseItems">
-      <project-selector @input="select" class="border-0" multiple v-model="selectedProject" />
+      <project-selector v-model="selectedProject" class="border-0" multiple @input="select" />
     </slide-up-down>
   </div>
 </template>
@@ -25,10 +25,10 @@ import utils from '@/mixins/utils'
  */
 export default {
   name: 'FilterProject',
-  mixins: [utils],
   components: {
     ProjectSelector
   },
+  mixins: [utils],
   data() {
     return {
       collapseItems: false

--- a/src/components/filter/types/FilterRecommendedBy.vue
+++ b/src/components/filter/types/FilterRecommendedBy.vue
@@ -1,12 +1,14 @@
 <template>
-  <filter-boilerplate ref="filter"
-                      v-bind="propsWithout('hide-show-more')"
-                      hide-show-more
-                      hide-exclude
-                      hide-sort
-                      hide-contextualize
-                      :infinite-scroll="false"
-                      @reset-filter-values="resetFilterValues">
+  <filter-boilerplate
+    ref="filter"
+    v-bind="propsWithout('hide-show-more')"
+    hide-show-more
+    hide-exclude
+    hide-sort
+    hide-contextualize
+    :infinite-scroll="false"
+    @reset-filter-values="resetFilterValues"
+  >
     <template #all>
       <span class="d-flex">
         <span class="filter__items__item__label px-1 text-truncate w-100 d-inline-block">
@@ -16,7 +18,12 @@
     </template>
     <template #items-group>
       <b-form-checkbox-group stacked v-model="selected" class="list-group-item p-0 border-0" @change="selectUsers">
-        <b-form-checkbox v-for="{ user, count } in recommendedByUsersSorted" :value="user" class="filter__items__item" :key="user">
+        <b-form-checkbox
+          v-for="{ user, count } in recommendedByUsersSorted"
+          :value="user"
+          class="filter__items__item"
+          :key="user"
+        >
           <span class="d-flex">
             <span class="filter__items__item__label px-1 text-truncate w-100 d-inline-block">
               <user-display :username="user" hide-avatar hide-link />
@@ -53,32 +60,32 @@ export default {
   mixins: [utils],
   computed: {
     ...mapState('recommended', { recommendedByUsers: 'byUsers' }),
-    recommendedByUsersSorted () {
+    recommendedByUsersSorted() {
       // Sort by count (decreasing) and ensure the current user is first
       return sortBy(this.recommendedByUsers, ({ user, count }) => {
         return user === this.currentUserId ? -1e9 : -count
       })
     },
-    currentUserId () {
+    currentUserId() {
       return this.$config ? this.$config.get('uid', 'local') : 'local'
     },
     selected: {
-      get () {
+      get() {
         return this.getFilterValuesByName(this.filter.name)
       },
-      set (values) {
+      set(values) {
         this.selectUsers(values)
       }
     }
   },
-  async mounted () {
+  async mounted() {
     await this.$store.dispatch('recommended/fetchIndicesRecommendations')
   },
   methods: {
-    resetFilterValues (_, refresh) {
+    resetFilterValues(_, refresh) {
       return this.selectUsers([], refresh)
     },
-    async selectUsers (users = [], refresh = true) {
+    async selectUsers(users = [], refresh = true) {
       this.setFilterValue(this.filter, { key: users })
       await this.$store.dispatch('recommended/getDocumentsRecommendedBy', users)
       this.$root.$emit('filter::add-filter-values', this.filter, this.selected)

--- a/src/components/filter/types/FilterRecommendedBy.vue
+++ b/src/components/filter/types/FilterRecommendedBy.vue
@@ -17,12 +17,12 @@
       </span>
     </template>
     <template #items-group>
-      <b-form-checkbox-group stacked v-model="selected" class="list-group-item p-0 border-0" @change="selectUsers">
+      <b-form-checkbox-group v-model="selected" stacked class="list-group-item p-0 border-0" @change="selectUsers">
         <b-form-checkbox
           v-for="{ user, count } in recommendedByUsersSorted"
+          :key="user"
           :value="user"
           class="filter__items__item"
-          :key="user"
         >
           <span class="d-flex">
             <span class="filter__items__item__label px-1 text-truncate w-100 d-inline-block">
@@ -52,11 +52,11 @@ import utils from '@/mixins/utils'
  */
 export default {
   name: 'FilterRecommendedBy',
-  extends: FilterAbstract,
   components: {
     FilterBoilerplate,
     UserDisplay
   },
+  extends: FilterAbstract,
   mixins: [utils],
   computed: {
     ...mapState('recommended', { recommendedByUsers: 'byUsers' }),

--- a/src/components/filter/types/FilterStarred.vue
+++ b/src/components/filter/types/FilterStarred.vue
@@ -10,7 +10,7 @@
     @reset-filter-values="resetFilterValues"
   >
     <template #items-group>
-      <b-form-checkbox-group stacked v-model="selected" class="list-group-item p-0 border-0" @change="changeYesNoValue">
+      <b-form-checkbox-group v-model="selected" stacked class="list-group-item p-0 border-0" @change="changeYesNoValue">
         <b-form-checkbox :value="true" class="filter__items__item">
           <span>
             <span class="filter__items__item__label px-1 text-truncate w-100 d-inline-block">
@@ -48,10 +48,10 @@ import utils from '@/mixins/utils'
  */
 export default {
   name: 'FilterStarred',
-  extends: FilterAbstract,
   components: {
     FilterBoilerplate
   },
+  extends: FilterAbstract,
   mixins: [utils],
   computed: {
     total() {

--- a/src/components/filter/types/FilterStarred.vue
+++ b/src/components/filter/types/FilterStarred.vue
@@ -1,12 +1,14 @@
 <template>
-  <filter-boilerplate ref="filter"
-                      v-bind="propsWithout('hide-show-more')"
-                      hide-show-more
-                      hide-exclude
-                      hide-contextualize
-                      hide-sort
-                      :infinite-scroll="false"
-                      @reset-filter-values="resetFilterValues">
+  <filter-boilerplate
+    ref="filter"
+    v-bind="propsWithout('hide-show-more')"
+    hide-show-more
+    hide-exclude
+    hide-contextualize
+    hide-sort
+    :infinite-scroll="false"
+    @reset-filter-values="resetFilterValues"
+  >
     <template #items-group>
       <b-form-checkbox-group stacked v-model="selected" class="list-group-item p-0 border-0" @change="changeYesNoValue">
         <b-form-checkbox :value="true" class="filter__items__item">
@@ -52,29 +54,29 @@ export default {
   },
   mixins: [utils],
   computed: {
-    total () {
+    total() {
       return Math.max(get(this, '$refs.filter.total', 0) - this.starredDocuments.length, 0)
     },
     selected: {
-      get () {
+      get() {
         return this.getFilterValuesByName(this.filter.name)
       },
-      set (values) {
+      set(values) {
         this.changeYesNoValue(values)
       }
     },
-    starredDocuments () {
+    starredDocuments() {
       return this.filter.starredDocuments
     }
   },
-  mounted () {
+  mounted() {
     return this.$store.dispatch('starred/fetchIndicesStarredDocuments')
   },
   methods: {
-    resetFilterValues (_, refresh) {
+    resetFilterValues(_, refresh) {
       return this.changeYesNoValue([], refresh)
     },
-    changeYesNoValue (values = [], refresh = true) {
+    changeYesNoValue(values = [], refresh = true) {
       if (values.length === 2) {
         values = values.slice(1)
       }

--- a/src/components/widget/WidgetDiskUsage.vue
+++ b/src/components/widget/WidgetDiskUsage.vue
@@ -58,15 +58,20 @@ export default {
       total: null
     }
   },
-  async created() {
-    this.$set(this, 'path', this.dataDir)
-    await this.loadData()
-  },
   computed: {
     ...mapState('insights', ['project']),
     dataDir() {
       return this.$config.get('mountedDataDir') || this.$config.get('dataDir')
     }
+  },
+  watch: {
+    project() {
+      this.$set(this, 'path', this.dataDir)
+    }
+  },
+  async created() {
+    this.$set(this, 'path', this.dataDir)
+    await this.loadData()
   },
   mounted() {
     this.$store.subscribe(async ({ type }) => {
@@ -94,11 +99,6 @@ export default {
       this.$set(this, 'total', total)
     }),
     humanSize
-  },
-  watch: {
-    project() {
-      this.$set(this, 'path', this.dataDir)
-    }
   }
 }
 </script>

--- a/src/components/widget/WidgetDiskUsage.vue
+++ b/src/components/widget/WidgetDiskUsage.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="widget widget--disk-usage d-flex align-items-center text-center">
     <v-wait for="disk usage" class="flex-grow-1" transition="fade">
-      <fa icon="circle-notch" spin slot="waiting" size="2x" />
+      <fa slot="waiting" icon="circle-notch" spin size="2x" />
       <p :class="{ 'card-body': widget.card }">
         <fa icon="weight" class="widget__icon" size="2x" />
         <strong class="widget__main-figure" :title="total">
           {{ humanSize(total, false, $t('human.size')) }}
         </strong>
-        <a class="widget__details" v-b-modal.modal-disk-usage-details>
+        <a v-b-modal.modal-disk-usage-details class="widget__details">
           {{ $t('widget.diskUsage.details') }}
         </a>
       </p>

--- a/src/components/widget/WidgetDiskUsage.vue
+++ b/src/components/widget/WidgetDiskUsage.vue
@@ -51,24 +51,24 @@ export default {
       type: Object
     }
   },
-  data () {
+  data() {
     return {
       onDisk: null,
       path: null,
       total: null
     }
   },
-  async created () {
+  async created() {
     this.$set(this, 'path', this.dataDir)
     await this.loadData()
   },
   computed: {
     ...mapState('insights', ['project']),
-    dataDir () {
+    dataDir() {
       return this.$config.get('mountedDataDir') || this.$config.get('dataDir')
     }
   },
-  mounted () {
+  mounted() {
     this.$store.subscribe(async ({ type }) => {
       if (type === 'insights/project') {
         await this.loadData()
@@ -76,7 +76,7 @@ export default {
     })
   },
   methods: {
-    async sumTotal () {
+    async sumTotal() {
       const index = this.$store.state.insights.project
       const body = bodybuilder()
         .andQuery('match', 'type', 'Document')
@@ -96,7 +96,7 @@ export default {
     humanSize
   },
   watch: {
-    project () {
+    project() {
       this.$set(this, 'path', this.dataDir)
     }
   }
@@ -104,21 +104,21 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .widget {
-    min-height: 100%;
+.widget {
+  min-height: 100%;
 
-    &__main-figure {
-      display: block;
-      font-size: 1.8rem;
-    }
+  &__main-figure {
+    display: block;
+    font-size: 1.8rem;
+  }
 
-    &__details {
-      color: $link-color;
-      cursor: pointer;
+  &__details {
+    color: $link-color;
+    cursor: pointer;
 
-      &:hover {
-        text-decoration: underline;
-      }
+    &:hover {
+      text-decoration: underline;
     }
   }
+}
 </style>

--- a/src/components/widget/WidgetDocumentsByCreationDate.vue
+++ b/src/components/widget/WidgetDocumentsByCreationDate.vue
@@ -1,11 +1,20 @@
 <template>
   <div class="widget">
-    <div class="widget__header d-md-flex align-items-center" v-if="widget.title" :class="{ 'card-header': widget.card }">
+    <div
+      class="widget__header d-md-flex align-items-center"
+      v-if="widget.title"
+      :class="{ 'card-header': widget.card }"
+    >
       <h4 v-html="widget.title" class="m-0 flex-grow-1"></h4>
       <div class="widget__header__selectors d-flex align-items-center">
         <slot name="selector" :selectedPath="selectedPath" :setSelectedPath="setSelectedPath"></slot>
         <div class="btn-group">
-          <span v-for="(value, interval) in intervals" :key="interval" class="btn btn-link border py-1 px-2" :class="{ 'active': selectedInterval === interval }">
+          <span
+            v-for="(value, interval) in intervals"
+            :key="interval"
+            class="btn btn-link border py-1 px-2"
+            :class="{ active: selectedInterval === interval }"
+          >
             <span class="widget__header__selectors__selector" @click="setSelectedInterval(interval)">
               {{ $t('widget.creationDate.intervals.' + interval) }}
             </span>
@@ -19,28 +28,54 @@
           <fa icon="circle-notch" spin size="2x"></fa>
         </div>
         <div class="widget__content__chart align-items-center" v-if="data.length > 0">
-            <column-chart :data="slicedDataForMurmur" :max-value="maxValue" :x-axis-tick-format="xAxisTickFormat">
-              <template #tooltip="{ datum: { date, value: total } }">
-                <h5 class="m-0">{{ tooltipFormat(date) }}</h5>
-                <p class="m-0">{{ $tc('widget.creationDate.document', total,  { total }) }}</p>
-              </template>
-            </column-chart>
-            <div v-if="isDatesRangeSliced" class="widget__content__chart__range">
-              <div class="widget__content__chart__range__selection border border-primary" :style="datesRangeSelectionStyle">
-                <b-button pill variant="outline-dark" @click="previousDatesRangeSlice" v-if="hasPreviousDatesRangeSlice" class="widget__content__chart__range__selection__previous bg-white">
-                  <fa icon="angle-left" />
-                </b-button>
-                <b-button pill variant="outline-dark" @click="nextDatesRangeSlice" v-if="hasNextDatesRangeSlice" class="widget__content__chart__range__selection__next bg-white">
-                  <fa icon="angle-right" />
-                </b-button>
-              </div>
-              <column-chart @click.native="jumpToSelectionRange" :data="dataForMurmur" :fixed-height="100" no-tooltips no-x-axis no-y-axis />
+          <column-chart :data="slicedDataForMurmur" :max-value="maxValue" :x-axis-tick-format="xAxisTickFormat">
+            <template #tooltip="{ datum: { date, value: total } }">
+              <h5 class="m-0">{{ tooltipFormat(date) }}</h5>
+              <p class="m-0">{{ $tc('widget.creationDate.document', total, { total }) }}</p>
+            </template>
+          </column-chart>
+          <div v-if="isDatesRangeSliced" class="widget__content__chart__range">
+            <div
+              class="widget__content__chart__range__selection border border-primary"
+              :style="datesRangeSelectionStyle"
+            >
+              <b-button
+                pill
+                variant="outline-dark"
+                @click="previousDatesRangeSlice"
+                v-if="hasPreviousDatesRangeSlice"
+                class="widget__content__chart__range__selection__previous bg-white"
+              >
+                <fa icon="angle-left" />
+              </b-button>
+              <b-button
+                pill
+                variant="outline-dark"
+                @click="nextDatesRangeSlice"
+                v-if="hasNextDatesRangeSlice"
+                class="widget__content__chart__range__selection__next bg-white"
+              >
+                <fa icon="angle-right" />
+              </b-button>
             </div>
-            <div class="d-flex align-items-center mt-2">
-              <p class="widget__content__missing small my-0 text-muted" v-if="missing" :title="$t('widget.creationDate.missingTooltip')">
-                {{ $tc('widget.creationDate.missing', missing, { total: $n(missing) }) }}
-              </p>
-            </div>
+            <column-chart
+              @click.native="jumpToSelectionRange"
+              :data="dataForMurmur"
+              :fixed-height="100"
+              no-tooltips
+              no-x-axis
+              no-y-axis
+            />
+          </div>
+          <div class="d-flex align-items-center mt-2">
+            <p
+              class="widget__content__missing small my-0 text-muted"
+              v-if="missing"
+              :title="$t('widget.creationDate.missingTooltip')"
+            >
+              {{ $tc('widget.creationDate.missing', missing, { total: $n(missing) }) }}
+            </p>
+          </div>
         </div>
         <div v-else class="text-muted text-center">
           {{ $t('widget.noData') }}
@@ -74,7 +109,7 @@ export default {
       type: Object
     }
   },
-  data () {
+  data() {
     return {
       data: [],
       intervals: {
@@ -103,146 +138,153 @@ export default {
     }
   },
   watch: {
-    project () {
+    project() {
       this.$set(this, 'mounted', false)
       this.$set(this, 'selectedPath', this.dataDir)
       this.init()
     }
   },
-  mounted () {
+  mounted() {
     this.$set(this, 'selectedPath', this.dataDir)
     this.$nextTick(() => this.init())
   },
   computed: {
     ...mapState('insights', ['project']),
-    chartWidth () {
+    chartWidth() {
       if (this.mounted) {
         return this.$el.querySelector('.widget__content__chart')?.offsetWidth || 0
       }
       return 0
     },
-    maxTicks () {
+    maxTicks() {
       return Math.floor(this.chartWidth / 35)
     },
-    maxValue () {
+    maxValue() {
       return d3.max(this.data, ({ doc_count: value = 0 }) => value)
     },
-    dataDir () {
+    dataDir() {
       return this.$config.get('mountedDataDir') || this.$config.get('dataDir')
     },
-    selectedIntervalFormat () {
+    selectedIntervalFormat() {
       return this.intervals[this.selectedInterval].xAxisFormat
     },
-    selectedTooltipFormat () {
+    selectedTooltipFormat() {
       return this.intervals[this.selectedInterval].tooltipFormat
     },
-    selectedIntervalTime () {
+    selectedIntervalTime() {
       return this.intervals[this.selectedInterval].time
     },
-    selectedIntervalBins () {
+    selectedIntervalBins() {
       return this.intervals[this.selectedInterval].bins
     },
-    binByDate () {
+    binByDate() {
       return this.datesHistogram.reduce((res, bin) => {
         const key = bin.x0.getTime()
         res[key] = bin
         return res
       }, {})
     },
-    datesExtent () {
-      return d3.extent(this.data, d => d.date)
+    datesExtent() {
+      return d3.extent(this.data, (d) => d.date)
     },
-    datesScale () {
+    datesScale() {
       return d3.scaleTime().domain(this.datesExtent).rangeRound([0, this.chartWidth])
     },
-    datesHistogram () {
+    datesHistogram() {
       const minTime = this.selectedIntervalTime.offset(this.datesExtent[0], -1)
       const maxTime = this.selectedIntervalTime.offset(this.datesExtent[1], 1)
       const bins = this.selectedIntervalBins(minTime, maxTime)
       // set the parameters for the histogram
-      const histogram = d3.histogram()
-        .value(d => d.date)
+      const histogram = d3
+        .histogram()
+        .value((d) => d.date)
         .domain(this.datesScale.domain())
         .thresholds(this.datesScale.ticks(bins.length))
       return histogram(this.data)
     },
-    slicedDatesHistogram () {
+    slicedDatesHistogram() {
       return this.datesHistogram.slice(this.datesRangeSliceStart, this.datesRangeSliceEnd)
     },
-    maxSliceStart () {
+    maxSliceStart() {
       return Math.max(0, this.datesHistogram.length - this.maxTicks)
     },
-    datesRangeSliceStart () {
+    datesRangeSliceStart() {
       return Math.min(this.sliceStart, this.maxSliceStart)
     },
-    datesRangeSliceEnd () {
+    datesRangeSliceEnd() {
       return this.datesRangeSliceStart + this.maxTicks
     },
-    hasNextDatesRangeSlice () {
+    hasNextDatesRangeSlice() {
       return this.datesRangeSliceStart < this.maxSliceStart
     },
-    hasPreviousDatesRangeSlice () {
+    hasPreviousDatesRangeSlice() {
       return this.datesRangeSliceStart > 0
     },
-    isDatesRangeSliced () {
+    isDatesRangeSliced() {
       return this.datesHistogram.length > this.maxTicks
     },
-    dataForMurmur () {
-      return this.datesHistogram.map(bin => {
-        return { date: bin.x0, value: d3.sum(bin, d => d.doc_count) }
+    dataForMurmur() {
+      return this.datesHistogram.map((bin) => {
+        return { date: bin.x0, value: d3.sum(bin, (d) => d.doc_count) }
       })
     },
-    slicedDataForMurmur () {
-      return this.slicedDatesHistogram.map(bin => {
-        return { date: bin.x0, value: d3.sum(bin, d => d.doc_count) }
+    slicedDataForMurmur() {
+      return this.slicedDatesHistogram.map((bin) => {
+        return { date: bin.x0, value: d3.sum(bin, (d) => d.doc_count) }
       })
     },
-    datesRangeSelectionStyle () {
+    datesRangeSelectionStyle() {
       const ticks = this.datesHistogram.length
-      const left = `${this.datesRangeSliceStart / ticks * 100}%`
-      const right = `${(ticks - this.datesRangeSliceEnd) / ticks * 100}%`
+      const left = `${(this.datesRangeSliceStart / ticks) * 100}%`
+      const right = `${((ticks - this.datesRangeSliceEnd) / ticks) * 100}%`
       return { right, left }
     },
-    aggDateHistogramOptions () {
+    aggDateHistogramOptions() {
       return {
         ...FilterDate.getIntervalOptions(this.selectedInterval),
         order: { _key: 'asc' },
         min_doc_count: 1
       }
     },
-    selectedPathTokens () {
+    selectedPathTokens() {
       return this.selectedPath !== this.dataDir ? [this.selectedPath] : []
     },
-    loader () {
+    loader() {
       return uniqueId('loading-creation-date-buckets')
     }
   },
   methods: {
-    async init () {
+    async init() {
       await this.loadData()
       this.mounted = true
       this.sliceStart = this.maxSliceStart
     },
-    isBucketKeyInRange (key) {
+    isBucketKeyInRange(key) {
       return key > 0 && key < new Date().getTime()
     },
-    bodybuilderBase ({ size = 1000, from = 0 } = {}) {
+    bodybuilderBase({ size = 1000, from = 0 } = {}) {
       const field = 'metadata.tika_metadata_dcterms_created'
       return bodybuilder()
         .size(0)
-        .andQuery('bool', bool => {
+        .andQuery('bool', (bool) => {
           // Add all path tokens in a "should" statement
-          this.selectedPathTokens.forEach(t => {
+          this.selectedPathTokens.forEach((t) => {
             bool.orQuery('term', 'dirname.tree', t)
           })
           return bool
         })
         .andQuery('match', 'type', 'Document')
-        .agg('date_histogram', field, 'agg_by_creation_date', sub => {
-          return sub.agg('bucket_sort', { size, from }, 'bucket_sort_truncate')
-        }, this.aggDateHistogramOptions)
+        .agg(
+          'date_histogram',
+          field,
+          'agg_by_creation_date',
+          (sub) => {
+            return sub.agg('bucket_sort', { size, from }, 'bucket_sort_truncate')
+          },
+          this.aggDateHistogramOptions
+        )
     },
-    async loadData () {
+    async loadData() {
       this.$wait.start(this.loader)
       this.missing = 0
       const body = this.bodybuilderBase().build()
@@ -261,37 +303,37 @@ export default {
       this.$set(this, 'data', data)
       this.$wait.end(this.loader)
     },
-    setSelectedPath (path) {
+    setSelectedPath(path) {
       this.mounted = false
       this.selectedPath = path
       this.init()
     },
-    setSelectedInterval (value) {
+    setSelectedInterval(value) {
       this.mounted = false
       this.selectedInterval = value
       this.init()
     },
-    nextDatesRangeSlice () {
+    nextDatesRangeSlice() {
       const step = Math.round(this.slicedDatesHistogram.length * 0.1)
       this.sliceStart = Math.min(this.sliceStart + step, this.maxSliceStart)
     },
-    previousDatesRangeSlice () {
+    previousDatesRangeSlice() {
       const step = Math.round(this.slicedDatesHistogram.length * 0.1)
       this.sliceStart = Math.max(this.sliceStart - step, 0)
     },
-    tooltipFormat (date) {
+    tooltipFormat(date) {
       if (isFunction(this.selectedTooltipFormat)) {
         return this.selectedTooltipFormat(date)
       }
       return d3.timeFormat(this.selectedTooltipFormat)(date)
     },
-    xAxisTickFormat (date) {
+    xAxisTickFormat(date) {
       if (isFunction(this.selectedIntervalFormat)) {
         return this.selectedIntervalFormat(date)
       }
       return d3.timeFormat(this.selectedIntervalFormat)(date)
     },
-    jumpToSelectionRange ({ target, clientX }) {
+    jumpToSelectionRange({ target, clientX }) {
       const { width } = target.getBBox()
       const { left } = target.getBoundingClientRect()
       const x = (clientX - left) / width
@@ -303,57 +345,56 @@ export default {
 </script>
 
 <style lang="scss">
-  .widget {
-    min-height: 100%;
+.widget {
+  min-height: 100%;
 
-    &__header__selectors__selector {
-      cursor: pointer;
+  &__header__selectors__selector {
+    cursor: pointer;
+  }
+
+  &__content {
+    &__spinner {
+      text-align: center;
+      background: $card-bg;
+      padding: $spacer;
     }
 
-    &__content {
+    &__chart {
+      &__range {
+        position: relative;
 
-      &__spinner {
-        text-align: center;
-        background: $card-bg;
-        padding: $spacer;
-      }
+        &__selection {
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          left: 0;
+          background: rgba($gray-300, 0.5);
+          pointer-events: none;
 
-      &__chart {
-
-        &__range {
-          position: relative;
-
-          &__selection {
+          &__previous,
+          &__next {
+            pointer-events: all;
             position: absolute;
-            top: 0;
-            bottom: 0;
+            top: 50%;
+            width: 2.5rem;
+            height: 2.5rem;
+            line-height: 2.5rem;
+            padding: 0;
+            background: white;
+          }
+
+          &__previous {
             left: 0;
-            background: rgba($gray-300, 0.5);
-            pointer-events: none;
+            transform: translate(-50%, -50%);
+          }
 
-            &__previous, &__next {
-              pointer-events: all;
-              position: absolute;
-              top: 50%;
-              width: 2.5rem;
-              height: 2.5rem;
-              line-height: 2.5rem;
-              padding: 0;
-              background: white;
-            }
-
-            &__previous {
-              left: 0;
-              transform: translate(-50%, -50%);
-            }
-
-            &__next {
-              right: 0;
-              transform: translate(50%, -50%);
-            }
+          &__next {
+            right: 0;
+            transform: translate(50%, -50%);
           }
         }
       }
     }
   }
+}
 </style>

--- a/src/components/widget/WidgetDocumentsByCreationDate.vue
+++ b/src/components/widget/WidgetDocumentsByCreationDate.vue
@@ -137,17 +137,6 @@ export default {
       selectedPath: null
     }
   },
-  watch: {
-    project() {
-      this.$set(this, 'mounted', false)
-      this.$set(this, 'selectedPath', this.dataDir)
-      this.init()
-    }
-  },
-  mounted() {
-    this.$set(this, 'selectedPath', this.dataDir)
-    this.$nextTick(() => this.init())
-  },
   computed: {
     ...mapState('insights', ['project']),
     chartWidth() {
@@ -252,6 +241,17 @@ export default {
     loader() {
       return uniqueId('loading-creation-date-buckets')
     }
+  },
+  watch: {
+    project() {
+      this.$set(this, 'mounted', false)
+      this.$set(this, 'selectedPath', this.dataDir)
+      this.init()
+    }
+  },
+  mounted() {
+    this.$set(this, 'selectedPath', this.dataDir)
+    this.$nextTick(() => this.init())
   },
   methods: {
     async init() {

--- a/src/components/widget/WidgetDocumentsByCreationDate.vue
+++ b/src/components/widget/WidgetDocumentsByCreationDate.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="widget">
     <div
-      class="widget__header d-md-flex align-items-center"
       v-if="widget.title"
+      class="widget__header d-md-flex align-items-center"
       :class="{ 'card-header': widget.card }"
     >
-      <h4 v-html="widget.title" class="m-0 flex-grow-1"></h4>
+      <h4 class="m-0 flex-grow-1" v-html="widget.title"></h4>
       <div class="widget__header__selectors d-flex align-items-center">
         <slot name="selector" :selectedPath="selectedPath" :setSelectedPath="setSelectedPath"></slot>
         <div class="btn-group">
@@ -24,10 +24,10 @@
     </div>
     <div class="widget__content" :class="{ 'card-body': widget.card }">
       <v-wait :for="loader">
-        <div class="widget__content__spinner" slot="waiting">
+        <div slot="waiting" class="widget__content__spinner">
           <fa icon="circle-notch" spin size="2x"></fa>
         </div>
-        <div class="widget__content__chart align-items-center" v-if="data.length > 0">
+        <div v-if="data.length > 0" class="widget__content__chart align-items-center">
           <column-chart :data="slicedDataForMurmur" :max-value="maxValue" :x-axis-tick-format="xAxisTickFormat">
             <template #tooltip="{ datum: { date, value: total } }">
               <h5 class="m-0">{{ tooltipFormat(date) }}</h5>
@@ -40,37 +40,37 @@
               :style="datesRangeSelectionStyle"
             >
               <b-button
+                v-if="hasPreviousDatesRangeSlice"
                 pill
                 variant="outline-dark"
-                @click="previousDatesRangeSlice"
-                v-if="hasPreviousDatesRangeSlice"
                 class="widget__content__chart__range__selection__previous bg-white"
+                @click="previousDatesRangeSlice"
               >
                 <fa icon="angle-left" />
               </b-button>
               <b-button
+                v-if="hasNextDatesRangeSlice"
                 pill
                 variant="outline-dark"
-                @click="nextDatesRangeSlice"
-                v-if="hasNextDatesRangeSlice"
                 class="widget__content__chart__range__selection__next bg-white"
+                @click="nextDatesRangeSlice"
               >
                 <fa icon="angle-right" />
               </b-button>
             </div>
             <column-chart
-              @click.native="jumpToSelectionRange"
               :data="dataForMurmur"
               :fixed-height="100"
               no-tooltips
               no-x-axis
               no-y-axis
+              @click.native="jumpToSelectionRange"
             />
           </div>
           <div class="d-flex align-items-center mt-2">
             <p
-              class="widget__content__missing small my-0 text-muted"
               v-if="missing"
+              class="widget__content__missing small my-0 text-muted"
               :title="$t('widget.creationDate.missingTooltip')"
             >
               {{ $tc('widget.creationDate.missing', missing, { total: $n(missing) }) }}

--- a/src/components/widget/WidgetDocumentsByCreationDateByPath.vue
+++ b/src/components/widget/WidgetDocumentsByCreationDateByPath.vue
@@ -1,8 +1,17 @@
 <template>
   <widget-documents-by-creation-date :widget="widget" ref="widgetDocumentsByCreationDate">
     <template #selector="{ selectedPath, setSelectedPath }">
-      <span v-b-modal.modal-widget-select-path class="mr-3 py-1 px-2 border btn btn-link d-inline-flex" v-if="selectedPath">
-        <tree-breadcrumb datadir-icon="filter" :path="selectedPath" no-datadir @input="treeViewPath = $event"></tree-breadcrumb>
+      <span
+        v-b-modal.modal-widget-select-path
+        class="mr-3 py-1 px-2 border btn btn-link d-inline-flex"
+        v-if="selectedPath"
+      >
+        <tree-breadcrumb
+          datadir-icon="filter"
+          :path="selectedPath"
+          no-datadir
+          @input="treeViewPath = $event"
+        ></tree-breadcrumb>
         <span v-if="selectedPath === dataDir">
           {{ $t('widget.creationDate.filterFolder') }}
         </span>
@@ -17,8 +26,15 @@
         @ok="setSelectedPath(treeViewPath)"
         :ok-title="$t('widget.creationDate.selectFolder')"
         scrollable
-        size="lg">
-        <tree-view :path="treeViewPath || selectedPath" :project="project" @input="treeViewPath = $event" count size></tree-view>
+        size="lg"
+      >
+        <tree-view
+          :path="treeViewPath || selectedPath"
+          :project="project"
+          @input="treeViewPath = $event"
+          count
+          size
+        ></tree-view>
       </b-modal>
     </template>
   </widget-documents-by-creation-date>
@@ -49,19 +65,19 @@ export default {
       type: Object
     }
   },
-  data () {
+  data() {
     return {
       treeViewPath: null
     }
   },
   computed: {
     ...mapState('insights', ['project']),
-    dataDir () {
+    dataDir() {
       return this.$config.get('mountedDataDir') || this.$config.get('dataDir')
     }
   },
   watch: {
-    project () {
+    project() {
       this.$set(this, 'treeViewPath', this.dataDir)
     }
   }

--- a/src/components/widget/WidgetDocumentsByCreationDateByPath.vue
+++ b/src/components/widget/WidgetDocumentsByCreationDateByPath.vue
@@ -1,10 +1,10 @@
 <template>
-  <widget-documents-by-creation-date :widget="widget" ref="widgetDocumentsByCreationDate">
+  <widget-documents-by-creation-date ref="widgetDocumentsByCreationDate" :widget="widget">
     <template #selector="{ selectedPath, setSelectedPath }">
       <span
+        v-if="selectedPath"
         v-b-modal.modal-widget-select-path
         class="mr-3 py-1 px-2 border btn btn-link d-inline-flex"
-        v-if="selectedPath"
       >
         <tree-breadcrumb
           datadir-icon="filter"
@@ -17,23 +17,23 @@
         </span>
       </span>
       <b-modal
+        id="modal-widget-select-path"
         body-class="p-0 border-bottom"
         cancel-variant="outline-primary"
         :cancel-title="$t('global.cancel')"
         hide-header
-        id="modal-widget-select-path"
         lazy
-        @ok="setSelectedPath(treeViewPath)"
         :ok-title="$t('widget.creationDate.selectFolder')"
         scrollable
         size="lg"
+        @ok="setSelectedPath(treeViewPath)"
       >
         <tree-view
           :path="treeViewPath || selectedPath"
           :project="project"
-          @input="treeViewPath = $event"
           count
           size
+          @input="treeViewPath = $event"
         ></tree-view>
       </b-modal>
     </template>

--- a/src/components/widget/WidgetDuplicates.vue
+++ b/src/components/widget/WidgetDuplicates.vue
@@ -7,7 +7,14 @@
       <v-wait for="duplicate-counters" transition="fade">
         <fa icon="circle-notch" spin slot="waiting" size="2x" class="m-auto d-block"></fa>
         <div>
-          <stacked-bar-chart :data="data" :x-axis-tick-format="humanNumber" label-above :bar-colors="colors" :keys="keys" :groups="groups"></stacked-bar-chart>
+          <stacked-bar-chart
+            :data="data"
+            :x-axis-tick-format="humanNumber"
+            label-above
+            :bar-colors="colors"
+            :keys="keys"
+            :groups="groups"
+          ></stacked-bar-chart>
           <p class="small text-muted mb-0">
             {{ $t('widget.duplicates.duplicated') }}
           </p>
@@ -37,7 +44,7 @@ export default {
       type: Object
     }
   },
-  data () {
+  data() {
     return {
       data: [],
       colors: ['#193D87', '#6081c4'],
@@ -45,10 +52,10 @@ export default {
       groups: ['Duplicates*', 'Documents']
     }
   },
-  async created () {
+  async created() {
     await this.loadData()
   },
-  mounted () {
+  mounted() {
     this.$store.subscribe(async ({ type }) => {
       // The project changed
       if (type === 'insights/project') {
@@ -57,17 +64,17 @@ export default {
     })
   },
   methods: {
-    async count (query) {
+    async count(query) {
       const index = this.$store.state.insights.project
       const body = { track_total_hits: true, query: { query_string: { query } } }
       const res = await elasticsearch.search({ index, body, size: 0 })
       return get(res, 'hits.total.value', 0)
     },
-    countTotal () {
+    countTotal() {
       const q = 'type:Document'
       return this.count(q)
     },
-    countDuplicates () {
+    countDuplicates() {
       const q = 'type:Duplicate'
       return this.count(q)
     },
@@ -82,11 +89,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .widget--duplicates {
-    width: 100%;
+.widget--duplicates {
+  width: 100%;
 
-    &:deep(.stacked-bar-chart__groups__item__label) {
-      display: none;
-    }
+  &:deep(.stacked-bar-chart__groups__item__label) {
+    display: none;
   }
+}
 </style>

--- a/src/components/widget/WidgetDuplicates.vue
+++ b/src/components/widget/WidgetDuplicates.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="widget widget--duplicates">
-    <div class="widget__header" v-if="widget.title" :class="{ 'card-header': widget.card }">
-      <h4 v-html="widget.title" class="m-0"></h4>
+    <div v-if="widget.title" class="widget__header" :class="{ 'card-header': widget.card }">
+      <h4 class="m-0" v-html="widget.title"></h4>
     </div>
     <div class="p-4">
       <v-wait for="duplicate-counters" transition="fade">
-        <fa icon="circle-notch" spin slot="waiting" size="2x" class="m-auto d-block"></fa>
+        <fa slot="waiting" icon="circle-notch" spin size="2x" class="m-auto d-block"></fa>
         <div>
           <stacked-bar-chart
             :data="data"

--- a/src/components/widget/WidgetEmpty.vue
+++ b/src/components/widget/WidgetEmpty.vue
@@ -20,27 +20,27 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @use "sass:math";
+@use 'sass:math';
 
-  .widget--empty {
-    width: 100%;
+.widget--empty {
+  width: 100%;
 
-    &:before {
-      content: "";
-      display: block;
-      padding-top: math.div(9, 16) * 100%;
-    }
-
-    &:after {
-      color: $text-muted;
-      content: "This is an empty widget";
-      font-weight: lighter;
-      left: 0;
-      position: absolute;
-      right: 0;
-      text-align: center;
-      top: 50%;
-      transform: translateY(-50%);
-    }
+  &:before {
+    content: '';
+    display: block;
+    padding-top: math.div(9, 16) * 100%;
   }
+
+  &:after {
+    color: $text-muted;
+    content: 'This is an empty widget';
+    font-weight: lighter;
+    left: 0;
+    position: absolute;
+    right: 0;
+    text-align: center;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+}
 </style>

--- a/src/components/widget/WidgetEntities.vue
+++ b/src/components/widget/WidgetEntities.vue
@@ -53,14 +53,6 @@ export default {
       }
     }
   },
-  created() {
-    return this.loadData()
-  },
-  watch: {
-    project() {
-      return this.loadData()
-    }
-  },
   computed: {
     total() {
       return sum(values(this.entities))
@@ -80,6 +72,14 @@ export default {
     project() {
       return this.$store.state.insights.project
     }
+  },
+  watch: {
+    project() {
+      return this.loadData()
+    }
+  },
+  created() {
+    return this.loadData()
   },
   methods: {
     async loadData() {

--- a/src/components/widget/WidgetEntities.vue
+++ b/src/components/widget/WidgetEntities.vue
@@ -1,11 +1,16 @@
 <template>
   <div class="widget widget--entities">
     <v-wait :for="loader" transition="fade">
-      <div slot="waiting" class="widget__spinner" >
-        <fa icon="circle-notch" spin size="2x"/>
+      <div slot="waiting" class="widget__spinner">
+        <fa icon="circle-notch" spin size="2x" />
       </div>
       <div class="widget__content row text-center" :class="{ 'card-body': widget.card }">
-        <div v-for="category in categories" :key="category" class="widget__content__count col-3" :class="{ 'widget__content__count--muted': !entities[category] }">
+        <div
+          v-for="category in categories"
+          :key="category"
+          class="widget__content__count col-3"
+          :class="{ 'widget__content__count--muted': !entities[category] }"
+        >
           <fa fixed-width :icon="category | namedEntityIcon" class="mr-1" />
           <span v-html="$tc(`widget.entities.${category}`, entities[category], { count: humanEntities[category] })" />
         </div>
@@ -38,7 +43,7 @@ export default {
       type: Object
     }
   },
-  data () {
+  data() {
     return {
       entities: {
         emails: 0,
@@ -48,36 +53,36 @@ export default {
       }
     }
   },
-  created () {
+  created() {
     return this.loadData()
   },
   watch: {
-    project () {
+    project() {
       return this.loadData()
     }
   },
   computed: {
-    total () {
+    total() {
       return sum(values(this.entities))
     },
-    humanEntities () {
+    humanEntities() {
       return Object.entries(this.entities).reduce((human, [key, value]) => {
         human[key] = humanNumber(value)
         return human
       }, {})
     },
-    categories () {
+    categories() {
       return Object.keys(this.entities)
     },
-    loader () {
+    loader() {
       return uniqueId('loading-entities-count-')
     },
-    project () {
+    project() {
       return this.$store.state.insights.project
     }
   },
   methods: {
-    async loadData () {
+    async loadData() {
       this.$wait.start(this.loader)
       this.entities.emails = await this.countFor('EMAIL')
       this.entities.locations = await this.countFor('LOCATION')
@@ -85,41 +90,37 @@ export default {
       this.entities.people = await this.countFor('PERSON')
       this.$wait.end(this.loader)
     },
-    async countFor (category) {
+    async countFor(category) {
       const index = this.project
       const body = this.bodybuilderFor(category).build()
       const preference = 'widget-entities'
       const { count = 0 } = await elasticsearch.count({ index, body, preference })
       return count
     },
-    bodybuilderFor (category) {
-      return bodybuilder()
-        .andQuery('match', 'type', 'NamedEntity')
-        .andQuery('match', 'category', category)
+    bodybuilderFor(category) {
+      return bodybuilder().andQuery('match', 'type', 'NamedEntity').andQuery('match', 'category', category)
     }
   }
 }
 </script>
 
 <style lang="scss" scoped>
-  .widget {
-    min-height: 100%;
-    position: relative;
+.widget {
+  min-height: 100%;
+  position: relative;
 
-    &__spinner {
-      text-align: center;
-      width: 100%;
-      padding: $spacer;
-    }
+  &__spinner {
+    text-align: center;
+    width: 100%;
+    padding: $spacer;
+  }
 
-    &__content {
-
-      &__count {
-
-        &--muted {
-          color: $text-muted
-        }
+  &__content {
+    &__count {
+      &--muted {
+        color: $text-muted;
       }
     }
   }
+}
 </style>

--- a/src/components/widget/WidgetFileBarometer.vue
+++ b/src/components/widget/WidgetFileBarometer.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="widget widget--file-barometer d-flex align-items-center text-center">
     <v-wait for="barometer counters" class="flex-grow-1" transition="fade">
-      <fa icon="circle-notch" spin slot="waiting" size="2x" />
+      <fa slot="waiting" icon="circle-notch" spin size="2x" />
       <p :class="{ 'card-body': widget.card }">
         <fa icon="hdd" class="widget__icon" size="2x" />
         <strong class="widget__main-figure" :title="total">

--- a/src/components/widget/WidgetFileBarometer.vue
+++ b/src/components/widget/WidgetFileBarometer.vue
@@ -35,16 +35,16 @@ export default {
       type: Object
     }
   },
-  data () {
+  data() {
     return {
       onDisk: null,
       total: null
     }
   },
-  async created () {
+  async created() {
     await this.loadData()
   },
-  mounted () {
+  mounted() {
     this.$store.subscribe(async ({ type }) => {
       // The project changed
       if (type === 'insights/project') {
@@ -53,18 +53,18 @@ export default {
     })
   },
   methods: {
-    async count (query) {
+    async count(query) {
       const index = this.$store.state.insights.project
       const body = { track_total_hits: true, query: { query_string: { query } } }
       const preference = 'widget-file-barometer'
       const res = await elasticsearch.search({ index, body, preference, size: 0 })
       return res?.hits?.total?.value || 0
     },
-    countTotal () {
+    countTotal() {
       const q = 'type:Document'
       return this.count(q)
     },
-    countOnDisk () {
+    countOnDisk() {
       const q = 'type:Document AND extractionLevel:0'
       return this.count(q)
     },
@@ -80,12 +80,12 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .widget {
-    min-height: 100%;
+.widget {
+  min-height: 100%;
 
-    &__main-figure {
-      display: block;
-      font-size: 1.8rem;
-    }
+  &__main-figure {
+    display: block;
+    font-size: 1.8rem;
   }
+}
 </style>

--- a/src/components/widget/WidgetListGroup.vue
+++ b/src/components/widget/WidgetListGroup.vue
@@ -54,14 +54,14 @@ export default {
       items: []
     }
   },
-  async mounted() {
-    const items = await this.applyPipelineChain(this.widget.pipeline)(this.widget.items)
-    this.$set(this, 'items', items)
-  },
   computed: {
     ...mapGetters('pipelines', {
       applyPipelineChain: 'applyPipelineChainByCategory'
     })
+  },
+  async mounted() {
+    const items = await this.applyPipelineChain(this.widget.pipeline)(this.widget.items)
+    this.$set(this, 'items', items)
   }
 }
 </script>

--- a/src/components/widget/WidgetListGroup.vue
+++ b/src/components/widget/WidgetListGroup.vue
@@ -1,22 +1,22 @@
 <template>
   <div class="widget widget--list-group">
-    <div class="widget__header" v-if="widget.title" :class="{ 'card-header': widget.card }">
-      <h4 v-html="widget.title" class="m-0 h"></h4>
+    <div v-if="widget.title" class="widget__header" :class="{ 'card-header': widget.card }">
+      <h4 class="m-0 h" v-html="widget.title"></h4>
     </div>
     <div class="list-group widget__list" :class="{ 'list-group-flush': widget.card }">
       <component
-        class="list-group-item list-group-item-action widget__list__item"
         :is="item | itemComponent"
-        :href="item.href"
         v-for="(item, i) in items"
         :key="i"
+        class="list-group-item list-group-item-action widget__list__item"
+        :href="item.href"
         :class="{ active: item.active }"
         :target="item | itemTarget"
       >
         <div class="widget__list__item__label">
           {{ item.label }}
         </div>
-        <div class="widget__list__item__description" v-if="item.description">
+        <div v-if="item.description" class="widget__list__item__description">
           {{ item.description }}
         </div>
       </component>
@@ -32,6 +32,15 @@ import { mapGetters } from 'vuex'
  */
 export default {
   name: 'WidgetListGroup',
+  filters: {
+    itemComponent({ href = null } = {}) {
+      return href ? 'a' : 'div'
+    },
+    itemTarget({ href = null } = {}) {
+      const origin = window.location.origin
+      return !href || href.indexOf(origin) === 0 ? null : '_blank'
+    }
+  },
   props: {
     /**
      * The widget definition object.
@@ -43,15 +52,6 @@ export default {
   data() {
     return {
       items: []
-    }
-  },
-  filters: {
-    itemComponent({ href = null } = {}) {
-      return href ? 'a' : 'div'
-    },
-    itemTarget({ href = null } = {}) {
-      const origin = window.location.origin
-      return !href || href.indexOf(origin) === 0 ? null : '_blank'
     }
   },
   async mounted() {

--- a/src/components/widget/WidgetListGroup.vue
+++ b/src/components/widget/WidgetListGroup.vue
@@ -4,7 +4,15 @@
       <h4 v-html="widget.title" class="m-0 h"></h4>
     </div>
     <div class="list-group widget__list" :class="{ 'list-group-flush': widget.card }">
-      <component class="list-group-item list-group-item-action widget__list__item" :is="item | itemComponent" :href="item.href" v-for="(item, i) in items" :key="i" :class="{ active: item.active }" :target="item | itemTarget">
+      <component
+        class="list-group-item list-group-item-action widget__list__item"
+        :is="item | itemComponent"
+        :href="item.href"
+        v-for="(item, i) in items"
+        :key="i"
+        :class="{ active: item.active }"
+        :target="item | itemTarget"
+      >
         <div class="widget__list__item__label">
           {{ item.label }}
         </div>
@@ -32,21 +40,21 @@ export default {
       type: Object
     }
   },
-  data () {
+  data() {
     return {
       items: []
     }
   },
   filters: {
-    itemComponent ({ href = null } = {}) {
+    itemComponent({ href = null } = {}) {
       return href ? 'a' : 'div'
     },
-    itemTarget ({ href = null } = {}) {
+    itemTarget({ href = null } = {}) {
       const origin = window.location.origin
       return !href || href.indexOf(origin) === 0 ? null : '_blank'
     }
   },
-  async mounted () {
+  async mounted() {
     const items = await this.applyPipelineChain(this.widget.pipeline)(this.widget.items)
     this.$set(this, 'items', items)
   },
@@ -59,28 +67,28 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .widget {
-    &--list-group {
-      min-height: 100%;
-    }
+.widget {
+  &--list-group {
+    min-height: 100%;
+  }
 
-    &__list {
-      &__item {
-        color: $body-color;
+  &__list {
+    &__item {
+      color: $body-color;
 
-        &[href] {
-          color: $link-color;
-        }
+      &[href] {
+        color: $link-color;
+      }
 
-        &__label {
-          color: inherit;
-        }
+      &__label {
+        color: inherit;
+      }
 
-        &__description {
-          color: $text-muted;
-          font-size: 0.8em;
-        }
+      &__description {
+        color: $text-muted;
+        font-size: 0.8em;
       }
     }
   }
+}
 </style>

--- a/src/components/widget/WidgetText.vue
+++ b/src/components/widget/WidgetText.vue
@@ -29,14 +29,6 @@ export default {
       content: ''
     }
   },
-  watch: {
-    async widget() {
-      this.content = await this.applyPipelineChain(this.widget.pipeline)(this.widgetContent)
-    }
-  },
-  async mounted() {
-    this.content = await this.applyPipelineChain(this.widget.pipeline)(this.widgetContent)
-  },
   computed: {
     ...mapGetters('pipelines', {
       applyPipelineChain: 'applyPipelineChainByCategory'
@@ -47,6 +39,14 @@ export default {
     widgetContent() {
       return this.widget.content || this.defaultContent
     }
+  },
+  watch: {
+    async widget() {
+      this.content = await this.applyPipelineChain(this.widget.pipeline)(this.widgetContent)
+    }
+  },
+  async mounted() {
+    this.content = await this.applyPipelineChain(this.widget.pipeline)(this.widgetContent)
   }
 }
 </script>

--- a/src/components/widget/WidgetText.vue
+++ b/src/components/widget/WidgetText.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="widget widget--text">
-    <div class="widget__header" v-if="widget.title" :class="{ 'card-header': widget.card }">
-      <h4 v-html="widget.title" class="m-0 h"></h4>
+    <div v-if="widget.title" class="widget__header" :class="{ 'card-header': widget.card }">
+      <h4 class="m-0 h" v-html="widget.title"></h4>
     </div>
     <div class="widget__content lead" :class="{ 'card-body': widget.card }" v-html="content"></div>
   </div>
@@ -29,13 +29,13 @@ export default {
       content: ''
     }
   },
-  async mounted() {
-    this.content = await this.applyPipelineChain(this.widget.pipeline)(this.widgetContent)
-  },
   watch: {
     async widget() {
       this.content = await this.applyPipelineChain(this.widget.pipeline)(this.widgetContent)
     }
+  },
+  async mounted() {
+    this.content = await this.applyPipelineChain(this.widget.pipeline)(this.widgetContent)
   },
   computed: {
     ...mapGetters('pipelines', {

--- a/src/components/widget/WidgetText.vue
+++ b/src/components/widget/WidgetText.vue
@@ -24,16 +24,16 @@ export default {
       type: Object
     }
   },
-  data () {
+  data() {
     return {
       content: ''
     }
   },
-  async mounted () {
+  async mounted() {
     this.content = await this.applyPipelineChain(this.widget.pipeline)(this.widgetContent)
   },
   watch: {
-    async widget () {
+    async widget() {
       this.content = await this.applyPipelineChain(this.widget.pipeline)(this.widgetContent)
     }
   },
@@ -41,10 +41,10 @@ export default {
     ...mapGetters('pipelines', {
       applyPipelineChain: 'applyPipelineChainByCategory'
     }),
-    defaultContent () {
+    defaultContent() {
       return this.$config.get('widgetTextDefaultContent', settings.widgetTextDefaultContent)
     },
-    widgetContent () {
+    widgetContent() {
       return this.widget.content || this.defaultContent
     }
   }
@@ -52,7 +52,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .widget--text {
-    min-height: 100%;
-  }
+.widget--text {
+  min-height: 100%;
+}
 </style>

--- a/src/components/widget/WidgetTreeMap.vue
+++ b/src/components/widget/WidgetTreeMap.vue
@@ -5,14 +5,11 @@
     </div>
     <div class="widget__content lead" :class="{ 'card-body': widget.card }">
       <div class="d-flex flex-row">
-        <tree-breadcrumb
-          :path="currentPath"
-          no-datadir
-          @input="update($event)"
-          v-if="currentPath" />
+        <tree-breadcrumb :path="currentPath" no-datadir @input="update($event)" v-if="currentPath" />
         <router-link
           :to="{ name: 'search', query: { index: widget.index, 'f[path]': currentPath } }"
-          class="widget__content__search">
+          class="widget__content__search"
+        >
           {{ $t('widget.treemap.seeDocuments') }}
         </router-link>
       </div>
@@ -47,70 +44,65 @@ export default {
       type: Object
     }
   },
-  data () {
+  data() {
     return {
       currentPath: null,
       height: 500,
       id: uniqueId('widget_tree_map')
     }
   },
-  async mounted () {
+  async mounted() {
     await this.update(this.$config.get('dataDir'))
     this.scrollToWidget()
   },
   methods: {
-    scrollToWidget () {
+    scrollToWidget() {
       const scrollTo = get(this.$route, 'query.scrollTo', false)
       if (scrollTo === 'WidgetTreeMap') {
-        const target = this.$el.querySelector(`#${ this.id }`)
+        const target = this.$el.querySelector(`#${this.id}`)
         setTimeout(() => VueScrollTo.scrollTo(target, 100, { offset: 620, force: true }), 500)
       }
     },
-    renderTreeMap (data) {
+    renderTreeMap(data) {
       const width = document.getElementById(this.id).offsetWidth
 
-      const root = hierarchy(data).sum(d => d.doc_count)
-      treemap()
-        .size([width, this.height])
-        .padding(2)(root)
+      const root = hierarchy(data).sum((d) => d.doc_count)
+      treemap().size([width, this.height]).padding(2)(root)
 
-      const svg = select(`#${ this.id } > svg`)
-        .append('g')
+      const svg = select(`#${this.id} > svg`).append('g')
 
-      const leaf = svg.selectAll('g')
-        .data(root.leaves())
-        .enter()
+      const leaf = svg.selectAll('g').data(root.leaves()).enter()
 
       leaf
         .append('rect')
-        .attr('x', d => d.x0)
-        .attr('y', d => d.y0)
-        .attr('width', d => d.x1 - d.x0)
-        .attr('height', d => d.y1 - d.y0)
+        .attr('x', (d) => d.x0)
+        .attr('y', (d) => d.y0)
+        .attr('width', (d) => d.x1 - d.x0)
+        .attr('height', (d) => d.y1 - d.y0)
         .style('fill', '#FA4070')
         .style('fill-opacity', 0.5)
-        .on('click', d => this.update(d.data.key))
+        .on('click', (d) => this.update(d.data.key))
         .on('mouseover', (_, index, nodes) => select(nodes[index]).style('cursor', 'pointer'))
       leaf
         .append('text')
-        .attr('x', d => d.x0 + 5)
-        .attr('y', d => d.y0 + 20)
-        .text(d => basename(d.data.key))
+        .attr('x', (d) => d.x0 + 5)
+        .attr('y', (d) => d.y0 + 20)
+        .text((d) => basename(d.data.key))
         .attr('font-size', '12px')
         .attr('fill', 'black')
-        .on('click', d => this.update(d.data.key))
+        .on('click', (d) => this.update(d.data.key))
         .on('mouseover', (_, index, nodes) => select(nodes[index]).style('cursor', 'pointer'))
       leaf
         .append('text')
-        .attr('x', d => d.x0 + 5)
-        .attr('y', d => d.y0 + 30)
-        .text(d => `${ format(',d')(d.data.doc_count) } files`)
+        .attr('x', (d) => d.x0 + 5)
+        .attr('y', (d) => d.y0 + 30)
+        .text((d) => `${format(',d')(d.data.doc_count)} files`)
         .attr('font-size', '10px')
         .attr('fill', '#25252A')
-        .on('click', d => this.update(d.data.key))
+        .on('click', (d) => this.update(d.data.key))
         .on('mouseover', (_, index, nodes) => select(nodes[index]).style('cursor', 'pointer'))
     },
-    async getData (path) {
+    async getData(path) {
       const aggregationOptions = {
         include: path + '/.*',
         exclude: path + '/.*/.*',
@@ -121,15 +113,16 @@ export default {
         .andQuery('match', 'type', 'Document')
         .andQuery('match', 'extractionLevel', 0)
         .andFilter('term', 'dirname.tree', path)
-        .agg('terms', 'dirname.tree', aggregationOptions, 'byDirname',
-          sub => sub.agg('bucket_sort', { size: 50, from: 0 }, 'bucket_truncate'))
+        .agg('terms', 'dirname.tree', aggregationOptions, 'byDirname', (sub) =>
+          sub.agg('bucket_sort', { size: 50, from: 0 }, 'bucket_truncate')
+        )
         .build()
       const result = await elasticsearch.search({ index: this.widget.index, body, size: 0 })
       const children = get(result, 'aggregations.byDirname.buckets', [])
       const others = get(result, 'aggregations.byDirname.sum_other_doc_count', [])
       return { children, others }
     },
-    async update (path = null) {
+    async update(path = null) {
       let children = null
       let others = null
       try {
@@ -142,23 +135,20 @@ export default {
         const currentPath = isNull(children) ? null : path
         const message = isNull(children) ? 'Please select a correct data file' : 'No folders'
         this.$set(this, 'currentPath', currentPath)
-        select(`#${ this.id } > svg`).remove()
+        select(`#${this.id} > svg`).remove()
         const span = document.createElement('span')
         span.setAttribute('class', 'error')
         const text = document.createTextNode(message)
         span.appendChild(text)
         document.getElementById(this.id).appendChild(span)
-      // Still data to display
+        // Still data to display
       } else {
         this.$set(this, 'currentPath', path)
-        select(`#${ this.id } > .error`).remove()
-        if (select(`#${ this.id } > svg`).size() === 0) {
-          select(`#${ this.id }`)
-            .append('svg')
-            .attr('width', '100%')
-            .attr('height', this.height)
+        select(`#${this.id} > .error`).remove()
+        if (select(`#${this.id} > svg`).size() === 0) {
+          select(`#${this.id}`).append('svg').attr('width', '100%').attr('height', this.height)
         } else {
-          select(`#${ this.id } > svg > g`).remove()
+          select(`#${this.id} > svg > g`).remove()
         }
         children.push({ key: this.$t('widget.treemap.others'), doc_count: others })
         this.renderTreeMap({ children })
@@ -169,7 +159,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .widget--tree-map {
-    min-height: 100%;
-  }
+.widget--tree-map {
+  min-height: 100%;
+}
 </style>

--- a/src/components/widget/WidgetTreeMap.vue
+++ b/src/components/widget/WidgetTreeMap.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="widget widget--tree-map">
-    <div class="widget__header" v-if="widget.title" :class="{ 'card-header': widget.card }">
-      <h4 v-html="widget.title" class="m-0 h"></h4>
+    <div v-if="widget.title" class="widget__header" :class="{ 'card-header': widget.card }">
+      <h4 class="m-0 h" v-html="widget.title"></h4>
     </div>
     <div class="widget__content lead" :class="{ 'card-body': widget.card }">
       <div class="d-flex flex-row">
-        <tree-breadcrumb :path="currentPath" no-datadir @input="update($event)" v-if="currentPath" />
+        <tree-breadcrumb v-if="currentPath" :path="currentPath" no-datadir @input="update($event)" />
         <router-link
           :to="{ name: 'search', query: { index: widget.index, 'f[path]': currentPath } }"
           class="widget__content__search"

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -50,7 +50,7 @@ class Core extends Behaviors {
    * @param api - Datashare api interface
    * @param mode - mode of authentication ('local' or 'server'
    */
-  constructor (LocalVue = Vue, api = new Api(null, null), mode = getMode(MODE_NAME.LOCAL)) {
+  constructor(LocalVue = Vue, api = new Api(null, null), mode = getMode(MODE_NAME.LOCAL)) {
     super(LocalVue)
     this.LocalVue = LocalVue
     this._api = api
@@ -67,7 +67,7 @@ class Core extends Behaviors {
    * @param {Object} options - Option to pass to the plugin
    * @returns {Core} the current instance of Core
    */
-  use (Plugin, options) {
+  use(Plugin, options) {
     this.LocalVue.use(Plugin, options)
     return this
   }
@@ -75,7 +75,7 @@ class Core extends Behaviors {
    * Configure all default Vue plugins for this application
    * @returns {Core} the current instance of Core
    */
-  useAll () {
+  useAll() {
     this.useI18n()
     this.useBootstrapVue()
     this.useCommons()
@@ -88,7 +88,7 @@ class Core extends Behaviors {
    * Configure vue-i18n plugin
    * @returns {Core} the current instance of Core
    */
-  useI18n () {
+  useI18n() {
     this.use(VueI18n)
     this.i18n = new VueI18n({
       locale: settings.defaultLocale,
@@ -103,7 +103,7 @@ class Core extends Behaviors {
    * Configure bootstrap-vue plugin
    * @returns {Core} the current instance of Core
    */
-  useBootstrapVue () {
+  useBootstrapVue() {
     this.use(BootstrapVue, {
       BPopover: {
         boundaryPadding: 14
@@ -115,7 +115,7 @@ class Core extends Behaviors {
    * Configure vue-router plugin
    * @returns {Core} the current instance of Core
    */
-  useRouter () {
+  useRouter() {
     this.use(VueRouter)
     this.router = new VueRouter(router)
     guards(this)
@@ -125,7 +125,7 @@ class Core extends Behaviors {
    * Configure most common Vue plugins (Murmur, VueProgressBar, VueShortkey, VueScrollTo and VueCalendar)
    * @returns {Core} the current instance of Core
    */
-  useCommons () {
+  useCommons() {
     // Common plugins
     this.use(Murmur)
     this.use(VueProgressBar, { color: settings.progressBar.color })
@@ -143,7 +143,7 @@ class Core extends Behaviors {
    * Configure vue-wait plugin
    * @returns {Core} the current instance of Core
    */
-  useWait () {
+  useWait() {
     this.use(VueWait)
     this.wait = new VueWait({ useVuex: true })
     return this
@@ -152,13 +152,15 @@ class Core extends Behaviors {
    * Add a $core property to the instance's Vue
    * @returns {Core} the current instance of Core
    */
-  useCore () {
+  useCore() {
     const core = this
-    this.use(class VueCore {
-      static install (Vue) {
-        Vue.prototype.$core = core
+    this.use(
+      class VueCore {
+        static install(Vue) {
+          Vue.prototype.$core = core
+        }
       }
-    })
+    )
     return this
   }
   /**
@@ -168,7 +170,7 @@ class Core extends Behaviors {
    * @reject {Object} - The Error object
    * @returns {Promise<Object>}
    */
-  async configure () {
+  async configure() {
     try {
       // Override Murmur default value for content-placeholder
       this.config.set('content-placeholder.rows', settings.contentPlaceholder.rows)
@@ -200,7 +202,7 @@ class Core extends Behaviors {
     }
   }
 
-  getDefaultProject () {
+  getDefaultProject() {
     const userProjects = this.config.get('groups_by_applications.datashare', [])
     if (userProjects.length === 0) return ''
     const defaultProject = this.config.get('defaultProject', '')
@@ -212,9 +214,9 @@ class Core extends Behaviors {
    * @param {String} [selector=#app] - Query selector to the mounting point
    * @returns {Vue} The instantiated Vue
    */
-  mount (selector = '#app') {
+  mount(selector = '#app') {
     // Render function returns a router-view component by default
-    const render = h => h('router-view')
+    const render = (h) => h('router-view')
     // We do not necessarily use the default Vue so we can use this function
     // from our unit tests
     const vm = new this.LocalVue({
@@ -230,7 +232,7 @@ class Core extends Behaviors {
   /**
    * Build a promise to be resolved when the application is configured.
    */
-  defer () {
+  defer() {
     this._ready = new Promise((resolve, reject) => {
       this._readyResolve = resolve
       this._readyReject = reject
@@ -244,7 +246,7 @@ class Core extends Behaviors {
    * @param {...Mixed} args - Additional params to pass to the event
    * @returns {Core} the current instance of Core
    */
-  dispatch (name, ...args) {
+  dispatch(name, ...args) {
     dispatch(name, { app: this, core: this, ...args })
     return this
   }
@@ -254,7 +256,7 @@ class Core extends Behaviors {
    * @fullfil {Object} Current user
    * @type {Promise<Object>}
    */
-  getUser () {
+  getUser() {
     return this.api.getUser()
   }
   /**
@@ -262,7 +264,7 @@ class Core extends Behaviors {
    * @param {String} title - Title to append to the page
    * @param {String} [suffix=Datashare] - Suffix to the title
    */
-  setPageTitle (title = null, suffix = 'Datashare') {
+  setPageTitle(title = null, suffix = 'Datashare') {
     if (document && document.title) {
       document.title = title ? `${title} - ${suffix}` : suffix
     }
@@ -272,7 +274,7 @@ class Core extends Behaviors {
    * @fullfil {Object} The actual application core instance.
    * @type {Promise<Object>}
    */
-  get ready () {
+  get ready() {
     if (!this._ready) {
       this.defer()
     }
@@ -283,49 +285,49 @@ class Core extends Behaviors {
    * @type {Core}
    * @deprecated
    */
-  get app () {
+  get app() {
     return this
   }
   /**
    * The application core instance
    * @type {Core}
    */
-  get core () {
+  get core() {
     return this
   }
   /**
    * The Vue class to instantiate the application with
    * @type {Vue}
    */
-  get localVue () {
+  get localVue() {
     return this.LocalVue
   }
   /**
    * The Vuex instance
    * @type {Vuex.Store}
    */
-  get store () {
+  get store() {
     return this._store
   }
   /**
    * The Auth module instance
    * @type {Auth}
    */
-  get auth () {
+  get auth() {
     return this._auth
   }
   /**
    * The configuration object provided by Murmur
    * @type {Object}
    */
-  get config () {
+  get config() {
     return Murmur.config
   }
   /**
    * The Datashare api interface
    * @type {Api}
    */
-  get api () {
+  get api() {
     return this._api
   }
   /**
@@ -333,7 +335,7 @@ class Core extends Behaviors {
    * @param {...Mixed} options - Options to pass to the Core constructor
    * @returns {Core}
    */
-  static init (...options) {
+  static init(...options) {
     return new Core(...options)
   }
 }

--- a/src/core/FiltersMixin.js
+++ b/src/core/FiltersMixin.js
@@ -7,69 +7,70 @@ import uniqueId from 'lodash/uniqueId'
   @mixin FiltersMixin
   @typicalname datashare
 */
-const FiltersMixin = superclass => class extends superclass {
-  /**
-   * Register a filter
-   * @memberof FiltersMixin.prototype
-   * @param {...Mixed} args - Filter's params.
-   * @param {String} args.type - Type of the filter.
-   * @param {Object} args.options - Options to pass to the filter constructor.
-   * @param {String} args.options.name - Name of the filter.
-   * @param {String} args.options.key - Key of the filter. Typically ElasticSearch field name.
-   * @param {String} [args.options.icon=null] - Icon of the filter.
-   * @param {Boolean} [args.options.isSearchable=false] - Set if this filter should be searchable or not.
-   * @param {function} [args.options.alternativeSearch=()=>{})] - Set a function about how to transform query term before searching for it.
-   * @param {Number} [args.options.order=null] - Order of the filter. Will be added as last filter by default.
-   */
-  registerFilter (...args) {
-    this.store.commit('search/addFilter', ...args)
+const FiltersMixin = (superclass) =>
+  class extends superclass {
+    /**
+     * Register a filter
+     * @memberof FiltersMixin.prototype
+     * @param {...Mixed} args - Filter's params.
+     * @param {String} args.type - Type of the filter.
+     * @param {Object} args.options - Options to pass to the filter constructor.
+     * @param {String} args.options.name - Name of the filter.
+     * @param {String} args.options.key - Key of the filter. Typically ElasticSearch field name.
+     * @param {String} [args.options.icon=null] - Icon of the filter.
+     * @param {Boolean} [args.options.isSearchable=false] - Set if this filter should be searchable or not.
+     * @param {function} [args.options.alternativeSearch=()=>{})] - Set a function about how to transform query term before searching for it.
+     * @param {Number} [args.options.order=null] - Order of the filter. Will be added as last filter by default.
+     */
+    registerFilter(...args) {
+      this.store.commit('search/addFilter', ...args)
+    }
+    /**
+     * Unregister a filter
+     * @memberof FiltersMixin.prototype
+     * @param {String} name - Name of the filter to unregister
+     */
+    unregisterFilter(name) {
+      this.store.commit('search/removeFilter', name)
+    }
+    /**
+     * Register a filter only for a specific project
+     * @memberof FiltersMixin.prototype
+     * @param {String} name - Name of the project
+     * @param {...Mixed} args - Filter's options.
+     * @param {String} args.name - Name of the filter
+     * @param {String} args.type - Type of the filter.
+     * @param {Object} args.options - Options to pass to the filter constructor
+     */
+    registerFilterForProject(project, { type, options = {} } = {}) {
+      options = cloneDeep(options)
+      options.name = options.name || uniqueId('core:filter-')
+      // Watch store mutations
+      return this.toggleForProject({
+        project,
+        // Conditional callbacks
+        withFn: () => this.registerFilter({ type, options }),
+        withoutFn: () => this.unregisterFilter(options.name)
+      })
+    }
+    /**
+     * Unregister a filter only for a specific project
+     * @memberof FiltersMixin.prototype
+     * @param {String} name - Name of the project
+     * @param {String} name - Name of the filter
+     */
+    unregisterFilterForProject(project, name) {
+      const filters = this.store.state.search.filters
+      const position = findIndex(filters, ({ options }) => options.name === name)
+      const { type, options } = filters[position]
+      // Watch store mutations
+      return this.toggleForProject({
+        project,
+        // Conditional callbacks
+        withFn: () => this.unregisterFilter(name),
+        withoutFn: () => this.registerFilter({ type, options, position })
+      })
+    }
   }
-  /**
-   * Unregister a filter
-   * @memberof FiltersMixin.prototype
-   * @param {String} name - Name of the filter to unregister
-   */
-  unregisterFilter (name) {
-    this.store.commit('search/removeFilter', name)
-  }
-  /**
-   * Register a filter only for a specific project
-   * @memberof FiltersMixin.prototype
-   * @param {String} name - Name of the project
-   * @param {...Mixed} args - Filter's options.
-   * @param {String} args.name - Name of the filter
-   * @param {String} args.type - Type of the filter.
-   * @param {Object} args.options - Options to pass to the filter constructor
-   */
-  registerFilterForProject (project, { type, options = {} } = {}) {
-    options = cloneDeep(options)
-    options.name = options.name || uniqueId('core:filter-')
-    // Watch store mutations
-    return this.toggleForProject({
-      project,
-      // Conditional callbacks
-      withFn: () => this.registerFilter({ type, options }),
-      withoutFn: () => this.unregisterFilter(options.name)
-    })
-  }
-  /**
-   * Unregister a filter only for a specific project
-   * @memberof FiltersMixin.prototype
-   * @param {String} name - Name of the project
-   * @param {String} name - Name of the filter
-   */
-  unregisterFilterForProject (project, name) {
-    const filters = this.store.state.search.filters
-    const position = findIndex(filters, ({ options }) => options.name === name)
-    const { type, options } = filters[position]
-    // Watch store mutations
-    return this.toggleForProject({
-      project,
-      // Conditional callbacks
-      withFn: () => this.unregisterFilter(name),
-      withoutFn: () => this.registerFilter({ type, options, position })
-    })
-  }
-}
 
 export default FiltersMixin

--- a/src/core/HooksMixin.js
+++ b/src/core/HooksMixin.js
@@ -5,63 +5,64 @@ import { uniqueId, cloneDeep } from 'lodash'
   @mixin HooksMixin
   @typicalname datashare
 */
-const HooksMixin = superclass => class extends superclass {
-  /**
-   * Register a hook
-   * @memberof HooksMixin.prototype
-   * @param {...Mixed} args - Hook's options
-   * @param {String} args.name - Name of the hook
-   * @param {String} args.target - Target of the hook
-   * @param {Number} args.order - Priority of the hook
-   * @param {Object} args.definition - Options to pass to the hook constructor
-   */
-  registerHook (...args) {
-    this.store.commit('hooks/register', ...args)
+const HooksMixin = (superclass) =>
+  class extends superclass {
+    /**
+     * Register a hook
+     * @memberof HooksMixin.prototype
+     * @param {...Mixed} args - Hook's options
+     * @param {String} args.name - Name of the hook
+     * @param {String} args.target - Target of the hook
+     * @param {Number} args.order - Priority of the hook
+     * @param {Object} args.definition - Options to pass to the hook constructor
+     */
+    registerHook(...args) {
+      this.store.commit('hooks/register', ...args)
+    }
+    /**
+     * Unregister a specific hook
+     * @memberof HooksMixin.prototype
+     * @param {String} name - Name of the hook
+     */
+    unregisterHook(...args) {
+      this.store.commit('hooks/unregister', ...args)
+    }
+    /**
+     * Unregister all hooks from a target
+     * @param {String} name - Name of the target
+     * @memberof HooksMixin.prototype
+     */
+    resetHook(name) {
+      this.store.commit('hooks/resetTarget', name)
+    }
+    /**
+     * Unregister all hooks, on every targets
+     * @memberof HooksMixin.prototype
+     */
+    resetHooks() {
+      this.store.commit('hooks/reset')
+    }
+    /**
+     * Register a hook for a specific project
+     * @memberof HooksMixin.prototype
+     * @param {String} project - Project to add this hook to
+     * @param {Object} options - Hook's options
+     * @param {String} options.name - Name of the hook
+     * @param {String} options.target - Target of the hook
+     * @param {Number} options.order - Priority of the hook
+     * @param {Object} options.definition - Options to pass to the hook constructor
+     */
+    registerHookForProject(project, options) {
+      options = cloneDeep(options)
+      options.name = options.name || uniqueId('core:hooked-component-')
+      // Watch store mutations
+      return this.toggleForProject({
+        project,
+        // Conditional callbacks
+        withFn: () => this.registerHook(options),
+        withoutFn: () => this.unregisterHook(options.name)
+      })
+    }
   }
-  /**
-   * Unregister a specific hook
-   * @memberof HooksMixin.prototype
-   * @param {String} name - Name of the hook
-   */
-  unregisterHook (...args) {
-    this.store.commit('hooks/unregister', ...args)
-  }
-  /**
-   * Unregister all hooks from a target
-   * @param {String} name - Name of the target
-   * @memberof HooksMixin.prototype
-   */
-  resetHook (name) {
-    this.store.commit('hooks/resetTarget', name)
-  }
-  /**
-   * Unregister all hooks, on every targets
-   * @memberof HooksMixin.prototype
-   */
-  resetHooks () {
-    this.store.commit('hooks/reset')
-  }
-  /**
-   * Register a hook for a specific project
-   * @memberof HooksMixin.prototype
-   * @param {String} project - Project to add this hook to
-   * @param {Object} options - Hook's options
-   * @param {String} options.name - Name of the hook
-   * @param {String} options.target - Target of the hook
-   * @param {Number} options.order - Priority of the hook
-   * @param {Object} options.definition - Options to pass to the hook constructor
-   */
-  registerHookForProject (project, options) {
-    options = cloneDeep(options)
-    options.name = options.name || uniqueId('core:hooked-component-')
-    // Watch store mutations
-    return this.toggleForProject({
-      project,
-      // Conditional callbacks
-      withFn: () => this.registerHook(options),
-      withoutFn: () => this.unregisterHook(options.name)
-    })
-  }
-}
 
 export default HooksMixin

--- a/src/core/PipelinesMixin.js
+++ b/src/core/PipelinesMixin.js
@@ -5,64 +5,65 @@ import { findIndex, uniqueId, cloneDeep } from 'lodash'
   @mixin PipelinesMixin
   @typicalname datashare
 */
-const PipelinesMixin = superclass => class extends superclass {
-  /**
-   * Register a pipeline
-   * @memberof PipelinesMixin.prototype
-   * @param {...Mixed} args - Pipeline's options.
-   * @param {String} args.name - Name of the pipeline
-   * @param {String|Function} args.type - Type of the pipeline.
-   * @param {String} category - The pipeline to target
-   */
-  registerPipeline (...args) {
-    this.store.commit('pipelines/register', ...args)
+const PipelinesMixin = (superclass) =>
+  class extends superclass {
+    /**
+     * Register a pipeline
+     * @memberof PipelinesMixin.prototype
+     * @param {...Mixed} args - Pipeline's options.
+     * @param {String} args.name - Name of the pipeline
+     * @param {String|Function} args.type - Type of the pipeline.
+     * @param {String} category - The pipeline to target
+     */
+    registerPipeline(...args) {
+      this.store.commit('pipelines/register', ...args)
+    }
+    /**
+     * Unregister a pipeline
+     * @param {String} name - Name of the pipeline
+     * @memberof PipelinesMixin.prototype
+     */
+    unregisterPipeline(name) {
+      this.store.commit('pipelines/unregister', name)
+    }
+    /**
+     * Register a pipeline for a specific project
+     * @memberof PipelinesMixin.prototype
+     * @param {String} project - Name of the project
+     * @param {...Mixed} args - Pipeline's options.
+     * @param {String} args.name - Name of the pipeline
+     * @param {String|Function} args.type - Type of the pipeline.
+     * @param {String} category - The pipeline to target
+     */
+    registerPipelineForProject(project, { name, ...options } = {}) {
+      options = cloneDeep(options)
+      name = name || uniqueId('core:pipeline-')
+      // Watch store mutations
+      return this.toggleForProject({
+        project,
+        // Conditional callbacks
+        withFn: () => this.registerPipeline({ name, ...options }),
+        withoutFn: () => this.unregisterPipeline(name)
+      })
+    }
+    /**
+     * Unregister a pipeline for a specific project
+     * @memberof PipelinesMixin.prototype
+     * @param {String} project - Name of the project
+     * @param {String} name - Name of the pipeline
+     */
+    unregisterPipelineForProject(project, name) {
+      const pipelines = this.store.state.pipelines.registered
+      const position = findIndex(pipelines, ({ options }) => options.name === name)
+      const pipeline = pipelines[position]
+      // Watch store mutations
+      return this.toggleForProject({
+        project,
+        // Conditional callbacks
+        withFn: () => this.unregisterPipeline(name),
+        withoutFn: () => this.registerPipeline({ position, ...pipeline })
+      })
+    }
   }
-  /**
-   * Unregister a pipeline
-   * @param {String} name - Name of the pipeline
-   * @memberof PipelinesMixin.prototype
-   */
-  unregisterPipeline (name) {
-    this.store.commit('pipelines/unregister', name)
-  }
-  /**
-   * Register a pipeline for a specific project
-   * @memberof PipelinesMixin.prototype
-   * @param {String} project - Name of the project
-   * @param {...Mixed} args - Pipeline's options.
-   * @param {String} args.name - Name of the pipeline
-   * @param {String|Function} args.type - Type of the pipeline.
-   * @param {String} category - The pipeline to target
-   */
-  registerPipelineForProject (project, { name, ...options } = {}) {
-    options = cloneDeep(options)
-    name = name || uniqueId('core:pipeline-')
-    // Watch store mutations
-    return this.toggleForProject({
-      project,
-      // Conditional callbacks
-      withFn: () => this.registerPipeline({ name, ...options }),
-      withoutFn: () => this.unregisterPipeline(name)
-    })
-  }
-  /**
-   * Unregister a pipeline for a specific project
-   * @memberof PipelinesMixin.prototype
-   * @param {String} project - Name of the project
-   * @param {String} name - Name of the pipeline
-   */
-  unregisterPipelineForProject (project, name) {
-    const pipelines = this.store.state.pipelines.registered
-    const position = findIndex(pipelines, ({ options }) => options.name === name)
-    const pipeline = pipelines[position]
-    // Watch store mutations
-    return this.toggleForProject({
-      project,
-      // Conditional callbacks
-      withFn: () => this.unregisterPipeline(name),
-      withoutFn: () => this.registerPipeline({ position, ...pipeline })
-    })
-  }
-}
 
 export default PipelinesMixin

--- a/src/core/ProjectsMixin.js
+++ b/src/core/ProjectsMixin.js
@@ -5,56 +5,66 @@ import { castArray, compact, get, noop, uniq } from 'lodash'
   @mixin ProjectsMixin
   @typicalname datashare
 */
-const ProjectsMixin = superclass => class extends superclass {
-  /**
-   * Call a function when a project is selected
-   * @param {String} name - Name of the project
-   * @param {Function} withFn - Function to call when the project is selected
-   * @param {Function} withoutFn - Function to call when the project is unselected
-   * @param {String} mutationType - Mutation type that will be watched for changes.
-   * @param {String} storePath - Path to the project in the store
-   * @memberof ProjectsMixin.prototype
-   */
-  toggleForProject ({ project = null, withFn = noop, withoutFn = noop, mutationType = 'search/indices', storePath = 'search.indices' } = {}, ...args) {
-    const toggle = projects => {
-      if (castArray(projects).includes(project)) {
-        return withFn(...args)
+const ProjectsMixin = (superclass) =>
+  class extends superclass {
+    /**
+     * Call a function when a project is selected
+     * @param {String} name - Name of the project
+     * @param {Function} withFn - Function to call when the project is selected
+     * @param {Function} withoutFn - Function to call when the project is unselected
+     * @param {String} mutationType - Mutation type that will be watched for changes.
+     * @param {String} storePath - Path to the project in the store
+     * @memberof ProjectsMixin.prototype
+     */
+    toggleForProject(
+      {
+        project = null,
+        withFn = noop,
+        withoutFn = noop,
+        mutationType = 'search/indices',
+        storePath = 'search.indices'
+      } = {},
+      ...args
+    ) {
+      const toggle = (projects) => {
+        if (castArray(projects).includes(project)) {
+          return withFn(...args)
+        }
+        return withoutFn(...args)
       }
-      return withoutFn(...args)
+      // Toggle once
+      toggle(get(this.store.state, storePath))
+      // Watch store mutations
+      return this.store.subscribe(({ type, payload }) => {
+        if (type === mutationType) {
+          // The payload contains the name of the selected project
+          toggle(payload)
+        }
+      })
     }
-    // Toggle once
-    toggle(get(this.store.state, storePath))
-    // Watch store mutations
-    return this.store.subscribe(({ type, payload }) => {
-      if (type === mutationType) {
-        // The payload contains the name of the selected project
-        toggle(payload)
-      }
-    })
-  }
-  /**
-   * Create a default project on Datashare using the API
-   * @memberof ProjectsMixin.prototype
-   * @returns {Promise:Object} The HTTP response object
-   */
-  createDefaultProject () {
-    const defaultProject = this.config.get('defaultProject')
-    return this.api.createProject(defaultProject)
-  }
-  /**
-   * List all projects this user has access to.
-   * @returns {Array:String}
-   */
-  get projects () {
-    const projects = this.config.get('groups_by_applications.datashare', [])
-    // In local mode, we ensure the "defaultProject" is included. In server mode,
-    // the list of projects defines what the user can see.
-    if (this.config.get('mode') === 'LOCAL') {
+    /**
+     * Create a default project on Datashare using the API
+     * @memberof ProjectsMixin.prototype
+     * @returns {Promise:Object} The HTTP response object
+     */
+    createDefaultProject() {
       const defaultProject = this.config.get('defaultProject')
-      return compact(uniq([...projects, defaultProject]).sort())
+      return this.api.createProject(defaultProject)
     }
-    return [...projects].sort()
+    /**
+     * List all projects this user has access to.
+     * @returns {Array:String}
+     */
+    get projects() {
+      const projects = this.config.get('groups_by_applications.datashare', [])
+      // In local mode, we ensure the "defaultProject" is included. In server mode,
+      // the list of projects defines what the user can see.
+      if (this.config.get('mode') === 'LOCAL') {
+        const defaultProject = this.config.get('defaultProject')
+        return compact(uniq([...projects, defaultProject]).sort())
+      }
+      return [...projects].sort()
+    }
   }
-}
 
 export default ProjectsMixin

--- a/src/core/WidgetsMixin.js
+++ b/src/core/WidgetsMixin.js
@@ -5,107 +5,108 @@ import { uniqueId, cloneDeep } from 'lodash'
   @mixin WidgetsMixin
   @typicalname datashare
 */
-const WidgetsMixin = superclass => class extends superclass {
-  /**
-   * Register a widget
-   * @memberof WidgetsMixin.prototype
-   * @param {...Mixed} args - Widget's options passed to widget constructor
-   * @param {String} args.name - Name of the widget
-   * @param {Boolean} args.card - Either or not this widget should be a `card` component from Boostrap.
-   * @param {Number} args.cols - Number of columns to fill in the grid (from 1 to 12)
-   * @param {String} [args.type=WidgetEmpty] - Type of the widget
-   */
-  registerWidget (...args) {
-    this.store.commit('insights/addWidget', ...args)
+const WidgetsMixin = (superclass) =>
+  class extends superclass {
+    /**
+     * Register a widget
+     * @memberof WidgetsMixin.prototype
+     * @param {...Mixed} args - Widget's options passed to widget constructor
+     * @param {String} args.name - Name of the widget
+     * @param {Boolean} args.card - Either or not this widget should be a `card` component from Boostrap.
+     * @param {Number} args.cols - Number of columns to fill in the grid (from 1 to 12)
+     * @param {String} [args.type=WidgetEmpty] - Type of the widget
+     */
+    registerWidget(...args) {
+      this.store.commit('insights/addWidget', ...args)
+    }
+    /**
+     * Unregister a widget
+     * @memberof WidgetsMixin.prototype
+     * @param {String} name - Name of the widget to unregister
+     */
+    unregisterWidget(...args) {
+      this.store.commit('insights/removeWidget', ...args)
+    }
+    /**
+     * Unregister all widgets
+     * @memberof WidgetsMixin.prototype
+     */
+    clearWidgets() {
+      this.store.commit('insights/clearWidgets')
+    }
+    /**
+     * Register a widget for a specific project
+     * @memberof WidgetsMixin.prototype
+     * @param {String} project - Name of the project to add this widget to
+     * @param {Object} options - Widget's options passed to widget constructor
+     * @param {String} options.name - Name of the widget
+     * @param {Boolean} options.card - Either or not this widget should be a `card` component from Boostrap
+     * @param {Number} options.cols - Number of columns to fill in the grid (from 1 to 12)
+     * @param {String} [options.type=WidgetEmpty] - Type of the widget
+     */
+    registerWidgetForProject(project, options) {
+      options = cloneDeep(options)
+      const name = options.name || uniqueId('core:insight-')
+      // Watch store mutations
+      return this.toggleForProject({
+        project,
+        // Widgets are bound to the insights module, not the search module
+        mutationType: 'insights/project',
+        storePath: 'insights.project',
+        // Conditional callbacks
+        withFn: () => this.registerWidget({ ...options, name }),
+        withoutFn: () => this.unregisterWidget(name)
+      })
+    }
+    /**
+     * Replace an existing widget
+     * @memberof WidgetsMixin.prototype
+     * @param {String} name - Name of the widget to replace
+     * @param {Object} options - Widget's options passed to widget constructor.
+     * @param {Boolean} options.card - Either or not this widget should be a `card` component from Boostrap
+     * @param {Number} options.cols - Number of columns to fill in the grid (from 1 to 12)
+     * @param {String} [options.type=WidgetEmpty] - Type of the widget
+     * @example
+     * datashare.replaceWidget('default-text', {
+     *  card: true,
+     *  cols: 6,
+     *  type: 'WidgetText',
+     *  content: "Welcome to my amazing project dashboard!",
+     *  title: "Secret Project",
+     *  order: "-1"
+     * })
+     */
+    replaceWidget(name, options) {
+      // Unregister existing widget
+      this.unregisterWidget(name)
+      // Register the new one and ensure the "name" of the widget
+      // is the same than the one we replace
+      this.registerWidget({ ...options, name })
+    }
+    /**
+     * Replace an existing widget for a specific project
+     * @memberof WidgetsMixin.prototype
+     * @param {String} project - Name of the project to add this widget to
+     * @param {String} name - Name of the widget to replace
+     * @param {Object} options - Widget's options passed to widget constructor. Each widget class can define its own default values.
+     * @param {Boolean} options.card - Either or not this widget should be a `card` component from Boostrap
+     * @param {Number} options.cols - Number of columns to fill in the grid (from 1 to 12)
+     * @param {String} [options.type=WidgetEmpty] - Type of the widget
+     */
+    replaceWidgetForProject(project, name, options) {
+      // Save the initial option of the existing widget
+      const initialOptions = this.store.getters['insights/getWidget']({ name })
+      // Watch store mutations
+      return this.toggleForProject({
+        project,
+        // Widgets are bound to the insights module, not the search module
+        mutationType: 'insights/project',
+        storePath: 'insights.project',
+        // Conditional callbacks
+        withFn: () => this.replaceWidget(name, options),
+        withoutFn: () => this.replaceWidget(name, initialOptions)
+      })
+    }
   }
-  /**
-   * Unregister a widget
-   * @memberof WidgetsMixin.prototype
-   * @param {String} name - Name of the widget to unregister
-   */
-  unregisterWidget (...args) {
-    this.store.commit('insights/removeWidget', ...args)
-  }
-  /**
-   * Unregister all widgets
-   * @memberof WidgetsMixin.prototype
-   */
-  clearWidgets () {
-    this.store.commit('insights/clearWidgets')
-  }
-  /**
-   * Register a widget for a specific project
-   * @memberof WidgetsMixin.prototype
-   * @param {String} project - Name of the project to add this widget to
-   * @param {Object} options - Widget's options passed to widget constructor
-   * @param {String} options.name - Name of the widget
-   * @param {Boolean} options.card - Either or not this widget should be a `card` component from Boostrap
-   * @param {Number} options.cols - Number of columns to fill in the grid (from 1 to 12)
-   * @param {String} [options.type=WidgetEmpty] - Type of the widget
-   */
-  registerWidgetForProject (project, options) {
-    options = cloneDeep(options)
-    const name = options.name || uniqueId('core:insight-')
-    // Watch store mutations
-    return this.toggleForProject({
-      project,
-      // Widgets are bound to the insights module, not the search module
-      mutationType: 'insights/project',
-      storePath: 'insights.project',
-      // Conditional callbacks
-      withFn: () => this.registerWidget({ ...options, name }),
-      withoutFn: () => this.unregisterWidget(name)
-    })
-  }
-  /**
-   * Replace an existing widget
-   * @memberof WidgetsMixin.prototype
-   * @param {String} name - Name of the widget to replace
-   * @param {Object} options - Widget's options passed to widget constructor.
-   * @param {Boolean} options.card - Either or not this widget should be a `card` component from Boostrap
-   * @param {Number} options.cols - Number of columns to fill in the grid (from 1 to 12)
-   * @param {String} [options.type=WidgetEmpty] - Type of the widget
-   * @example
-   * datashare.replaceWidget('default-text', {
-   *  card: true,
-   *  cols: 6,
-   *  type: 'WidgetText',
-   *  content: "Welcome to my amazing project dashboard!",
-   *  title: "Secret Project",
-   *  order: "-1"
-   * })
-   */
-  replaceWidget (name, options) {
-    // Unregister existing widget
-    this.unregisterWidget(name)
-    // Register the new one and ensure the "name" of the widget
-    // is the same than the one we replace
-    this.registerWidget({ ...options, name })
-  }
-  /**
-   * Replace an existing widget for a specific project
-   * @memberof WidgetsMixin.prototype
-   * @param {String} project - Name of the project to add this widget to
-   * @param {String} name - Name of the widget to replace
-   * @param {Object} options - Widget's options passed to widget constructor. Each widget class can define its own default values.
-   * @param {Boolean} options.card - Either or not this widget should be a `card` component from Boostrap
-   * @param {Number} options.cols - Number of columns to fill in the grid (from 1 to 12)
-   * @param {String} [options.type=WidgetEmpty] - Type of the widget
-   */
-  replaceWidgetForProject (project, name, options) {
-    // Save the initial option of the existing widget
-    const initialOptions = this.store.getters['insights/getWidget']({ name })
-    // Watch store mutations
-    return this.toggleForProject({
-      project,
-      // Widgets are bound to the insights module, not the search module
-      mutationType: 'insights/project',
-      storePath: 'insights.project',
-      // Conditional callbacks
-      withFn: () => this.replaceWidget(name, options),
-      withoutFn: () => this.replaceWidget(name, initialOptions)
-    })
-  }
-}
 
 export default WidgetsMixin

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -3,7 +3,7 @@ import Core from './Core'
 import { apiInstance } from '@/api/apiInstance'
 export { default as Core } from './Core'
 
-export function createCore (LocalVue = Vue, api = apiInstance) {
+export function createCore(LocalVue = Vue, api = apiInstance) {
   const core = Core.init(LocalVue, api)
   // Configure the core with server conf.
   // No need for async since the promise is resolved in by another function reference (see ready)

--- a/src/filters/byteSize.js
+++ b/src/filters/byteSize.js
@@ -1,4 +1,4 @@
-export default function byteSize (humanSize) {
+export default function byteSize(humanSize) {
   const powers = { k: 1, m: 2, g: 3 }
   const regex = /([0-9]+)([KMG])/
 

--- a/src/filters/humanNumber.js
+++ b/src/filters/humanNumber.js
@@ -1,12 +1,12 @@
-export default function humanNumber (n, { K = '%K', M = '%M', B = '%B' } = { }) {
+export default function humanNumber(n, { K = '%K', M = '%M', B = '%B' } = {}) {
   switch (true) {
-  case n < 1e3:
-    return n
-  case n < 1e6:
-    return K.replace('%', +(n / 1e3).toFixed(1))
-  case n < 1e9:
-    return M.replace('%', +(n / 1e6).toFixed(1))
-  default:
-    return B.replace('%', +(n / 1e9).toFixed(1))
+    case n < 1e3:
+      return n
+    case n < 1e6:
+      return K.replace('%', +(n / 1e3).toFixed(1))
+    case n < 1e9:
+      return M.replace('%', +(n / 1e6).toFixed(1))
+    default:
+      return B.replace('%', +(n / 1e9).toFixed(1))
   }
 }

--- a/src/filters/humanSize.js
+++ b/src/filters/humanSize.js
@@ -1,4 +1,8 @@
-export default function humanSize (size, showBytes = false, { B = '% B', KB = '% KB', MB = '% MB', GB = '% GB', TB = '% TB' } = { }) {
+export default function humanSize(
+  size,
+  showBytes = false,
+  { B = '% B', KB = '% KB', MB = '% MB', GB = '% GB', TB = '% TB' } = {}
+) {
   if (size === -1 || size === '' || size === undefined || size === null) return 'unknown'
   const unitIndex = Math.floor(size === 0 ? 0 : Math.log(size) / Math.log(1024))
   const value = (size / Math.pow(1024, unitIndex)).toFixed(2)

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,7 @@ if (process.env.NODE_ENV !== 'test' && window) {
     // Everything is fine
     .then(() => datashare.mount())
     // Redirect to the error page
-    .catch(error => {
+    .catch((error) => {
       const vm = datashare.mount()
       // Unauthenticated error during initialization:
       // redirect the user to the login page

--- a/src/mixins/datashareSourceMixin.js
+++ b/src/mixins/datashareSourceMixin.js
@@ -1,6 +1,6 @@
 export const mixin = {
   methods: {
-    async getSource (document, config = {}) {
+    async getSource(document, config = {}) {
       try {
         return await this.$core.api.getSource(document, config)
       } catch (error) {

--- a/src/mixins/docs.js
+++ b/src/mixins/docs.js
@@ -10,7 +10,7 @@ import { join } from 'path'
 import { getOS } from '@/utils/utils'
 
 const ROUTE_DOCS_PATH = require.context('../../public/docs', true, /\.md/, 'lazy').keys()
-const ROUTE_DOCS_META = ROUTE_DOCS_PATH.map(path => {
+const ROUTE_DOCS_META = ROUTE_DOCS_PATH.map((path) => {
   // Remove the './' prefix
   path = join(path)
   // Import metadata for this Markdown file
@@ -19,25 +19,25 @@ const ROUTE_DOCS_META = ROUTE_DOCS_PATH.map(path => {
 
 export default {
   methods: {
-    findRouteDocMeta (path) {
+    findRouteDocMeta(path) {
       const resourcePath = trimStart(path, '/').split('?').shift()
       return find(ROUTE_DOCS_META, { resourcePath })
     },
-    findRouteDocMetaBySlug (slug) {
+    findRouteDocMetaBySlug(slug) {
       return find(ROUTE_DOCS_META, { slug })
     },
-    isRouteDocValid (path) {
+    isRouteDocValid(path) {
       // We use the browser's URL parser to extract config filter
       const uri = new URL(path, 'http://void/')
       // Config filters are written as search params (param=value)
       const searchParams = [...uri.searchParams.entries()]
       return every(searchParams, ([key, val]) => this.$config.get(key) === val)
     },
-    parseRouteDefinition (definition) {
+    parseRouteDefinition(definition) {
       const os = getOS()
       return template(definition)({ os })
     },
-    flattentRouteDocsDefinitions (routes = this.$router.options.routes) {
+    flattentRouteDocsDefinitions(routes = this.$router.options.routes) {
       let definitions = []
       for (const route of routes) {
         if (route.meta && route.meta.docs) {
@@ -51,22 +51,24 @@ export default {
     }
   },
   computed: {
-    allRouteDocs () {
+    allRouteDocs() {
       return this.flattentRouteDocsDefinitions()
     },
-    validRouteDocs () {
+    validRouteDocs() {
       return filter(this.allRouteDocs, this.isRouteDocValid)
     },
-    validRouteDocsMeta () {
+    validRouteDocsMeta() {
       return this.validRouteDocs.map(this.findRouteDocMeta)
     },
-    currentRouteDocs () {
-      return compact(get(this, '$route.meta.docs', []).map(definition => {
-        // Inject current OS in the URL
-        const path = this.parseRouteDefinition(definition)
-        // The route must be valid
-        return this.isRouteDocValid(path) ? this.findRouteDocMeta(path) : null
-      }))
+    currentRouteDocs() {
+      return compact(
+        get(this, '$route.meta.docs', []).map((definition) => {
+          // Inject current OS in the URL
+          const path = this.parseRouteDefinition(definition)
+          // The route must be valid
+          return this.isRouteDocValid(path) ? this.findRouteDocMeta(path) : null
+        })
+      )
     }
   }
 }

--- a/src/mixins/features.js
+++ b/src/mixins/features.js
@@ -2,18 +2,18 @@ import camelCase from 'lodash/camelCase'
 
 export default {
   methods: {
-    hasFeature (name) {
+    hasFeature(name) {
       const value = this.getConfigFeatureValue(name)
       return [0, '0', 'false', null, undefined].indexOf(value) === -1
     },
-    getConfigFeatureValue (name) {
+    getConfigFeatureValue(name) {
       return this.getConfigFeatureValueFromEnv(name) || this.getConfigFeatureValueFromConfig(name)
     },
-    getConfigFeatureValueFromEnv (name) {
+    getConfigFeatureValueFromEnv(name) {
       const key = `VUE_APP_FEATURE_${name.toUpperCase()}`
       return process.env[key] || null
     },
-    getConfigFeatureValueFromConfig (name) {
+    getConfigFeatureValueFromConfig(name) {
       const key = camelCase(`VUE_APP_FEATURE_${name.toUpperCase()}`)
       return this.$config ? this.$config.get(key, null) : null
     }

--- a/src/mixins/filters.js
+++ b/src/mixins/filters.js
@@ -4,7 +4,7 @@ import utils from '@/mixins/utils'
 export default {
   mixins: [utils],
   methods: {
-    labelToHuman (label) {
+    labelToHuman(label) {
       if (this.$te(label)) {
         return this.$t(label)
       } else if (this.$te('global.' + label)) {
@@ -15,31 +15,31 @@ export default {
         return this.translationKeyToHuman(label)
       }
     },
-    translationKeyToHuman (label = '') {
+    translationKeyToHuman(label = '') {
       return last(String(label).split('.'))
     },
-    getFilterByName (name) {
+    getFilterByName(name) {
       return this.$store.getters['search/getFilter']({ name })
     },
-    getFilterValuesByName (name) {
+    getFilterValuesByName(name) {
       return get(this, `$store.state.search.values.${name}`, [])
     },
-    setFilterValue (filter, item) {
+    setFilterValue(filter, item) {
       this.$store.commit('search/setFilterValue', filter.itemParam(item))
     },
-    removeFilterValue ({ name }) {
+    removeFilterValue({ name }) {
       this.$store.commit('search/removeFilter', name)
     },
-    refreshRouteAndSearch () {
+    refreshRouteAndSearch() {
       this.refreshRoute()
       this.refreshSearch()
     },
-    refreshRoute () {
+    refreshRoute() {
       const name = 'search'
       const query = this.$store.getters['search/toRouteQuery']()
       return this.$router.push({ name, query }).catch(() => {})
     },
-    refreshSearch () {
+    refreshSearch() {
       return this.$store.dispatch('search/query')
     }
   }

--- a/src/mixins/ner.js
+++ b/src/mixins/ner.js
@@ -2,18 +2,20 @@ import { icon as faIcon } from '@fortawesome/fontawesome-svg-core'
 
 export const mixin = {
   methods: {
-    getCategoryIcon (category = '') {
-      return {
-        person: 'id-badge',
-        organization: 'building',
-        location: 'map-marker-alt',
-        email: 'envelope'
-      }[category.toLowerCase()] || 'ban'
+    getCategoryIcon(category = '') {
+      return (
+        {
+          person: 'id-badge',
+          organization: 'building',
+          location: 'map-marker-alt',
+          email: 'envelope'
+        }[category.toLowerCase()] || 'ban'
+      )
     },
-    getCategoryClass (category = 'muted', prefix = '') {
+    getCategoryClass(category = 'muted', prefix = '') {
       return `${prefix}category-${category.toLowerCase()}`
     },
-    getCategoryIconSvg (category = '') {
+    getCategoryIconSvg(category = '') {
       const iconName = this.getCategoryIcon(category)
       const iconRendering = faIcon({ prefix: 'fas', iconName })
       return iconRendering ? iconRendering.html[0] : null

--- a/src/mixins/polling.js
+++ b/src/mixins/polling.js
@@ -5,39 +5,39 @@ import { find, findIndex, filter, isFunction } from 'lodash'
  * on a regular interval.
  */
 export default {
-  data () {
+  data() {
     return {
       registeredPolls: []
     }
   },
-  beforeDestroy () {
+  beforeDestroy() {
     this.unregisteredPools()
   },
   methods: {
-    unregisteredPools () {
+    unregisteredPools() {
       // Clear all pools
       this.registeredPolls.forEach(this.unregisteredPoll)
     },
-    unregisteredPoll ({ id }) {
+    unregisteredPoll({ id }) {
       const index = findIndex(this.registeredPolls, { id })
       // Clear the timeout
       clearTimeout(id)
       // Delete the function from the poll
       this.registeredPolls.splice(index, 1)
     },
-    registerPoll ({ fn, timeout = 2000, immediate = false } = {}) {
+    registerPoll({ fn, timeout = 2000, immediate = false } = {}) {
       // Scheddule the pool first to get its id
       const id = this.schedulePool({ fn, timeout, immediate })
       // And add it to the list to retreive it later
       this.registeredPolls.push({ fn, id })
     },
-    registerPollOnce ({ fn, ...rest } = {}) {
+    registerPollOnce({ fn, ...rest } = {}) {
       // Find all matching poll functions
       filter(this.registeredPolls, { fn }).forEach(this.unregisteredPoll)
       // Register the poll again with the new option
       return this.registerPoll({ fn, ...rest })
     },
-    schedulePool ({ fn, timeout, immediate = false }) {
+    schedulePool({ fn, timeout, immediate = false }) {
       // Return the id of the setInterval
       return setTimeout(async () => {
         const pool = find(this.registeredPolls, { fn })
@@ -49,14 +49,14 @@ export default {
           } else {
             this.unregisteredPoll(pool)
           }
-        // Reject promise triggers unregistering of the pool
+          // Reject promise triggers unregistering of the pool
         } catch (_) {
           this.unregisteredPoll(pool)
         }
-      // If immediate is true, the timeout is set to 0
+        // If immediate is true, the timeout is set to 0
       }, !immediate * this.callOrGetTimeout(timeout))
     },
-    callOrGetTimeout (timeout) {
+    callOrGetTimeout(timeout) {
       if (isFunction(timeout)) {
         return timeout()
       }

--- a/src/mixins/preview.js
+++ b/src/mixins/preview.js
@@ -3,35 +3,37 @@ import { kebabCase, startCase } from 'lodash'
 
 export default {
   computed: {
-    isPreviewActivated () {
+    isPreviewActivated() {
       return !!this.$config.get('previewHost')
     },
-    sessionIdHeaderValue () {
+    sessionIdHeaderValue() {
       return getCookie(process.env.VUE_APP_DS_COOKIE_NAME)
     },
-    sessionIdHeaderName () {
+    sessionIdHeaderName() {
       let dsCookieName = kebabCase(process.env.VUE_APP_DS_COOKIE_NAME)
       dsCookieName = dsCookieName.split('-').map(startCase).join('-')
       return `X-${dsCookieName}`
     }
   },
   methods: {
-    arrayBufferToBase64 (buffer) {
+    arrayBufferToBase64(buffer) {
       let binary = ''
       const bytes = [].slice.call(new Uint8Array(buffer))
-      bytes.forEach(b => { binary += String.fromCharCode(b) })
+      bytes.forEach((b) => {
+        binary += String.fromCharCode(b)
+      })
       // Create a base64 string from a string
       return btoa(binary)
     },
-    getPreviewMetaUrl ({ index, id, routing } = { }) {
+    getPreviewMetaUrl({ index, id, routing } = {}) {
       const host = this.$config.get('previewHost')
       return `${host}/api/v1/thumbnail/${index}/${id}.json?routing=${routing}`
     },
-    getPreviewUrl ({ index, id, routing } = { }, { page = 0, size = 'sm' } = { }) {
+    getPreviewUrl({ index, id, routing } = {}, { page = 0, size = 'sm' } = {}) {
       const host = this.$config.get('previewHost')
       return `${host}/api/v1/thumbnail/${index}/${id}?routing=${routing}&page=${page}&size=${size}`
     },
-    async fetchPreview (url) {
+    async fetchPreview(url) {
       const request = new Request(url)
       const response = await fetch(request, {
         method: 'GET',
@@ -45,7 +47,7 @@ export default {
       }
       return response
     },
-    async fetchPreviewAsBase64 (url) {
+    async fetchPreviewAsBase64(url) {
       const response = await this.fetchPreview(url)
       const buffer = await response.arrayBuffer()
       const imageStr = this.arrayBufferToBase64(buffer)

--- a/src/mixins/shortkeys.js
+++ b/src/mixins/shortkeys.js
@@ -10,20 +10,20 @@ export default {
      */
     shortkeyScope: {
       type: String,
-      default () {
+      default() {
         return this.$options.name
       }
     }
   },
   methods: {
-    getShortkey (name) {
+    getShortkey(name) {
       return shortkeys[this.shortkeyScope][name]
     },
-    getKeys (name) {
+    getKeys(name) {
       const shortkey = this.getShortkey(name)
       return shortkey === undefined ? undefined : shortkey.keys[getShortkeyOS()]
     },
-    getAction (name) {
+    getAction(name) {
       const shortkey = this.getShortkey(name)
       const functionName = shortkey.action
       if (isFunction(this[functionName])) {

--- a/src/mixins/utils.js
+++ b/src/mixins/utils.js
@@ -1,27 +1,22 @@
 const utils = {
-  data () {
+  data() {
     return {
-      termIndexColors: [
-        '#ECFC7A',
-        '#CDFD94',
-        '#A8FDAC',
-        '#52FDEA'
-      ]
+      termIndexColors: ['#ECFC7A', '#CDFD94', '#A8FDAC', '#52FDEA']
     }
   },
   computed: {
-    isServer () {
+    isServer() {
       return this.$config && this.$config.get('mode') === 'SERVER'
     }
   },
   methods: {
-    getTermIndexColor (index) {
+    getTermIndexColor(index) {
       return this.termIndexColors[index % this.termIndexColors.length]
     },
-    getTermIndexBorderColor (index) {
+    getTermIndexBorderColor(index) {
       return { 'border-color': this.getTermIndexColor(index) }
     },
-    getTermIndexBackgroundColor (index) {
+    getTermIndexBackgroundColor(index) {
       return { 'background-color': this.getTermIndexColor(index) }
     }
   }

--- a/src/pages/App.vue
+++ b/src/pages/App.vue
@@ -46,35 +46,35 @@ export default {
     VuePerfectScrollbar
   },
   computed: {
-    signinUrl () {
+    signinUrl() {
       return process.env.VUE_APP_DS_AUTH_SIGNIN
     },
-    matchedRouteNames () {
-      return compact(this.$route.matched.map(r => r.name))
+    matchedRouteNames() {
+      return compact(this.$route.matched.map((r) => r.name))
     },
-    isSearchRoute () {
+    isSearchRoute() {
       return this.matchedRouteNames.indexOf('search') > -1
     },
-    isHiddingFiltersPanel () {
+    isHiddingFiltersPanel() {
       return this.isSearchRoute && !this.$store.state.search.showFilters
     },
-    doesRouteHaveSidebar () {
+    doesRouteHaveSidebar() {
       return some(this.$route.matched, ({ components }) => {
         return !!components.sidebar
       })
     },
-    isContextSidebarReduced () {
+    isContextSidebarReduced() {
       return this.isHiddingFiltersPanel || !this.doesRouteHaveSidebar
     }
   },
-  created () {
+  created() {
     EventBus.$on('http::error', this.handleHttpError)
   },
-  beforeDestroy () {
+  beforeDestroy() {
     EventBus.$off('http::error', this.handleHttpError)
   },
   methods: {
-    handleHttpError (err) {
+    handleHttpError(err) {
       const code = get(err, 'request.response.status') || get(err, 'response.status')
       if (code === 401) {
         this.$bvToast.show('logged-out-toast')
@@ -85,48 +85,49 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .app {
-    // In CSS variables so they can be updated
-    --app-nav-height: #{$app-nav-height};
-    --app-sidebar-width: #{$app-sidebar-width};
+.app {
+  // In CSS variables so they can be updated
+  --app-nav-height: #{$app-nav-height};
+  --app-sidebar-width: #{$app-sidebar-width};
 
-    background: $app-sidebar-bg;
-    min-height: 100vh;
-    transition: filter 200ms;
-    margin-left: $app-sidebar-reduced-width;
+  background: $app-sidebar-bg;
+  min-height: 100vh;
+  transition: filter 200ms;
+  margin-left: $app-sidebar-reduced-width;
 
-    &__main {
-      background: $body-bg;
-      box-shadow: $box-shadow-lg;
-      padding-bottom: 0;
+  &__main {
+    background: $body-bg;
+    box-shadow: $box-shadow-lg;
+    padding-bottom: 0;
 
-      &--has-context-sidebar {
-        background: $app-context-sidebar-bg;
-      }
+    &--has-context-sidebar {
+      background: $app-context-sidebar-bg;
+    }
 
-      &, &--has-context-sidebar &__view {
-        mask:  0 0 no-repeat luminance url('../assets/images/corner-top.svg'),
+    &,
+    &--has-context-sidebar &__view {
+      mask: 0 0 no-repeat luminance url('../assets/images/corner-top.svg'),
         0 100% no-repeat luminance url('../assets/images/corner-bottom.svg'),
         0 0 no-repeat luminance linear-gradient(white 0%, white 100%);
-        mask-composite: exclude;
-      }
+      mask-composite: exclude;
+    }
 
-      & &__context-sidebar {
-        background: $app-context-sidebar-bg;
-        color: $app-context-sidebar-color;
-        height: 100vh;
-        left: 0;
-        max-height: 100vh;
-        max-width: $app-context-sidebar-width;
-        min-width: $app-context-sidebar-width;
-        position: sticky;
-        top: 0;
-        width: $app-context-sidebar-width;
-      }
+    & &__context-sidebar {
+      background: $app-context-sidebar-bg;
+      color: $app-context-sidebar-color;
+      height: 100vh;
+      left: 0;
+      max-height: 100vh;
+      max-width: $app-context-sidebar-width;
+      min-width: $app-context-sidebar-width;
+      position: sticky;
+      top: 0;
+      width: $app-context-sidebar-width;
+    }
 
-      & &__view {
-        background: $body-bg;
-      }
+    & &__view {
+      background: $body-bg;
     }
   }
+}
 </style>

--- a/src/pages/App.vue
+++ b/src/pages/App.vue
@@ -5,7 +5,7 @@
       <app-sidebar></app-sidebar>
     </div>
     <div class="app__main flex-grow-1 d-flex" :class="{ 'app__main--has-context-sidebar': doesRouteHaveSidebar }">
-      <vue-perfect-scrollbar class="app__main__context-sidebar p-1" v-if="!isContextSidebarReduced">
+      <vue-perfect-scrollbar v-if="!isContextSidebarReduced" class="app__main__context-sidebar p-1">
         <router-view name="sidebar"></router-view>
       </vue-perfect-scrollbar>
       <div class="app__main__view flex-grow-1">

--- a/src/pages/BatchDownload.vue
+++ b/src/pages/BatchDownload.vue
@@ -2,11 +2,11 @@
   <div class="batch-download mt-4 container">
     <v-wait for="load download tasks">
       <div slot="waiting" class="card py-2">
-        <content-placeholder class="py-2 px-3" v-for="index in 3" :key="index" />
+        <content-placeholder v-for="index in 3" :key="index" class="py-2 px-3" />
       </div>
       <tasks-list :tasks="tasks">
         <template #default="{ item: { name, properties, state } }">
-          <div class="d-flex batch-download__item" :id="'batch-download__item--' + properties.batchDownload.uuid">
+          <div :id="'batch-download__item--' + properties.batchDownload.uuid" class="d-flex batch-download__item">
             <a
               v-if="properties.batchDownload.exists"
               :href="downloadResultsUrl(name)"
@@ -18,8 +18,8 @@
             </a>
             <span
               v-else
-              class="batch-download__item__link batch-download__item__link--disabled"
               v-b-tooltip
+              class="batch-download__item__link batch-download__item__link--disabled"
               :title="$t('batchDownload.noFile')"
             >
               <fa icon="times" fixed-width />
@@ -57,21 +57,16 @@ export default {
     BatchDownloadActions,
     TasksList
   },
-  mixins: [features, polling],
-  data() {
-    return {
-      tasks: []
-    }
-  },
   filters: {
     basename(str) {
       return str.split('/').pop()
     }
   },
-  async mounted() {
-    this.$wait.start('load download tasks')
-    await this.startPollingDownloadTasks()
-    this.$wait.end('load download tasks')
+  mixins: [features, polling],
+  data() {
+    return {
+      tasks: []
+    }
   },
   computed: {
     hasPendingBatchDownloadTasks() {
@@ -84,6 +79,11 @@ export default {
         maxSize: this.$core.config.get('batchDownloadMaxSize')
       }
     }
+  },
+  async mounted() {
+    this.$wait.start('load download tasks')
+    await this.startPollingDownloadTasks()
+    this.$wait.end('load download tasks')
   },
   methods: {
     startPollingDownloadTasks() {

--- a/src/pages/BatchDownload.vue
+++ b/src/pages/BatchDownload.vue
@@ -5,13 +5,23 @@
         <content-placeholder class="py-2 px-3" v-for="index in 3" :key="index" />
       </div>
       <tasks-list :tasks="tasks">
-        <template v-slot="{ item: { name, properties, state } }">
+        <template #default="{ item: { name, properties, state } }">
           <div class="d-flex batch-download__item" :id="'batch-download__item--' + properties.batchDownload.uuid">
-            <a v-if="properties.batchDownload.exists" :href="downloadResultsUrl(name)" class="batch-download__item__link" target="_blank">
+            <a
+              v-if="properties.batchDownload.exists"
+              :href="downloadResultsUrl(name)"
+              class="batch-download__item__link"
+              target="_blank"
+            >
               <fa icon="download" fixed-width />
               {{ properties.batchDownload.filename | basename }}
             </a>
-            <span v-else class="batch-download__item__link batch-download__item__link--disabled" v-b-tooltip :title="$t('batchDownload.noFile')">
+            <span
+              v-else
+              class="batch-download__item__link batch-download__item__link--disabled"
+              v-b-tooltip
+              :title="$t('batchDownload.noFile')"
+            >
               <fa icon="times" fixed-width />
               {{ properties.batchDownload.filename | basename }}
             </span>
@@ -21,7 +31,8 @@
               :state="state"
               :value="properties.batchDownload"
               @relaunched="startPollingDownloadTasks"
-              @deleted="getDownloadTasks" />
+              @deleted="getDownloadTasks"
+            />
           </div>
         </template>
         <template #empty>
@@ -47,27 +58,27 @@ export default {
     TasksList
   },
   mixins: [features, polling],
-  data () {
+  data() {
     return {
       tasks: []
     }
   },
   filters: {
-    basename (str) {
+    basename(str) {
       return str.split('/').pop()
     }
   },
-  async mounted () {
+  async mounted() {
     this.$wait.start('load download tasks')
     await this.startPollingDownloadTasks()
     this.$wait.end('load download tasks')
   },
   computed: {
-    hasPendingBatchDownloadTasks () {
+    hasPendingBatchDownloadTasks() {
       const pendingStates = ['RUNNING', 'QUEUED']
       return some(this.tasks, ({ state }) => pendingStates.includes(state))
     },
-    batchDownloadLimitations () {
+    batchDownloadLimitations() {
       return {
         maxNbFiles: this.$core.config.get('batchDownloadMaxNbFiles'),
         maxSize: this.$core.config.get('batchDownloadMaxSize')
@@ -75,7 +86,7 @@ export default {
     }
   },
   methods: {
-    startPollingDownloadTasks () {
+    startPollingDownloadTasks() {
       const fn = this.getDownloadTasks
       const timeout = () => random(1000, 4000)
       // Register the `getDownloadTasks` for later
@@ -83,22 +94,25 @@ export default {
       // Execute the `getDownloadTasks` method immediatly
       return fn()
     },
-    async getDownloadTasks () {
+    async getDownloadTasks() {
       this.tasks = this.sortByDateTime(await this.$core.api.getTasks('BatchDownloadRunner'))
       // Return true if it has pending download tasks to tell the
       // polling function to continue to poll tasks.
       return this.hasPendingBatchDownloadTasks
     },
-    sortByDateTime (tasks) {
+    sortByDateTime(tasks) {
       const dateRegExp = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d/
       return tasks.sort(function (a, b) {
-        return new Date(b.properties.batchDownload.filename.match(dateRegExp)[0]) - new Date(a.properties.batchDownload.filename.match(dateRegExp)[0])
+        return (
+          new Date(b.properties.batchDownload.filename.match(dateRegExp)[0]) -
+          new Date(a.properties.batchDownload.filename.match(dateRegExp)[0])
+        )
       })
     },
-    downloadResultsUrl (name) {
+    downloadResultsUrl(name) {
       return `/api/task/${name}/result`
     },
-    cleanName (name) {
+    cleanName(name) {
       return name.split('.').pop().split('@').shift()
     }
   }

--- a/src/pages/BatchSearch.vue
+++ b/src/pages/BatchSearch.vue
@@ -28,12 +28,12 @@ import { mapState } from 'vuex'
 
 export default {
   name: 'BatchSearches',
-  mixins: [polling, utils],
   components: {
     BatchSearchFilterQuery,
     BatchSearchClearFilters,
     BatchSearchTable
   },
+  mixins: [polling, utils],
   async mounted() {
     if (!this.hasBatchSearch) {
       await this.getBatchSearch()

--- a/src/pages/BatchSearch.vue
+++ b/src/pages/BatchSearch.vue
@@ -34,6 +34,15 @@ export default {
     BatchSearchTable
   },
   mixins: [polling, utils],
+  computed: {
+    ...mapState('batchSearch', ['hasBatchSearch']),
+    howToLink() {
+      return '#/docs/all-batch-search-documents'
+    },
+    noBatchSearch() {
+      return this.$t('batchSearch.empty', { howToLink: this.howToLink })
+    }
+  },
   async mounted() {
     if (!this.hasBatchSearch) {
       await this.getBatchSearch()
@@ -44,15 +53,6 @@ export default {
       this.$wait.start('load haveBatchSearch')
       await this.$store.dispatch('batchSearch/hasBatchSearch')
       this.$wait.end('load haveBatchSearch')
-    }
-  },
-  computed: {
-    ...mapState('batchSearch', ['hasBatchSearch']),
-    howToLink() {
-      return '#/docs/all-batch-search-documents'
-    },
-    noBatchSearch() {
-      return this.$t('batchSearch.empty', { howToLink: this.howToLink })
     }
   }
 }

--- a/src/pages/BatchSearch.vue
+++ b/src/pages/BatchSearch.vue
@@ -4,14 +4,14 @@
       <fa slot="waiting" class="d-flex mx-auto mt-5" icon="circle-notch" size="2x" spin />
       <template v-if="hasBatchSearch">
         <div class="d-flex flex-wrap align-items-center">
-          <batch-search-filter-query class="batch-search__search-bar my-1"/>
-          <batch-search-clear-filters class="batch-search__clear-filter-btn m-1"/>
+          <batch-search-filter-query class="batch-search__search-bar my-1" />
+          <batch-search-clear-filters class="batch-search__clear-filter-btn m-1" />
         </div>
-        <batch-search-table/>
+        <batch-search-table />
       </template>
       <template v-else>
-        <div class="batch-search__none  text-center">
-          <div class="batch-search__none__message b-table-empty-row" v-html="noBatchSearch"/>
+        <div class="batch-search__none text-center">
+          <div class="batch-search__none__message b-table-empty-row" v-html="noBatchSearch" />
         </div>
       </template>
     </v-wait>
@@ -34,13 +34,13 @@ export default {
     BatchSearchClearFilters,
     BatchSearchTable
   },
-  async mounted () {
+  async mounted() {
     if (!this.hasBatchSearch) {
       await this.getBatchSearch()
     }
   },
   methods: {
-    async getBatchSearch () {
+    async getBatchSearch() {
       this.$wait.start('load haveBatchSearch')
       await this.$store.dispatch('batchSearch/hasBatchSearch')
       this.$wait.end('load haveBatchSearch')
@@ -48,10 +48,10 @@ export default {
   },
   computed: {
     ...mapState('batchSearch', ['hasBatchSearch']),
-    howToLink () {
+    howToLink() {
       return '#/docs/all-batch-search-documents'
     },
-    noBatchSearch () {
+    noBatchSearch() {
       return this.$t('batchSearch.empty', { howToLink: this.howToLink })
     }
   }
@@ -60,7 +60,7 @@ export default {
 <style lang="scss" scoped>
 .batch-search__none__message {
   padding: 0.75em;
-  border:1px solid #dee2e6;
+  border: 1px solid #dee2e6;
   background-color: white;
 }
 </style>

--- a/src/pages/BatchSearchResults.vue
+++ b/src/pages/BatchSearchResults.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="batch-search-results" v-if="isLoaded">
+  <div v-if="isLoaded" class="batch-search-results">
     <div class="my-4 container">
       <div class="mx-1 mb-2">
         <router-link :to="generateTo">
@@ -32,7 +32,7 @@
                 {{ $t('batchSearch.published') }}
               </dt>
               <dd>
-                <b-form-checkbox @change="changePublished" switch v-model="batchSearch.published" />
+                <b-form-checkbox v-model="batchSearch.published" switch @change="changePublished" />
               </dd>
             </div>
             <div>
@@ -125,7 +125,7 @@
     <div class="container">
       <v-wait for="load batchSearch results">
         <div slot="waiting" class="card py-2">
-          <content-placeholder class="py-2 px-3" v-for="index in 3" :key="index" />
+          <content-placeholder v-for="index in 3" :key="index" class="py-2 px-3" />
         </div>
         <div class="batch-search-results__queries">
           <div class="card">
@@ -141,9 +141,9 @@
               show-empty
               striped
               :sort-by="sortBy"
-              @sort-changed="sortChanged"
               :sort-desc="orderBy"
               tbody-tr-class="batch-search-results__queries__query"
+              @sort-changed="sortChanged"
             >
               <template #cell(documentNumber)="{ item }">
                 {{ item.documentNumber + 1 }}
@@ -151,17 +151,17 @@
               <template #cell(documentPath)="{ item, index }">
                 <router-link
                   class="batch-search-results__queries__query__link"
-                  @click.native.prevent="openDocumentModal(index)"
                   target="_blank"
                   :to="{
                     name: 'document-standalone',
                     params: { index: item.project.name, id: item.documentId, routing: item.rootId },
                     query: { q: item.query }
                   }"
+                  @click.native.prevent="openDocumentModal(index)"
                 >
                   <active-text-truncate
-                    class="batch-search-results__queries__query__link__path"
                     v-b-tooltip.hover
+                    class="batch-search-results__queries__query__link__path"
                     :title="item.documentPath"
                   >
                     {{ item.documentPath }}
@@ -192,8 +192,8 @@
           </div>
         </div>
         <custom-pagination
-          class="batch-search-results__pagination my-4"
           v-model="currentPage"
+          class="batch-search-results__pagination my-4"
           :per-page="perPage"
           :total-rows="totalItems"
         />
@@ -201,9 +201,9 @@
     </div>
     <b-modal id="document-modal" size="xl" lazy hide-header hide-footer body-class="p-0">
       <div v-if="documentInModal" :key="documentInModalIndex">
-        <document-navbar :index="documentInModal.index" :id="documentInModal.id" :routing="documentInModal.routing">
+        <document-navbar :id="documentInModal.id" :index="documentInModal.index" :routing="documentInModal.routing">
           <template #back>
-            <a @click="$bvModal.hide('document-modal')" role="button" class="small text-white">
+            <a role="button" class="small text-white" @click="$bvModal.hide('document-modal')">
               <fa icon="chevron-circle-left"></fa>
               <span class="ml-2">
                 {{ $t('Back to results') }}
@@ -264,6 +264,10 @@ export default {
     UserDisplay,
     QuickItemNav
   },
+  filters: {
+    humanSize,
+    humanNumber
+  },
   mixins: [utils],
   props: {
     /**
@@ -278,10 +282,6 @@ export default {
     indices: {
       type: [String, Array]
     }
-  },
-  filters: {
-    humanSize,
-    humanNumber
   },
   data() {
     return {

--- a/src/pages/BatchSearchResults.vue
+++ b/src/pages/BatchSearchResults.vue
@@ -24,7 +24,7 @@
                 {{ $t('batchSearch.projects') }}
               </dt>
               <dd>
-                {{ batchSearch.projects.map(project => project.name).join(', ') }}
+                {{ batchSearch.projects.map((project) => project.name).join(', ') }}
               </dd>
             </div>
             <div v-if="isServer && isMyBatchSearch">
@@ -143,36 +143,47 @@
               :sort-by="sortBy"
               @sort-changed="sortChanged"
               :sort-desc="orderBy"
-              tbody-tr-class="batch-search-results__queries__query">
-              <template v-slot:cell(documentNumber)="{ item }">
+              tbody-tr-class="batch-search-results__queries__query"
+            >
+              <template #cell(documentNumber)="{ item }">
                 {{ item.documentNumber + 1 }}
               </template>
-              <template v-slot:cell(documentPath)="{ item, index }">
-                <router-link class="batch-search-results__queries__query__link"
-                             @click.native.prevent="openDocumentModal(index)"
-                             target="_blank"
-                             :to="{
-                               name: 'document-standalone',
-                               params: { index: item.project.name, id: item.documentId, routing: item.rootId },
-                               query: { q: item.query } }">
-                  <active-text-truncate class="batch-search-results__queries__query__link__path"
-                                        v-b-tooltip.hover :title="item.documentPath">
+              <template #cell(documentPath)="{ item, index }">
+                <router-link
+                  class="batch-search-results__queries__query__link"
+                  @click.native.prevent="openDocumentModal(index)"
+                  target="_blank"
+                  :to="{
+                    name: 'document-standalone',
+                    params: { index: item.project.name, id: item.documentId, routing: item.rootId },
+                    query: { q: item.query }
+                  }"
+                >
+                  <active-text-truncate
+                    class="batch-search-results__queries__query__link__path"
+                    v-b-tooltip.hover
+                    :title="item.documentPath"
+                  >
                     {{ item.documentPath }}
                   </active-text-truncate>
                 </router-link>
               </template>
-              <template v-slot:cell(creationDate)="{ item }">
+              <template #cell(creationDate)="{ item }">
                 <span :title="moment(item.creationDate).locale($i18n.locale).format('LLL')">
-                  {{ moment(item.creationDate).isValid() ? moment(item.creationDate).locale($i18n.locale).format('LL') : '' }}
+                  {{
+                    moment(item.creationDate).isValid()
+                      ? moment(item.creationDate).locale($i18n.locale).format('LL')
+                      : ''
+                  }}
                 </span>
               </template>
-              <template v-slot:cell(contentType)="{ item }">
+              <template #cell(contentType)="{ item }">
                 <content-type-badge :value="item.contentType" :document-name="item.documentPath"></content-type-badge>
               </template>
-              <template v-slot:cell(contentLength)="{ item }">
+              <template #cell(contentLength)="{ item }">
                 {{ getDocumentSize(item.contentLength, '-') }}
               </template>
-              <template v-slot:cell(empty)>
+              <template #cell(empty)>
                 <div class="text-center">
                   {{ $t('batchSearchResults.empty') }}
                 </div>
@@ -180,11 +191,16 @@
             </b-table>
           </div>
         </div>
-        <custom-pagination class="batch-search-results__pagination my-4" v-model="currentPage" :per-page="perPage" :total-rows="totalItems" />
+        <custom-pagination
+          class="batch-search-results__pagination my-4"
+          v-model="currentPage"
+          :per-page="perPage"
+          :total-rows="totalItems"
+        />
       </v-wait>
     </div>
     <b-modal id="document-modal" size="xl" lazy hide-header hide-footer body-class="p-0">
-      <div  v-if="documentInModal" :key="documentInModalIndex">
+      <div v-if="documentInModal" :key="documentInModalIndex">
         <document-navbar :index="documentInModal.index" :id="documentInModal.id" :routing="documentInModal.routing">
           <template #back>
             <a @click="$bvModal.hide('document-modal')" role="button" class="small text-white">
@@ -199,15 +215,18 @@
               v-model="documentInModalIndex"
               :total-items="totalItems"
               @previous="handlePrevNextRoute"
-              @next="handlePrevNextRoute">
+              @next="handlePrevNextRoute"
+            >
             </quick-item-nav>
           </template>
         </document-navbar>
         <v-wait for="load batchSearch results">
-          <document-view :id="documentInModal.id"
-                         :index="documentInModal.index"
-                         :q="documentInModal.q"
-                         :routing="documentInModal.routing" />
+          <document-view
+            :id="documentInModal.id"
+            :index="documentInModal.index"
+            :q="documentInModal.q"
+            :routing="documentInModal.routing"
+          />
         </v-wait>
       </div>
     </b-modal>
@@ -264,7 +283,7 @@ export default {
     humanSize,
     humanNumber
   },
-  data () {
+  data() {
     return {
       documentInModalPageIndex: null,
       isMyBatchSearch: false,
@@ -276,51 +295,51 @@ export default {
     }
   },
   watch: {
-    page () {
+    page() {
       this.fetch()
     },
-    queries (queries, oldQueries = []) {
+    queries(queries, oldQueries = []) {
       // Check array values to avoid unnecessary fetching
       if (!isEqual(queries, oldQueries)) {
         this.fetch()
       }
     },
-    sort () {
+    sort() {
       this.fetch()
     },
-    order () {
+    order() {
       this.fetch()
     }
   },
-  async created () {
+  async created() {
     await this.fetch()
     await this.setIsMyBatchSearch()
   },
   computed: {
     ...mapState('batchSearch', ['batchSearch', 'results']),
-    isLoaded () {
+    isLoaded() {
       return !!Object.keys(this.batchSearch).length
     },
     currentPage: {
-      get () {
+      get() {
         return this.page
       },
-      set (pageNumber) {
+      set(pageNumber) {
         this.page = pageNumber
         this.$router.push(this.generateLinkToBatchSearchResults(pageNumber, this.selectedQueries))
       }
     },
-    projectField () {
+    projectField() {
       return this.hasMultipleProjects
         ? {
-          key: 'project.name',
-          label: this.$t('batchSearchResults.project'),
-          sortable: true,
-          name: 'prj_id'
-        }
+            key: 'project.name',
+            label: this.$t('batchSearchResults.project'),
+            sortable: true,
+            name: 'prj_id'
+          }
         : null
     },
-    fields () {
+    fields() {
       return compact([
         {
           key: 'documentNumber',
@@ -361,10 +380,10 @@ export default {
         }
       ])
     },
-    selectedQueries () {
+    selectedQueries() {
       return get(this, '$store.state.batchSearch.selectedQueries', [])
     },
-    generateTo () {
+    generateTo() {
       const baseTo = { name: 'batch-search' }
       const searchQueryExists = this.$route.query.query
       return {
@@ -372,27 +391,27 @@ export default {
         ...(searchQueryExists && { query: { query: this.$route.query.query } })
       }
     },
-    fuzzinessLabel () {
+    fuzzinessLabel() {
       if (this.batchSearch.phraseMatches) {
         return this.$t('batchSearch.proximitySearches')
       }
       return this.$t('batchSearch.fuzziness')
     },
-    perPage () {
+    perPage() {
       return settings.batchSearchResults.size
     },
-    sortBy () {
-      return find(this.fields, item => item.name === this.sort).key
+    sortBy() {
+      return find(this.fields, (item) => item.name === this.sort).key
     },
-    orderBy () {
+    orderBy() {
       return this.order === 'desc'
     },
-    totalItems () {
+    totalItems() {
       if (this.selectedQueries.length === 0) {
         return this.batchSearch.nbResults
       } else {
         const queryKeys = Object.keys(this.batchSearch.queries)
-        return sumBy(queryKeys, query => {
+        return sumBy(queryKeys, (query) => {
           const findQuery = find(this.selectedQueries, ['label', query])
           if (findQuery) {
             return this.batchSearch.queries[query]
@@ -400,14 +419,14 @@ export default {
         })
       }
     },
-    numberOfPages () {
+    numberOfPages() {
       return Math.ceil(this.totalItems / this.perPage)
     },
-    hasDocumentInModal () {
+    hasDocumentInModal() {
       const pageIndex = this.documentInModalPageIndex
       return pageIndex !== null && this.results[pageIndex]
     },
-    documentInModal () {
+    documentInModal() {
       if (!this.hasDocumentInModal) {
         return null
       }
@@ -417,10 +436,10 @@ export default {
       return { index, id, routing, q }
     },
     documentInModalIndex: {
-      get () {
+      get() {
         return this.pageOffset + this.documentInModalPageIndex
       },
-      async set (index) {
+      async set(index) {
         if (index >= this.pageOffset + this.perPage) {
           this.page++
         } else if (index < this.pageOffset) {
@@ -429,54 +448,58 @@ export default {
         this.documentInModalPageIndex = index - this.pageOffset
       }
     },
-    pageOffset () {
+    pageOffset() {
       return (this.page - 1) * this.perPage
     },
-    isFirstDocument () {
+    isFirstDocument() {
       return this.documentInModalPageIndex === 0
     },
-    isLastDocument () {
+    isLastDocument() {
       const totalResultsIndices = this.results.length - 1
       return this.documentInModalPageIndex === totalResultsIndices
     },
-    hasMultipleProjects () {
+    hasMultipleProjects() {
       return this.batchSearch.projects.length > 1
     }
   },
-  beforeRouteEnter (to, from, next) {
-    next(vm => {
+  beforeRouteEnter(to, from, next) {
+    next((vm) => {
       vm.$set(vm, 'published', vm.batchSearch.published)
       vm.$set(vm, 'page', parseInt(get(to, 'query.page', vm.page)))
       vm.$set(vm, 'queries', castArray(get(to, 'query.queries', vm.queries)))
       vm.$set(vm, 'sort', get(to, 'query.sort', vm.sort))
       vm.$set(vm, 'order', get(to, 'query.order', vm.order))
       const queries = castArray(get(to, 'query.queries', vm.queries))
-      const selectedQueries = queries.map(query => { return { label: query } })
+      const selectedQueries = queries.map((query) => {
+        return { label: query }
+      })
       vm.$store.commit('batchSearch/selectedQueries', selectedQueries)
     })
   },
-  beforeRouteUpdate (to, from, next) {
+  beforeRouteUpdate(to, from, next) {
     this.$set(this, 'page', parseInt(get(to, 'query.page', this.page)))
     this.$set(this, 'queries', castArray(get(to, 'query.queries', this.queries)))
     this.$set(this, 'sort', get(to, 'query.sort', this.sort))
     this.$set(this, 'order', get(to, 'query.order', this.order))
     const queries = castArray(get(to, 'query.queries', this.queries))
-    const selectedQueries = queries.map(query => { return { label: query } })
+    const selectedQueries = queries.map((query) => {
+      return { label: query }
+    })
     this.$store.commit('batchSearch/selectedQueries', selectedQueries)
     next()
   },
-  beforeRouteLeave (to, from, next) {
+  beforeRouteLeave(to, from, next) {
     this.$store.commit('batchSearch/batchSearch', {})
     this.$store.commit('batchSearch/selectedQueries', [])
     next()
   },
   methods: {
-    handlePrevNextRoute () {
+    handlePrevNextRoute() {
       if (this.isFirstDocument || this.isLastDocument) {
         this.$router.push(this.generateLinkToBatchSearchResults(this.currentPage, this.selectedQueries))
       }
     },
-    async fetch () {
+    async fetch() {
       this.$wait.start('load batchSearch results')
       this.$Progress.start()
       await this.$store.dispatch('batchSearch/getBatchSearch', this.uuid)
@@ -486,22 +509,22 @@ export default {
       this.$Progress.finish()
       this.$wait.end('load batchSearch results')
     },
-    async setIsMyBatchSearch () {
+    async setIsMyBatchSearch() {
       const username = await this.$core.auth.getUsername()
       this.isMyBatchSearch = username === get(this, 'batchSearch.user.id')
     },
-    async sortChanged (ctx) {
-      const sort = find(this.fields, item => item.key === ctx.sortBy).name
+    async sortChanged(ctx) {
+      const sort = find(this.fields, (item) => item.key === ctx.sortBy).name
       const order = ctx.sortDesc ? 'desc' : 'asc'
       this.$router.push(this.generateLinkToBatchSearchResults(this.page, this.selectedQueries, sort, order))
     },
-    filter () {
+    filter() {
       this.$router.push(this.generateLinkToBatchSearchResults(1, this.selectedQueries))
     },
-    linkGen (page) {
+    linkGen(page) {
       return this.generateLinkToBatchSearchResults(page, this.selectedQueries)
     },
-    generateLinkToBatchSearchResults (page = this.page, queries = this.queries, sort = this.sort, order = this.order) {
+    generateLinkToBatchSearchResults(page = this.page, queries = this.queries, sort = this.sort, order = this.order) {
       return {
         name: 'batch-search.results',
         params: {
@@ -510,21 +533,21 @@ export default {
         },
         query: {
           page,
-          queries: queries.map(query => query.label),
+          queries: queries.map((query) => query.label),
           sort,
           order,
           queries_sort: this.$route.query.queries_sort || undefined
         }
       }
     },
-    getDocumentSize (value) {
+    getDocumentSize(value) {
       const size = humanSize(value)
       return size === 'unknown' ? '-' : size
     },
-    changePublished (published) {
+    changePublished(published) {
       this.$store.dispatch('batchSearch/updateBatchSearch', { batchId: this.uuid, published })
     },
-    openDocumentModal (pageIndex) {
+    openDocumentModal(pageIndex) {
       this.$set(this, 'documentInModalPageIndex', pageIndex)
       this.$bvModal.show('document-modal')
     },
@@ -535,17 +558,16 @@ export default {
 
 <style lang="scss" scoped>
 .batch-search-results {
-
   &__info {
     display: grid;
     overflow: hidden;
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     grid-gap: 0px;
-    margin:0 -1px -1px;
+    margin: 0 -1px -1px;
     border-left: 1px solid $border-color;
 
     & > div {
-      padding: $spacer $spacer  $spacer;
+      padding: $spacer $spacer $spacer;
       border: 1px solid $border-color;
       border-left: 0;
       border-top: 0;
@@ -561,11 +583,9 @@ export default {
         font-weight: bolder;
       }
     }
-
   }
 
   &__queries {
-
     &:deep(.table-responsive) {
       margin: 0;
     }

--- a/src/pages/BatchSearchResults.vue
+++ b/src/pages/BatchSearchResults.vue
@@ -269,6 +269,37 @@ export default {
     humanNumber
   },
   mixins: [utils],
+  beforeRouteEnter(to, from, next) {
+    next((vm) => {
+      vm.$set(vm, 'published', vm.batchSearch.published)
+      vm.$set(vm, 'page', parseInt(get(to, 'query.page', vm.page)))
+      vm.$set(vm, 'queries', castArray(get(to, 'query.queries', vm.queries)))
+      vm.$set(vm, 'sort', get(to, 'query.sort', vm.sort))
+      vm.$set(vm, 'order', get(to, 'query.order', vm.order))
+      const queries = castArray(get(to, 'query.queries', vm.queries))
+      const selectedQueries = queries.map((query) => {
+        return { label: query }
+      })
+      vm.$store.commit('batchSearch/selectedQueries', selectedQueries)
+    })
+  },
+  beforeRouteUpdate(to, from, next) {
+    this.$set(this, 'page', parseInt(get(to, 'query.page', this.page)))
+    this.$set(this, 'queries', castArray(get(to, 'query.queries', this.queries)))
+    this.$set(this, 'sort', get(to, 'query.sort', this.sort))
+    this.$set(this, 'order', get(to, 'query.order', this.order))
+    const queries = castArray(get(to, 'query.queries', this.queries))
+    const selectedQueries = queries.map((query) => {
+      return { label: query }
+    })
+    this.$store.commit('batchSearch/selectedQueries', selectedQueries)
+    next()
+  },
+  beforeRouteLeave(to, from, next) {
+    this.$store.commit('batchSearch/batchSearch', {})
+    this.$store.commit('batchSearch/selectedQueries', [])
+    next()
+  },
   props: {
     /**
      * The unique id of the batch search
@@ -293,27 +324,6 @@ export default {
       queries: [],
       sort: settings.batchSearchResults.sort
     }
-  },
-  watch: {
-    page() {
-      this.fetch()
-    },
-    queries(queries, oldQueries = []) {
-      // Check array values to avoid unnecessary fetching
-      if (!isEqual(queries, oldQueries)) {
-        this.fetch()
-      }
-    },
-    sort() {
-      this.fetch()
-    },
-    order() {
-      this.fetch()
-    }
-  },
-  async created() {
-    await this.fetch()
-    await this.setIsMyBatchSearch()
   },
   computed: {
     ...mapState('batchSearch', ['batchSearch', 'results']),
@@ -462,36 +472,26 @@ export default {
       return this.batchSearch.projects.length > 1
     }
   },
-  beforeRouteEnter(to, from, next) {
-    next((vm) => {
-      vm.$set(vm, 'published', vm.batchSearch.published)
-      vm.$set(vm, 'page', parseInt(get(to, 'query.page', vm.page)))
-      vm.$set(vm, 'queries', castArray(get(to, 'query.queries', vm.queries)))
-      vm.$set(vm, 'sort', get(to, 'query.sort', vm.sort))
-      vm.$set(vm, 'order', get(to, 'query.order', vm.order))
-      const queries = castArray(get(to, 'query.queries', vm.queries))
-      const selectedQueries = queries.map((query) => {
-        return { label: query }
-      })
-      vm.$store.commit('batchSearch/selectedQueries', selectedQueries)
-    })
+  watch: {
+    page() {
+      this.fetch()
+    },
+    queries(queries, oldQueries = []) {
+      // Check array values to avoid unnecessary fetching
+      if (!isEqual(queries, oldQueries)) {
+        this.fetch()
+      }
+    },
+    sort() {
+      this.fetch()
+    },
+    order() {
+      this.fetch()
+    }
   },
-  beforeRouteUpdate(to, from, next) {
-    this.$set(this, 'page', parseInt(get(to, 'query.page', this.page)))
-    this.$set(this, 'queries', castArray(get(to, 'query.queries', this.queries)))
-    this.$set(this, 'sort', get(to, 'query.sort', this.sort))
-    this.$set(this, 'order', get(to, 'query.order', this.order))
-    const queries = castArray(get(to, 'query.queries', this.queries))
-    const selectedQueries = queries.map((query) => {
-      return { label: query }
-    })
-    this.$store.commit('batchSearch/selectedQueries', selectedQueries)
-    next()
-  },
-  beforeRouteLeave(to, from, next) {
-    this.$store.commit('batchSearch/batchSearch', {})
-    this.$store.commit('batchSearch/selectedQueries', [])
-    next()
+  async created() {
+    await this.fetch()
+    await this.setIsMyBatchSearch()
   },
   methods: {
     handlePrevNextRoute() {

--- a/src/pages/DocumentStandalone.vue
+++ b/src/pages/DocumentStandalone.vue
@@ -37,20 +37,20 @@ export default {
 </script>
 
 <style lang="scss">
-  .document-standalone {
-    max-width: 1140px;
-    margin: 5vh auto;
-    border: $border-color 1px solid;
-    border-radius: $border-radius-lg;
-    box-shadow: $box-shadow-sm;
+.document-standalone {
+  max-width: 1140px;
+  margin: 5vh auto;
+  border: $border-color 1px solid;
+  border-radius: $border-radius-lg;
+  box-shadow: $box-shadow-sm;
 
-    @media (max-width: #{1140px + $app-sidebar-reduced-width}) {
-      margin: 0 auto;
-      border: 0;
-    }
-
-    .document-navbar {
-      border-radius: $border-radius-lg $border-radius-lg 0 0;
-    }
+  @media (max-width: #{1140px + $app-sidebar-reduced-width}) {
+    margin: 0 auto;
+    border: 0;
   }
+
+  .document-navbar {
+    border-radius: $border-radius-lg $border-radius-lg 0 0;
+  }
+}
 </style>

--- a/src/pages/DocumentView.vue
+++ b/src/pages/DocumentView.vue
@@ -6,7 +6,8 @@
       :class="{ 'document--standalone': isStandalone, 'document--modal': isModal }"
       v-if="doc"
       v-shortkey="getKeys('tabNavigation')"
-      @shortkey="getAction('tabNavigation')">
+      @shortkey="getAction('tabNavigation')"
+    >
       <div class="document__header">
         <hook name="document.header:before"></hook>
         <h3 class="document__header__name" :class="{ 'document__header__name--has-subject': doc.hasSubject }">
@@ -20,18 +21,23 @@
         <hook name="document.header.tags:before"></hook>
         <document-tags-form
           class="px-3 mx-0"
-          :displayForm="false"
-          :displayTags="true"
+          :display-form="false"
+          :display-tags="true"
           :document="doc"
           mode="dark"
-          :tags="tags"></document-tags-form>
+          :tags="tags"
+        ></document-tags-form>
         <hook name="document.header.tags:after"></hook>
         <hook name="document.header.nav:before"></hook>
         <nav class="document__header__nav text-nowrap overflow-auto">
           <ul class="list-inline m-0">
             <hook name="document.header.nav.items:before" tag="li"></hook>
             <template v-for="tab in visibleTabs">
-              <hook :name="`document.header.nav.items.${tab.name}:before`" :key="`hook.${tab.name}:before`" tag="li"></hook>
+              <hook
+                :name="`document.header.nav.items.${tab.name}:before`"
+                :key="`hook.${tab.name}:before`"
+                tag="li"
+              ></hook>
               <li class="document__header__nav__item list-inline-item" :key="tab.name" :title="$t(tab.label)">
                 <a @click="$root.$emit('document::tab', tab.name)" :class="{ active: isTabActive(tab.name) }">
                   <hook :name="`document.header.nav.${tab.name}:before`"></hook>
@@ -41,7 +47,11 @@
                   <hook :name="`document.header.nav.${tab.name}:after`"></hook>
                 </a>
               </li>
-              <hook :name="`document.header.nav.items.${tab.name}:after`" :key="`hook.${tab.name}:after`" tag="li"></hook>
+              <hook
+                :name="`document.header.nav.items.${tab.name}:after`"
+                :key="`hook.${tab.name}:after`"
+                tag="li"
+              ></hook>
             </template>
             <hook name="document.header.nav.items:after" tag="li"></hook>
           </ul>
@@ -56,7 +66,8 @@
           :key="tab.name"
           :is="getComponentIfActive(tab)"
           v-for="tab in visibleTabs"
-          v-bind="getPropsIfActive(tab)">
+          v-bind="getPropsIfActive(tab)"
+        >
         </component>
       </div>
     </div>
@@ -102,18 +113,18 @@ export default {
       default: ''
     }
   },
-  data () {
+  data() {
     return {
       activeTab: 'extracted-text',
       tabsThoughtPipeline: []
     }
   },
   watch: {
-    doc () {
+    doc() {
       return this.setTabs()
     }
   },
-  async mounted () {
+  async mounted() {
     if (!this.$wait.is('load document data')) {
       await this.getDoc()
     }
@@ -124,69 +135,69 @@ export default {
   },
   computed: {
     ...mapState('document', ['doc', 'parentDocument', 'tags']),
-    visibleTabs () {
-      return filter(this.tabsThoughtPipeline, t => !t.hidden)
+    visibleTabs() {
+      return filter(this.tabsThoughtPipeline, (t) => !t.hidden)
     },
-    tabsPipeline () {
+    tabsPipeline() {
       return this.$store.getters['pipelines/applyPipelineChainByCategory']('document-view-tabs')
     },
-    tabs () {
+    tabs() {
       return !this.doc
         ? []
         : [
-          {
-            name: 'extracted-text',
-            label: 'document.extractedText',
-            component: () => import('@/components/document/DocumentTabExtractedText'),
-            icon: 'align-left',
-            props: {
-              document: this.doc,
-              q: this.q
+            {
+              name: 'extracted-text',
+              label: 'document.extractedText',
+              component: () => import('@/components/document/DocumentTabExtractedText'),
+              icon: 'align-left',
+              props: {
+                document: this.doc,
+                q: this.q
+              }
+            },
+            {
+              name: 'preview',
+              label: 'document.preview',
+              component: () => import('@/components/document/DocumentTabPreview'),
+              icon: 'eye',
+              props: {
+                document: this.doc
+              }
+            },
+            {
+              name: 'details',
+              label: 'document.tabDetails',
+              component: () => import('@/components/document/DocumentTabDetails'),
+              icon: 'info-circle',
+              props: {
+                document: this.doc,
+                parentDocument: this.parentDocument
+              }
+            },
+            {
+              name: 'named-entities',
+              label: 'document.namedEntities',
+              hidden: this.$config.isnt('manageDocuments') && !this.doc.hasNerTags,
+              component: () => import('@/components/document/DocumentTabNamedEntities'),
+              icon: 'database',
+              props: {
+                document: this.doc
+              }
             }
-          },
-          {
-            name: 'preview',
-            label: 'document.preview',
-            component: () => import('@/components/document/DocumentTabPreview'),
-            icon: 'eye',
-            props: {
-              document: this.doc
-            }
-          },
-          {
-            name: 'details',
-            label: 'document.tabDetails',
-            component: () => import('@/components/document/DocumentTabDetails'),
-            icon: 'info-circle',
-            props: {
-              document: this.doc,
-              parentDocument: this.parentDocument
-            }
-          },
-          {
-            name: 'named-entities',
-            label: 'document.namedEntities',
-            hidden: this.$config.isnt('manageDocuments') && !this.doc.hasNerTags,
-            component: () => import('@/components/document/DocumentTabNamedEntities'),
-            icon: 'database',
-            props: {
-              document: this.doc
-            }
-          }
-        ]
+          ]
     },
-    indexActiveTab () {
-      return findIndex(this.visibleTabs, tab => tab.name === this.activeTab)
+    indexActiveTab() {
+      return findIndex(this.visibleTabs, (tab) => tab.name === this.activeTab)
     },
-    isStandalone () {
+    isStandalone() {
       return this.$route.name === 'document-standalone'
     },
-    isModal () {
+    isModal() {
       return this.$route.name === 'document-modal'
     }
   },
   methods: {
-    async getDoc (params = { id: this.id, routing: this.routing, index: this.index }) {
+    async getDoc(params = { id: this.id, routing: this.routing, index: this.index }) {
       this.$wait.start('load document data')
       this.$Progress.start()
       await this.$store.dispatch('document/get', params)
@@ -203,7 +214,7 @@ export default {
       this.$wait.end('load document data')
       this.$Progress.finish()
     },
-    async setTabs () {
+    async setTabs() {
       if (this.doc) {
         // This apply the document-view-tabs pipeline everytime a document is loaded
         this.tabsThoughtPipeline = await this.tabsPipeline(this.tabs, this.doc)
@@ -211,62 +222,62 @@ export default {
         this.tabsThoughtPipeline = []
       }
     },
-    getDownloadStatus () {
+    getDownloadStatus() {
       return this.$store.dispatch('downloads/fetchIndexStatus', this.index)
     },
-    isTabActive (name) {
+    isTabActive(name) {
       return this.activeTab === name
     },
-    activateTab (name) {
+    activateTab(name) {
       if (findIndex(this.visibleTabs, { name }) > -1) {
         this.$set(this, 'activeTab', name)
         this.$root.$emit('document::content::changed')
         return name
       }
     },
-    tabClass (name) {
+    tabClass(name) {
       return {
         active: this.isTabActive(name),
         ['document__content__pane--' + name]: true
       }
     },
-    shortKeyAction (event) {
+    shortKeyAction(event) {
       switch (event.srcKey) {
-      case 'goToPreviousTab':
-        this.goToPreviousTab()
-        break
-      case 'goToNextTab':
-        this.goToNextTab()
-        break
+        case 'goToPreviousTab':
+          this.goToPreviousTab()
+          break
+        case 'goToNextTab':
+          this.goToNextTab()
+          break
       }
     },
-    goToPreviousTab () {
+    goToPreviousTab() {
       const indexPreviousActiveTab = this.indexActiveTab === 0 ? this.visibleTabs.length - 1 : this.indexActiveTab - 1
       this.$set(this, 'activeTab', this.visibleTabs[indexPreviousActiveTab].name)
     },
-    goToNextTab () {
+    goToNextTab() {
       const indexNextActiveTab = this.indexActiveTab === this.visibleTabs.length - 1 ? 0 : this.indexActiveTab + 1
       this.$set(this, 'activeTab', this.visibleTabs[indexNextActiveTab].name)
     },
-    getComponentIfActive ({ component, name }) {
+    getComponentIfActive({ component, name }) {
       if (this.isTabActive(name)) {
         return component
       }
       return 'div'
     },
-    getPropsIfActive ({ name, props }) {
+    getPropsIfActive({ name, props }) {
       if (this.isTabActive(name)) {
         return props
       }
       return {}
     }
   },
-  beforeRouteEnter (to, _from, next) {
-    next(vm => {
+  beforeRouteEnter(to, _from, next) {
+    next((vm) => {
       vm.getDoc(to.params)
     })
   },
-  beforeRouteUpdate (to, _from, next) {
+  beforeRouteUpdate(to, _from, next) {
     this.getDoc(to.params)
     next()
   }
@@ -278,7 +289,8 @@ export default {
   background: white;
   margin: 0;
 
-  &--standalone, &--modal {
+  &--standalone,
+  &--modal {
     min-height: 100vh;
   }
 
@@ -296,7 +308,8 @@ export default {
     &__name {
       padding: 0 $spacer;
 
-      a, a:hover {
+      a,
+      a:hover {
         color: white;
       }
 
@@ -309,7 +322,7 @@ export default {
     &__nav {
       padding: $spacer $spacer 0;
 
-      & &__item  {
+      & &__item {
         margin: 0;
 
         a {
@@ -319,15 +332,16 @@ export default {
           font-size: 0.8em;
           font-weight: bolder;
           margin: 0;
-          padding: $spacer * .75 $spacer;
+          padding: $spacer * 0.75 $spacer;
           position: relative;
           text-transform: uppercase;
 
           &:hover {
-            background: rgba(white, .05);
+            background: rgba(white, 0.05);
           }
 
-          &.active, &.active:hover {
+          &.active,
+          &.active:hover {
             background: white;
             color: $link-color;
             font-weight: bold;
@@ -335,7 +349,7 @@ export default {
             &:before {
               border-top: 2px solid $secondary;
               box-shadow: 0 0 10px 0 $secondary;
-              content: "";
+              content: '';
               left: 0;
               position: absolute;
               right: 0;
@@ -352,7 +366,6 @@ export default {
   }
 
   &__content {
-
     &__pane {
       max-width: 100%;
     }

--- a/src/pages/DocumentView.vue
+++ b/src/pages/DocumentView.vue
@@ -95,6 +95,15 @@ export default {
     Hook
   },
   mixins: [shortkeys],
+  beforeRouteEnter(to, _from, next) {
+    next((vm) => {
+      vm.getDoc(to.params)
+    })
+  },
+  beforeRouteUpdate(to, _from, next) {
+    this.getDoc(to.params)
+    next()
+  },
   props: {
     id: {
       type: String
@@ -118,20 +127,6 @@ export default {
       activeTab: 'extracted-text',
       tabsThoughtPipeline: []
     }
-  },
-  watch: {
-    doc() {
-      return this.setTabs()
-    }
-  },
-  async mounted() {
-    if (!this.$wait.is('load document data')) {
-      await this.getDoc()
-    }
-    await this.getDownloadStatus()
-    await this.setTabs()
-    // Listen for event to switch tab
-    this.$root.$on('document::tab', this.activateTab)
   },
   computed: {
     ...mapState('document', ['doc', 'parentDocument', 'tags']),
@@ -195,6 +190,20 @@ export default {
     isModal() {
       return this.$route.name === 'document-modal'
     }
+  },
+  watch: {
+    doc() {
+      return this.setTabs()
+    }
+  },
+  async mounted() {
+    if (!this.$wait.is('load document data')) {
+      await this.getDoc()
+    }
+    await this.getDownloadStatus()
+    await this.setTabs()
+    // Listen for event to switch tab
+    this.$root.$on('document::tab', this.activateTab)
   },
   methods: {
     async getDoc(params = { id: this.id, routing: this.routing, index: this.index }) {
@@ -271,15 +280,6 @@ export default {
       }
       return {}
     }
-  },
-  beforeRouteEnter(to, _from, next) {
-    next((vm) => {
-      vm.getDoc(to.params)
-    })
-  },
-  beforeRouteUpdate(to, _from, next) {
-    this.getDoc(to.params)
-    next()
   }
 }
 </script>

--- a/src/pages/DocumentView.vue
+++ b/src/pages/DocumentView.vue
@@ -1,11 +1,11 @@
 <template>
   <v-wait for="load document data">
-    <content-placeholder class="document py-2 px-3" slot="waiting"></content-placeholder>
+    <content-placeholder slot="waiting" class="document py-2 px-3"></content-placeholder>
     <div
-      class="d-flex flex-column document"
-      :class="{ 'document--standalone': isStandalone, 'document--modal': isModal }"
       v-if="doc"
       v-shortkey="getKeys('tabNavigation')"
+      class="d-flex flex-column document"
+      :class="{ 'document--standalone': isStandalone, 'document--modal': isModal }"
       @shortkey="getAction('tabNavigation')"
     >
       <div class="document__header">
@@ -13,7 +13,7 @@
         <h3 class="document__header__name" :class="{ 'document__header__name--has-subject': doc.hasSubject }">
           <hook name="document.header.name:before"></hook>
           <document-sliced-name interactive-root :document="doc" />
-          <div class="document__header__name__subject" v-if="doc.hasSubject">
+          <div v-if="doc.hasSubject" class="document__header__name__subject">
             {{ doc.subject }}
           </div>
           <hook name="document.header.name:after"></hook>
@@ -34,22 +34,22 @@
             <hook name="document.header.nav.items:before" tag="li"></hook>
             <template v-for="tab in visibleTabs">
               <hook
-                :name="`document.header.nav.items.${tab.name}:before`"
                 :key="`hook.${tab.name}:before`"
+                :name="`document.header.nav.items.${tab.name}:before`"
                 tag="li"
               ></hook>
-              <li class="document__header__nav__item list-inline-item" :key="tab.name" :title="$t(tab.label)">
-                <a @click="$root.$emit('document::tab', tab.name)" :class="{ active: isTabActive(tab.name) }">
+              <li :key="tab.name" class="document__header__nav__item list-inline-item" :title="$t(tab.label)">
+                <a :class="{ active: isTabActive(tab.name) }" @click="$root.$emit('document::tab', tab.name)">
                   <hook :name="`document.header.nav.${tab.name}:before`"></hook>
-                  <fa :icon="tab.icon" v-if="tab.icon" class="mr-2"></fa>
-                  <component v-if="tab.labelComponent" :is="tab.labelComponent"></component>
+                  <fa v-if="tab.icon" :icon="tab.icon" class="mr-2"></fa>
+                  <component :is="tab.labelComponent" v-if="tab.labelComponent"></component>
                   <template v-else>{{ $t(tab.label) }}</template>
                   <hook :name="`document.header.nav.${tab.name}:after`"></hook>
                 </a>
               </li>
               <hook
-                :name="`document.header.nav.items.${tab.name}:after`"
                 :key="`hook.${tab.name}:after`"
+                :name="`document.header.nav.items.${tab.name}:after`"
                 tag="li"
               ></hook>
             </template>
@@ -61,11 +61,11 @@
       </div>
       <div class="d-flex flex-grow-1 flex-column tab-content document__content">
         <component
-          class="document__content__pane tab-pane flex-grow-1 w-100"
-          :class="tabClass(tab.name)"
-          :key="tab.name"
           :is="getComponentIfActive(tab)"
           v-for="tab in visibleTabs"
+          :key="tab.name"
+          class="document__content__pane tab-pane flex-grow-1 w-100"
+          :class="tabClass(tab.name)"
           v-bind="getPropsIfActive(tab)"
         >
         </component>
@@ -89,12 +89,12 @@ import shortkeys from '@/mixins/shortkeys'
 
 export default {
   name: 'DocumentView',
-  mixins: [shortkeys],
   components: {
     DocumentSlicedName,
     DocumentTagsForm,
     Hook
   },
+  mixins: [shortkeys],
   props: {
     id: {
       type: String

--- a/src/pages/Error.vue
+++ b/src/pages/Error.vue
@@ -8,11 +8,11 @@ import settings from '@/utils/settings'
 
 export default {
   name: 'Error',
-  mixins: [utils],
   components: {
     FontAwesomeLayers,
     VersionNumber
   },
+  mixins: [utils],
   props: {
     error: {
       type: [String, Error]
@@ -31,9 +31,6 @@ export default {
     return {
       username: null
     }
-  },
-  async mounted() {
-    this.username = await this.$core.auth.getUsername()
   },
   computed: {
     titleAsString() {
@@ -60,18 +57,21 @@ export default {
     logoutLink() {
       return Api.getFullUrl(process.env.VUE_APP_DS_AUTH_SIGNOUT)
     }
+  },
+  async mounted() {
+    this.username = await this.$core.auth.getUsername()
   }
 }
 </script>
 
 <template>
   <div class="error d-flex flex-column">
-    <div class="error__header p-3 text-right" v-if="showHeader">
+    <div v-if="showHeader" class="error__header p-3 text-right">
       <a
+        v-b-tooltip.html
         class="btn btn-outline-light btn-sm"
         :href="logoutLink"
         :title="$t('menu.connectedAs', { username })"
-        v-b-tooltip.html
       >
         <fa icon="sign-out-alt" fixed-width></fa>
         {{ $t('menu.logout') }}

--- a/src/pages/Error.vue
+++ b/src/pages/Error.vue
@@ -27,37 +27,37 @@ export default {
       type: Number
     }
   },
-  data () {
+  data() {
     return {
       username: null
     }
   },
-  async mounted () {
+  async mounted() {
     this.username = await this.$core.auth.getUsername()
   },
   computed: {
-    titleAsString () {
+    titleAsString() {
       if (!this.title) {
         return this.error instanceof Error ? this.error.message : this.error
       }
       return this.title
     },
-    helpLink () {
+    helpLink() {
       return this.$config.get('helpLink', settings.helpLink)
     },
-    faqLink () {
+    faqLink() {
       return this.$config.get('faqLink', settings.faqLink)
     },
-    userGuidesLink () {
+    userGuidesLink() {
       return this.$config.get('userGuidesLink', settings.userGuidesLink)
     },
-    devWikiLink () {
+    devWikiLink() {
       return this.$config.get('devWikiLink', settings.devWikiLink)
     },
-    showHeader () {
+    showHeader() {
       return this.isServer && !!this.username
     },
-    logoutLink () {
+    logoutLink() {
       return Api.getFullUrl(process.env.VUE_APP_DS_AUTH_SIGNOUT)
     }
   }
@@ -67,10 +67,12 @@ export default {
 <template>
   <div class="error d-flex flex-column">
     <div class="error__header p-3 text-right" v-if="showHeader">
-      <a class="btn btn-outline-light btn-sm"
-         :href="logoutLink"
-         :title="$t('menu.connectedAs', { username })"
-         v-b-tooltip.html>
+      <a
+        class="btn btn-outline-light btn-sm"
+        :href="logoutLink"
+        :title="$t('menu.connectedAs', { username })"
+        v-b-tooltip.html
+      >
         <fa icon="sign-out-alt" fixed-width></fa>
         {{ $t('menu.logout') }}
       </a>
@@ -127,63 +129,62 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  .error {
-    background: $app-context-sidebar-bg no-repeat right bottom;
-    color: $app-context-sidebar-color;
-    width: 100%;
-    min-height: 100vh;
+.error {
+  background: $app-context-sidebar-bg no-repeat right bottom;
+  color: $app-context-sidebar-color;
+  width: 100%;
+  min-height: 100vh;
 
-    &__container {
-      margin: $spacer auto;
-      text-align: center;
+  &__container {
+    margin: $spacer auto;
+    text-align: center;
 
-      &__heading {
-        display: flex;
+    &__heading {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: center;
+
+      &__code {
+        display: inline-flex;
         flex-direction: row;
         align-items: center;
         justify-content: center;
+        background: $app-sidebar-bg;
+        border-radius: 1em;
 
-        &__code {
-          display: inline-flex;
-          flex-direction: row;
-          align-items: center;
-          justify-content: center;
-          background: $app-sidebar-bg;
-          border-radius: 1em;
-
-          &__icon {
-            transform: scale(1.1);
-          }
-
-          &__value {
-            font-size: 0.6em;
-
-            &:empty {
-              display: none;
-            }
-          }
+        &__icon {
+          transform: scale(1.1);
         }
-      }
 
-      &__description {
-        margin-bottom: $spacer * 5;
-      }
+        &__value {
+          font-size: 0.6em;
 
-      &__links {
-
-        &__item {
-
-          &:not(:last-of-type):after {
-            content: "|";
-            margin: 0 $spacer;
-            color: $app-sidebar-link-color;
-          }
-
-          &, a {
-            color: $app-sidebar-link-color;
+          &:empty {
+            display: none;
           }
         }
       }
     }
+
+    &__description {
+      margin-bottom: $spacer * 5;
+    }
+
+    &__links {
+      &__item {
+        &:not(:last-of-type):after {
+          content: '|';
+          margin: 0 $spacer;
+          color: $app-sidebar-link-color;
+        }
+
+        &,
+        a {
+          color: $app-sidebar-link-color;
+        }
+      }
+    }
   }
+}
 </style>

--- a/src/pages/Indexing.vue
+++ b/src/pages/Indexing.vue
@@ -3,56 +3,64 @@
     <div class="mt-4 container">
       <div class="mb-3 d-flex">
         <b-btn-group class="indexing__actions mr-2">
-          <b-btn class="indexing__actions__stop-pending-tasks"
-                 variant="outline-primary"
-                 type="b-btn"
-                 :disabled="!hasPendingTasks"
-                 @click="stopPendingTasks">
+          <b-btn
+            class="indexing__actions__stop-pending-tasks"
+            variant="outline-primary"
+            type="b-btn"
+            :disabled="!hasPendingTasks"
+            @click="stopPendingTasks"
+          >
             <fa icon="hand-paper" class="mr-1" />
             {{ $t('indexing.stopPendingTasks') }}
           </b-btn>
-          <b-btn class="indexing__actions__delete-done-tasks"
-                 variant="outline-primary"
-                 :disabled="!hasDoneTasks"
-                 @click="deleteDoneTasks">
+          <b-btn
+            class="indexing__actions__delete-done-tasks"
+            variant="outline-primary"
+            :disabled="!hasDoneTasks"
+            @click="deleteDoneTasks"
+          >
             <fa icon="trash-alt" class="mr-1" />
             {{ $t('indexing.deleteDoneTasks') }}
           </b-btn>
         </b-btn-group>
 
         <div class="ml-auto">
-          <b-btn variant="primary"
-                 class="mr-2 indexing__actions__extract"
-                 v-b-modal:[extractingFormId]>
+          <b-btn variant="primary" class="mr-2 indexing__actions__extract" v-b-modal:[extractingFormId]>
             <fa icon="search-plus" class="mr-2" />
             {{ $t('indexing.extractText') }}
           </b-btn>
-          <b-btn variant="primary"
-                 class="indexing__actions__find-named-entites mr-2"
-                 :disabled="!canOpenFindNamedEntitiesForm"
-                 :title="findNamedEntitiesTooltip"
-                 v-b-tooltip
-                 v-b-modal:[findNamedEntitiesFormId]>
+          <b-btn
+            variant="primary"
+            class="indexing__actions__find-named-entites mr-2"
+            :disabled="!canOpenFindNamedEntitiesForm"
+            :title="findNamedEntitiesTooltip"
+            v-b-tooltip
+            v-b-modal:[findNamedEntitiesFormId]
+          >
             <fa icon="user-tag" class="mr-2" />
             {{ $t('indexing.findNamedEntities') }}
           </b-btn>
 
-          <b-modal :id="extractingFormId"
-                   body-bg-variant="darker"
-                   hide-footer
-                   modal-class="indexing__form-modal extracting__form"
-                   size="md">
+          <b-modal
+            :id="extractingFormId"
+            body-bg-variant="darker"
+            hide-footer
+            modal-class="indexing__form-modal extracting__form"
+            size="md"
+          >
             <template #modal-title>
               <fa icon="search-plus" class="mr-1" />
               {{ $t('indexing.extractText') }}
             </template>
             <extracting-form id="extracting-form" :finally="closeExtractingForm" />
           </b-modal>
-          <b-modal :id="findNamedEntitiesFormId"
-                   body-bg-variant="darker"
-                   hide-footer
-                   modal-class="indexing__form-modal find-named-entities__form"
-                   size="md">
+          <b-modal
+            :id="findNamedEntitiesFormId"
+            body-bg-variant="darker"
+            hide-footer
+            modal-class="indexing__form-modal find-named-entities__form"
+            size="md"
+          >
             <template #modal-title>
               <fa icon="user-tag" class="mr-1" />
               {{ $t('indexing.findNamedEntities') }}
@@ -86,59 +94,59 @@ import settings from '@/utils/settings'
 import { getOS } from '@/utils/utils'
 
 export default {
-  name: 'indexing',
+  name: 'Indexing',
   components: {
     ExtractingForm,
     FindNamedEntitiesForm,
     TasksList
   },
   mixins: [polling],
-  data () {
+  data() {
     return {
       count: 0
     }
   },
   computed: {
     ...mapState('indexing', ['tasks']),
-    hasIndexedDocuments () {
+    hasIndexedDocuments() {
       return this.count > 0
     },
-    hasPendingTasks () {
+    hasPendingTasks() {
       return this.pendingTasks.length !== 0
     },
-    hasDoneTasks () {
+    hasDoneTasks() {
       return this.tasks.length - this.pendingTasks.length > 0
     },
-    pendingTasks () {
+    pendingTasks() {
       return filter(this.tasks, { state: 'RUNNING' })
     },
-    sortedTasks () {
+    sortedTasks() {
       // Move running tasks on top
       const states = ['RUNNING']
       return sortBy(this.tasks, ({ state }) => -states.indexOf(state))
     },
-    extractingFormId () {
+    extractingFormId() {
       return uniqueId('extracting-form-')
     },
-    canOpenFindNamedEntitiesForm () {
+    canOpenFindNamedEntitiesForm() {
       return this.hasDoneTasks || this.hasIndexedDocuments
     },
-    findNamedEntitiesFormId () {
+    findNamedEntitiesFormId() {
       return uniqueId('find-named-entities-form-')
     },
-    findNamedEntitiesTooltip () {
+    findNamedEntitiesTooltip() {
       return !this.canOpenFindNamedEntitiesForm ? this.$t('indexing.findNamedEntitiesTooltip') : ''
     },
-    howToLink () {
+    howToLink() {
       const os = getOS()
       const fallback = settings.documentationLinks.indexing.default
       return settings.documentationLinks.indexing[os] || fallback
     },
-    indices () {
+    indices() {
       return this.$store.state.search.indices
     }
   },
-  async mounted () {
+  async mounted() {
     this.$wait.start('load indexing tasks')
     this.count = await this.countAny()
     await this.startPollingTasks()
@@ -148,29 +156,29 @@ export default {
     this.$wait.end('load indexing tasks')
   },
   methods: {
-    async countAny () {
+    async countAny() {
       const index = this.indices.join(',')
       const preference = 'indexing'
       const { count = 0 } = await elasticsearch.count({ index, preference })
       return count
     },
-    closeExtractingForm () {
+    closeExtractingForm() {
       this.$bvModal.hide(this.extractingFormId)
       return this.startPollingTasks()
     },
-    closeFindNamedEntitiesForm () {
+    closeFindNamedEntitiesForm() {
       this.$bvModal.hide(this.findNamedEntitiesFormId)
       return this.startPollingTasks()
     },
-    async stopPendingTasks () {
+    async stopPendingTasks() {
       await this.$store.dispatch('indexing/stopPendingTasks')
       await this.$store.dispatch('indexing/getTasks')
     },
-    async deleteDoneTasks () {
+    async deleteDoneTasks() {
       await this.$store.dispatch('indexing/deleteDoneTasks')
       await this.$store.dispatch('indexing/getTasks')
     },
-    startPollingTasks () {
+    startPollingTasks() {
       const fn = this.getTasks
       const timeout = () => random(1000, 4000)
       // Register the `getTasks` for later
@@ -178,7 +186,7 @@ export default {
       // Execute the `getTasks` method immediatly
       return fn()
     },
-    async getTasks () {
+    async getTasks() {
       await this.$store.dispatch('indexing/getTasks')
       // Continue to poll task if they are pending ones
       return this.hasPendingTasks
@@ -188,9 +196,9 @@ export default {
 </script>
 
 <style lang="scss">
-  .indexing {
-    &__table td {
-      vertical-align: middle;
-    }
+.indexing {
+  &__table td {
+    vertical-align: middle;
   }
+}
 </style>

--- a/src/pages/Indexing.vue
+++ b/src/pages/Indexing.vue
@@ -25,17 +25,17 @@
         </b-btn-group>
 
         <div class="ml-auto">
-          <b-btn variant="primary" class="mr-2 indexing__actions__extract" v-b-modal:[extractingFormId]>
+          <b-btn v-b-modal:[extractingFormId] variant="primary" class="mr-2 indexing__actions__extract">
             <fa icon="search-plus" class="mr-2" />
             {{ $t('indexing.extractText') }}
           </b-btn>
           <b-btn
+            v-b-tooltip
+            v-b-modal:[findNamedEntitiesFormId]
             variant="primary"
             class="indexing__actions__find-named-entites mr-2"
             :disabled="!canOpenFindNamedEntitiesForm"
             :title="findNamedEntitiesTooltip"
-            v-b-tooltip
-            v-b-modal:[findNamedEntitiesFormId]
           >
             <fa icon="user-tag" class="mr-2" />
             {{ $t('indexing.findNamedEntities') }}

--- a/src/pages/Insights.vue
+++ b/src/pages/Insights.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="insights">
-    <div class="bg-secondary text-white insights__toolbox position-sticky sticky-top mb-4" v-if="isServer">
+    <div v-if="isServer" class="bg-secondary text-white insights__toolbox position-sticky sticky-top mb-4">
       <div class="container py-2 d-flex align-items-center">
         <div class="pr-2">
           {{ $t('insights.selectProject') }}
@@ -12,7 +12,7 @@
     </div>
     <div class="container insights__container">
       <b-row class="align-items-stretch">
-        <b-col v-for="(widget, index) in instantiatedWidgets" :md="widget.cols" :key="index">
+        <b-col v-for="(widget, index) in instantiatedWidgets" :key="index" :md="widget.cols">
           <div class="insights__container__widget" :class="{ card: widget.card }">
             <component :is="widget.component" :widget="widget" class="flex-grow-1" />
           </div>

--- a/src/pages/Insights.vue
+++ b/src/pages/Insights.vue
@@ -44,25 +44,24 @@ export default {
       }
     }
   },
-  beforeMount () {
+  beforeMount() {
     this.$store.commit('insights/project', this.$store.state.search.indices[0])
   }
 }
 </script>
 
 <style lang="scss" scoped>
-  .insights {
+.insights {
+  &__container {
+    margin-top: $spacer;
 
-    &__container {
-      margin-top: $spacer;
-
-      &__widget {
-        display: flex;
-        flex-direction: row;
-        margin-bottom: $grid-gutter-width;
-        min-height: calc(100% - #{$grid-gutter-width});
-        position: relative;
-      }
+    &__widget {
+      display: flex;
+      flex-direction: row;
+      margin-bottom: $grid-gutter-width;
+      min-height: calc(100% - #{$grid-gutter-width});
+      position: relative;
     }
   }
+}
 </style>

--- a/src/pages/Landing.vue
+++ b/src/pages/Landing.vue
@@ -9,7 +9,7 @@
       <hook name="landing.form.heading:after"></hook>
       <search-bar class="landing__form__search-bar py-3" size="md"></search-bar>
       <hook name="landing.form.project:before"></hook>
-      <div class="mt-5 text-white" v-if="isServer">
+      <div v-if="isServer" class="mt-5 text-white">
         <div class="landing__form__projects">
           <h2 class="text-uppercase h5">
             {{ $t('filter.projects') }}
@@ -31,12 +31,12 @@ import utils from '@/mixins/utils'
 
 export default {
   name: 'Landing',
-  mixins: [utils],
   components: {
     Hook,
     ProjectCards,
     SearchBar
-  }
+  },
+  mixins: [utils]
 }
 </script>
 

--- a/src/pages/Landing.vue
+++ b/src/pages/Landing.vue
@@ -4,7 +4,7 @@
     <div class="landing__form py-5">
       <hook name="landing.form.heading:before"></hook>
       <h1 class="landing__form__heading text-special">
-        <img src="~images/logo-color.svg" alt="Datashare">
+        <img src="~images/logo-color.svg" alt="Datashare" />
       </h1>
       <hook name="landing.form.heading:after"></hook>
       <search-bar class="landing__form__search-bar py-3" size="md"></search-bar>
@@ -41,43 +41,43 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .landing {
+.landing {
+  position: relative;
+  min-height: 100vh;
+  @include gradient-directional($primary, $secondary);
+
+  &__form {
+    z-index: 100;
     position: relative;
-    min-height: 100vh;
-    @include gradient-directional($primary, $secondary);
+    top: -2 * $spacer;
+    max-width: 660px;
+    width: 100%;
+    margin: auto;
 
-    &__form {
-      z-index: 100;
-      position: relative;
-      top: -2 * $spacer;
-      max-width: 660px;
-      width: 100%;
-      margin: auto;
+    &__heading {
+      text-align: center;
+      color: white;
+      font-weight: 400;
+      font-size: 3rem;
 
-      &__heading {
-        text-align: center;
-        color: white;
-        font-weight: 400;
-        font-size: 3rem;
-
-        img {
-          height: 6rem;
-          margin-bottom: $spacer;
-          transform: translateX(-9.5%); // half of logo width
-        }
-      }
-
-      &__search-bar {
-        margin: 0;
-        position: relative;
-        z-index: 100;
-      }
-
-      &__no-projects {
-        font-size: $font-size-lg;
-        position: relative;
-        z-index: 50;
+      img {
+        height: 6rem;
+        margin-bottom: $spacer;
+        transform: translateX(-9.5%); // half of logo width
       }
     }
+
+    &__search-bar {
+      margin: 0;
+      position: relative;
+      z-index: 100;
+    }
+
+    &__no-projects {
+      font-size: $font-size-lg;
+      position: relative;
+      z-index: 50;
+    }
   }
+}
 </style>

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -35,14 +35,14 @@ import settings from '@/utils/settings'
 export default {
   name: 'Login',
   computed: {
-    signinUrl () {
+    signinUrl() {
       return process.env.VUE_APP_DS_AUTH_SIGNIN
     },
-    helpLink () {
+    helpLink() {
       return this.$config.get('helpLink', settings.helpLink)
     }
   },
-  async mounted () {
+  async mounted() {
     if (await this.$core.auth.getUsername()) {
       return this.$router.push('/')
     }
@@ -51,18 +51,18 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .login {
-    background: theme-color('dark');
-    min-height: 100vh;
-    padding: 10vh;
+.login {
+  background: theme-color('dark');
+  min-height: 100vh;
+  padding: 10vh;
 
-    &__card {
-      margin:0 auto;
-      max-width: 660px;
+  &__card {
+    margin: 0 auto;
+    max-width: 660px;
 
-      &__heading h2 {
-        font-size: 2.5rem;
-      }
+    &__heading h2 {
+      font-size: 2.5rem;
     }
   }
+}
 </style>

--- a/src/pages/RouteDoc.vue
+++ b/src/pages/RouteDoc.vue
@@ -22,28 +22,28 @@ export default {
       type: String
     }
   },
-  data () {
+  data() {
     return {
       html: null
     }
   },
   computed: {
-    meta () {
+    meta() {
       return this.findRouteDocMetaBySlug(this.slug)
     }
   },
-  mounted () {
+  mounted() {
     this.fetch()
   },
-  beforeRouteEnter (to, from, next) {
-    next(vm => vm.fetch(to.params.slug))
+  beforeRouteEnter(to, from, next) {
+    next((vm) => vm.fetch(to.params.slug))
   },
-  async beforeRouteUpdate (to, from, next) {
+  async beforeRouteUpdate(to, from, next) {
     await this.fetch(to.params.slug)
     next()
   },
   methods: {
-    async fetch (slug = this.slug) {
+    async fetch(slug = this.slug) {
       const { resourcePath } = this.findRouteDocMetaBySlug(slug)
       const module = await import(/* webpackChunkName: "[request]" */ '../../public/docs/' + resourcePath)
       this.html = module.default
@@ -53,60 +53,69 @@ export default {
 </script>
 
 <style lang="scss">
-  .route-doc {
-    min-height: 100vh;
+.route-doc {
+  min-height: 100vh;
 
-    &__header {
-      &__description {
-        max-width: 880px;
+  &__header {
+    &__description {
+      max-width: 880px;
+    }
+  }
+
+  &__content {
+    & > h1 {
+      display: none;
+    }
+
+    h2 {
+      @include font-size($h2-font-size * 0.8);
+    }
+    h3 {
+      @include font-size($h3-font-size * 0.8);
+    }
+    h4 {
+      @include font-size($h4-font-size * 0.8);
+    }
+    h5 {
+      @include font-size($h5-font-size * 0.8);
+    }
+    h6 {
+      @include font-size($h6-font-size * 0.8);
+    }
+
+    img {
+      display: block;
+      max-height: 60vh;
+      max-width: 750px;
+      width: auto;
+
+      @media (max-width: 1370px) {
+        max-width: 100%;
       }
     }
 
-    &__content {
+    blockquote {
+      background-color: $gray-100;
+      margin-bottom: $spacer;
+      padding: 1rem;
 
-      & > h1 {
-        display: none;
+      *:last-of-type {
+        margin-bottom: 0;
       }
 
-      h2 { @include font-size($h2-font-size * .8); }
-      h3 { @include font-size($h3-font-size * .8); }
-      h4 { @include font-size($h4-font-size * .8); }
-      h5 { @include font-size($h5-font-size * .8); }
-      h6 { @include font-size($h6-font-size * .8); }
+      pre {
+        background-color: transparent;
+        border: 0;
+        margin-bottom: 0;
+        margin-top: 0;
+        padding: 0;
 
-      img  {
-        display: block;
-        max-height: 60vh;
-        max-width: 750px;
-        width: auto;
-
-        @media (max-width: 1370px) {
-          max-width: 100%;
-        }
-      }
-
-      blockquote {
-        background-color: $gray-100;
-        margin-bottom: $spacer;
-        padding: 1rem;
-
-        *:last-of-type {
-          margin-bottom: 0;
-        }
-
-        pre {
-          background-color: transparent;
-          border: 0;
-          margin-bottom: 0;
-          margin-top: 0;
-          padding: 0;
-
-          code {
-            @include font-size(inherit);
-            color: $gray-900; // Effectively the base text color
-          }
+        code {
+          @include font-size(inherit);
+          color: $gray-900; // Effectively the base text color
         }
       }
     }
   }
+}
 </style>

--- a/src/pages/RouteDoc.vue
+++ b/src/pages/RouteDoc.vue
@@ -17,6 +17,13 @@ export default {
     PageHeader
   },
   mixins: [docs],
+  beforeRouteEnter(to, from, next) {
+    next((vm) => vm.fetch(to.params.slug))
+  },
+  async beforeRouteUpdate(to, from, next) {
+    await this.fetch(to.params.slug)
+    next()
+  },
   props: {
     slug: {
       type: String
@@ -34,13 +41,6 @@ export default {
   },
   mounted() {
     this.fetch()
-  },
-  beforeRouteEnter(to, from, next) {
-    next((vm) => vm.fetch(to.params.slug))
-  },
-  async beforeRouteUpdate(to, from, next) {
-    await this.fetch(to.params.slug)
-    next()
   },
   methods: {
     async fetch(slug = this.slug) {

--- a/src/pages/Search.vue
+++ b/src/pages/Search.vue
@@ -3,15 +3,15 @@
     <hook name="search:before" />
     <div class="d-flex">
       <button
-        class="search__show-filters align-self-center ml-3 btn btn-link px-0"
-        @click="clickOnShowFilters()"
         v-if="!showFilters"
-        :title="$t('search.showFilters')"
         v-b-tooltip.right
+        class="search__show-filters align-self-center ml-3 btn btn-link px-0"
+        :title="$t('search.showFilters')"
+        @click="clickOnShowFilters()"
       >
         <fa icon="arrow-right" />
         <span class="sr-only">{{ $t('search.showFilters') }}</span>
-        <b-badge pill variant="warning" class="search__show-filters__counter" v-if="activeFilters">
+        <b-badge v-if="activeFilters" pill variant="warning" class="search__show-filters__counter">
           {{ activeFilters }}
         </b-badge>
       </button>
@@ -19,10 +19,10 @@
     </div>
     <div class="px-0 search__body">
       <hook name="search.body:before" />
-      <component :is="bodyWrapper" class="search__body__search-results search__body__results" ref="searchBodyScrollbar">
+      <component :is="bodyWrapper" ref="searchBodyScrollbar" class="search__body__search-results search__body__results">
         <div v-if="!!error" class="py-5 text-center">
           {{ errorMessage }}
-          <div class="mt-2" v-if="isRequestTimeoutError">
+          <div v-if="isRequestTimeoutError" class="mt-2">
             <b-button @click="refresh">
               <fa icon="redo" class="mr-1"></fa>
               {{ $t('search.errors.tryAgain') }}
@@ -37,7 +37,7 @@
         </div>
       </component>
       <transition name="slide-right">
-        <div class="search__body__document" v-if="showDocument">
+        <div v-if="showDocument" class="search__body__document">
           <search-document-navbar class="search__body__document__navbar" :is-shrinked="isShrinked" />
           <div class="search__body__document__wrapper">
             <div id="search__body__document__wrapper" class="overflow-auto text-break" @scroll="handleScroll">
@@ -142,19 +142,6 @@ export default {
       next()
     }
   },
-  async created() {
-    try {
-      this.$store.dispatch('search/updateFromRouteQuery', this.$route.query)
-      await this.search()
-    } catch (_) {
-      this.wrongQuery()
-    }
-  },
-  mounted() {
-    this.$root.$on('index::delete::all', this.search)
-    this.$root.$on('filter::starred::refresh', this.refresh)
-    this.$root.$on('document::content::changed', this.updateScrollBars)
-  },
   watch: {
     showDocument(show) {
       if (show) {
@@ -179,6 +166,19 @@ export default {
     currentDocument() {
       this.updateScrollBars()
     }
+  },
+  async created() {
+    try {
+      this.$store.dispatch('search/updateFromRouteQuery', this.$route.query)
+      await this.search()
+    } catch (_) {
+      this.wrongQuery()
+    }
+  },
+  mounted() {
+    this.$root.$on('index::delete::all', this.search)
+    this.$root.$on('filter::starred::refresh', this.refresh)
+    this.$root.$on('document::content::changed', this.updateScrollBars)
   },
   methods: {
     handleScroll(e) {

--- a/src/pages/Search.vue
+++ b/src/pages/Search.vue
@@ -78,6 +78,19 @@ export default {
     SearchDocumentNavbar,
     SearchResults
   },
+  async beforeRouteUpdate(to, from, next) {
+    if (to.name === 'search' && this.isDifferentFromQuery(to.query)) {
+      try {
+        this.$store.dispatch('search/updateFromRouteQuery', to.query)
+        await this.search()
+        next()
+      } catch (_) {
+        this.wrongQuery()
+      }
+    } else {
+      next()
+    }
+  },
   data() {
     return {
       errorMessages: {
@@ -127,19 +140,6 @@ export default {
     },
     bodyWrapper() {
       return this.layout === 'list' ? VuePerfectScrollbar : 'div'
-    }
-  },
-  async beforeRouteUpdate(to, from, next) {
-    if (to.name === 'search' && this.isDifferentFromQuery(to.query)) {
-      try {
-        this.$store.dispatch('search/updateFromRouteQuery', to.query)
-        await this.search()
-        next()
-      } catch (_) {
-        this.wrongQuery()
-      }
-    } else {
-      next()
     }
   },
   watch: {

--- a/src/pages/Search.vue
+++ b/src/pages/Search.vue
@@ -2,7 +2,13 @@
   <div class="search" :class="{ 'search--show-document': showDocument, [`search--${layout}`]: true }">
     <hook name="search:before" />
     <div class="d-flex">
-      <button class="search__show-filters align-self-center ml-3 btn btn-link px-0" @click="clickOnShowFilters()" v-if="!showFilters" :title="$t('search.showFilters')" v-b-tooltip.right>
+      <button
+        class="search__show-filters align-self-center ml-3 btn btn-link px-0"
+        @click="clickOnShowFilters()"
+        v-if="!showFilters"
+        :title="$t('search.showFilters')"
+        v-b-tooltip.right
+      >
         <fa icon="arrow-right" />
         <span class="sr-only">{{ $t('search.showFilters') }}</span>
         <b-badge pill variant="warning" class="search__show-filters__counter" v-if="activeFilters">
@@ -32,7 +38,7 @@
       </component>
       <transition name="slide-right">
         <div class="search__body__document" v-if="showDocument">
-          <search-document-navbar class="search__body__document__navbar" :is-shrinked="isShrinked"/>
+          <search-document-navbar class="search__body__document__navbar" :is-shrinked="isShrinked" />
           <div class="search__body__document__wrapper">
             <div id="search__body__document__wrapper" class="overflow-auto text-break" @scroll="handleScroll">
               <router-view class="search__body__document__wrapper__view" />
@@ -40,7 +46,11 @@
           </div>
         </div>
       </transition>
-      <router-link v-show="showDocument" class="search__body__backdrop" :to="{ name: 'search', query: toRouteQuery }"></router-link>
+      <router-link
+        v-show="showDocument"
+        class="search__body__backdrop"
+        :to="{ name: 'search', query: toRouteQuery }"
+      ></router-link>
       <hook name="search.body:after" />
     </div>
     <hook name="search:after" />
@@ -68,7 +78,7 @@ export default {
     SearchDocumentNavbar,
     SearchResults
   },
-  data () {
+  data() {
     return {
       errorMessages: {
         BadRequest: 'search.errors.badRequest',
@@ -85,13 +95,13 @@ export default {
   computed: {
     ...mapState('search', ['isReady', 'showFilters', 'error', 'layout']),
     ...mapState('document', { currentDocument: 'doc' }),
-    toRouteQuery () {
+    toRouteQuery() {
       return this.$store.getters['search/toRouteQuery']()
     },
-    showDocument () {
+    showDocument() {
       return ['document'].indexOf(this.$route.name) > -1
     },
-    errorMessage () {
+    errorMessage() {
       const defaultMessage = this.$t('search.errors.somethingWrong')
       for (const type in this.errorMessages) {
         // The error is an instance of the key and it exist as a translation key
@@ -101,25 +111,25 @@ export default {
       }
       return get(this.error, 'body.error.root_cause.0.reason', defaultMessage)
     },
-    isRequestTimeoutError () {
+    isRequestTimeoutError() {
       return this.error instanceof esErrors.RequestTimeout
     },
     showFilters: {
-      get () {
+      get() {
         return this.$store.state.search.showFilters
       },
-      set () {
+      set() {
         this.$store.commit('search/toggleFilters')
       }
     },
-    activeFilters () {
+    activeFilters() {
       return this.$store.getters['search/activeFilters'].length
     },
-    bodyWrapper () {
+    bodyWrapper() {
       return this.layout === 'list' ? VuePerfectScrollbar : 'div'
     }
   },
-  async beforeRouteUpdate (to, from, next) {
+  async beforeRouteUpdate(to, from, next) {
     if (to.name === 'search' && this.isDifferentFromQuery(to.query)) {
       try {
         this.$store.dispatch('search/updateFromRouteQuery', to.query)
@@ -132,7 +142,7 @@ export default {
       next()
     }
   },
-  async created () {
+  async created() {
     try {
       this.$store.dispatch('search/updateFromRouteQuery', this.$route.query)
       await this.search()
@@ -140,18 +150,18 @@ export default {
       this.wrongQuery()
     }
   },
-  mounted () {
+  mounted() {
     this.$root.$on('index::delete::all', this.search)
     this.$root.$on('filter::starred::refresh', this.refresh)
     this.$root.$on('document::content::changed', this.updateScrollBars)
   },
   watch: {
-    showDocument (show) {
+    showDocument(show) {
       if (show) {
         this.isShrinked = false
       }
     },
-    isReady (isReady) {
+    isReady(isReady) {
       if (isReady) {
         this.$Progress.finish()
         clearInterval(this.intervalId)
@@ -163,207 +173,207 @@ export default {
       }
       this.updateScrollBars()
     },
-    $route () {
+    $route() {
       this.updateScrollBars()
     },
-    currentDocument () {
+    currentDocument() {
       this.updateScrollBars()
     }
   },
   methods: {
-    handleScroll (e) {
+    handleScroll(e) {
       this.$set(this, 'isShrinked', e.target.scrollTop > 40)
     },
-    search (queryOrParams = null) {
+    search(queryOrParams = null) {
       try {
         return this.$store.dispatch('search/query', queryOrParams)
       } catch (_) {
         this.wrongQuery()
       }
     },
-    refresh () {
+    refresh() {
       try {
         return this.$store.dispatch('search/refresh', false)
       } catch (_) {
         this.wrongQuery()
       }
     },
-    wrongQuery () {
+    wrongQuery() {
       this.$Progress.finish()
     },
-    clickOnShowFilters () {
+    clickOnShowFilters() {
       this.showFilters = !this.showFilters
     },
-    isDifferentFromQuery (query) {
+    isDifferentFromQuery(query) {
       return !isEqual(query, this.$store.getters['search/toRouteQuery']())
     },
-    updateScrollBars () {
-      compact([this.$refs.searchBodyScrollbar])
-        .forEach(ref => ref?.ps?.update())
+    updateScrollBars() {
+      compact([this.$refs.searchBodyScrollbar]).forEach((ref) => ref?.ps?.update())
     }
   }
 }
 </script>
 
 <style lang="scss">
-  .search {
-    @include clearfix();
-    display: flex;
-    flex-direction: column;
-    max-height: 100vh;
+.search {
+  @include clearfix();
+  display: flex;
+  flex-direction: column;
+  max-height: 100vh;
 
-    &__show-filters.btn {
-      background: $app-context-sidebar-bg;
-      border-radius: 20px;
+  &__show-filters.btn {
+    background: $app-context-sidebar-bg;
+    border-radius: 20px;
+    color: white;
+    display: block;
+    height: 40px;
+    line-height: 40px;
+    min-width: 1px;
+    padding: 0;
+    position: relative;
+    text-align: center;
+    width: 40px;
+
+    &:hover {
+      background: lighten($app-context-sidebar-bg, 10%);
       color: white;
+    }
+  }
+
+  .btn &__show-filters__counter.badge {
+    position: absolute;
+  }
+
+  &--grid,
+  &--table {
+    &.search .search__body__backdrop {
       display: block;
-      height: 40px;
-      line-height: 40px;
-      min-width: 1px;
-      padding: 0;
-      position: relative;
-      text-align: center;
-      width: 40px;
-
-      &:hover {
-        background: lighten($app-context-sidebar-bg, 10%);
-        color: white;
-      }
     }
 
-    .btn &__show-filters__counter.badge {
+    &.search .search__body__document {
+      background: white;
+      border-radius: 0;
+      bottom: 0;
+      box-shadow: $modal-content-box-shadow-sm-up;
+      max-width: calc(100vw - var(--app-sidebar-width));
+      position: fixed;
+      right: 0;
+      top: 0;
+      width: $document-min-width;
+      z-index: 20;
+    }
+  }
+
+  &--list {
+    &.search .search__body__results {
+      background: white;
+      right: auto;
+      width: calc(#{$search-results-list-width} - #{$spacer * 2});
+    }
+
+    &.search .search__body__document,
+    &.search .search__body__results {
+      border-radius: $card-border-radius;
+      box-shadow: 0 2px 10px 0 rgba(black, 0.05), 0 2px 30px 0 rgba(black, 0.02);
+      overflow: hidden;
+    }
+  }
+
+  &__body {
+    height: calc(100vh - var(--app-nav-height));
+    overflow: hidden;
+    position: relative;
+
+    & &__document,
+    & &__results {
+      bottom: $spacer;
       position: absolute;
+      top: 0;
+      z-index: 10;
     }
 
-    &--grid, &--table {
+    & &__results {
+      left: $spacer;
+      overflow: auto;
+      right: $spacer;
+    }
 
-      &.search .search__body__backdrop {
-        display: block;
+    & &__document {
+      z-index: 20;
+      right: $spacer;
+      padding: 0;
+      margin: 0;
+      flex: 1 0 auto;
+      display: flex;
+      flex-direction: column;
+
+      width: 100%;
+      max-width: calc(100% - #{$search-results-list-width} - #{$spacer});
+
+      &.slide-right-enter-active,
+      &.slide-right-leave-active {
+        transition: 0.3s;
       }
 
-      &.search .search__body__document {
+      &.slide-right-enter,
+      &.slide-right-leave-to {
+        transform: translateX(100%);
+        opacity: 0;
+      }
+
+      &__wrapper {
+        position: relative;
+        flex-grow: 1;
+
+        & > * {
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+        }
+
+        &__view {
+          min-height: 100%;
+          display: flex;
+          flex-direction: column;
+          width: 100%;
+
+          .document {
+            flex-grow: 1;
+            min-height: 100%;
+          }
+        }
+      }
+
+      @media (max-width: $document-float-breakpoint-width) {
+        z-index: 20;
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        right: 0;
+        width: $document-min-width;
+        max-width: calc(100vw - var(--app-sidebar-width));
         background: white;
         border-radius: 0;
-        bottom: 0;
         box-shadow: $modal-content-box-shadow-sm-up;
-        max-width: calc(100vw - var(--app-sidebar-width));
-        position: fixed;
-        right: 0;
-        top: 0;
-        width: $document-min-width;
-        z-index: 20;
       }
     }
 
-    &--list {
+    &__backdrop {
+      cursor: pointer;
+      z-index: 15;
+      position: fixed;
+      top: 0;
+      bottom: 0;
+      width: 100%;
+      background: rgba($modal-backdrop-bg, $modal-backdrop-opacity);
+      display: none;
 
-      &.search .search__body__results {
-        background: white;
-        right: auto;
-        width: calc(#{$search-results-list-width}  - #{$spacer * 2});
-      }
-
-      &.search .search__body__document,
-      &.search .search__body__results {
-        border-radius: $card-border-radius;
-        box-shadow: 0 2px 10px 0 rgba(black, .05), 0 2px 30px 0 rgba(black, .02);
-        overflow: hidden;
-      }
-
-    }
-
-    &__body {
-      height: calc(100vh - var(--app-nav-height));
-      overflow: hidden;
-      position: relative;
-
-      & &__document, & &__results {
-        bottom: $spacer;
-        position: absolute;
-        top: 0;
-        z-index: 10;
-      }
-
-      & &__results {
-        left: $spacer;
-        overflow: auto;
-        right: $spacer;
-      }
-
-      & &__document {
-        z-index: 20;
-        right: $spacer;
-        padding: 0;
-        margin: 0;
-        flex: 1 0 auto;
-        display: flex;
-        flex-direction: column;
-
-        width: 100%;
-        max-width: calc(100% - #{$search-results-list-width} - #{$spacer});
-
-        &.slide-right-enter-active, &.slide-right-leave-active {
-          transition: .3s;
-        }
-
-        &.slide-right-enter, &.slide-right-leave-to {
-          transform: translateX(100%);
-          opacity: 0;
-        }
-
-        &__wrapper {
-          position: relative;
-          flex-grow: 1;
-
-          & > * {
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-          }
-
-          &__view {
-            min-height: 100%;
-            display: flex;
-            flex-direction: column;
-            width: 100%;
-
-            .document {
-              flex-grow: 1;
-              min-height: 100%;
-            }
-          }
-        }
-
-        @media (max-width: $document-float-breakpoint-width) {
-          z-index: 20;
-          position: fixed;
-          top: 0;
-          bottom: 0;
-          right: 0;
-          width: $document-min-width;
-          max-width: calc(100vw - var(--app-sidebar-width));
-          background: white;
-          border-radius: 0;
-          box-shadow: $modal-content-box-shadow-sm-up;
-        }
-      }
-
-      &__backdrop {
-        cursor: pointer;
-        z-index: 15;
-        position: fixed;
-        top: 0;
-        bottom: 0;
-        width: 100%;
-        background: rgba($modal-backdrop-bg, $modal-backdrop-opacity);
-        display: none;
-
-        @media (max-width: $document-float-breakpoint-width) {
-          display: block;
-        }
+      @media (max-width: $document-float-breakpoint-width) {
+        display: block;
       }
     }
   }
+}
 </style>

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -2,20 +2,20 @@
   <div>
     <page-header icon="cog" :title="$t('server.title')" :description="$t('server.description')">
       <template #tabs>
-        <b-tab :title="$t('serverSettings.title')" active v-if="!isServer">
+        <b-tab v-if="!isServer" :title="$t('serverSettings.title')" active>
           <server-settings class="card container mt-4" />
         </b-tab>
-        <b-tab :title="$t('plugins.title')" v-if="!isServer">
+        <b-tab v-if="!isServer" :title="$t('plugins.title')">
           <b-card-text>
             <plugins />
           </b-card-text>
         </b-tab>
-        <b-tab :title="$t('extensions.title')" v-if="!isServer">
+        <b-tab v-if="!isServer" :title="$t('extensions.title')">
           <b-card-text>
             <extensions />
           </b-card-text>
         </b-tab>
-        <b-tab :title="$t('api.title')" v-if="isServer">
+        <b-tab v-if="isServer" :title="$t('api.title')">
           <b-card-text>
             <api />
           </b-card-text>
@@ -35,13 +35,13 @@ import utils from '@/mixins/utils'
 
 export default {
   name: 'Settings',
-  mixins: [utils],
   components: {
     Api,
     Extensions,
     PageHeader,
     Plugins,
     ServerSettings
-  }
+  },
+  mixins: [utils]
 }
 </script>

--- a/src/pages/Tasks.vue
+++ b/src/pages/Tasks.vue
@@ -14,7 +14,7 @@
             {{ $t('batchDownload.title') }}
           </template>
         </b-tab>
-        <b-tab :active="defaultTab === 2" v-if="!isServer">
+        <b-tab v-if="!isServer" :active="defaultTab === 2">
           <template #title>
             <fa icon="search-plus" fixed-width class="mr-1" />
             {{ $t('indexing.title') }}
@@ -43,10 +43,20 @@ import PageHeader from '@/components/PageHeader'
 
 export default {
   name: 'Tasks',
-  mixins: [utils],
   components: {
     BatchSearchForm,
     PageHeader
+  },
+  mixins: [utils],
+  beforeRouteEnter(to, from, next) {
+    return next((vm) => {
+      const defaultTab = vm.tabRoutes.indexOf(to.name)
+      if (defaultTab > -1) {
+        vm.defaultTab = defaultTab
+      } else if (!vm.$route.name.includes('batch-search')) {
+        vm.$router.push({ name: 'batch-search' })
+      }
+    })
   },
   data() {
     return {
@@ -73,16 +83,6 @@ export default {
     tabRoutes() {
       return ['batch-search', 'batch-download', 'indexing']
     }
-  },
-  beforeRouteEnter(to, from, next) {
-    return next((vm) => {
-      const defaultTab = vm.tabRoutes.indexOf(to.name)
-      if (defaultTab > -1) {
-        vm.defaultTab = defaultTab
-      } else if (!vm.$route.name.includes('batch-search')) {
-        vm.$router.push({ name: 'batch-search' })
-      }
-    })
   }
 }
 </script>

--- a/src/pages/Tasks.vue
+++ b/src/pages/Tasks.vue
@@ -48,21 +48,21 @@ export default {
     BatchSearchForm,
     PageHeader
   },
-  data () {
+  data() {
     return {
       defaultTab: null
     }
   },
   computed: {
     tab: {
-      get () {
-        const index = findIndex(this.tabRoutes, name => {
+      get() {
+        const index = findIndex(this.tabRoutes, (name) => {
           return this.$route.name.startsWith(name)
         })
         // Use the defaultTab value when the current route doesn't match with any tab
         return index > -1 ? index : this.defaultTab
       },
-      set (value) {
+      set(value) {
         const name = this.tabRoutes[value]
         // Change tab only if the route changed
         if (name !== this.$route.name) {
@@ -70,12 +70,12 @@ export default {
         }
       }
     },
-    tabRoutes () {
+    tabRoutes() {
       return ['batch-search', 'batch-download', 'indexing']
     }
   },
-  beforeRouteEnter (to, from, next) {
-    return next(vm => {
+  beforeRouteEnter(to, from, next) {
+    return next((vm) => {
       const defaultTab = vm.tabRoutes.indexOf(to.name)
       if (defaultTab > -1) {
         vm.defaultTab = defaultTab

--- a/src/pages/UserHistory.vue
+++ b/src/pages/UserHistory.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="user-history">
-    <page-header icon="clock" :title="$t('userHistory.heading')" :description="$t('userHistory.description')" :tab.sync="tab">
+    <page-header
+      icon="clock"
+      :title="$t('userHistory.heading')"
+      :description="$t('userHistory.description')"
+      :tab.sync="tab"
+    >
       <template #tabs>
         <b-tab :active="defaultTab == 0">
           <template #title>
@@ -15,12 +20,14 @@
           </template>
         </b-tab>
       </template>
-      <confirm-button class="btn btn-primary"
-                      :disabled="!totalEvents || $wait.is(loader)"
-                      :confirmed="deleteUserHistory"
-                      :label="$t('global.confirmLabel')"
-                      :yes="$t('global.yes')"
-                      :no="$t('global.no')">
+      <confirm-button
+        class="btn btn-primary"
+        :disabled="!totalEvents || $wait.is(loader)"
+        :confirmed="deleteUserHistory"
+        :label="$t('global.confirmLabel')"
+        :yes="$t('global.yes')"
+        :no="$t('global.no')"
+      >
         <fa icon="trash-alt" class="mr-1"></fa>
         {{ $t('userHistory.clear') }}
       </confirm-button>
@@ -32,8 +39,8 @@
         </div>
       </template>
       <router-view :events="this.events" />
-      <div class="user-history__pagination pt-2" v-if="totalEvents > perPage" >
-        <custom-pagination v-model="currentPage" :per-page="perPage" :total-rows="totalEvents"/>
+      <div class="user-history__pagination pt-2" v-if="totalEvents > perPage">
+        <custom-pagination v-model="currentPage" :per-page="perPage" :total-rows="totalEvents" />
       </div>
     </v-wait>
   </div>
@@ -48,7 +55,7 @@ export default {
   components: {
     PageHeader
   },
-  data () {
+  data() {
     return {
       events: [],
       totalEvents: 0,
@@ -59,12 +66,12 @@ export default {
   },
   computed: {
     tab: {
-      get () {
-        return findIndex(this.tabRoutes, name => {
+      get() {
+        return findIndex(this.tabRoutes, (name) => {
           return this.$route.name.startsWith(name)
         })
       },
-      set (value) {
+      set(value) {
         const name = this.tabRoutes[value]
         // Change tab only if the route changed
         if (name !== this.$route.name) {
@@ -72,30 +79,30 @@ export default {
         }
       }
     },
-    tabRoutes () {
+    tabRoutes() {
       return ['document-history', 'search-history']
     },
-    loader () {
+    loader() {
       return uniqueId('user-history-load-events-')
     },
-    perPage () {
+    perPage() {
       return settings.userHistory.size
     },
-    pageOffset () {
+    pageOffset() {
       return (this.page - 1) * this.perPage
     },
     currentPage: {
-      get () {
+      get() {
         return this.page
       },
-      set (pageNumber) {
+      set(pageNumber) {
         this.page = pageNumber
         this.$router.push({ query: { page: this.page, from: this.pageOffset, size: this.perPage } })
       }
     }
   },
-  beforeRouteEnter (to, from, next) {
-    return next(vm => {
+  beforeRouteEnter(to, from, next) {
+    return next((vm) => {
       const defaultTab = vm.tabRoutes.indexOf(to.name)
       if (!isEqual(from.path, to.path)) {
         vm.page = 1
@@ -107,7 +114,7 @@ export default {
       }
     })
   },
-  beforeRouteUpdate (to, from, next) {
+  beforeRouteUpdate(to, from, next) {
     const defaultTab = this.tabRoutes.indexOf(to.name)
     if (!isEqual(from.path, to.path)) {
       this.page = 1
@@ -119,35 +126,35 @@ export default {
     }
     next()
   },
-  created () {
+  created() {
     this.getUserHistoryWithSpinner()
   },
   watch: {
-    $route () {
+    $route() {
       this.getUserHistoryWithSpinner()
     }
   },
   methods: {
-    async getUserHistoryWithSpinner () {
+    async getUserHistoryWithSpinner() {
       this.$wait.start(this.loader)
       await this.getUserHistory()
       this.$wait.end(this.loader)
     },
-    async getUserHistory () {
+    async getUserHistory() {
       const type = this.getTypeOfCurrentPage()
       const events = await this.$core.api.getUserHistory(type, this.pageOffset, this.perPage)
       this.$set(this, 'events', events.items)
       this.$set(this, 'totalEvents', events.total)
     },
-    async deleteUserHistory () {
+    async deleteUserHistory() {
       const type = this.getTypeOfCurrentPage()
       await this.$core.api.deleteUserHistory(type)
       this.$set(this, 'events', [])
       this.$set(this, 'totalEvents', 0)
     },
-    getTypeOfCurrentPage () {
+    getTypeOfCurrentPage() {
       const type = this.$route.path.split('/').pop()
-      if (this.tabRoutes.some(tab => tab.startsWith(type))) {
+      if (this.tabRoutes.some((tab) => tab.startsWith(type))) {
         return type
       } else {
         return this.defaultType
@@ -158,21 +165,21 @@ export default {
 </script>
 
 <style lang="scss">
-  .user-history {
-    background: $body-bg;
-    color: $body-color;
-    overflow: auto;
-    position: relative;
+.user-history {
+  background: $body-bg;
+  color: $body-color;
+  overflow: auto;
+  position: relative;
 
-    &__header {
-      z-index: 100;
-      background: inherit;
-      position: sticky;
-      top:0;
-    }
-
-    &__pagination {
-      max-width: 40%;
-    }
+  &__header {
+    z-index: 100;
+    background: inherit;
+    position: sticky;
+    top: 0;
   }
+
+  &__pagination {
+    max-width: 40%;
+  }
+}
 </style>

--- a/src/pages/UserHistory.vue
+++ b/src/pages/UserHistory.vue
@@ -38,8 +38,8 @@
           <fa icon="circle-notch" spin size="2x"></fa>
         </div>
       </template>
-      <router-view :events="this.events" />
-      <div class="user-history__pagination pt-2" v-if="totalEvents > perPage">
+      <router-view :events="events" />
+      <div v-if="totalEvents > perPage" class="user-history__pagination pt-2">
         <custom-pagination v-model="currentPage" :per-page="perPage" :total-rows="totalEvents" />
       </div>
     </v-wait>
@@ -54,6 +54,31 @@ import settings from '@/utils/settings'
 export default {
   components: {
     PageHeader
+  },
+  beforeRouteEnter(to, from, next) {
+    return next((vm) => {
+      const defaultTab = vm.tabRoutes.indexOf(to.name)
+      if (!isEqual(from.path, to.path)) {
+        vm.page = 1
+      }
+      if (defaultTab > -1) {
+        vm.defaultTab = defaultTab
+      } else if (vm.$route.name !== 'document-history') {
+        vm.$router.push({ name: 'document-history' })
+      }
+    })
+  },
+  beforeRouteUpdate(to, from, next) {
+    const defaultTab = this.tabRoutes.indexOf(to.name)
+    if (!isEqual(from.path, to.path)) {
+      this.page = 1
+    }
+    if (defaultTab > -1) {
+      this.defaultTab = defaultTab
+    } else if (this.$route.name !== 'document-history') {
+      this.$router.push({ name: 'document-history' })
+    }
+    next()
   },
   data() {
     return {
@@ -101,38 +126,13 @@ export default {
       }
     }
   },
-  beforeRouteEnter(to, from, next) {
-    return next((vm) => {
-      const defaultTab = vm.tabRoutes.indexOf(to.name)
-      if (!isEqual(from.path, to.path)) {
-        vm.page = 1
-      }
-      if (defaultTab > -1) {
-        vm.defaultTab = defaultTab
-      } else if (vm.$route.name !== 'document-history') {
-        vm.$router.push({ name: 'document-history' })
-      }
-    })
-  },
-  beforeRouteUpdate(to, from, next) {
-    const defaultTab = this.tabRoutes.indexOf(to.name)
-    if (!isEqual(from.path, to.path)) {
-      this.page = 1
-    }
-    if (defaultTab > -1) {
-      this.defaultTab = defaultTab
-    } else if (this.$route.name !== 'document-history') {
-      this.$router.push({ name: 'document-history' })
-    }
-    next()
-  },
-  created() {
-    this.getUserHistoryWithSpinner()
-  },
   watch: {
     $route() {
       this.getUserHistoryWithSpinner()
     }
+  },
+  created() {
+    this.getUserHistoryWithSpinner()
   },
   methods: {
     async getUserHistoryWithSpinner() {

--- a/src/pages/UserHistoryDocument.vue
+++ b/src/pages/UserHistoryDocument.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="user-history">
     <div class="mt-4">
-      <ul class="list-unstyled user-history__list card mb-4" v-if="events.length">
+      <ul v-if="events.length" class="list-unstyled user-history__list card mb-4">
         <li v-for="event in events" :key="event.id" class="user-history__list__item">
           <router-link :to="{ path: event.uri }" class="p-3 d-flex">
             <document-thumbnail
@@ -23,7 +23,7 @@
           </router-link>
         </li>
       </ul>
-      <div class="text-muted text-center" v-else>
+      <div v-else class="text-muted text-center">
         {{ $t('userHistory.empty') }}
       </div>
     </div>
@@ -46,19 +46,19 @@ export default {
       type: Array
     }
   },
+  computed: {
+    documentPathRegexp() {
+      const routes = this.$router.getRoutes()
+      const { path } = find(routes, { name: 'document-standalone' }) || {}
+      return pathToRegexp(path)
+    }
+  },
   methods: {
     eventAsDocument({ uri }) {
       // Ensure the URI starts with a / and doesn't contain query params
       const path = `/${trimStart(uri.split('?').shift(0), '/')}`
       const [, _index, _id, _routing] = this.documentPathRegexp.exec(path) || []
       return new Document({ _index, _id, _routing })
-    }
-  },
-  computed: {
-    documentPathRegexp() {
-      const routes = this.$router.getRoutes()
-      const { path } = find(routes, { name: 'document-standalone' }) || {}
-      return pathToRegexp(path)
     }
   }
 }

--- a/src/pages/UserHistoryDocument.vue
+++ b/src/pages/UserHistoryDocument.vue
@@ -4,7 +4,13 @@
       <ul class="list-unstyled user-history__list card mb-4" v-if="events.length">
         <li v-for="event in events" :key="event.id" class="user-history__list__item">
           <router-link :to="{ path: event.uri }" class="p-3 d-flex">
-            <document-thumbnail :document="eventAsDocument(event)" size="40" crop lazy class="mr-3 user-history__list__item__preview" />
+            <document-thumbnail
+              :document="eventAsDocument(event)"
+              size="40"
+              crop
+              lazy
+              class="mr-3 user-history__list__item__preview"
+            />
             <div class="flex-grow-1">
               <div class="user-history__list__item__name font-weight-bold">
                 {{ event.name }}
@@ -18,7 +24,7 @@
         </li>
       </ul>
       <div class="text-muted text-center" v-else>
-        {{  $t('userHistory.empty') }}
+        {{ $t('userHistory.empty') }}
       </div>
     </div>
   </div>
@@ -41,7 +47,7 @@ export default {
     }
   },
   methods: {
-    eventAsDocument ({ uri }) {
+    eventAsDocument({ uri }) {
       // Ensure the URI starts with a / and doesn't contain query params
       const path = `/${trimStart(uri.split('?').shift(0), '/')}`
       const [, _index, _id, _routing] = this.documentPathRegexp.exec(path) || []
@@ -49,9 +55,9 @@ export default {
     }
   },
   computed: {
-    documentPathRegexp () {
+    documentPathRegexp() {
       const routes = this.$router.getRoutes()
-      const { path } = find(routes, { name: 'document-standalone' }) || { }
+      const { path } = find(routes, { name: 'document-standalone' }) || {}
       return pathToRegexp(path)
     }
   }
@@ -59,41 +65,39 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .user-history {
-    &__list {
+.user-history {
+  &__list {
+    &__item {
+      &:nth-child(odd) {
+        background: $table-accent-bg;
+      }
 
-      &__item {
+      &:not(:last-of-type) {
+        border-bottom: 1px solid $border-color;
+      }
 
-        &:nth-child(odd) {
-          background: $table-accent-bg;
-        }
+      a:hover {
+        text-decoration: none;
+        color: $table-hover-color;
+        background-color: $table-hover-bg;
+      }
 
-        &:not(:last-of-type) {
-          border-bottom: 1px solid $border-color;
-        }
+      & &__preview.document-thumbnail--crop {
+        width: 40px;
+        min-width: 40px;
+        height: 40px;
+      }
 
-        a:hover {
-          text-decoration: none;
-          color: $table-hover-color;
-          background-color: $table-hover-bg;
-        }
+      a > div {
+        min-width: 0;
+      }
 
-        & &__preview.document-thumbnail--crop {
-          width: 40px;
-          min-width: 40px;
-          height: 40px;
-        }
-
-        a > div {
-          min-width: 0;
-        }
-
-        &__uri {
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
-        }
+      &__uri {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
     }
   }
+}
 </style>

--- a/src/pages/UserHistorySearch.vue
+++ b/src/pages/UserHistorySearch.vue
@@ -5,14 +5,15 @@
         <li v-for="event in searches" :key="event.id" class="user-history__list__item">
           <div class="user-history__list__item__delete float-right m-4">
             <confirm-button
-                class="btn btn-outline-danger"
-                placement="leftbottom"
-                :confirmed="() => deleteUserEvent(event)"
-                :label="$t('userHistory.confirmDelete')"
-                :no="$t('global.no')"
-                :yes="$t('global.yes')">
-                <fa icon="trash-alt" />
-                {{ $t('userHistory.delete') }}
+              class="btn btn-outline-danger"
+              placement="leftbottom"
+              :confirmed="() => deleteUserEvent(event)"
+              :label="$t('userHistory.confirmDelete')"
+              :no="$t('global.no')"
+              :yes="$t('global.yes')"
+            >
+              <fa icon="trash-alt" />
+              {{ $t('userHistory.delete') }}
             </confirm-button>
           </div>
           <router-link :to="{ path: event.uri }" class="p-3 d-block">
@@ -20,16 +21,18 @@
               {{ event.name }}
             </div>
             <div class="user-history__list__item__query">
-              <applied-search-filters-item read-only
-                                           v-for="(filter, index) in filtersItems(event)"
-                                          :key="index"
-                                          :filter="filter" />
+              <applied-search-filters-item
+                read-only
+                v-for="(filter, index) in filtersItems(event)"
+                :key="index"
+                :filter="filter"
+              />
             </div>
           </router-link>
         </li>
       </ul>
       <div class="text-muted text-center" v-else>
-        {{  $t('userHistory.empty') }}
+        {{ $t('userHistory.empty') }}
       </div>
     </div>
   </div>
@@ -48,20 +51,20 @@ export default {
       type: Array
     }
   },
-  data () {
+  data() {
     return {
       searches: this.events
     }
   },
   methods: {
-    filtersItems ({ uri }) {
+    filtersItems({ uri }) {
       return this.createFiltersFromURI(uri)
     },
-    isIgnoredFilter ({ name, value }) {
+    isIgnoredFilter({ name, value }) {
       const ignored = ['from', 'size', 'sort', 'field']
       return ignored.includes(name) || (name === 'q' && ['', '*'].includes(value))
     },
-    createFiltersFromURI (uri) {
+    createFiltersFromURI(uri) {
       const urlSearchParams = new URLSearchParams(uri.split('?').slice(1).pop())
       const params = Object.fromEntries(urlSearchParams.entries())
       // Reduce params list into an array
@@ -85,14 +88,14 @@ export default {
         return filters
       }, [])
     },
-    async deleteUserEvent (event) {
+    async deleteUserEvent(event) {
       try {
         await this.$core.api.deleteUserEvent(event.id)
         this.$root.$bvToast.toast(this.$t('userHistory.deleted'), { noCloseButton: true, variant: 'success' })
       } catch (_) {
         this.$root.$bvToast.toast(this.$t('userHistory.notDeleted'), { noCloseButton: true, variant: 'warning' })
       } finally {
-        const searches = this.searches.filter(e => !(e === event))
+        const searches = this.searches.filter((e) => !(e === event))
         this.$set(this, 'searches', searches)
       }
     }
@@ -101,25 +104,23 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .user-history {
-    &__list {
+.user-history {
+  &__list {
+    &__item {
+      a:hover {
+        text-decoration: none;
+        color: $table-hover-color;
+        background-color: $table-hover-bg;
+      }
 
-      &__item {
+      &:nth-child(odd) {
+        background: $table-accent-bg;
+      }
 
-        a:hover {
-          text-decoration: none;
-          color: $table-hover-color;
-          background-color: $table-hover-bg;
-        }
-
-        &:nth-child(odd) {
-          background: $table-accent-bg;
-        }
-
-        &:not(:last-of-type) {
-          border-bottom: 1px solid $border-color;
-        }
+      &:not(:last-of-type) {
+        border-bottom: 1px solid $border-color;
       }
     }
   }
+}
 </style>

--- a/src/pages/UserHistorySearch.vue
+++ b/src/pages/UserHistorySearch.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="user-history">
     <div class="mt-4">
-      <ul class="list-unstyled user-history__list card mb-4" v-if="events.length">
+      <ul v-if="events.length" class="list-unstyled user-history__list card mb-4">
         <li v-for="event in searches" :key="event.id" class="user-history__list__item">
           <div class="user-history__list__item__delete float-right m-4">
             <confirm-button
@@ -22,16 +22,16 @@
             </div>
             <div class="user-history__list__item__query">
               <applied-search-filters-item
-                read-only
                 v-for="(filter, index) in filtersItems(event)"
                 :key="index"
+                read-only
                 :filter="filter"
               />
             </div>
           </router-link>
         </li>
       </ul>
-      <div class="text-muted text-center" v-else>
+      <div v-else class="text-muted text-center">
         {{ $t('userHistory.empty') }}
       </div>
     </div>

--- a/src/router/guards.js
+++ b/src/router/guards.js
@@ -2,12 +2,12 @@ import get from 'lodash/get'
 import isFunction from 'lodash/isFunction'
 
 export default ({ router, auth, store, config, i18n, setPageTitle }) => {
-  async function checkUserAuthentication (to, from, next) {
+  async function checkUserAuthentication(to, from, next) {
     try {
       // This route skip auth
-      if (to.matched.some(r => get(r, 'meta.skipsAuth', false))) {
+      if (to.matched.some((r) => get(r, 'meta.skipsAuth', false))) {
         next()
-      // The user is authenticated
+        // The user is authenticated
       } else if (await auth.getUsername()) {
         const path = await store.dispatch('app/popRedirectAfterLogin')
         if (to.path !== path && path !== null) {
@@ -15,7 +15,7 @@ export default ({ router, auth, store, config, i18n, setPageTitle }) => {
         } else {
           next()
         }
-      // The user isn't authenticated
+        // The user isn't authenticated
       } else {
         store.commit('app/setRedirectAfterLogin', to.path)
         next({ name: 'login' })
@@ -25,7 +25,7 @@ export default ({ router, auth, store, config, i18n, setPageTitle }) => {
     }
   }
 
-  function checkUserProjects (to, from, next) {
+  function checkUserProjects(to, from, next) {
     const projects = config.get('groups_by_applications.datashare', [])
     // No project given for this user
     if (!projects.length && ['error', 'login'].indexOf(to.name) === -1) {
@@ -36,12 +36,12 @@ export default ({ router, auth, store, config, i18n, setPageTitle }) => {
     }
   }
 
-  function reduceAppSideBar (to, from, next) {
+  function reduceAppSideBar(to, from, next) {
     store.dispatch('app/toggleSidebar', true)
     next()
   }
 
-  async function setPageTitleFromMeta ({ meta }, from, next) {
+  async function setPageTitleFromMeta({ meta }, from, next) {
     const params = { router, auth, store, config, i18n }
     const title = isFunction(meta.title) ? await meta.title(params) : meta.title
     setPageTitle(title)

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -46,11 +46,7 @@ export const router = {
               props: true,
               meta: {
                 title: ({ i18n }) => i18n.t('document.title'),
-                docs: [
-                  'all/star-documents.md',
-                  'all/tag-documents.md',
-                  'all/use-keyboard-shortcuts.md'
-                ]
+                docs: ['all/star-documents.md', 'all/tag-documents.md', 'all/use-keyboard-shortcuts.md']
               }
             }
           ]
@@ -116,9 +112,7 @@ export const router = {
               },
               meta: {
                 title: ({ i18n }) => i18n.t('batchSearch.title'),
-                docs: [
-                  'all/batch-search-documents.md'
-                ]
+                docs: ['all/batch-search-documents.md']
               }
             },
             {
@@ -203,7 +197,7 @@ export const router = {
           meta: {
             title: 'Document'
           },
-          props (route) {
+          props(route) {
             return { ...route.params, ...route.query }
           },
           component: () => import('@/pages/DocumentStandalone')
@@ -216,7 +210,7 @@ export const router = {
       meta: {
         title: 'Document'
       },
-      props (route) {
+      props(route) {
         return { ...route.params, ...route.query }
       },
       component: () => import('@/pages/DocumentModal')

--- a/src/store/filters/FilterContentType.js
+++ b/src/store/filters/FilterContentType.js
@@ -5,8 +5,8 @@ import types from '@/utils/types.json'
 import { getDocumentTypeLabel } from '@/utils/utils'
 
 export default class FilterContentType extends FilterText {
-  constructor (options) {
-    const alternativeSearch = query => {
+  constructor(options) {
+    const alternativeSearch = (query) => {
       return map(types, (item, key) => {
         if (toLower(item.label).includes(query)) {
           return key
@@ -15,7 +15,7 @@ export default class FilterContentType extends FilterText {
     }
     super({ alternativeSearch, ...options })
   }
-  itemLabel (item) {
+  itemLabel(item) {
     return getDocumentTypeLabel(item.key)
   }
 }

--- a/src/store/filters/FilterDate.js
+++ b/src/store/filters/FilterDate.js
@@ -1,16 +1,16 @@
 import FilterDocument from './FilterDocument'
 
 export default class FilterDate extends FilterDocument {
-  constructor (options) {
+  constructor(options) {
     super(options)
     this.component = 'FilterDate'
   }
-  itemLabel (item) {
+  itemLabel(item) {
     return item.key_as_string
   }
-  queryBuilder (body, param, func) {
-    return body.query('bool', sub => {
-      param.values.forEach(date => {
+  queryBuilder(body, param, func) {
+    return body.query('bool', (sub) => {
+      param.values.forEach((date) => {
         if (parseInt(date) === -62167219200000) {
           sub.notQuery('exists', this.key)
         } else {
@@ -23,25 +23,29 @@ export default class FilterDate extends FilterDocument {
       return sub
     })
   }
-  body (body, { size = 0, interval = 'month ' } = {}) {
-    return body
-      .query('match', 'type', 'Document')
-      .agg('date_histogram', this.key, {
+  body(body, { size = 0, interval = 'month ' } = {}) {
+    return body.query('match', 'type', 'Document').agg(
+      'date_histogram',
+      this.key,
+      {
         ...FilterDate.getIntervalOptions(interval),
         order: { _key: 'desc' },
         min_doc_count: 1
-      }, this.key, a => a.agg('bucket_sort', { size }, 'bucket_sort_truncate'))
+      },
+      this.key,
+      (a) => a.agg('bucket_sort', { size }, 'bucket_sort_truncate')
+    )
   }
-  static getIntervalOptions (interval = 'month') {
+  static getIntervalOptions(interval = 'month') {
     switch (interval) {
-    case 'day':
-      return { interval: '1d', format: 'yyyy-MM-dd', missing: '0001-01-01' }
-    case 'month':
-      return { interval: '1M', format: 'yyyy-MM', missing: '0001-01' }
-    case 'year':
-      return { interval: '1y', format: 'yyyy', missing: '0001' }
-    default:
-      return { interval: '1M', format: 'yyyy-MM', missing: '0001-01' }
+      case 'day':
+        return { interval: '1d', format: 'yyyy-MM-dd', missing: '0001-01-01' }
+      case 'month':
+        return { interval: '1M', format: 'yyyy-MM', missing: '0001-01' }
+      case 'year':
+        return { interval: '1y', format: 'yyyy', missing: '0001' }
+      default:
+        return { interval: '1M', format: 'yyyy-MM', missing: '0001-01' }
     }
   }
 }

--- a/src/store/filters/FilterDateRange.js
+++ b/src/store/filters/FilterDateRange.js
@@ -3,12 +3,12 @@ import moment from 'moment'
 import FilterDate from './FilterDate'
 
 export default class FilterDateRange extends FilterDate {
-  constructor (options) {
+  constructor(options) {
     super(options)
     this.component = 'FilterDateRange'
   }
 
-  itemLabel (item) {
+  itemLabel(item) {
     if (isInteger(item.key)) {
       const timestamp = item.key + new Date().getTimezoneOffset() * 60 * 1000
       return moment(timestamp).locale(localStorage.getItem('locale')).format('L')
@@ -17,14 +17,14 @@ export default class FilterDateRange extends FilterDate {
     }
   }
 
-  queryBuilder (body, param, func) {
-    return body.query('bool', sub => {
+  queryBuilder(body, param, func) {
+    return body.query('bool', (sub) => {
       sub[func]('range', this.key, { gte: new Date(min(param.values)), lte: new Date(max(param.values)) })
       return sub
     })
   }
 
-  get values () {
-    return uniq(super.values.map(v => parseInt(v)))
+  get values() {
+    return uniq(super.values.map((v) => parseInt(v)))
   }
 }

--- a/src/store/filters/FilterDocument.js
+++ b/src/store/filters/FilterDocument.js
@@ -1,12 +1,12 @@
 import FilterType from './FilterType'
 
 export default class FilterDocument extends FilterType {
-  constructor (options) {
+  constructor(options) {
     super(options)
     this.component = 'FilterDocument'
   }
 
-  addParentIncludeFilter (body, param) {
-    return body.query('has_parent', { parent_type: 'Document' }, q => this.addChildIncludeFilter(q, param))
+  addParentIncludeFilter(body, param) {
+    return body.query('has_parent', { parent_type: 'Document' }, (q) => this.addChildIncludeFilter(q, param))
   }
 }

--- a/src/store/filters/FilterExtractionLevel.js
+++ b/src/store/filters/FilterExtractionLevel.js
@@ -2,12 +2,12 @@ import FilterText from './FilterText'
 import { getExtractionLevelTranslationKey } from '@/utils/utils'
 
 export default class FilterExtractionLevel extends FilterText {
-  constructor (options) {
+  constructor(options) {
     super(options)
     this.sort = '_key'
     this.sortByOrder = 'asc'
   }
-  itemLabel (item) {
+  itemLabel(item) {
     return getExtractionLevelTranslationKey(item.key)
   }
 }

--- a/src/store/filters/FilterLanguage.js
+++ b/src/store/filters/FilterLanguage.js
@@ -1,7 +1,7 @@
 import FilterText from './FilterText'
 
 export default class FilterLanguage extends FilterText {
-  itemLabel (item) {
+  itemLabel(item) {
     return `filter.lang.${item.key}`
   }
 }

--- a/src/store/filters/FilterNamedEntity.js
+++ b/src/store/filters/FilterNamedEntity.js
@@ -9,7 +9,7 @@ export const namedEntityCategoryTranslation = {
 }
 
 export default class FilterNamedEntity extends FilterType {
-  constructor (options) {
+  constructor(options) {
     super(options)
     this.category = options.category || 'PERSON'
     this.component = 'FilterNamedEntity'
@@ -23,60 +23,65 @@ export default class FilterNamedEntity extends FilterType {
     ]
   }
 
-  isSelfAffected (body) {
-    return includes(JSON.stringify(body.build()), '"term":{"category":"' + namedEntityCategoryTranslation[this.name] + '"}')
+  isSelfAffected(body) {
+    return includes(
+      JSON.stringify(body.build()),
+      '"term":{"category":"' + namedEntityCategoryTranslation[this.name] + '"}'
+    )
   }
 
-  queryBuilder (body, param, func) {
-    return body[func]('bool', b => {
-      b.orQuery('has_child', 'type', 'NamedEntity', {}, sub => {
-        return sub.query('query_string', {
-          default_field: 'mentionNorm',
-          query: param.values.map(v => `(${v})`).join(' OR ')
-        }).query('query_string', {
-          default_field: 'category',
-          query: namedEntityCategoryTranslation[param.name] || param.name
-        })
+  queryBuilder(body, param, func) {
+    return body[func]('bool', (b) => {
+      b.orQuery('has_child', 'type', 'NamedEntity', {}, (sub) => {
+        return sub
+          .query('query_string', {
+            default_field: 'mentionNorm',
+            query: param.values.map((v) => `(${v})`).join(' OR ')
+          })
+          .query('query_string', {
+            default_field: 'category',
+            query: namedEntityCategoryTranslation[param.name] || param.name
+          })
       })
 
       b.orQuery('query_string', {
         default_field: 'mentionNorm',
-        query: param.values.map(v => `(${v})`).join(' OR ')
+        query: param.values.map((v) => `(${v})`).join(' OR ')
       })
       return b
     })
   }
 
-  addChildIncludeFilter (body, param) {
+  addChildIncludeFilter(body, param) {
     return this.queryBuilder(body, param, 'query')
   }
 
-  addParentIncludeFilter (body, param) {
+  addParentIncludeFilter(body, param) {
     if (this.isSelfAffected(body)) {
       return body.query('terms', 'mentionNorm', param.values)
     } else {
-      return body.query('has_parent', { parent_type: 'Document' }, q => {
-        return q.query('has_child', 'type', 'NamedEntity', {}, r => {
+      return body.query('has_parent', { parent_type: 'Document' }, (q) => {
+        return q.query('has_child', 'type', 'NamedEntity', {}, (r) => {
           return r.query('terms', 'mentionNorm', param.values)
         })
       })
     }
   }
 
-  addParentExcludeFilter (body, param) {
-    return body.query('has_parent', { parent_type: 'Document' }, q => {
-      return q.notQuery('has_child', 'type', 'NamedEntity', {}, r => {
+  addParentExcludeFilter(body, param) {
+    return body.query('has_parent', { parent_type: 'Document' }, (q) => {
+      return q.notQuery('has_child', 'type', 'NamedEntity', {}, (r) => {
         return r.query('terms', 'mentionNorm', param.values)
       })
     })
   }
 
-  body (body, options, from = 0, size = 50) {
+  body(body, options, from = 0, size = 50) {
     return body
       .query('term', 'type', 'NamedEntity')
       .filter('term', 'isHidden', 'false')
       .filter('term', 'category', this.category)
-      .agg('terms', 'mentionNorm', this.key, { ...options }, sub => {
+      .agg('terms', 'mentionNorm', this.key, { ...options }, (sub) => {
         return sub.agg('bucket_sort', { size, from }, 'bucket_truncate')
       })
   }

--- a/src/store/filters/FilterPath.js
+++ b/src/store/filters/FilterPath.js
@@ -4,22 +4,22 @@ import uniq from 'lodash/uniq'
 import FilterDocument from './FilterDocument'
 
 export default class FilterPath extends FilterDocument {
-  constructor (options) {
+  constructor(options) {
     super(options)
     this.prefix = true
     this.component = 'FilterPath'
   }
 
-  queryBuilder (body, param, func) {
-    return body.query('bool', sub => {
-      compact(param.values).forEach(dirname => {
+  queryBuilder(body, param, func) {
+    return body.query('bool', (sub) => {
+      compact(param.values).forEach((dirname) => {
         /**
          * @deprecated Since 9.4.2, the dirname field is tokenized using the
          * "lowercase" filter. To ensure retro-compatibility, we apply the
          * filter using both lowercase and orignal value for this field (if they
          * are different).
          */
-        uniq([dirname, dirname.toLowerCase()]).forEach(token => {
+        uniq([dirname, dirname.toLowerCase()]).forEach((token) => {
           sub[func]('term', 'dirname.tree', trimEnd(token, '/'))
         })
       })

--- a/src/store/filters/FilterRecommendedBy.js
+++ b/src/store/filters/FilterRecommendedBy.js
@@ -1,16 +1,16 @@
 import FilterText from './FilterText'
 
 export default class FilterRecommendedBy extends FilterText {
-  constructor (options) {
+  constructor(options) {
     super(options)
     this.component = 'FilterRecommendedBy'
   }
 
-  addChildIncludeFilter (body) {
+  addChildIncludeFilter(body) {
     return body.addFilter('terms', this.key, this.rootState.recommended.documents)
   }
 
-  addChildExcludeFilter (body) {
+  addChildExcludeFilter(body) {
     return body.notFilter('terms', this.key, this.rootState.recommended.documents)
   }
 }

--- a/src/store/filters/FilterStarred.js
+++ b/src/store/filters/FilterStarred.js
@@ -2,27 +2,27 @@ import { get, map } from 'lodash'
 import FilterText from './FilterText'
 
 export default class FilterStarred extends FilterText {
-  constructor (options) {
+  constructor(options) {
     super(options)
     this.component = 'FilterStarred'
   }
-  addChildIncludeFilter (body, param) {
+  addChildIncludeFilter(body, param) {
     if (param.values[0]) {
       return body.addFilter('terms', this.key, this.starredDocumentIds)
     } else {
       return body.notFilter('terms', this.key, this.starredDocumentIds)
     }
   }
-  itemLabel (item) {
+  itemLabel(item) {
     return get(FilterStarred.starredLabels, item.key, item.key)
   }
-  get starredDocuments () {
+  get starredDocuments() {
     return this.rootState.starred.documents
   }
-  get starredDocumentIds () {
+  get starredDocumentIds() {
     return map(this.starredDocuments, 'id')
   }
-  static get starredLabels () {
+  static get starredLabels() {
     return {
       all: 'global.all',
       true: 'filter.starred',

--- a/src/store/filters/FilterText.js
+++ b/src/store/filters/FilterText.js
@@ -7,7 +7,16 @@ const _VALUES = typeof Symbol === 'function' ? Symbol('_values') : '_values'
 const _ROOT_STATE = typeof Symbol === 'function' ? Symbol('_ROOT_state') : '_ROOT_state'
 
 export default class FilterText {
-  constructor ({ name, key, icon = null, isSearchable = false, alternativeSearch = () => {}, order = null, fromElasticSearch = true, preference = '_local' } = { }) {
+  constructor({
+    name,
+    key,
+    icon = null,
+    isSearchable = false,
+    alternativeSearch = () => {},
+    order = null,
+    fromElasticSearch = true,
+    preference = '_local'
+  } = {}) {
     this.name = name
     this.key = key
     this.icon = icon
@@ -21,42 +30,50 @@ export default class FilterText {
     this.sortByOrder = 'desc'
   }
 
-  itemParam (item) {
+  itemParam(item) {
     return { name: this.name, value: item.key }
   }
 
-  itemLabel (item) {
+  itemLabel(item) {
     return item.key || item.value
   }
 
-  addChildIncludeFilter (body, param) {
+  addChildIncludeFilter(body, param) {
     return body.addFilter('terms', this.key, param.values)
   }
 
-  addParentIncludeFilter (body, param) {
-    return body.query('has_parent', { parent_type: 'Document' }, q => q.query('terms', this.key, param.values))
+  addParentIncludeFilter(body, param) {
+    return body.query('has_parent', { parent_type: 'Document' }, (q) => q.query('terms', this.key, param.values))
   }
 
-  addParentExcludeFilter (body, param) {
-    return body.query('has_parent', { parent_type: 'Document' }, q => q.notQuery('terms', this.key, param.values))
+  addParentExcludeFilter(body, param) {
+    return body.query('has_parent', { parent_type: 'Document' }, (q) => q.notQuery('terms', this.key, param.values))
   }
 
-  addChildExcludeFilter (body, param) {
+  addChildExcludeFilter(body, param) {
     return body.notFilter('terms', this.key, param.values)
   }
 
-  body (body, options, from = 0, size = 8) {
-    return body
-      .query('match', 'type', 'Document')
-      .agg('terms', this.key, this.key, sub => {
-        return sub.agg('bucket_sort', {
-          size,
-          from
-        }, 'bucket_truncate')
-      }, options)
+  body(body, options, from = 0, size = 8) {
+    return body.query('match', 'type', 'Document').agg(
+      'terms',
+      this.key,
+      this.key,
+      (sub) => {
+        return sub.agg(
+          'bucket_sort',
+          {
+            size,
+            from
+          },
+          'bucket_truncate'
+        )
+      },
+      options
+    )
   }
 
-  addFilter (body) {
+  addFilter(body) {
     if (this.hasValues()) {
       if (this.reverse) {
         if (this.isNamedEntityAggregation(body)) {
@@ -74,46 +91,45 @@ export default class FilterText {
     }
   }
 
-  hasValues () {
+  hasValues() {
     return this.values.length > 0
   }
 
-  isNamedEntityAggregation (body) {
-    return some([
-      '"must":{"term":{"type":"NamedEntity"}}',
-      '"must":[{"term":{"type":"NamedEntity"}}'
-    ], str => includes(JSON.stringify(body.build()), str))
+  isNamedEntityAggregation(body) {
+    return some(['"must":{"term":{"type":"NamedEntity"}}', '"must":[{"term":{"type":"NamedEntity"}}'], (str) =>
+      includes(JSON.stringify(body.build()), str)
+    )
   }
 
-  applyTo (body) {
+  applyTo(body) {
     this.addFilter(body)
   }
 
-  bindRootState (rootState) {
+  bindRootState(rootState) {
     this[_ROOT_STATE] = this[_ROOT_STATE] || rootState
   }
 
-  get rootState () {
+  get rootState() {
     return this[_ROOT_STATE]
   }
 
-  get state () {
+  get state() {
     return this?.rootState?.search
   }
 
-  get values () {
+  get values() {
     return this[_VALUES] || get(this, ['state', 'values', this.name], [])
   }
 
-  set values (values) {
+  set values(values) {
     this[_VALUES] = values
   }
 
-  get reverse () {
+  get reverse() {
     return get(this, ['state', 'reversed'], []).indexOf(this.name) > -1
   }
 
-  get contextualized () {
+  get contextualized() {
     return get(this, ['state', 'contextualized'], []).indexOf(this.name) > -1
   }
 }

--- a/src/store/filters/FilterType.js
+++ b/src/store/filters/FilterType.js
@@ -1,16 +1,16 @@
 import FilterText from './FilterText'
 
 export default class FilterType extends FilterText {
-  constructor (...args) {
+  constructor(...args) {
     super(...args)
     this.component = 'FilterType'
   }
 
-  addChildIncludeFilter (body, param, func) {
+  addChildIncludeFilter(body, param, func) {
     return this.queryBuilder(body, param, 'orQuery')
   }
 
-  addChildExcludeFilter (body, param, func) {
+  addChildExcludeFilter(body, param, func) {
     return this.queryBuilder(body, param, 'notQuery')
   }
 }

--- a/src/store/hooks/HookedComponent.js
+++ b/src/store/hooks/HookedComponent.js
@@ -4,20 +4,20 @@ export const defaultOrder = 0
 export const defaultDefinition = { template: '<span></span>' }
 
 export class HookedComponent {
-  constructor ({ target, name, order = defaultOrder, definition = defaultDefinition }) {
+  constructor({ target, name, order = defaultOrder, definition = defaultDefinition }) {
     this.name = name || uniqueId('hooked-component-')
     this.target = target
     this.order = order
     this.definition = definition
   }
-  get component () {
+  get component() {
     if (isString(this.definition)) {
       const template = `<span>${this.definition}</span>`
       return { template }
     }
     return this.definition
   }
-  static create (...args) {
+  static create(...args) {
     return new HookedComponent(...args)
   }
 }

--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -8,10 +8,10 @@ export const state = () => ({
 })
 
 export const mutations = {
-  sidebarReduced (state, reduced) {
+  sidebarReduced(state, reduced) {
     Vue.set(state.sidebar, 'reduced', reduced)
   },
-  setRedirectAfterLogin (state, path = null) {
+  setRedirectAfterLogin(state, path = null) {
     if (!path || !path.startsWith('/login')) {
       Vue.set(state, 'redirectAfterLogin', path)
     }
@@ -19,13 +19,13 @@ export const mutations = {
 }
 
 export const actions = {
-  toggleSidebar ({ state, commit }, toggler = null) {
+  toggleSidebar({ state, commit }, toggler = null) {
     if (toggler === null) {
       return commit('sidebarReduced', !state.sidebar.reduced)
     }
     return commit('sidebarReduced', toggler)
   },
-  popRedirectAfterLogin ({ state: { redirectAfterLogin }, commit }) {
+  popRedirectAfterLogin({ state: { redirectAfterLogin }, commit }) {
     commit('setRedirectAfterLogin', null)
     return redirectAfterLogin
   }

--- a/src/store/modules/batchSearch.js
+++ b/src/store/modules/batchSearch.js
@@ -3,11 +3,19 @@ import map from 'lodash/map'
 
 import Vue from 'vue'
 import {
-  RESET, SINGLE_BATCH_SEARCH, SINGLE_BATCH_SEARCH_QUERIES, BATCH_SEARCHES, REMOVE_BATCH_SEARCH,
-  CLEAR_BATCH_SEARCH, SELECTED_QUERIES, RESULTS, TOTAL, HAS_BATCH_SEARCH
+  RESET,
+  SINGLE_BATCH_SEARCH,
+  SINGLE_BATCH_SEARCH_QUERIES,
+  BATCH_SEARCHES,
+  REMOVE_BATCH_SEARCH,
+  CLEAR_BATCH_SEARCH,
+  SELECTED_QUERIES,
+  RESULTS,
+  TOTAL,
+  HAS_BATCH_SEARCH
 } from '@/store/mutation-types'
 
-export function initialState () {
+export function initialState() {
   return {
     batchSearch: {},
     batchSearches: [],
@@ -22,53 +30,53 @@ export function initialState () {
 export const state = initialState()
 
 export const getters = {
-  queryKeys (state) {
+  queryKeys(state) {
     return map(state.queries, (count, label) => ({ label, count }))
   },
-  nbSelectedQueries (state) {
+  nbSelectedQueries(state) {
     return state.selectedQueries?.length ?? 0
   }
 }
 export const mutations = {
-  [RESET] (state) {
+  [RESET](state) {
     Object.assign(state, initialState())
   },
-  [SINGLE_BATCH_SEARCH] (state, batchSearch) {
+  [SINGLE_BATCH_SEARCH](state, batchSearch) {
     Vue.set(state, 'batchSearch', batchSearch)
   },
-  [SINGLE_BATCH_SEARCH_QUERIES] (state, queries) {
+  [SINGLE_BATCH_SEARCH_QUERIES](state, queries) {
     state.queries = queries
   },
-  [BATCH_SEARCHES] (state, batchSearches) {
+  [BATCH_SEARCHES](state, batchSearches) {
     Vue.set(state, 'batchSearches', batchSearches)
   },
-  [REMOVE_BATCH_SEARCH] (state, batchId) {
-    remove(state.batchSearches, batchSearch => batchSearch.uuid === batchId)
+  [REMOVE_BATCH_SEARCH](state, batchId) {
+    remove(state.batchSearches, (batchSearch) => batchSearch.uuid === batchId)
     state.hasBatchSearch = state.batchSearches.length > 0
     state.total = state.total - 1
   },
-  [CLEAR_BATCH_SEARCH] (state) {
+  [CLEAR_BATCH_SEARCH](state) {
     state.batchSearches = []
     state.hasBatchSearch = false
     state.total = 0
   },
-  [SELECTED_QUERIES] (state, selectedQueries) {
+  [SELECTED_QUERIES](state, selectedQueries) {
     Vue.set(state, 'selectedQueries', selectedQueries)
   },
-  [RESULTS] (state, results) {
+  [RESULTS](state, results) {
     Vue.set(state, 'results', results)
   },
-  [TOTAL] (state, total) {
+  [TOTAL](state, total) {
     state.total = total
   },
-  [HAS_BATCH_SEARCH] (state, hasBatchSearch) {
+  [HAS_BATCH_SEARCH](state, hasBatchSearch) {
     state.hasBatchSearch = hasBatchSearch
   }
 }
 
-export function actionBuilder (api) {
+export function actionBuilder(api) {
   return {
-    async getBatchSearch ({ commit }, batchId) {
+    async getBatchSearch({ commit }, batchId) {
       let batchSearch = {}
       try {
         batchSearch = await api.getBatchSearch(batchId)
@@ -76,7 +84,7 @@ export function actionBuilder (api) {
         commit(SINGLE_BATCH_SEARCH, batchSearch)
       }
     },
-    async getBatchSearchQueries ({ commit }, batchId) {
+    async getBatchSearchQueries({ commit }, batchId) {
       let queries = {}
       try {
         queries = await api.getBatchSearchQueries(batchId)
@@ -84,7 +92,7 @@ export function actionBuilder (api) {
         commit(SINGLE_BATCH_SEARCH_QUERIES, queries)
       }
     },
-    async hasBatchSearch ({ commit }) {
+    async hasBatchSearch({ commit }) {
       try {
         const batchSearches = await api.getBatchSearches()
         commit(HAS_BATCH_SEARCH, batchSearches.total > 0)
@@ -92,21 +100,35 @@ export function actionBuilder (api) {
         commit(HAS_BATCH_SEARCH, false)
       }
     },
-    async getBatchSearches ({ commit }, {
-      from = 0,
-      size = 100,
-      sort = 'batch_date',
-      order = 'asc',
-      query = '*',
-      field = 'all',
-      project = [],
-      state = [],
-      batchDate = null,
-      publishState = null
-    }) {
+    async getBatchSearches(
+      { commit },
+      {
+        from = 0,
+        size = 100,
+        sort = 'batch_date',
+        order = 'asc',
+        query = '*',
+        field = 'all',
+        project = [],
+        state = [],
+        batchDate = null,
+        publishState = null
+      }
+    ) {
       let batchSearches = []
       try {
-        batchSearches = await api.getBatchSearches(from, size, sort, order, query, field, project, state, batchDate, publishState)
+        batchSearches = await api.getBatchSearches(
+          from,
+          size,
+          sort,
+          order,
+          query,
+          field,
+          project,
+          state,
+          batchDate,
+          publishState
+        )
       } catch (_) {
         batchSearches = {
           items: [],
@@ -116,34 +138,17 @@ export function actionBuilder (api) {
       commit(TOTAL, batchSearches.total)
       commit(BATCH_SEARCHES, batchSearches.items)
     },
-    async onSubmit ({
-      commit,
-      dispatch
-    }, {
-      name,
-      csvFile,
-      description,
-      projects,
-      phraseMatch,
-      fuzziness,
-      fileTypes,
-      paths,
-      published
-    }) {
+    async onSubmit(
+      { commit, dispatch },
+      { name, csvFile, description, projects, phraseMatch, fuzziness, fileTypes, paths, published }
+    ) {
       // send the new batch search
       await api.batchSearch(name, csvFile, description, projects, phraseMatch, fuzziness, fileTypes, paths, published)
       commit(HAS_BATCH_SEARCH, true)
       // get all batch searches including the new one
       return dispatch('getBatchSearches', {})
     },
-    async getBatchSearchResults ({ commit }, {
-      batchId,
-      from,
-      size,
-      queries,
-      sort,
-      order
-    }) {
+    async getBatchSearchResults({ commit }, { batchId, from, size, queries, sort, order }) {
       let results = []
       try {
         results = await api.getBatchSearchResults(batchId, from, size, queries, sort, order)
@@ -152,7 +157,7 @@ export function actionBuilder (api) {
       }
       commit(RESULTS, results)
     },
-    async deleteBatchSearch ({ commit }, { batchId }) {
+    async deleteBatchSearch({ commit }, { batchId }) {
       try {
         await api.deleteBatchSearch(batchId)
         commit(REMOVE_BATCH_SEARCH, batchId)
@@ -161,17 +166,14 @@ export function actionBuilder (api) {
         return false
       }
     },
-    async updateBatchSearch (_, {
-      batchId,
-      published
-    }) {
+    async updateBatchSearch(_, { batchId, published }) {
       try {
         await api.updateBatchSearch(batchId, published)
       } catch (_) {
         // TODO do something
       }
     },
-    async deleteBatchSearches ({ commit }) {
+    async deleteBatchSearches({ commit }) {
       try {
         await api.deleteBatchSearches()
         commit(CLEAR_BATCH_SEARCH)
@@ -183,7 +185,7 @@ export function actionBuilder (api) {
   }
 }
 
-export function batchStoreBuilder (api) {
+export function batchStoreBuilder(api) {
   return {
     namespaced: true,
     state,

--- a/src/store/modules/documentNotes.js
+++ b/src/store/modules/documentNotes.js
@@ -2,7 +2,7 @@ import filter from 'lodash/filter'
 import hasIn from 'lodash/hasIn'
 import set from 'lodash/set'
 
-export function initialState () {
+export function initialState() {
   return {
     notes: {}
   }
@@ -10,20 +10,22 @@ export function initialState () {
 export const state = initialState()
 
 export const mutations = {
-  reset (state) {
+  reset(state) {
     const s = initialState()
-    Object.keys(s).forEach(key => { state[key] = s[key] })
+    Object.keys(s).forEach((key) => {
+      state[key] = s[key]
+    })
   },
-  setNotes (state, { project, notes }) {
+  setNotes(state, { project, notes }) {
     set(state, ['notes', project], notes)
   }
 }
-function actionsBuilder (api) {
+function actionsBuilder(api) {
   return {
-    filterNotesByPath ({ state }, { project, path }) {
-      return filter(state.notes[project], note => path.match(new RegExp(note.path)))
+    filterNotesByPath({ state }, { project, path }) {
+      return filter(state.notes[project], (note) => path.match(new RegExp(note.path)))
     },
-    async retrieveNotes ({ state, commit, dispatch }, { project, path }) {
+    async retrieveNotes({ state, commit, dispatch }, { project, path }) {
       if (!hasIn(state.notes, project)) {
         const notes = await api.retrieveNotes(project)
         commit('setNotes', { project, notes })
@@ -32,7 +34,7 @@ function actionsBuilder (api) {
     }
   }
 }
-export function documentNotesStoreBuilder (api) {
+export function documentNotesStoreBuilder(api) {
   return {
     namespaced: true,
     state,

--- a/src/store/modules/downloads.js
+++ b/src/store/modules/downloads.js
@@ -6,15 +6,15 @@ export const state = {
 }
 
 export const mutations = {
-  clear (state) {
+  clear(state) {
     Vue.set(state, 'allowedFor', {})
   },
-  allowedFor (state, { index, allowed }) {
+  allowedFor(state, { index, allowed }) {
     Vue.set(state.allowedFor, index, allowed)
   }
 }
 
-function actionBuilder (api) {
+function actionBuilder(api) {
   const getIndexStatus = async ({ state }, index) => {
     try {
       if (!has(state.allowedFor, index)) {
@@ -26,21 +26,14 @@ function actionBuilder (api) {
       return false
     }
   }
-  const fetchIndexStatus = async ({
-    commit,
-    state
-  }, index) => {
+  const fetchIndexStatus = async ({ commit, state }, index) => {
     const allowed = await getIndexStatus({ state }, index)
     commit('allowedFor', {
       index,
       allowed
     })
   }
-  const fetchIndicesStatus = async ({
-    commit,
-    rootState,
-    state
-  }) => {
+  const fetchIndicesStatus = async ({ commit, rootState, state }) => {
     const promises = []
     for (const index of rootState.search.indices) {
       promises.push(fetchIndexStatus({ commit, state }, index))
@@ -54,7 +47,7 @@ function actionBuilder (api) {
   }
 }
 
-export function downloadsBuilder (api) {
+export function downloadsBuilder(api) {
   const actions = actionBuilder(api)
   return {
     namespaced: true,

--- a/src/store/modules/hooks.js
+++ b/src/store/modules/hooks.js
@@ -10,37 +10,37 @@ export const state = {
 }
 
 export const getters = {
-  hookedComponents (state) {
+  hookedComponents(state) {
     return () => {
       return orderBy(state.registered.map(HookedComponent.create), 'order', 'asc')
     }
   },
-  filterHookedComponentsByTarget (state, getters) {
-    return target => filter(getters.hookedComponents(), { target })
+  filterHookedComponentsByTarget(state, getters) {
+    return (target) => filter(getters.hookedComponents(), { target })
   },
-  getHookedComponentByName (state, getters) {
-    return name => find(getters.hookedComponents(), { name })
+  getHookedComponentByName(state, getters) {
+    return (name) => find(getters.hookedComponents(), { name })
   }
 }
 
 export const mutations = {
-  register (state, { target, order, name, definition }) {
+  register(state, { target, order, name, definition }) {
     const index = name ? findIndex(state.registered, { name }) : -1
     if (index === -1) {
       state.registered.push({ target, order, name, definition })
     }
   },
-  unregister (state, name) {
+  unregister(state, name) {
     const index = findIndex(state.registered, { name })
     if (index > -1) {
       state.registered.splice(index, 1)
     }
   },
-  reset (state) {
+  reset(state) {
     state.registered.splice(0, state.registered.length)
   },
-  resetTarget (state, target) {
-    state.registered = filter(state.registered, r => r.target !== target)
+  resetTarget(state, target) {
+    state.registered = filter(state.registered, (r) => r.target !== target)
   }
 }
 

--- a/src/store/modules/indexing.js
+++ b/src/store/modules/indexing.js
@@ -2,7 +2,7 @@ import { remove } from 'lodash'
 import { getField, updateField } from 'vuex-map-fields'
 import Vue from 'vue'
 
-export function initialState () {
+export function initialState() {
   return {
     form: {
       filter: true,
@@ -27,65 +27,67 @@ export const getters = {
 
 export const mutations = {
   updateField,
-  reset (state) {
+  reset(state) {
     // acquire initial state
     const s = initialState()
-    Object.keys(s).forEach(key => { state[key] = s[key] })
+    Object.keys(s).forEach((key) => {
+      state[key] = s[key]
+    })
   },
-  stopPendingTasks (state) {
-    remove(state.tasks, item => item.state === 'RUNNING')
+  stopPendingTasks(state) {
+    remove(state.tasks, (item) => item.state === 'RUNNING')
   },
-  stopTask (state, name) {
-    remove(state.tasks, item => item.name === name)
+  stopTask(state, name) {
+    remove(state.tasks, (item) => item.name === name)
   },
-  deleteDoneTasks (state) {
-    remove(state.tasks, item => item.state === 'DONE')
+  deleteDoneTasks(state) {
+    remove(state.tasks, (item) => item.state === 'DONE')
   },
-  updateTasks (state, raw) {
+  updateTasks(state, raw) {
     Vue.set(state, 'tasks', raw)
   },
-  resetExtractForm (state) {
+  resetExtractForm(state) {
     state.form.ocr = initialState().form.ocr
   },
-  resetFindNamedEntitiesForm (state) {
+  resetFindNamedEntitiesForm(state) {
     state.form.pipeline = initialState().form.pipeline
     state.form.offline = initialState().form.offline
   }
 }
 
-function actionsBuilder (api) {
+function actionsBuilder(api) {
   return {
-    submitExtract ({ state }) {
+    submitExtract({ state }) {
       if (state.form.path) {
         return api.indexPath(state.form.path, state.form)
       }
       return api.index(state.form)
     },
-    runBatchSearch () {
+    runBatchSearch() {
       return api.runBatchSearch()
     },
-    submitFindNamedEntities ({ state }) {
+    submitFindNamedEntities({ state }) {
       return api.findNames(state.form.pipeline, { syncModels: !state.form.offline })
     },
-    async stopPendingTasks ({ commit }) {
+    async stopPendingTasks({ commit }) {
       try {
         await api.stopPendingTasks()
         return commit('stopPendingTasks')
       } catch (_) {}
     },
-    async stopTask ({ commit }, name) {
+    async stopTask({ commit }, name) {
       try {
         await api.stopTask(name)
         commit('stopTask', name)
       } catch (_) {}
     },
-    async deleteDoneTasks ({ commit }) {
+    async deleteDoneTasks({ commit }) {
       try {
         await api.deleteDoneTasks()
         commit('deleteDoneTasks')
       } catch (_) {}
     },
-    async getTasks ({ commit }) {
+    async getTasks({ commit }) {
       try {
         const tasks = await api.getTasks()
         commit('updateTasks', tasks)
@@ -93,18 +95,18 @@ function actionsBuilder (api) {
         commit('updateTasks', [])
       }
     },
-    async deleteAll ({ rootState }) {
+    async deleteAll({ rootState }) {
       for (const index of rootState.search.indices) {
         await api.deleteAll(index)
       }
     },
-    getNerPipelines () {
+    getNerPipelines() {
       return api.getNerPipelines()
     }
   }
 }
 
-export function indexingStoreBuilder (api) {
+export function indexingStoreBuilder(api) {
   return {
     namespaced: true,
     state,

--- a/src/store/modules/insights.js
+++ b/src/store/modules/insights.js
@@ -7,7 +7,7 @@ import Vue from 'vue'
 import widgets from '@/store/widgets'
 import * as widgetTypes from '@/store/widgets'
 
-export function initialState () {
+export function initialState() {
   return {
     project: '',
     widgets: cloneDeep({ widgets }).widgets
@@ -17,32 +17,32 @@ export function initialState () {
 const state = initialState()
 
 const mutations = {
-  reset (state) {
+  reset(state) {
     const s = initialState()
-    Object.keys(s).forEach(key => Vue.set(state, key, s[key]))
+    Object.keys(s).forEach((key) => Vue.set(state, key, s[key]))
   },
-  removeWidget (state, name) {
-    const index = findIndex(state.widgets, options => options.name === name)
+  removeWidget(state, name) {
+    const index = findIndex(state.widgets, (options) => options.name === name)
     Vue.delete(state.widgets, index)
   },
-  addWidget (state, options) {
+  addWidget(state, options) {
     if (!options.name || !find(state.widgets, { name: options.name })) {
       state.widgets.push(options)
     }
   },
-  clearWidgets (state) {
+  clearWidgets(state) {
     Vue.set(state, 'widgets', [])
   },
-  project (state, project) {
+  project(state, project) {
     Vue.set(state, 'project', project)
   }
 }
 
 export const getters = {
-  getWidget (state, getters) {
-    return predicate => find(state.widgets, predicate)
+  getWidget(state, getters) {
+    return (predicate) => find(state.widgets, predicate)
   },
-  instantiateWidget (state) {
+  instantiateWidget(state) {
     return ({ type = 'WidgetEmpty', ...options } = {}) => {
       const Type = widgetTypes[type]
       const widget = new Type(options)
@@ -52,7 +52,7 @@ export const getters = {
       return widget
     }
   },
-  instantiatedWidgets (state, getters) {
+  instantiatedWidgets(state, getters) {
     const widgets = state.widgets.map(getters.instantiateWidget)
     return sortBy(widgets, ['order'])
   }

--- a/src/store/modules/pipelines.js
+++ b/src/store/modules/pipelines.js
@@ -9,13 +9,13 @@ export const state = {
 }
 
 export const getters = {
-  instantiatePipeline (state) {
-    return ({ type = 'IdentityPipeline', ...options } = { }) => {
+  instantiatePipeline(state) {
+    return ({ type = 'IdentityPipeline', ...options } = {}) => {
       // The given type is a class with a `apply` method
       if (type?.prototype?.apply) {
         // eslint-disable-next-line new-cap
         return new type(options)
-      // The given type is function
+        // The given type is function
       } else if (isFunction(type)) {
         return new pipelineTypes.SimplePipeline({ apply: type, ...options })
       }
@@ -24,37 +24,43 @@ export const getters = {
       return new Type(options)
     }
   },
-  instantiatedPipelines (state, getters) {
-    return orderBy(state.registered.map(pipeline => {
-      return getters.instantiatePipeline(pipeline)
-    }, 'order', 'asc'))
+  instantiatedPipelines(state, getters) {
+    return orderBy(
+      state.registered.map(
+        (pipeline) => {
+          return getters.instantiatePipeline(pipeline)
+        },
+        'order',
+        'asc'
+      )
+    )
   },
-  getPipelineByName (state) {
-    return name => find(state.registered, { name })
+  getPipelineByName(state) {
+    return (name) => find(state.registered, { name })
   },
-  getPipelinesByCategory (state, getters) {
+  getPipelinesByCategory(state, getters) {
     return (category = null) => {
       return orderBy(filter(state.registered, { category }), 'order', 'asc')
     }
   },
-  getInstantiatedPipelineByName (state, getters) {
-    return name => {
+  getInstantiatedPipelineByName(state, getters) {
+    return (name) => {
       const pipeline = getters.getPipelineByName(name)
       return pipeline ? getters.instantiatePipeline(pipeline) : null
     }
   },
-  getInstantiatedPipelineByCategory (state, getters) {
+  getInstantiatedPipelineByCategory(state, getters) {
     return (category = null) => {
       return getters.getPipelinesByCategory(category).map(getters.instantiatePipeline)
     }
   },
-  getPipelineChainByCategory (state, getters) {
+  getPipelineChainByCategory(state, getters) {
     return (category = null) => {
       const pipelines = getters.getInstantiatedPipelineByCategory(category)
-      return pipelines.map(p => p.apply.bind(p))
+      return pipelines.map((p) => p.apply.bind(p))
     }
   },
-  getFullPipelineChainByCategory (state, getters) {
+  getFullPipelineChainByCategory(state, getters) {
     return (category = null, ...contextualPipelines) => {
       const prePipelines = getters.getPipelineChainByCategory(`${category}:pre`)
       const mainPipelines = getters.getPipelineChainByCategory(category)
@@ -62,7 +68,7 @@ export const getters = {
       return concat(prePipelines, mainPipelines, compact(contextualPipelines), postPipelines)
     }
   },
-  applyPipelineChainByCategory (state, getters) {
+  applyPipelineChainByCategory(state, getters) {
     return (category = null, ...mainPipelines) => {
       const allPipelines = getters.getFullPipelineChainByCategory(category, ...mainPipelines)
       // Return a closure function that must be invoked with the value
@@ -77,14 +83,14 @@ export const getters = {
 }
 
 export const mutations = {
-  register (state, { name, ...options }) {
+  register(state, { name, ...options }) {
     name = name || uniqueId('pipeline-')
     const index = name ? findIndex(state.registered, { name }) : -1
     if (index === -1) {
       state.registered.push({ name, ...options })
     }
   },
-  unregister (state, name) {
+  unregister(state, name) {
     const index = findIndex(state.registered, { name })
     if (index > -1) {
       state.registered.splice(index, 1)

--- a/src/store/modules/recommended.js
+++ b/src/store/modules/recommended.js
@@ -8,22 +8,22 @@ export const state = {
 }
 
 export const mutations = {
-  documents (state, documents) {
+  documents(state, documents) {
     Vue.set(state, 'documents', documents)
   },
-  byUsers (state, byUsers) {
+  byUsers(state, byUsers) {
     Vue.set(state, 'byUsers', byUsers)
   },
-  total (state, total) {
+  total(state, total) {
     Vue.set(state, 'total', total)
   }
 }
-function actionsBuilder (api) {
+function actionsBuilder(api) {
   return {
-    async fetchIndicesRecommendations ({ rootState, commit }) {
+    async fetchIndicesRecommendations({ rootState, commit }) {
       try {
         const { indices } = rootState.search
-        const recommendationsByProject = indices.map(index => api.getRecommendationsByProject(index))
+        const recommendationsByProject = indices.map((index) => api.getRecommendationsByProject(index))
         const recommendations = await Promise.all(recommendationsByProject)
         const total = sumBy(recommendations, 'totalCount')
         const aggregates = flatten(map(recommendations, 'aggregates'))
@@ -40,11 +40,11 @@ function actionsBuilder (api) {
         commit('total', 0)
       }
     },
-    async getDocumentsRecommendedBy ({ rootState, commit }, users) {
+    async getDocumentsRecommendedBy({ rootState, commit }, users) {
       try {
         if (users.length) {
           const { indices } = rootState.search
-          const documentsByProject = indices.map(index => api.getDocumentsRecommendedBy(index, users))
+          const documentsByProject = indices.map((index) => api.getDocumentsRecommendedBy(index, users))
           commit('documents', flatten(await Promise.all(documentsByProject)))
         } else {
           commit('documents', [])
@@ -55,7 +55,7 @@ function actionsBuilder (api) {
     }
   }
 }
-export function recommendedStoreBuilder (api) {
+export function recommendedStoreBuilder(api) {
   return {
     namespaced: true,
     state,

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -1,7 +1,27 @@
 import {
-  castArray, concat, cloneDeep, each, endsWith, flatten,
-  filter as filterCollection, find, findIndex, get, has, includes, isString, join,
-  keys, map, omit, orderBy, range, random, reduce, toString, uniq
+  castArray,
+  concat,
+  cloneDeep,
+  each,
+  endsWith,
+  flatten,
+  filter as filterCollection,
+  find,
+  findIndex,
+  get,
+  has,
+  includes,
+  isString,
+  join,
+  keys,
+  map,
+  omit,
+  orderBy,
+  range,
+  random,
+  reduce,
+  toString,
+  uniq
 } from 'lodash'
 import lucene from 'lucene'
 import Vue from 'vue'
@@ -13,7 +33,7 @@ import * as filterTypes from '@/store/filters'
 import { isNarrowScreen } from '@/utils/screen'
 import settings from '@/utils/settings'
 
-export function initialState () {
+export function initialState() {
   return cloneDeep({
     error: null,
     field: settings.defaultSearchField,
@@ -38,7 +58,7 @@ export function initialState () {
 export const state = initialState()
 
 export const getters = {
-  instantiateFilter (state, getters, rootState) {
+  instantiateFilter(state, getters, rootState) {
     return ({ type = 'FilterText', options } = {}) => {
       const Type = filterTypes[type]
       const filter = new Type(options)
@@ -48,60 +68,68 @@ export const getters = {
       return filter
     }
   },
-  instantiatedFilters (state, getters) {
-    return orderBy(state.filters.map(filter => getters.instantiateFilter(filter)), 'order', 'asc')
+  instantiatedFilters(state, getters) {
+    return orderBy(
+      state.filters.map((filter) => getters.instantiateFilter(filter)),
+      'order',
+      'asc'
+    )
   },
-  getFilter (state, getters) {
-    return predicate => find(getters.instantiatedFilters, predicate)
+  getFilter(state, getters) {
+    return (predicate) => find(getters.instantiatedFilters, predicate)
   },
-  getFields (state) {
+  getFields(state) {
     return () => find(settings.searchFields, { key: state.field }).fields
   },
-  hasFilterValue (state, getters) {
-    return item => !!find(getters.instantiatedFilters, ({ name, values }) => {
-      return name === item.name && values.indexOf(item.value) > -1
-    })
+  hasFilterValue(state, getters) {
+    return (item) =>
+      !!find(getters.instantiatedFilters, ({ name, values }) => {
+        return name === item.name && values.indexOf(item.value) > -1
+      })
   },
-  hasFilterValues (state, getters) {
-    return name => !!find(getters.instantiatedFilters,
-      filter => filter.name === name && filter.values.length > 0)
+  hasFilterValues(state, getters) {
+    return (name) => !!find(getters.instantiatedFilters, (filter) => filter.name === name && filter.values.length > 0)
   },
-  isFilterContextualized (state, getters) {
-    return name => {
-      return !!find(getters.instantiatedFilters, filter => {
+  isFilterContextualized(state, getters) {
+    return (name) => {
+      return !!find(getters.instantiatedFilters, (filter) => {
         return filter.name === name && filter.contextualized
       })
     }
   },
-  isFilterReversed (state, getters) {
-    return name => {
-      return !!find(getters.instantiatedFilters, filter => {
+  isFilterReversed(state, getters) {
+    return (name) => {
+      return !!find(getters.instantiatedFilters, (filter) => {
         return filter.name === name && filter.reverse
       })
     }
   },
-  activeFilters (state, getters) {
-    return filterCollection(getters.instantiatedFilters, f => f.hasValues())
+  activeFilters(state, getters) {
+    return filterCollection(getters.instantiatedFilters, (f) => f.hasValues())
   },
-  filterValuesAsRouteQuery (state, getters) {
+  filterValuesAsRouteQuery(state, getters) {
     return () => {
-      return reduce(keys(state.values), (memo, name) => {
-        // We need to look for the filter's definition in order to us its `id`
-        // as key for the URL params. This was we track configured filter instead
-        // of arbitrary values provided by the user. This allow to retrieve special
-        // behaviors depending on the filter definition.
-        const filter = find(getters.instantiatedFilters, { name })
-        // We don't add filterValue that match with any existing filters
-        // defined in the `aggregation` store.
-        if (filter && filter.values.length > 0) {
-          const key = filter.reverse ? `f[-${filter.name}]` : `f[${filter.name}]`
-          memo[key] = filter.values
-        }
-        return memo
-      }, {})
+      return reduce(
+        keys(state.values),
+        (memo, name) => {
+          // We need to look for the filter's definition in order to us its `id`
+          // as key for the URL params. This was we track configured filter instead
+          // of arbitrary values provided by the user. This allow to retrieve special
+          // behaviors depending on the filter definition.
+          const filter = find(getters.instantiatedFilters, { name })
+          // We don't add filterValue that match with any existing filters
+          // defined in the `aggregation` store.
+          if (filter && filter.values.length > 0) {
+            const key = filter.reverse ? `f[-${filter.name}]` : `f[${filter.name}]`
+            memo[key] = filter.values
+          }
+          return memo
+        },
+        {}
+      )
     }
   },
-  toRouteQuery (state, getters) {
+  toRouteQuery(state, getters) {
     return () => ({
       q: state.query,
       from: state.from,
@@ -112,29 +140,37 @@ export const getters = {
       ...getters.filterValuesAsRouteQuery()
     })
   },
-  toRouteQueryWithStamp (state, getters) {
+  toRouteQueryWithStamp(state, getters) {
     return () => ({
       ...getters.toRouteQuery(),
       // A random string of 6 chars
-      stamp: String.fromCharCode.apply(null, range(6).map(() => random(97, 122)))
+      stamp: String.fromCharCode.apply(
+        null,
+        range(6).map(() => random(97, 122))
+      )
     })
   },
-  retrieveQueryTerms (state) {
+  retrieveQueryTerms(state) {
     let terms = []
-    function getTerm (query, path, start, operator) {
+    function getTerm(query, path, start, operator) {
       const term = get(query, join([path, 'term'], '.'), '')
       const field = get(query, join([path, 'field'], '.'), '')
       const prefix = get(query, join([path, 'prefix'], '.'), '')
       const regex = get(query, join([path, 'regex'], '.'), false)
       const negation = ['-', '!'].includes(prefix) || start === 'NOT' || endsWith(operator, 'NOT')
       if (term !== '*' && term !== '' && !includes(map(terms, 'label'), term)) {
-        terms = concat(terms, { field: field === '<implicit>' ? '' : field, label: term.replace('\\', ''), negation, regex })
+        terms = concat(terms, {
+          field: field === '<implicit>' ? '' : field,
+          label: term.replace('\\', ''),
+          negation,
+          regex
+        })
       }
       if (term === '' && has(query, join([path, 'left'], '.'))) {
         retTerms(get(query, 'left'))
       }
     }
-    function retTerms (query, operator = null) {
+    function retTerms(query, operator = null) {
       getTerm(query, 'left', get(query, 'start', null), operator)
       if (get(query, 'right.left', null) === null) {
         getTerm(query, 'right', null, get(query, 'operator', null))
@@ -149,117 +185,121 @@ export const getters = {
       return []
     }
   },
-  retrieveContentQueryTerms (state, getters) {
+  retrieveContentQueryTerms(state, getters) {
     const fields = ['', 'content']
-    return filterCollection(getters.retrieveQueryTerms, item => fields.includes(item.field))
+    return filterCollection(getters.retrieveQueryTerms, (item) => fields.includes(item.field))
   },
-  sortBy (state) {
+  sortBy(state) {
     return find(settings.searchSortFields, { name: state.sort })
   }
 }
 
 export const mutations = {
-  reset (state, excludedKeys = ['index', 'indices', 'showFilters', 'layout', 'size', 'sort']) {
+  reset(state, excludedKeys = ['index', 'indices', 'showFilters', 'layout', 'size', 'sort']) {
     const s = initialState()
-    Object.keys(s).forEach(key => {
+    Object.keys(s).forEach((key) => {
       if (excludedKeys.indexOf(key) === -1) {
         Vue.set(state, key, s[key])
       }
     })
   },
-  resetFilters (state) {
+  resetFilters(state) {
     const { filters } = initialState()
     Vue.set(state, 'filters', filters)
   },
-  resetFiltersAndValues (state) {
+  resetFiltersAndValues(state) {
     const { filters } = initialState()
     Vue.set(state, 'filters', filters)
     Vue.set(state, 'values', {})
     Vue.set(state, 'from', 0)
   },
-  resetFilterValues (state) {
+  resetFilterValues(state) {
     Vue.set(state, 'values', {})
     Vue.set(state, 'from', 0)
   },
-  resetQuery (state) {
+  resetQuery(state) {
     Vue.set(state, 'query', '')
     Vue.set(state, 'field', settings.defaultSearchField)
     Vue.set(state, 'from', 0)
   },
-  query (state, query) {
+  query(state, query) {
     Vue.set(state, 'query', query)
   },
-  q (state, query) {
+  q(state, query) {
     Vue.set(state, 'query', query)
   },
-  from (state, from) {
+  from(state, from) {
     Vue.set(state, 'from', Number(from))
   },
-  size (state, size) {
+  size(state, size) {
     Vue.set(state, 'size', Number(size))
   },
-  sort (state, sort) {
+  sort(state, sort) {
     Vue.set(state, 'sort', sort)
   },
-  isReady (state, isReady = !state.isReady) {
+  isReady(state, isReady = !state.isReady) {
     Vue.set(state, 'isReady', isReady)
   },
-  error (state, error = null) {
+  error(state, error = null) {
     Vue.set(state, 'error', error)
   },
-  index (state, index) {
+  index(state, index) {
     Vue.set(state, 'index', index)
     Vue.set(state, 'indices', [index])
   },
-  indices (state, indices) {
+  indices(state, indices) {
     // Clean indices list to ensure we received an array. This means
     // this mutation can also receive a string with a commat separated
     // list of indices.
-    const cleaned = flatten(castArray(indices).map(str => str.split(',')))
+    const cleaned = flatten(castArray(indices).map((str) => str.split(',')))
     Vue.set(state, 'indices', cleaned)
     Vue.set(state, 'index', cleaned[0])
   },
-  layout (state, layout) {
+  layout(state, layout) {
     Vue.set(state, 'layout', layout)
   },
-  field (state, field) {
-    const fields = settings.searchFields.map(field => field.key)
+  field(state, field) {
+    const fields = settings.searchFields.map((field) => field.key)
     Vue.set(state, 'field', fields.indexOf(field) > -1 ? field : settings.defaultSearchField)
   },
-  buildResponse (state, raw) {
+  buildResponse(state, raw) {
     Vue.set(state, 'response', new EsDocList(raw))
   },
-  addFilterValue (state, filter) {
+  addFilterValue(state, filter) {
     // We cast the new filter values to allow several new values at the same time
     const values = castArray(filter.value)
     // Look for existing values for this name
     const existingValues = get(state, ['values', filter.name], [])
-    const existingValuesAsString = map(existingValues, value => toString(value))
+    const existingValuesAsString = map(existingValues, (value) => toString(value))
     Vue.set(state.values, filter.name, uniq(existingValuesAsString.concat(values)))
   },
-  setFilterValue (state, filter) {
+  setFilterValue(state, filter) {
     const values = castArray(filter.value)
     Vue.set(state.values, filter.name, values)
   },
-  addFilterValues (state, { filter, values }) {
+  addFilterValues(state, { filter, values }) {
     const existingValues = get(state, ['values', filter.name], [])
     Vue.set(state.values, filter.name, uniq(existingValues.concat(castArray(values))))
   },
-  removeFilterValue (state, filter) {
+  removeFilterValue(state, filter) {
     // Look for existing values for this name
     const existingValues = get(state, ['values', filter.name], [])
     // Filter the values for this name to remove the given value
-    Vue.set(state.values, filter.name, filterCollection(existingValues, value => value !== filter.value))
+    Vue.set(
+      state.values,
+      filter.name,
+      filterCollection(existingValues, (value) => value !== filter.value)
+    )
   },
-  removeFilter (state, name) {
+  removeFilter(state, name) {
     const i = findIndex(state.filters, ({ options }) => options.name === name)
     Vue.delete(state.filters, i)
     if (name in state.values) {
       Vue.delete(state.values, name)
     }
   },
-  addFilter (state, { type = 'FilterText', options = {}, position = null } = {}) {
-    if (!find(state.filters, filter => filter.options.name === options.name)) {
+  addFilter(state, { type = 'FilterText', options = {}, position = null } = {}) {
+    if (!find(state.filters, (filter) => filter.options.name === options.name)) {
       if (position === null) {
         state.filters.push({ type, options })
       } else {
@@ -267,15 +307,15 @@ export const mutations = {
       }
     }
   },
-  contextualizeFilter (state, name) {
+  contextualizeFilter(state, name) {
     if (state.contextualized.indexOf(name) === -1) {
       state.contextualized.push(name)
     }
   },
-  decontextualizeFilter (state, name) {
+  decontextualizeFilter(state, name) {
     Vue.delete(state.contextualized, state.contextualized.indexOf(name))
   },
-  toggleContextualizedFilter (state, name) {
+  toggleContextualizedFilter(state, name) {
     const i = state.contextualized.indexOf(name)
     if (i === -1) {
       state.contextualized.push(name)
@@ -283,15 +323,15 @@ export const mutations = {
       Vue.delete(state.contextualized, i)
     }
   },
-  excludeFilter (state, name) {
+  excludeFilter(state, name) {
     if (state.reversed.indexOf(name) === -1) {
       state.reversed.push(name)
     }
   },
-  includeFilter (state, name) {
+  includeFilter(state, name) {
     Vue.delete(state.reversed, state.reversed.indexOf(name))
   },
-  toggleFilter (state, name) {
+  toggleFilter(state, name) {
     const i = state.reversed.indexOf(name)
     if (i === -1) {
       state.reversed.push(name)
@@ -299,23 +339,27 @@ export const mutations = {
       Vue.delete(state.reversed, i)
     }
   },
-  toggleFilters (state, toggler = !state.showFilters) {
+  toggleFilters(state, toggler = !state.showFilters) {
     Vue.set(state, 'showFilters', toggler)
   }
 }
 
-function actionsBuilder (api) {
+function actionsBuilder(api) {
   return {
-    async refresh ({
-      state,
-      commit,
-      getters
-    }, updateIsReady = true) {
+    async refresh({ state, commit, getters }, updateIsReady = true) {
       commit('isReady', !updateIsReady)
       commit('error', null)
       try {
         const indices = state.indices.join(',')
-        const raw = await elasticsearch.searchDocs(indices, state.query, getters.instantiatedFilters, state.from, state.size, state.sort, getters.getFields())
+        const raw = await elasticsearch.searchDocs(
+          indices,
+          state.query,
+          getters.instantiatedFilters,
+          state.from,
+          state.size,
+          state.sort,
+          getters.getFields()
+        )
         commit('buildResponse', raw)
         commit('isReady', true)
         return raw
@@ -325,18 +369,15 @@ function actionsBuilder (api) {
         throw error
       }
     },
-    updateFromRouteQuery ({
-      commit,
-      getters
-    }, query) {
-      ['q', 'index', 'indices', 'from', 'size', 'sort', 'field'].forEach(key => {
+    updateFromRouteQuery({ commit, getters }, query) {
+      ;['q', 'index', 'indices', 'from', 'size', 'sort', 'field'].forEach((key) => {
         if (key in query) {
           // Add the query to the state with a mutation to avoid triggering a search
           commit(key, query[key])
         }
       })
       // Iterate over the list of filter
-      each(getters.instantiatedFilters, filter => {
+      each(getters.instantiatedFilters, (filter) => {
         // The filter key are formatted in the URL as follow.
         // See `query-string` for more info about query string format.
         each([`f[${filter.name}]`, `f[-${filter.name}]`], (key, isReverse) => {
@@ -354,19 +395,18 @@ function actionsBuilder (api) {
         })
       })
     },
-    query ({
-      state,
-      commit,
-      dispatch
-    }, q = {
-      index: state.index,
-      indices: state.indices,
-      query: state.query,
-      from: state.from,
-      size: state.size,
-      sort: state.sort,
-      field: state.field
-    }) {
+    query(
+      { state, commit, dispatch },
+      q = {
+        index: state.index,
+        indices: state.indices,
+        query: state.query,
+        from: state.from,
+        size: state.size,
+        sort: state.sort,
+        field: state.field
+      }
+    ) {
       // Only the "query" parameter must be treaten differently
       if (has(q, 'query')) {
         commit('query', q.query)
@@ -376,94 +416,68 @@ function actionsBuilder (api) {
       // Then mutates all values if they are in queryOrParams. The mutation
       // for "indices" must be after "index" since the two mutations are
       // updating concurent values.
-      ['index', 'indices', 'from', 'size', 'sort', 'field'].forEach(key => {
+      ;['index', 'indices', 'from', 'size', 'sort', 'field'].forEach((key) => {
         if (has(q, key)) {
           commit(key, q[key])
         }
       })
       return dispatch('refresh', true)
     },
-    queryFilter ({
-      state,
-      getters
-    }, params) {
-      return elasticsearch.searchFilter(
-        state.indices.join(','),
-        getters.getFilter({ name: params.name }),
-        state.query,
-        getters.instantiatedFilters,
-        !getters.isFilterContextualized(params.name),
-        params.options,
-        getters.getFields(),
-        params.from,
-        params.size
-      ).then(raw => new EsDocList(raw))
+    queryFilter({ state, getters }, params) {
+      return elasticsearch
+        .searchFilter(
+          state.indices.join(','),
+          getters.getFilter({ name: params.name }),
+          state.query,
+          getters.instantiatedFilters,
+          !getters.isFilterContextualized(params.name),
+          params.options,
+          getters.getFields(),
+          params.from,
+          params.size
+        )
+        .then((raw) => new EsDocList(raw))
     },
-    setFilterValue ({
-      commit,
-      dispatch
-    }, filter) {
+    setFilterValue({ commit, dispatch }, filter) {
       commit('setFilterValue', filter)
       return dispatch('query')
     },
-    addFilterValue ({
-      commit,
-      dispatch
-    }, filter) {
+    addFilterValue({ commit, dispatch }, filter) {
       commit('addFilterValue', filter)
       return dispatch('query')
     },
-    removeFilterValue ({
-      commit,
-      dispatch
-    }, filter) {
+    removeFilterValue({ commit, dispatch }, filter) {
       commit('removeFilterValue', filter)
       return dispatch('query')
     },
-    resetFilterValues ({
-      commit,
-      dispatch
-    }, name) {
+    resetFilterValues({ commit, dispatch }, name) {
       commit('resetFilterValues', name)
       return dispatch('query')
     },
-    toggleFilter ({
-      commit,
-      dispatch
-    }, name) {
+    toggleFilter({ commit, dispatch }, name) {
       commit('toggleFilter', name)
       return dispatch('query')
     },
-    previousPage ({
-      state,
-      commit,
-      dispatch
-    }, name) {
+    previousPage({ state, commit, dispatch }, name) {
       commit('from', state.from - state.size)
       return dispatch('query')
     },
-    nextPage ({
-      state,
-      commit,
-      dispatch
-    }, name) {
+    nextPage({ state, commit, dispatch }, name) {
       commit('from', state.from + state.size)
       return dispatch('query')
     },
-    deleteQueryTerm ({
-      state,
-      commit,
-      dispatch
-    }, term) {
-      function deleteQueryTermFromSimpleQuery (query) {
+    deleteQueryTerm({ state, commit, dispatch }, term) {
+      function deleteQueryTermFromSimpleQuery(query) {
         if (get(query, 'left.term', '') === term) query = omit(query, 'left')
         if (get(query, 'right.term', '') === term) query = omit(query, 'right')
         if (has(query, 'left.left')) query.left = deleteQueryTermFromSimpleQuery(get(query, 'left', null))
         if (has(query, 'right.left')) query.right = deleteQueryTermFromSimpleQuery(get(query, 'right', null))
-        if (has(query, 'right.right') && !has(query, 'right.left') && get(query, 'operator', '').includes('NOT')) query.operator = '<implicit>'
+        if (has(query, 'right.right') && !has(query, 'right.left') && get(query, 'operator', '').includes('NOT'))
+          query.operator = '<implicit>'
         if (has(query, 'start') && !has(query, 'left')) query = omit(query, 'start')
         if (has(query, 'operator') && (!has(query, 'left') || !has(query, 'right'))) query = omit(query, 'operator')
-        if (has(query, 'parenthesized') && (!has(query, 'left') || !has(query, 'right'))) query = omit(query, 'parenthesized')
+        if (has(query, 'parenthesized') && (!has(query, 'left') || !has(query, 'right')))
+          query = omit(query, 'parenthesized')
         return query
       }
 
@@ -471,10 +485,7 @@ function actionsBuilder (api) {
       commit('query', lucene.toString(query))
       return dispatch('query')
     },
-    async runBatchDownload ({
-      state,
-      getters
-    }, uri = null) {
+    async runBatchDownload({ state, getters }, uri = null) {
       const q = ['', null, undefined].indexOf(state.query) === -1 ? state.query : '*'
       const { indices: projectIds } = state
       const { query } = elasticsearch.rootSearch(getters.instantiatedFilters, q).build()
@@ -487,7 +498,7 @@ function actionsBuilder (api) {
   }
 }
 
-export function searchStoreBuilder (api) {
+export function searchStoreBuilder(api) {
   return {
     namespaced: true,
     state,

--- a/src/store/modules/settings.js
+++ b/src/store/modules/settings.js
@@ -1,17 +1,17 @@
-function actionBuilder (api) {
+function actionBuilder(api) {
   return {
-    getSettings () {
+    getSettings() {
       try {
         return api.getSettings()
       } catch (_) {}
     },
-    onSubmit (state, settings) {
+    onSubmit(state, settings) {
       return api.setSettings(settings)
     }
   }
 }
 
-export function settingsStoreBuilder (api) {
+export function settingsStoreBuilder(api) {
   return {
     namespaced: true,
     actions: actionBuilder(api)

--- a/src/store/modules/starred.js
+++ b/src/store/modules/starred.js
@@ -6,38 +6,38 @@ export const state = {
 }
 
 export const mutations = {
-  documents (state, documents = []) {
+  documents(state, documents = []) {
     state.documents.splice(0, state.documents.length)
     mutations.pushDocuments(state, documents)
   },
-  pushDocument (state, { index, id } = {}) {
+  pushDocument(state, { index, id } = {}) {
     const i = findIndex(state.documents, { index, id })
     // Document doesnt exist yet in the state
     if (i === -1) {
       state.documents.push({ index, id })
     }
   },
-  pushDocuments (state, documents = []) {
+  pushDocuments(state, documents = []) {
     for (const document of castArray(documents)) {
       mutations.pushDocument(state, document)
     }
   },
-  removeDocument (state, { index, id } = {}) {
+  removeDocument(state, { index, id } = {}) {
     const i = findIndex(state.documents, { index, id })
     // Document exist, we can remove it
     if (i > -1) {
       state.documents.splice(i, 1)
     }
   },
-  removeDocuments (state, documents = []) {
+  removeDocuments(state, documents = []) {
     for (const document of castArray(documents)) {
       mutations.removeDocument(state, document)
     }
   }
 }
-function actionsBuilder (api) {
+function actionsBuilder(api) {
   return {
-    async starDocuments ({ commit }, documents = []) {
+    async starDocuments({ commit }, documents = []) {
       const documentsByIndex = groupBy(castArray(documents), 'index')
       for (const [index, documents] of Object.entries(documentsByIndex)) {
         const documentIds = map(documents, 'id')
@@ -45,7 +45,7 @@ function actionsBuilder (api) {
         commit('pushDocuments', documents)
       }
     },
-    async unstarDocuments ({ commit }, documents = []) {
+    async unstarDocuments({ commit }, documents = []) {
       const documentsByIndex = groupBy(castArray(documents), 'index')
       for (const [index, documents] of Object.entries(documentsByIndex)) {
         const documentIds = map(documents, 'id')
@@ -53,7 +53,7 @@ function actionsBuilder (api) {
         commit('removeDocuments', documents)
       }
     },
-    toggleStarDocument ({ state, dispatch }, { index, id } = {}) {
+    toggleStarDocument({ state, dispatch }, { index, id } = {}) {
       const i = findIndex(state.documents, { index, id })
       if (i > -1) {
         return dispatch('unstarDocuments', { index, id })
@@ -61,17 +61,17 @@ function actionsBuilder (api) {
         return dispatch('starDocuments', { index, id })
       }
     },
-    async fetchIndicesStarredDocuments ({ commit, rootState }, indices = null) {
+    async fetchIndicesStarredDocuments({ commit, rootState }, indices = null) {
       for (const index of castArray(indices || rootState.search.indices)) {
         const ids = await api.getStarredDocuments(index)
-        const documents = castArray(ids).map(id => ({ id, index }))
+        const documents = castArray(ids).map((id) => ({ id, index }))
         commit('documents', documents)
       }
     }
   }
 }
 
-export function starredStoreBuilder (api) {
+export function starredStoreBuilder(api) {
   return {
     namespaced: true,
     state,

--- a/src/store/modules/treeView.js
+++ b/src/store/modules/treeView.js
@@ -11,9 +11,9 @@ export const state = {
 }
 
 export const getters = {
-  isOpen (state) {
-    return path => {
-      return some(state.openPaths, openPath => {
+  isOpen(state) {
+    return (path) => {
+      return some(state.openPaths, (openPath) => {
         const splitPath = split(path, '/')
         const splitOpenPath = split(openPath, '/')
         const slicedOpenPath = slice(splitOpenPath, 0, splitPath.length)
@@ -24,16 +24,16 @@ export const getters = {
 }
 
 export const mutations = {
-  togglePath (state, path) {
+  togglePath(state, path) {
     state.openPaths = xor(state.openPaths, castArray(path))
     return getters.isOpen(state)(path)
   },
-  addPath (state, path) {
+  addPath(state, path) {
     if (state.openPaths.indexOf(path) === -1) {
       state.openPaths.push(path)
     }
   },
-  removePath (state, path) {
+  removePath(state, path) {
     state.openPaths = without(state.openPaths, path)
   }
 }

--- a/src/store/pipelines/AddGlobalSearchMarks.js
+++ b/src/store/pipelines/AddGlobalSearchMarks.js
@@ -2,39 +2,34 @@ import IdentityPipeline from './IdentityPipeline'
 import escapeRegExp from 'lodash/escapeRegExp'
 
 class AddGlobalSearchMarks extends IdentityPipeline {
-  apply (content, { globalSearchTerms: terms }) {
+  apply(content, { globalSearchTerms: terms }) {
     return this.findTerms(content, 'length', terms).reduce(this.addTermMarks, content)
   }
-  findTerms (content, field, terms = []) {
-    return terms.map(term => {
+  findTerms(content, field, terms = []) {
+    return terms.map((term) => {
       const regex = new RegExp(term.regex ? term.label : escapeRegExp(term.label), 'gi')
       term[field] = (content.match(regex) || []).length
       return term
     })
   }
-  addTermMarks (content, term, index) {
+  addTermMarks(content, term, index) {
     const needle = new RegExp(term.label, 'gi')
     const borderColor = AddGlobalSearchMarks.getTermIndexColor(index)
-    return content.replace(needle, match => {
+    return content.replace(needle, (match) => {
       return `<mark class="global-search-term" style="border-color: ${borderColor}">${match}</mark>`
     })
   }
-  static getTermIndexColor (index) {
+  static getTermIndexColor(index) {
     return AddGlobalSearchMarks.termIndexColors[index % AddGlobalSearchMarks.termIndexColors.length]
   }
-  static getTermIndexBorderColor (index) {
+  static getTermIndexBorderColor(index) {
     return { 'border-color': AddGlobalSearchMarks.getTermIndexColor(index) }
   }
-  static getTermIndexBackgroundColor (index) {
+  static getTermIndexBackgroundColor(index) {
     return { 'background-color': AddGlobalSearchMarks.getTermIndexColor(index) }
   }
-  static get termIndexColors () {
-    return [
-      '#ECFC7A',
-      '#CDFD94',
-      '#A8FDAC',
-      '#52FDEA'
-    ]
+  static get termIndexColors() {
+    return ['#ECFC7A', '#CDFD94', '#A8FDAC', '#52FDEA']
   }
 }
 

--- a/src/store/pipelines/AddLabelComponents.js
+++ b/src/store/pipelines/AddLabelComponents.js
@@ -3,7 +3,7 @@ import isString from 'lodash/isString'
 import IdentityPipeline from './IdentityPipeline'
 
 class AddLabelComponents extends IdentityPipeline {
-  apply (value) {
+  apply(value) {
     return castArray(value).map(({ label, ...obj }) => {
       // If the given label is a string,
       // this pipeline will wrap it into a tiny component that

--- a/src/store/pipelines/AddLineBreaksPipeline.js
+++ b/src/store/pipelines/AddLineBreaksPipeline.js
@@ -2,8 +2,12 @@ import trim from 'lodash/trim'
 import IdentityPipeline from './IdentityPipeline'
 
 class AddLineBreaksPipeline extends IdentityPipeline {
-  apply (value) {
-    return value.split('\n').map(trim).map(row => `<p>${row}</p>`).join('')
+  apply(value) {
+    return value
+      .split('\n')
+      .map(trim)
+      .map((row) => `<p>${row}</p>`)
+      .join('')
   }
 }
 

--- a/src/store/pipelines/AddNamedEntitiesPipeline.js
+++ b/src/store/pipelines/AddNamedEntitiesPipeline.js
@@ -3,31 +3,35 @@ import { Highlight } from '@/utils/highlight'
 import IdentityPipeline from './IdentityPipeline'
 
 class AddNamedEntitiesPipeline extends IdentityPipeline {
-  apply (content, { namedEntities, shouldApplyNamedEntitiesMarks }) {
+  apply(content, { namedEntities, shouldApplyNamedEntitiesMarks }) {
     if (shouldApplyNamedEntitiesMarks) {
-      const marks = reduce(namedEntities, (all, { offsets, source: { mention, extractor, category } }) => {
-        const length = mention.length
-        offsets.forEach(start => {
-          if (start > -1) {
-            all.push({ start, length, category, extractor })
-          }
-        })
-        return all
-      }, [])
+      const marks = reduce(
+        namedEntities,
+        (all, { offsets, source: { mention, extractor, category } }) => {
+          const length = mention.length
+          offsets.forEach((start) => {
+            if (start > -1) {
+              all.push({ start, length, category, extractor })
+            }
+          })
+          return all
+        },
+        []
+      )
       // This is a function called on each highlighted text
       const each = this.buildNamedEntityMark.bind(this)
       return Highlight.create({ content, each }).ranges(marks)
     }
     return content
   }
-  buildNamedEntityMark ({ extractor, category, content: mention }) {
+  buildNamedEntityMark({ extractor, category, content: mention }) {
     const classNames = this.getCategoryClass(category, 'ner--')
     return this.namedEntityMarkTemplate({ classNames, extractor, mention })
   }
-  getCategoryClass (category = 'muted', prefix = '') {
+  getCategoryClass(category = 'muted', prefix = '') {
     return `${prefix}category-${category.toLowerCase()}`
   }
-  get namedEntityMarkTemplate () {
+  get namedEntityMarkTemplate() {
     return template('<mark class="ner <%= classNames %>" title="<%= extractor %>"><%= mention %></mark>')
   }
 }

--- a/src/store/pipelines/DeleteEmptyParagraphsPipeline.js
+++ b/src/store/pipelines/DeleteEmptyParagraphsPipeline.js
@@ -1,7 +1,7 @@
 import IdentityPipeline from './IdentityPipeline'
 
 class DeleteEmptyParagraphsPipeline extends IdentityPipeline {
-  apply (value) {
+  apply(value) {
     return value.replace(/<p>\s*<\/p>/gm, '')
   }
 }

--- a/src/store/pipelines/IdentityPipeline.js
+++ b/src/store/pipelines/IdentityPipeline.js
@@ -1,10 +1,10 @@
 class IdentityPipeline {
-  constructor ({ name, category = null, order = 0, ...defintion } = {}) {
+  constructor({ name, category = null, order = 0, ...defintion } = {}) {
     this.name = name
     this.category = category
     this.order = order
   }
-  apply (value) {
+  apply(value) {
     return value
   }
 }

--- a/src/store/pipelines/SanitizeHtml.js
+++ b/src/store/pipelines/SanitizeHtml.js
@@ -2,8 +2,8 @@ import xss from 'xss'
 import IdentityPipeline from './IdentityPipeline'
 
 class SanitizeHtml extends IdentityPipeline {
-  apply (content) {
-    function process (whiteList) {
+  apply(content) {
+    function process(whiteList) {
       return xss(content, { stripIgnoreTag: true, whiteList })
     }
 

--- a/src/store/pipelines/SimplePipeline.js
+++ b/src/store/pipelines/SimplePipeline.js
@@ -1,7 +1,7 @@
 import IdentityPipeline from './IdentityPipeline'
 
 class SimplePipeline extends IdentityPipeline {
-  constructor ({ apply, ...options }) {
+  constructor({ apply, ...options }) {
     super(options)
     this.apply = apply.bind(this)
   }

--- a/src/store/pipelines/UsernameIsYouPipeline.js
+++ b/src/store/pipelines/UsernameIsYouPipeline.js
@@ -1,14 +1,14 @@
 import IdentityPipeline from './IdentityPipeline'
 
 class UsernameIsYouPipeline extends IdentityPipeline {
-  async apply (username, auth) {
+  async apply(username, auth) {
     if (await this.isYou(username, auth)) {
       return window?.datashare?.i18n.t('global.you') || 'You'
     }
     return username
   }
-  async isYou (username, auth) {
-    return username === await auth.getUsername()
+  async isYou(username, auth) {
+    return username === (await auth.getUsername())
   }
 }
 

--- a/src/store/storeBuilder.js
+++ b/src/store/storeBuilder.js
@@ -19,7 +19,7 @@ import { starredStoreBuilder } from './modules/starred'
 import treeView from './modules/treeView'
 
 Vue.use(Vuex)
-export function storeBuilder (api) {
+export function storeBuilder(api) {
   return new Vuex.Store({
     modules: {
       app,
@@ -55,9 +55,9 @@ export function storeBuilder (api) {
           'search.showFilters',
           'search.layout'
         ],
-        filter (mutation) {
-        // Only for some mutations
-          return some(['search/', 'app/', 'doc/'], k => mutation.type.indexOf(k) === 0)
+        filter(mutation) {
+          // Only for some mutations
+          return some(['search/', 'app/', 'doc/'], (k) => mutation.type.indexOf(k) === 0)
         }
       })
     ]

--- a/src/store/widgets/WidgetDiskUsage.js
+++ b/src/store/widgets/WidgetDiskUsage.js
@@ -5,7 +5,7 @@ import WidgetEmpty from './WidgetEmpty'
  * Widget to display the disk space occupied by indexed files on the insights page.
  */
 class WidgetDiskUsage extends WidgetEmpty {
-  get component () {
+  get component() {
     return Component
   }
 }

--- a/src/store/widgets/WidgetDocumentsByCreationDate.js
+++ b/src/store/widgets/WidgetDocumentsByCreationDate.js
@@ -5,7 +5,7 @@ import WidgetText from './WidgetText'
  * Widget to display the number of file by creation date on the insights page.
  */
 class WidgetDocumentsByCreationDate extends WidgetText {
-  get component () {
+  get component() {
     return Component
   }
 }

--- a/src/store/widgets/WidgetDocumentsByCreationDateByPath.js
+++ b/src/store/widgets/WidgetDocumentsByCreationDateByPath.js
@@ -5,7 +5,7 @@ import WidgetDocumentsByCreationDate from './WidgetDocumentsByCreationDate'
  * Widget to display number of files by creation date by path
  */
 class WidgetDocumentsByCreationDateByPath extends WidgetDocumentsByCreationDate {
-  get component () {
+  get component() {
     return Component
   }
 }

--- a/src/store/widgets/WidgetDuplicates.js
+++ b/src/store/widgets/WidgetDuplicates.js
@@ -5,7 +5,7 @@ import WidgetText from './WidgetText'
  * Widget for the insights page indicating the proportion of duplicates in the data.
  */
 class WidgetDuplicates extends WidgetText {
-  get component () {
+  get component() {
     return Component
   }
 }

--- a/src/store/widgets/WidgetEmpty.js
+++ b/src/store/widgets/WidgetEmpty.js
@@ -15,19 +15,19 @@ class WidgetEmpty {
    * [Bootstrap's grid system](https://bootstrap-vue.org/docs/components/layout#layout-and-grid-system)
    * @param order=0 {number} - Order to display among the others widgets
    */
-  constructor ({ name = uniqueId('widget-'), card = true, cols = 12, order = 0 } = { }) {
+  constructor({ name = uniqueId('widget-'), card = true, cols = 12, order = 0 } = {}) {
     this.name = name
     this.card = card
     this.cols = cols
     this.order = order
   }
-  bindState (state) {
+  bindState(state) {
     this[_STATE] = this[_STATE] || state
   }
-  get state () {
+  get state() {
     return this[_STATE]
   }
-  get component () {
+  get component() {
     return Component
   }
 }

--- a/src/store/widgets/WidgetEntities.js
+++ b/src/store/widgets/WidgetEntities.js
@@ -5,7 +5,7 @@ import WidgetEmpty from './WidgetEmpty'
  * Widget to display text on the insights page
  */
 class WidgetEntities extends WidgetEmpty {
-  get component () {
+  get component() {
     return Component
   }
 }

--- a/src/store/widgets/WidgetFileBarometer.js
+++ b/src/store/widgets/WidgetFileBarometer.js
@@ -5,7 +5,7 @@ import WidgetEmpty from './WidgetEmpty'
  * Widget to display the number of indexed files on the insights page
  */
 class WidgetFileBarometer extends WidgetEmpty {
-  get component () {
+  get component() {
     return Component
   }
 }

--- a/src/store/widgets/WidgetListGroup.js
+++ b/src/store/widgets/WidgetListGroup.js
@@ -12,13 +12,13 @@ class WidgetListGroup extends WidgetEmpty {
    * @param pipeline='widget-list-group' {string} - I do not know
    * @param options {Object} - See WidgetEmpty for others options
    */
-  constructor ({ title = null, items = [], pipeline = 'widget-list-group', ...options }) {
+  constructor({ title = null, items = [], pipeline = 'widget-list-group', ...options }) {
     super(options)
     this.title = title
     this.items = items
     this.pipeline = pipeline
   }
-  get component () {
+  get component() {
     return Component
   }
 }

--- a/src/store/widgets/WidgetText.js
+++ b/src/store/widgets/WidgetText.js
@@ -12,14 +12,14 @@ class WidgetText extends WidgetEmpty {
    * @param pipeline='widget-text' {string} - Transformation to apply to the content
    * @param options {Object} - See WidgetEmpty for others options
    */
-  constructor ({ title = null, content = null, pipeline = 'widget-text', ...options }) {
+  constructor({ title = null, content = null, pipeline = 'widget-text', ...options }) {
     super(options)
     this.title = title
     this.content = content
     this.pipeline = pipeline
   }
 
-  get component () {
+  get component() {
     return Component
   }
 }

--- a/src/store/widgets/WidgetTreeMap.js
+++ b/src/store/widgets/WidgetTreeMap.js
@@ -11,17 +11,13 @@ class WidgetTreeMap extends WidgetEmpty {
    * @param index {string} - The Elasticsearch project of the Widget
    * @param options {Object} - See WidgetEmpty for others options
    */
-  constructor ({
-    title = null,
-    index = '',
-    ...options
-  }) {
+  constructor({ title = null, index = '', ...options }) {
     super(options)
     this.title = title
     this.index = index
   }
 
-  get component () {
+  get component() {
     return Component
   }
 }

--- a/src/store/widgets/index.js
+++ b/src/store/widgets/index.js
@@ -62,10 +62,30 @@ const widgets = [
     type: 'WidgetListGroup',
     title: 'More about data at ICIJ',
     items: [
-      { label: 'How ICIJ will rock its tech in 2020', href: 'https://www.icij.org/blog/2020/01/how-icij-will-rock-its-tech-in-2020/', description: 'Technology and data are our never-ending stories at ICIJ. So, at the turn of this new decade, you could well be wondering: what is coming next?' },
-      { label: 'What is Datashare? FAQs about our document analysis software', href: 'https://www.icij.org/blog/2019/11/what-is-datashare-frequently-asked-questions-about-our-document-analysis-software/', description: 'What makes ICIJ’s secure open-source software different from other tools? We answer some of the common questions about Datashare.' },
-      { label: 'Explore company secrets in Lux Leaks using Datashare', href: 'https://www.icij.org/blog/2020/03/explore-company-secrets-in-lux-leaks-using-datashare/', description: 'You can now search our Lux Leaks documents without installing any software. Get a taste for how ICIJ’s network of investigative reporters works using Datashare online.' },
-      { label: 'How we mined more than 715,000 Luanda Leaks records', href: 'https://www.icij.org/blog/2020/02/how-we-mined-more-than-715000-luanda-leaks-records/', description: 'Luanda Leaks was a trove of more than 175,000 emails – so how do we go about tackling such a massive dataset? And how can we be sure we haven’t missed major stories?' }
+      {
+        label: 'How ICIJ will rock its tech in 2020',
+        href: 'https://www.icij.org/blog/2020/01/how-icij-will-rock-its-tech-in-2020/',
+        description:
+          'Technology and data are our never-ending stories at ICIJ. So, at the turn of this new decade, you could well be wondering: what is coming next?'
+      },
+      {
+        label: 'What is Datashare? FAQs about our document analysis software',
+        href: 'https://www.icij.org/blog/2019/11/what-is-datashare-frequently-asked-questions-about-our-document-analysis-software/',
+        description:
+          'What makes ICIJ’s secure open-source software different from other tools? We answer some of the common questions about Datashare.'
+      },
+      {
+        label: 'Explore company secrets in Lux Leaks using Datashare',
+        href: 'https://www.icij.org/blog/2020/03/explore-company-secrets-in-lux-leaks-using-datashare/',
+        description:
+          'You can now search our Lux Leaks documents without installing any software. Get a taste for how ICIJ’s network of investigative reporters works using Datashare online.'
+      },
+      {
+        label: 'How we mined more than 715,000 Luanda Leaks records',
+        href: 'https://www.icij.org/blog/2020/02/how-we-mined-more-than-715000-luanda-leaks-records/',
+        description:
+          'Luanda Leaks was a trove of more than 175,000 emails – so how do we go about tackling such a massive dataset? And how can we be sure we haven’t missed major stories?'
+      }
     ]
   }
 ]

--- a/src/utils/event-bus.js
+++ b/src/utils/event-bus.js
@@ -2,7 +2,7 @@ import Vue from 'vue'
 
 export const EventBus = new Vue()
 
-export function dispatch (name, detail = {}) {
+export function dispatch(name, detail = {}) {
   const event = new CustomEvent(`datashare:${name}`, { detail })
   return document.dispatchEvent(event)
 }

--- a/src/utils/font-awesome-files.js
+++ b/src/utils/font-awesome-files.js
@@ -9,11 +9,11 @@ export { faFile as defaultIcon } from '@fortawesome/free-solid-svg-icons/faFile'
 
 // Import all file icon
 export const iconsContext = require.context('@fortawesome/free-solid-svg-icons', true, /faFile[A-Z]\w+\.js$/)
-export const icons = iconsContext.keys().map(key => {
+export const icons = iconsContext.keys().map((key) => {
   return iconsContext(key)[basename(key, '.js')]
 })
 
-export function findIcon (type) {
+export function findIcon(type) {
   // Remove leading .
   type = trim(type.toLowerCase(), '.')
   // Find the icon name
@@ -23,7 +23,7 @@ export function findIcon (type) {
   return icon
 }
 
-export function findContentTypeIcon (contentType) {
+export function findContentTypeIcon(contentType) {
   const extensions = get(types, [contentType, 'extensions'], [])
   const icon = get(types, [contentType, 'icon'], null)
   return (icon ? findIcon(icon) : find(extensions.map(findIcon))) || defaultIcon

--- a/src/utils/highlight.js
+++ b/src/utils/highlight.js
@@ -1,7 +1,7 @@
 import { filter, inRange, some, sortBy } from 'lodash'
 
 export class TextChunk {
-  constructor ({ content = '', start = 0, length = 0, previousChunk = null, ...data } = { }) {
+  constructor({ content = '', start = 0, length = 0, previousChunk = null, ...data } = {}) {
     this.content = content
     this.end = start + length
     this.start = start
@@ -9,36 +9,36 @@ export class TextChunk {
     this.data = data || {}
   }
 
-  highlight (iterator = null) {
+  highlight(iterator = null) {
     if (iterator) {
       return iterator({ ...this.data, content: this.content })
     }
     return `<mark>${this.content}</mark>`
   }
 
-  get isFirstChunk () {
+  get isFirstChunk() {
     return !this.previousChunk
   }
 
-  set previousChunk (previousChunk) {
+  set previousChunk(previousChunk) {
     if (previousChunk) {
       this._previousChunk = previousChunk
       previousChunk.nextChunk = this
     }
   }
 
-  get previousChunk () {
+  get previousChunk() {
     return this._previousChunk || null
   }
 }
 
 export class Highlight {
-  constructor ({ content = '', each = null } = {}) {
+  constructor({ content = '', each = null } = {}) {
     this.content = content
     this.each = each
   }
 
-  cleanRanges (ranges = []) {
+  cleanRanges(ranges = []) {
     ranges = sortBy(ranges, ['start', 'length'])
     // Remove overlaping ranges
     ranges = filter(ranges, (range, i) => {
@@ -46,15 +46,17 @@ export class Highlight {
       // Look into previous ranges to ensure none is overlaping
       return !some(previousRanges, ({ start, length }) => {
         // It starts in the current range
-        return inRange(start, range.start - 1, range.start + range.length + 1) ||
-        // Or it ends in the current range
-        inRange(start + length, range.start - 1, range.start + range.length + 1)
+        return (
+          inRange(start, range.start - 1, range.start + range.length + 1) ||
+          // Or it ends in the current range
+          inRange(start + length, range.start - 1, range.start + range.length + 1)
+        )
       })
     })
     return ranges
   }
 
-  ranges (ranges = []) {
+  ranges(ranges = []) {
     let textChunk = new TextChunk()
     this.cleanRanges(ranges).forEach(({ start, length, ...data }) => {
       const end = start + length
@@ -75,7 +77,7 @@ export class Highlight {
     return content
   }
 
-  static create (...args) {
+  static create(...args) {
     return new Highlight(...args)
   }
 }

--- a/src/utils/named-entities.js
+++ b/src/utils/named-entities.js
@@ -3,7 +3,7 @@ import { faMapMarkerAlt } from '@fortawesome/free-solid-svg-icons/faMapMarkerAlt
 import { faBuilding } from '@fortawesome/free-solid-svg-icons/faBuilding'
 import { faIdCardAlt } from '@fortawesome/free-solid-svg-icons/faIdCardAlt'
 
-export function namedEntityIcon (category) {
+export function namedEntityIcon(category) {
   const icons = {
     emails: faEnvelope,
     email: faEnvelope,

--- a/src/utils/screen.js
+++ b/src/utils/screen.js
@@ -1,3 +1,3 @@
-export function isNarrowScreen () {
+export function isNarrowScreen() {
   return (window.innerWidth || 0) < 1200
 }

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -7,7 +7,10 @@ export default {
       },
       {
         height: '1em',
-        boxes: [[0, '5em'], ['1em', '60%']]
+        boxes: [
+          [0, '5em'],
+          ['1em', '60%']
+        ]
       },
       {
         height: '1em',
@@ -15,7 +18,10 @@ export default {
       },
       {
         height: '1em',
-        boxes: [[0, '5em'], ['1em', '40%']]
+        boxes: [
+          [0, '5em'],
+          ['1em', '40%']
+        ]
       },
       {
         height: '1em',
@@ -37,9 +43,7 @@ export default {
       default: 'https://icij.gitbook.io/datashare/all/search-with-operators'
     }
   },
-  hotKeyPrevented: [
-    '.search-bar__input'
-  ],
+  hotKeyPrevented: ['.search-bar__input'],
   locales: [
     {
       key: 'en',

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -1,6 +1,6 @@
 import { escapeRegExp } from 'lodash'
 
-export function slugger (value = '') {
+export function slugger(value = '') {
   return value
     .toLowerCase()
     .trim()
@@ -8,11 +8,11 @@ export function slugger (value = '') {
     .replace(/\s/g, '-')
 }
 
-export function addLocalSearchMarksClassByOffsets ({ content = '', term = '', offsets = [], delta = 0 } = {}) {
+export function addLocalSearchMarksClassByOffsets({ content = '', term = '', offsets = [], delta = 0 } = {}) {
   // Create one chunk for each letter
   const chunks = content.split('')
   // Add mark tag to the corresponding letters
-  offsets.forEach(offset => {
+  offsets.forEach((offset) => {
     const start = offset - delta
     const end = start + term.length - 1
     // Only replace by offset in existing chunk
@@ -25,7 +25,7 @@ export function addLocalSearchMarksClassByOffsets ({ content = '', term = '', of
   return chunks.join('')
 }
 
-export function addLocalSearchMarksClassSensitive (content = '<div></div>', localSearchTerm = { label: '' }) {
+export function addLocalSearchMarksClassSensitive(content = '<div></div>', localSearchTerm = { label: '' }) {
   const escapedLocalSearchTerm = localSearchTerm.regex ? localSearchTerm.label : escapeRegExp(localSearchTerm.label)
   // In case the searched term is split on 2 lines in the content
   const escapedLocalSearchTermAsRegex = escapedLocalSearchTerm.replace(' ', '( |  |.|..| .)')
@@ -35,7 +35,7 @@ export function addLocalSearchMarksClassSensitive (content = '<div></div>', loca
   try {
     if (localSearchOccurrences === 0) throw new Error()
     const needle = new RegExp(`(${escapedLocalSearchTermAsRegex})`, 'gms')
-    const replacedContent = content.replace(needle, m => {
+    const replacedContent = content.replace(needle, (m) => {
       const term = m.replace(/(\r\n|\n|\r)/gm, ' ').replace('  ', ' ')
       return `<mark class="local-search-term">${term}</mark>`
     })
@@ -45,13 +45,13 @@ export function addLocalSearchMarksClassSensitive (content = '<div></div>', loca
       localSearchIndex,
       localSearchOccurrences
     }
-  // Silently fails
+    // Silently fails
   } catch (error) {
     return { content, localSearchIndex, localSearchOccurrences }
   }
 }
 
-export function addLocalSearchMarksClass (content = '<div></div>', localSearchTerm = { label: '' }) {
+export function addLocalSearchMarksClass(content = '<div></div>', localSearchTerm = { label: '' }) {
   const escapedLocalSearchTerm = localSearchTerm.regex ? localSearchTerm.label : escapeRegExp(localSearchTerm.label)
   // In case the searched term is split on 2 lines in the content
   const escapedLocalSearchTermAsRegex = escapedLocalSearchTerm.replace(' ', '( |  |.|..| .)')
@@ -61,7 +61,7 @@ export function addLocalSearchMarksClass (content = '<div></div>', localSearchTe
   try {
     if (localSearchOccurrences === 0) throw new Error()
     const needle = new RegExp(`(${escapedLocalSearchTermAsRegex})`, 'gims')
-    const replacedContent = content.replace(needle, m => {
+    const replacedContent = content.replace(needle, (m) => {
       const term = m.replace(/(\r\n|\n|\r)/gm, ' ').replace('  ', ' ')
       return `<mark class="local-search-term">${term}</mark>`
     })
@@ -71,18 +71,21 @@ export function addLocalSearchMarksClass (content = '<div></div>', localSearchTe
       localSearchIndex,
       localSearchOccurrences
     }
-  // Silently fails
+    // Silently fails
   } catch (error) {
     return { content, localSearchIndex, localSearchOccurrences }
   }
 }
 
-export function isUrl (url = '') {
-  const pattern = new RegExp('^(https?:\\/\\/)?' + // protocol
-    '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
-    '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
-    '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-    '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-    '(\\#[-a-z\\d_]*)?$', 'i') // fragment locator
+export function isUrl(url = '') {
+  const pattern = new RegExp(
+    '^(https?:\\/\\/)?' + // protocol
+      '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
+      '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
+      '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
+      '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
+      '(\\#[-a-z\\d_]*)?$',
+    'i'
+  ) // fragment locator
   return !!pattern.test(url)
 }

--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -1,8 +1,8 @@
 /**
  * This helper function returns true if the given node
  * has an overflow "auto" or "scroll"
-*/
-export function hasOverflow (node) {
+ */
+export function hasOverflow(node) {
   const { overflow } = window.getComputedStyle(node)
   return overflow === 'auto' || overflow === 'scroll'
 }
@@ -12,7 +12,7 @@ export function hasOverflow (node) {
  * @param {HTMLElement} element
  * @returns {Object}
  */
-export function getTranslateValues (element) {
+export function getTranslateValues(element) {
   const style = window.getComputedStyle(element)
   const matrix = style.transform || style.webkitTransform || style.mozTransform
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -7,12 +7,12 @@ import settings from '@/utils/settings'
 import { slugger } from '@/utils/strings'
 import types from '@/utils/types.json'
 
-function getDocumentTypeLabel (key) {
+function getDocumentTypeLabel(key) {
   if (key === undefined) return ''
   return get(types, [key, 'label'], key)
 }
 
-function getExtractionLevelTranslationKey (key) {
+function getExtractionLevelTranslationKey(key) {
   if (key === undefined) return ''
   const levels = {
     0: 'level00',
@@ -30,7 +30,7 @@ function getExtractionLevelTranslationKey (key) {
   return `filter.level.${get(levels, key, key)}`
 }
 
-function getOS () {
+function getOS() {
   let OSName = 'other'
   if (window.navigator.platform.includes('Mac')) OSName = 'mac'
   else if (window.navigator.platform.includes('Win')) OSName = 'windows'
@@ -38,22 +38,22 @@ function getOS () {
   return OSName
 }
 
-function getShortkeyOS () {
+function getShortkeyOS() {
   return getOS() === 'mac' ? 'mac' : 'default'
 }
 
-function objectIncludes (object, text) {
+function objectIncludes(object, text) {
   if (typeof object === 'string') {
     return object.toLowerCase().includes(text.toLowerCase())
   }
-  return Object.values(object).some(object => objectIncludes(object, text))
+  return Object.values(object).some((object) => objectIncludes(object, text))
 }
 
-function toVariant (string = '', defaultVariant = 'darker', prefix = '') {
+function toVariant(string = '', defaultVariant = 'darker', prefix = '') {
   return prefix + settings.variantsMap[slugger(string).toLowerCase()] || defaultVariant
 }
 
-function toVariantIcon (string = '', defaultVariant = 'darker') {
+function toVariantIcon(string = '', defaultVariant = 'darker') {
   const variant = toVariant(string, defaultVariant)
   const icons = {
     success: faCheck,
@@ -63,7 +63,7 @@ function toVariantIcon (string = '', defaultVariant = 'darker') {
   return icons[variant]
 }
 
-function toVariantColor (string = '', defaultVariant = 'darker') {
+function toVariantColor(string = '', defaultVariant = 'darker') {
   const variant = toVariant(string, defaultVariant)
   const style = getComputedStyle(document.body)
   return style.getPropertyValue(`--${variant}`) || '#eee'

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,8 +1,0 @@
-module.exports = {
-  env: {
-    jest: true
-  },
-  rules: {
-    'import/no-extraneous-dependencies': 'off'
-  }
-}

--- a/tests/e2e/custom-assertions/elementCount.js
+++ b/tests/e2e/custom-assertions/elementCount.js
@@ -18,10 +18,14 @@ exports.assertion = function (selector, count) {
   }
   this.command = function (cb) {
     const self = this
-    return this.api.execute(function (selector) {
-      return document.querySelectorAll(selector).length
-    }, [selector], function (res) {
-      cb.call(self, res)
-    })
+    return this.api.execute(
+      function (selector) {
+        return document.querySelectorAll(selector).length
+      },
+      [selector],
+      function (res) {
+        cb.call(self, res)
+      }
+    )
   }
 }

--- a/tests/e2e/runner.js
+++ b/tests/e2e/runner.js
@@ -9,22 +9,23 @@ const devConfigPromise = require('../../build/webpack.dev.conf')
 
 let server
 
-devConfigPromise.then(devConfig => {
-  const devServerOptions = devConfig.devServer
-  const compiler = webpack(webpackConfig)
-  server = new DevServer(compiler, devServerOptions)
-  const port = devServerOptions.port
-  const host = devServerOptions.host
-  return server.listen(port, host)
-})
+devConfigPromise
+  .then((devConfig) => {
+    const devServerOptions = devConfig.devServer
+    const compiler = webpack(webpackConfig)
+    server = new DevServer(compiler, devServerOptions)
+    const port = devServerOptions.port
+    const host = devServerOptions.host
+    return server.listen(port, host)
+  })
   .then(() => {
-  // 2. run the nightwatch test suite against it
-  // to run in additional browsers:
-  //    1. add an entry in test/e2e/nightwatch.conf.js under "test_settings"
-  //    2. add it to the --env flag below
-  // or override the environment flag, for example: `npm run e2e -- --env chrome,firefox`
-  // For more information on Nightwatch's config file, see
-  // http://nightwatchjs.org/guide#settings-file
+    // 2. run the nightwatch test suite against it
+    // to run in additional browsers:
+    //    1. add an entry in test/e2e/nightwatch.conf.js under "test_settings"
+    //    2. add it to the --env flag below
+    // or override the environment flag, for example: `npm run e2e -- --env chrome,firefox`
+    // For more information on Nightwatch's config file, see
+    // http://nightwatchjs.org/guide#settings-file
     let opts = process.argv.slice(2)
     if (opts.indexOf('--config') === -1) {
       opts = opts.concat(['--config', 'test/e2e/nightwatch.conf.js'])

--- a/tests/unit/api_mock.js
+++ b/tests/unit/api_mock.js
@@ -1,32 +1,32 @@
-function letTextContent (content) {
+function letTextContent(content) {
   return new TextContent(content)
 }
 class TextContent {
-  constructor (content) {
+  constructor(content) {
     this.content = content ?? ''
     this.offset = 0
     this.limit = this.content.length
     this.maxOffset = this.content.length
   }
-  withContent (content) {
+  withContent(content) {
     this.content = content
     this.limit = this.content.length
     this.maxOffset = content.length
     return this
   }
-  withOffset (offset) {
+  withOffset(offset) {
     this.offset = offset
     return this
   }
-  withLimit (limit) {
+  withLimit(limit) {
     this.limit = limit
     return this
   }
-  withMaxOffset (maxOffset) {
+  withMaxOffset(maxOffset) {
     this.maxOffset = maxOffset
     return this
   }
-  getResponse () {
+  getResponse() {
     return { content: this.content, limit: this.limit, offset: this.offset, maxOffset: this.maxOffset }
   }
 }

--- a/tests/unit/es_utils.js
+++ b/tests/unit/es_utils.js
@@ -3,12 +3,12 @@ import { dirname } from 'path'
 
 import EsDocList from '@/api/resources/EsDocList'
 
-function letData (index) {
+function letData(index) {
   return new IndexBuilder(index)
 }
 
 class IndexedNamedEntity {
-  constructor (mention, offset = 1, category = 'PERSON', isHidden = false, path = '') {
+  constructor(mention, offset = 1, category = 'PERSON', isHidden = false, path = '') {
     this.mention = mention
     this.offsets = castArray(offset)
     this.category = category
@@ -16,13 +16,13 @@ class IndexedNamedEntity {
     this.path = path
     return this
   }
-  get id () {
+  get id() {
     return this.path + this.mention + this.offsets
   }
 }
 
 class IndexedDocuments {
-  constructor () {
+  constructor() {
     this.baseName = 'document'
     this.numberOfDocuments = 0
     this.content = 'default content'
@@ -31,23 +31,23 @@ class IndexedDocuments {
     this.index = 'default-index'
     this.extractionLevel = 0
   }
-  setBaseName (pattern) {
+  setBaseName(pattern) {
     this.baseName = pattern
     return this
   }
-  withContent (content) {
+  withContent(content) {
     this.content = content
     return this
   }
-  withIndex (index) {
+  withIndex(index) {
     this.index = index
     return this
   }
-  withIndexingDate (indexingDate) {
+  withIndexingDate(indexingDate) {
     this.extractionDate = indexingDate
     return this
   }
-  count (numberOfDocuments) {
+  count(numberOfDocuments) {
     this.numberOfDocuments = numberOfDocuments
     for (let i = 0; i < this.numberOfDocuments; i++) {
       const doc = new IndexedDocument(this.baseName + '_' + (i + 1), this.index).withContent(this.content)
@@ -58,16 +58,16 @@ class IndexedDocuments {
     }
     return this.document
   }
-  commit (es) {
+  commit(es) {
     return letData(es).have(this).commit()
   }
-  static build () {
+  static build() {
     return new IndexedDocuments()
   }
 }
 
 class IndexedDocument {
-  constructor (path = uniqueId('/path/to/document/'), index = 'default-index') {
+  constructor(path = uniqueId('/path/to/document/'), index = 'default-index') {
     this.path = path
     this.dirname = dirname(path)
     this.join = { name: 'Document' }
@@ -84,23 +84,23 @@ class IndexedDocument {
     this.index = index
     this.extractionLevel = 0
   }
-  get id () {
+  get id() {
     return this.path
   }
-  setContentTextLength (length) {
+  setContentTextLength(length) {
     this.contentTextLength = length
     return this
   }
-  withContent (content) {
+  withContent(content) {
     this.content = content
     this.contentTextLength = content.length
     return this
   }
-  withContentLength (contentLength) {
+  withContentLength(contentLength) {
     this.contentLength = contentLength
     return this
   }
-  withContentType (contentType) {
+  withContentType(contentType) {
     this.metadata.tika_metadata_content_type = contentType
     this.contentType = contentType.split(';')[0].trim()
     if (contentType.indexOf('charset') > 0) {
@@ -108,99 +108,99 @@ class IndexedDocument {
     }
     return this
   }
-  withIndexingDate (indexingDate) {
+  withIndexingDate(indexingDate) {
     this.extractionDate = indexingDate
     return this
   }
-  withAuthor (author) {
+  withAuthor(author) {
     this.metadata.tika_metadata_dc_creator = author
     return this
   }
-  withCreationDate (creationDate) {
+  withCreationDate(creationDate) {
     this.metadata.tika_metadata_dcterms_created = creationDate
     return this
   }
-  withOtherMetadata (otherMetadata) {
+  withOtherMetadata(otherMetadata) {
     this.metadata.tika_metadata_another_metadata = otherMetadata
     return this
   }
-  withMetadata (metadata) {
+  withMetadata(metadata) {
     const md = isObject(metadata) ? metadata : {}
     this.metadata = { ...md, ...this.metadata }
     return this
   }
-  withLanguage (language) {
+  withLanguage(language) {
     this.language = language
     return this
   }
-  withNoContentTranslated () {
+  withNoContentTranslated() {
     this.content_translated = []
     return this
   }
-  withContentTranslated (content, sourceLanguage, targetLanguage) {
+  withContentTranslated(content, sourceLanguage, targetLanguage) {
     const translation = { content, source_language: sourceLanguage, target_language: targetLanguage }
     this.content_translated = [] || this.content_translated
     this.content_translated.push(translation)
     return this
   }
-  withNer (mention, offset = 1, category = 'PERSON', isHidden = false) {
+  withNer(mention, offset = 1, category = 'PERSON', isHidden = false) {
     this.nerList.push(new IndexedNamedEntity(mention, offset, category, isHidden, this.path))
     return this
   }
-  withParent (parentId) {
+  withParent(parentId) {
     this.parentDocument = parentId
     this.extractionLevel = 1
     this.parent = new IndexedDocument(parentId)
     return this
   }
-  withRoot (rootId) {
+  withRoot(rootId) {
     this.rootDocument = rootId
     this.root = new IndexedDocument(rootId)
     return this
   }
-  withPipeline (pipeline) {
+  withPipeline(pipeline) {
     this.nerTags.push(pipeline)
     return this
   }
-  withTags (tags) {
+  withTags(tags) {
     this.tags = tags
     return this
   }
-  getContentTranslated ({ sourceLanguage = this.language, targetLanguage = this.language } = {}) {
+  getContentTranslated({ sourceLanguage = this.language, targetLanguage = this.language } = {}) {
     const needle = { source_language: sourceLanguage, target_language: targetLanguage }
     const { content = null } = find(this.content_translated, needle) || {}
     return content
   }
-  hasParent () {
+  hasParent() {
     return this.parentDocument !== undefined
   }
-  hideNer (mention) {
+  hideNer(mention) {
     const ner = find(this.nerList, { mention: mention })
     ner.isHidden = true
     return ner
   }
-  commit (es) {
+  commit(es) {
     return letData(es).have(this).commit()
   }
-  static build (path, index) {
+  static build(path, index) {
     return new IndexedDocument(path, index)
   }
 }
 
 class IndexBuilder {
-  constructor (index) {
+  constructor(index) {
     this.index = index
     this.committedDocumentIds = []
   }
-  have (document) {
+  have(document) {
     this.document = document
     return this
   }
-  async hideNer (mention) {
+  async hideNer(mention) {
     await this.update(await this.document.hideNer(mention))
     return this
   }
-  async update (ner) {
+  async update(ner) {
     await this.index.update({
       index: process.env.VUE_APP_ES_INDEX,
       refresh: true,
@@ -212,7 +212,7 @@ class IndexBuilder {
       }
     })
   }
-  async commit () {
+  async commit() {
     if (isArray(this.document)) {
       // Copy this array into 'documents' because 'document'
       // will be overwritten by the next call to have
@@ -251,11 +251,11 @@ class IndexBuilder {
     }
     return this
   }
-  async commitAndGetLastDocument () {
+  async commitAndGetLastDocument() {
     await this.commit()
     return this.lastCommittedDocument
   }
-  _omit (obj, fields) {
+  _omit(obj, fields) {
     return Object.keys(obj).reduce((newObj, key) => {
       if (!fields.includes(key)) {
         newObj[key] = obj[key]
@@ -263,14 +263,14 @@ class IndexBuilder {
       return newObj
     }, {})
   }
-  get committedDocuments () {
-    const promises = this.committedDocumentIds.map(async id => {
+  get committedDocuments() {
+    const promises = this.committedDocumentIds.map(async (id) => {
       const raw = await this.index.get({ index: this.document.index, id })
       return EsDocList.instantiate(raw)
     })
     return Promise.all(promises)
   }
-  get lastCommittedDocument () {
+  get lastCommittedDocument() {
     return Promise.resolve().then(async () => {
       const id = this.committedDocumentIds.slice(-1).pop()
       const raw = await this.index.get({ index: this.document.index, id })

--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -5,7 +5,7 @@ global.console = Object.assign(global.console, {
   info: jest.fn()
 })
 
-window.matchMedia = jest.fn().mockImplementation(query => {
+window.matchMedia = jest.fn().mockImplementation((query) => {
   return {
     matches: false,
     media: query,

--- a/tests/unit/specs/api/elasticsearch.spec.js
+++ b/tests/unit/specs/api/elasticsearch.spec.js
@@ -29,8 +29,7 @@ describe('elasticsearch', () => {
   })
 
   it('should build an ES query with filters', async () => {
-    const filters = [new FilterText(
-      { name: 'contentType', key: 'contentType', isSearchable: true })]
+    const filters = [new FilterText({ name: 'contentType', key: 'contentType', isSearchable: true })]
     filters[0].values = ['value_01', 'value_02', 'value_03']
     const body = bodybuilder().from(0).size(25)
 
@@ -61,20 +60,23 @@ describe('elasticsearch', () => {
       size: 25,
       query: {
         bool: {
-          must: [{
-            match_all: {}
-          }, {
-            bool: {
-              should: [
-                {
-                  query_string: {
-                    query: '*',
-                    fields: undefined
+          must: [
+            {
+              match_all: {}
+            },
+            {
+              bool: {
+                should: [
+                  {
+                    query_string: {
+                      query: '*',
+                      fields: undefined
+                    }
                   }
-                }
-              ]
+                ]
+              }
             }
-          }]
+          ]
         }
       }
     })
@@ -90,19 +92,22 @@ describe('elasticsearch', () => {
       size: 25,
       query: {
         bool: {
-          must: [{
-            match_all: {}
-          }, {
-            bool: {
-              should: [
-                {
-                  query_string: {
-                    query: 'path:/home/datashare/path/*'
+          must: [
+            {
+              match_all: {}
+            },
+            {
+              bool: {
+                should: [
+                  {
+                    query_string: {
+                      query: 'path:/home/datashare/path/*'
+                    }
                   }
-                }
-              ]
+                ]
+              }
             }
-          }]
+          ]
         }
       }
     })
@@ -116,15 +121,18 @@ describe('elasticsearch', () => {
     expect(body.build()).toEqual({
       from: 0,
       size: 25,
-      sort: [{
-        extractionDate: {
-          order: 'asc'
+      sort: [
+        {
+          extractionDate: {
+            order: 'asc'
+          }
+        },
+        {
+          path: {
+            order: 'asc'
+          }
         }
-      }, {
-        path: {
-          order: 'asc'
-        }
-      }]
+      ]
     })
   })
 
@@ -136,30 +144,35 @@ describe('elasticsearch', () => {
     expect(body.build()).toEqual({
       from: 0,
       size: 25,
-      sort: [{
-        path: {
-          order: 'desc'
+      sort: [
+        {
+          path: {
+            order: 'desc'
+          }
         }
-      }]
+      ]
     })
   })
 
   it('should return the first 12 named entities', async () => {
     const id = 'document'
-    await letData(es).have(new IndexedDocument(id, index)
-      .withNer('ne_01')
-      .withNer('ne_02')
-      .withNer('ne_03')
-      .withNer('ne_04')
-      .withNer('ne_05')
-      .withNer('ne_06')
-      .withNer('ne_07')
-      .withNer('ne_08')
-      .withNer('ne_09')
-      .withNer('ne_10')
-      .withNer('ne_11')
-      .withNer('ne_12')
-    ).commit()
+    await letData(es)
+      .have(
+        new IndexedDocument(id, index)
+          .withNer('ne_01')
+          .withNer('ne_02')
+          .withNer('ne_03')
+          .withNer('ne_04')
+          .withNer('ne_05')
+          .withNer('ne_06')
+          .withNer('ne_07')
+          .withNer('ne_08')
+          .withNer('ne_09')
+          .withNer('ne_10')
+          .withNer('ne_11')
+          .withNer('ne_12')
+      )
+      .commit()
 
     const response = await elasticsearch.getDocumentNamedEntities(index, id, id, 0, 20)
 
@@ -167,20 +180,19 @@ describe('elasticsearch', () => {
   })
 
   it('should return only one named entity', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContent('this is a document mentioning ne_01')
-      .withNer('ne_01')
-    ).commit()
+    await letData(es)
+      .have(
+        new IndexedDocument('document_01', index).withContent('this is a document mentioning ne_01').withNer('ne_01')
+      )
+      .commit()
 
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContent('this is a document')
-      .withNer('document')
-    ).commit()
+    await letData(es)
+      .have(new IndexedDocument('document_02', index).withContent('this is a document').withNer('document'))
+      .commit()
 
-    await letData(es).have(new IndexedDocument('document_03', index)
-      .withContent('this is another document')
-      .withNer('another')
-    ).commit()
+    await letData(es)
+      .have(new IndexedDocument('document_03', index).withContent('this is another document').withNer('another'))
+      .commit()
 
     const filter = new FilterNamedEntity({ name: 'namedEntityPerson', key: 'byMentions', category: 'PERSON' })
     const response = await elasticsearch.searchFilter(index, filter, 'document')

--- a/tests/unit/specs/api/index.spec.js
+++ b/tests/unit/specs/api/index.spec.js
@@ -17,33 +17,37 @@ describe('Datashare backend client', () => {
   it('should return backend response to index', async () => {
     json = await api.index({})
     expect(json).toEqual({})
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/task/batchUpdate/index/file'),
-      method: 'POST',
-      data: {
-        options: {
-          filter: true,
-          ocr: false
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/task/batchUpdate/index/file'),
+        method: 'POST',
+        data: {
+          options: {
+            filter: true,
+            ocr: false
+          }
         }
-      }
-    }))
+      })
+    )
   })
 
   it('should return backend response to index when language is specified', async () => {
     json = await api.index({ language: 'fra' })
     expect(json).toEqual({})
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/task/batchUpdate/index/file'),
-      method: 'POST',
-      data: {
-        options: {
-          filter: true,
-          ocr: false,
-          language: 'fra',
-          ocrLanguage: 'fra'
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/task/batchUpdate/index/file'),
+        method: 'POST',
+        data: {
+          options: {
+            filter: true,
+            ocr: false,
+            language: 'fra',
+            ocrLanguage: 'fra'
+          }
         }
-      }
-    }))
+      })
+    )
   })
 
   it('should return backend response to findNames', async () => {
@@ -157,7 +161,17 @@ describe('Datashare backend client', () => {
     const fileTypes = [{ mime: 'application/pdf' }, { mime: 'text/plain' }]
     const paths = ['one', 'or', 'two', 'paths']
     const published = true
-    json = await api.batchSearch(name, csvFile, description, project, phraseMatch, fuzziness, fileTypes, paths, published)
+    json = await api.batchSearch(
+      name,
+      csvFile,
+      description,
+      project,
+      phraseMatch,
+      fuzziness,
+      fileTypes,
+      paths,
+      published
+    )
 
     const data = new FormData()
     data.append('name', name)
@@ -173,11 +187,13 @@ describe('Datashare backend client', () => {
     data.append('paths', 'paths')
     data.append('published', published)
     expect(json).toEqual({})
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/batch/search/project'),
-      method: 'POST',
-      data
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/batch/search/project'),
+        method: 'POST',
+        data
+      })
+    )
   })
 
   it('should return backend response to getBatchSearch', async () => {
@@ -284,7 +300,13 @@ describe('Datashare backend client', () => {
     json = await api.copyBatchSearch('12', 'copyName', 'copyDescription')
     const data = { description: 'copyDescription', name: 'copyName' }
     expect(json).toEqual({})
-    expect(mockAxios.request).toBeCalledWith({ url: Api.getFullUrl('/api/batch/search/copy/12'), method: 'POST', data, responseType: 'text', headers: { 'Content-Type': 'text/plain;charset=UTF-8' } })
+    expect(mockAxios.request).toBeCalledWith({
+      url: Api.getFullUrl('/api/batch/search/copy/12'),
+      method: 'POST',
+      data,
+      responseType: 'text',
+      headers: { 'Content-Type': 'text/plain;charset=UTF-8' }
+    })
   })
 
   it('should return backend response to getUserHistory', async () => {
@@ -296,7 +318,13 @@ describe('Datashare backend client', () => {
     json = await api.addHistoryEvent(['project1', 'project2'], 'DOCUMENT', 'docName', 'docUri')
     const data = { projectIds: ['project1', 'project2'], type: 'DOCUMENT', name: 'docName', uri: 'docUri' }
     expect(json).toEqual({})
-    expect(mockAxios.request).toBeCalledWith({ url: Api.getFullUrl('/api/users/me/history'), method: 'PUT', data, responseType: 'text', headers: { 'Content-Type': 'text/plain;charset=UTF-8' } })
+    expect(mockAxios.request).toBeCalledWith({
+      url: Api.getFullUrl('/api/users/me/history'),
+      method: 'PUT',
+      data,
+      responseType: 'text',
+      headers: { 'Content-Type': 'text/plain;charset=UTF-8' }
+    })
   })
 
   it('should return a backend response to deleteUserHistory', async () => {

--- a/tests/unit/specs/components/Api.spec.js
+++ b/tests/unit/specs/components/Api.spec.js
@@ -52,10 +52,12 @@ describe('Api.vue', () => {
     await flushPromises()
 
     expect(mockAxios.request).toBeCalledTimes(3)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/key/doe'),
-      method: 'PUT'
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/key/doe'),
+        method: 'PUT'
+      })
+    )
   })
 
   it('should delete the apiKey', async () => {

--- a/tests/unit/specs/components/AppSidebar.spec.js
+++ b/tests/unit/specs/components/AppSidebar.spec.js
@@ -12,17 +12,19 @@ jest.mock('@/utils/utils', () => {
 })
 
 describe('AppSidebar.vue', () => {
-  const mockApi = { getVersion: jest.fn().mockResolvedValue({ version: { 'git.commit.id.abbrev': '', 'git.build.version': '' } }) }
+  const mockApi = {
+    getVersion: jest.fn().mockResolvedValue({ version: { 'git.commit.id.abbrev': '', 'git.build.version': '' } })
+  }
 
   const { config, i18n, localVue, router, store } = Core.init(createLocalVue(), mockApi).useAll()
   let wrapper = null
 
-  function setServerMode () {
+  function setServerMode() {
     config.merge({ mode: 'SERVER' })
     return shallowMount(AppSidebar, { config, i18n, localVue, router, store })
   }
 
-  function setBasicAuthFilter () {
+  function setBasicAuthFilter() {
     config.merge({ authFilter: 'org.icij.datashare.session.BasicAuthAdaptorFilter', mode: 'SERVER' })
     return shallowMount(AppSidebar, { config, i18n, localVue, router, store })
   }
@@ -36,12 +38,16 @@ describe('AppSidebar.vue', () => {
 
   describe('the help link', () => {
     it('should be a github link if NOT in SERVER mode', () => {
-      expect(wrapper.find('.app-sidebar__container__menu__item--help a').attributes('href')).toEqual(expect.stringContaining('github.com'))
+      expect(wrapper.find('.app-sidebar__container__menu__item--help a').attributes('href')).toEqual(
+        expect.stringContaining('github.com')
+      )
     })
 
     it('should be another github link if in SERVER mode', () => {
       wrapper = setServerMode()
-      expect(wrapper.find('.app-sidebar__container__menu__item--help a').attributes('href')).toBe('https://github.com/ICIJ/datashare/wiki/Datashare-Support')
+      expect(wrapper.find('.app-sidebar__container__menu__item--help a').attributes('href')).toBe(
+        'https://github.com/ICIJ/datashare/wiki/Datashare-Support'
+      )
     })
   })
 

--- a/tests/unit/specs/components/AppliedSearchFilters.spec.js
+++ b/tests/unit/specs/components/AppliedSearchFilters.spec.js
@@ -98,7 +98,7 @@ describe('AppliedSearchFilters.vue', () => {
 
   describe('deletes applied filters', () => {
     beforeEach(() => {
-      wrapper = mount(AppliedSearchFilters, { localVue, router, store, mocks: { $t: msg => msg } })
+      wrapper = mount(AppliedSearchFilters, { localVue, router, store, mocks: { $t: (msg) => msg } })
     })
 
     it('should remove the "AND" on last applied filter deletion', async () => {

--- a/tests/unit/specs/components/BatchDownloadActions.spec.js
+++ b/tests/unit/specs/components/BatchDownloadActions.spec.js
@@ -8,7 +8,7 @@ describe('BatchDownloadActions.vue', () => {
   const { i18n, localVue } = Core.init(createLocalVue(), mockApi).useAll()
   const projects = [{ name: 'project' }]
 
-  function mockRunBatchDownload (name = 'BatchDownloadTask', batchDownload = {}, state = 'DONE') {
+  function mockRunBatchDownload(name = 'BatchDownloadTask', batchDownload = {}, state = 'DONE') {
     const data = {
       name,
       state,
@@ -19,12 +19,12 @@ describe('BatchDownloadActions.vue', () => {
     return { batchDownload, name, state }
   }
 
-  function mockDeleteBatchDownload (name = 'BatchDownloadTask', batchDownload = {}, state = 'DONE') {
+  function mockDeleteBatchDownload(name = 'BatchDownloadTask', batchDownload = {}, state = 'DONE') {
     mockApi.deleteTask.mockResolvedValue(true)
     return { batchDownload, name, state }
   }
 
-  function mockFailToDeleteBatchDownload (name = 'BatchDownloadTask', batchDownload = {}, state = 'RUNNING') {
+  function mockFailToDeleteBatchDownload(name = 'BatchDownloadTask', batchDownload = {}, state = 'RUNNING') {
     mockApi.deleteTask.mockRejectedValue(new Error(''))
     return { batchDownload, name, state }
   }

--- a/tests/unit/specs/components/BatchSearchActions.spec.js
+++ b/tests/unit/specs/components/BatchSearchActions.spec.js
@@ -16,9 +16,11 @@ describe('BatchSearchActions.vue', () => {
   const propsData = {
     batchSearch: {
       uuid: '12',
-      projects: [{
-        name: 'BatchSearchActions'
-      }],
+      projects: [
+        {
+          name: 'BatchSearchActions'
+        }
+      ],
       name: 'BatchSearch Test',
       description: 'This is the description of the batch search',
       state: 'SUCCESS',
@@ -46,7 +48,8 @@ describe('BatchSearchActions.vue', () => {
       {
         name: 'batch-search.results',
         path: 'batch-search/:index/:uuid'
-      }, {
+      },
+      {
         name: 'document-standalone',
         path: '/ds/:index/:id/:routing?'
       }
@@ -75,14 +78,18 @@ describe('BatchSearchActions.vue', () => {
 
   it('should display number of selected queries', async () => {
     const stateMock = { selectedQueries: [] }
-    let storeMock = new Vuex.Store({ modules: { batchSearch: { namespaced: true, state: stateMock, getters, mutations, actions: actionBuilder(api) } } })
+    let storeMock = new Vuex.Store({
+      modules: { batchSearch: { namespaced: true, state: stateMock, getters, mutations, actions: actionBuilder(api) } }
+    })
     wrapper = mount(BatchSearchActions, { i18n, localVue, propsData, router, store: storeMock, wait })
     await flushPromises()
 
     expect(wrapper.find('.batch-search-actions__item__counter').exists()).toBeFalsy()
 
     const state2 = { selectedQueries: ['test'] }
-    storeMock = new Vuex.Store({ modules: { batchSearch: { namespaced: true, state: state2, getters, mutations, actions: actionBuilder(api) } } })
+    storeMock = new Vuex.Store({
+      modules: { batchSearch: { namespaced: true, state: state2, getters, mutations, actions: actionBuilder(api) } }
+    })
     wrapper = mount(BatchSearchActions, { i18n, localVue, propsData, router, store: storeMock, wait })
     await flushPromises()
 
@@ -126,9 +133,11 @@ describe('BatchSearchActions.vue', () => {
     const propsData = {
       batchSearch: {
         uuid: '155',
-        projects: [{
-          name: 'BatchSearchActions'
-        }],
+        projects: [
+          {
+            name: 'BatchSearchActions'
+          }
+        ],
         description: 'This is the description of the batch search',
         state: 'QUEUED',
         date: '2019-07-18T14:45:34.869+0000',

--- a/tests/unit/specs/components/BatchSearchClearFiltersButton.spec.js
+++ b/tests/unit/specs/components/BatchSearchClearFiltersButton.spec.js
@@ -11,9 +11,12 @@ describe('BatchSearchClearFilters.vue', () => {
   let router = null
   beforeEach(() => {
     router = new VueRouter({
-      routes: [{
-        name: 'batch-search', path: 'batch-search'
-      }]
+      routes: [
+        {
+          name: 'batch-search',
+          path: 'batch-search'
+        }
+      ]
     })
   })
 

--- a/tests/unit/specs/components/BatchSearchFilter.spec.js
+++ b/tests/unit/specs/components/BatchSearchFilter.spec.js
@@ -6,7 +6,7 @@ import { Core } from '@/core'
 describe('BatchSearchFilter.vue', () => {
   const { i18n, localVue } = Core.init(createLocalVue()).useAll()
 
-  function createContainer () {
+  function createContainer() {
     const div = document.createElement('div')
     document.body.appendChild(div)
     return div

--- a/tests/unit/specs/components/BatchSearchFilterQuery.spec.js
+++ b/tests/unit/specs/components/BatchSearchFilterQuery.spec.js
@@ -28,16 +28,18 @@ describe('BatchSearchFilterQuery.vue', () => {
     let router = null
     beforeEach(() => {
       router = new VueRouter({
-        routes: [{
-          name: 'batch-search', path: 'batch-search'
-        }],
+        routes: [
+          {
+            name: 'batch-search',
+            path: 'batch-search'
+          }
+        ],
         mode: 'abstract'
       })
     })
 
     it('search updated on filterByQuery', async () => {
-      const wrapper = shallowMount(BatchSearchFilterQuery,
-        { i18n, localVue, router })
+      const wrapper = shallowMount(BatchSearchFilterQuery, { i18n, localVue, router })
       expect(wrapper.vm.search).toBe('')
       await wrapper.setData({ search: 'test' })
       await wrapper.vm.filterByQuery()
@@ -46,8 +48,7 @@ describe('BatchSearchFilterQuery.vue', () => {
     })
 
     it('field updated on filterByQuery', async () => {
-      const wrapper = shallowMount(BatchSearchFilterQuery,
-        { i18n, localVue, router })
+      const wrapper = shallowMount(BatchSearchFilterQuery, { i18n, localVue, router })
       expect(wrapper.vm.search).toBe('')
       await wrapper.setData({ field: 'name' })
       await wrapper.vm.filterByQuery()
@@ -56,8 +57,7 @@ describe('BatchSearchFilterQuery.vue', () => {
     })
 
     it('field and search updated on filterByQuery', async () => {
-      const wrapper = shallowMount(BatchSearchFilterQuery,
-        { i18n, localVue, router })
+      const wrapper = shallowMount(BatchSearchFilterQuery, { i18n, localVue, router })
       expect(wrapper.vm.search).toBe('')
       await wrapper.setData({ search: 'test', field: 'name' })
       await wrapper.vm.filterByQuery()

--- a/tests/unit/specs/components/BatchSearchForm.spec.js
+++ b/tests/unit/specs/components/BatchSearchForm.spec.js
@@ -7,7 +7,7 @@ import { Core } from '@/core'
 import { IndexedDocument, letData } from 'tests/unit/es_utils'
 import esConnectionHelper from 'tests/unit/specs/utils/esConnectionHelper'
 
-jest.mock('lodash/throttle', () => jest.fn(fn => fn))
+jest.mock('lodash/throttle', () => jest.fn((fn) => fn))
 
 describe('BatchSearchForm.vue', () => {
   const { i18n, localVue, wait } = Core.init(createLocalVue()).useAll()
@@ -16,7 +16,12 @@ describe('BatchSearchForm.vue', () => {
 
   const state = { batchSearches: [] }
   const actions = { onSubmit: jest.fn(), getBatchSearches: jest.fn() }
-  const store = new Vuex.Store({ modules: { batchSearch: { namespaced: true, state, actions }, search: { namespaced: true, actions: { queryFilter: jest.fn() } } } })
+  const store = new Vuex.Store({
+    modules: {
+      batchSearch: { namespaced: true, state, actions },
+      search: { namespaced: true, actions: { queryFilter: jest.fn() } }
+    }
+  })
   let wrapper = null
 
   beforeAll(() => Murmur.config.merge({ groups_by_applications: { datashare: [project] }, dataDir: '/root/project' }))
@@ -104,7 +109,11 @@ describe('BatchSearchForm.vue', () => {
     })
 
     it('should filter fileTypes according to the fileTypes input on mime file', () => {
-      wrapper.vm.$set(wrapper.vm, 'allFileTypes', [{ label: 'Visio document', mime: 'visio' }, { label: 'StarWriter 5 document', mime: 'vision' }, { label: 'Something else', mime: 'else' }])
+      wrapper.vm.$set(wrapper.vm, 'allFileTypes', [
+        { label: 'Visio document', mime: 'visio' },
+        { label: 'StarWriter 5 document', mime: 'vision' },
+        { label: 'Something else', mime: 'else' }
+      ])
       wrapper.vm.$set(wrapper.vm, 'fileType', 'visi')
 
       wrapper.vm.searchFileTypes()
@@ -115,7 +124,10 @@ describe('BatchSearchForm.vue', () => {
     })
 
     it('should filter according to the fileTypes input on label file', () => {
-      wrapper.vm.$set(wrapper.vm, 'allFileTypes', [{ label: 'Label PDF', mime: 'PDF' }, { label: 'another type', mime: 'other' }])
+      wrapper.vm.$set(wrapper.vm, 'allFileTypes', [
+        { label: 'Label PDF', mime: 'PDF' },
+        { label: 'another type', mime: 'other' }
+      ])
       wrapper.vm.$set(wrapper.vm, 'fileType', 'PDF')
 
       wrapper.vm.searchFileTypes()
@@ -139,7 +151,10 @@ describe('BatchSearchForm.vue', () => {
       wrapper.vm.$set(wrapper.vm, 'selectedFileType', { label: 'StarWriter 5 document' })
       wrapper.vm.searchFileType()
 
-      expect(wrapper.vm.fileTypes).toEqual([{ label: 'Excel 2003 XML spreadsheet visio' }, { label: 'StarWriter 5 document' }])
+      expect(wrapper.vm.fileTypes).toEqual([
+        { label: 'Excel 2003 XML spreadsheet visio' },
+        { label: 'StarWriter 5 document' }
+      ])
     })
   })
 
@@ -244,11 +259,13 @@ describe('BatchSearchForm.vue', () => {
 
       await wrapper.vm.retrieveFileTypes()
 
-      expect(wrapper.vm.allFileTypes).toEqual([{
-        extensions: ['.pdf'],
-        label: 'Portable Document Format (PDF)',
-        mime: 'application/pdf'
-      }])
+      expect(wrapper.vm.allFileTypes).toEqual([
+        {
+          extensions: ['.pdf'],
+          label: 'Portable Document Format (PDF)',
+          mime: 'application/pdf'
+        }
+      ])
     })
 
     it('should return content type itself if content type description does NOT exist', async () => {
@@ -256,11 +273,13 @@ describe('BatchSearchForm.vue', () => {
 
       await wrapper.vm.retrieveFileTypes()
 
-      expect(wrapper.vm.allFileTypes).toEqual([{
-        extensions: [],
-        label: 'application/test',
-        mime: 'application/test'
-      }])
+      expect(wrapper.vm.allFileTypes).toEqual([
+        {
+          extensions: [],
+          label: 'application/test',
+          mime: 'application/test'
+        }
+      ])
     })
   })
 

--- a/tests/unit/specs/components/BatchSearchResultsFilters.spec.js
+++ b/tests/unit/specs/components/BatchSearchResultsFilters.spec.js
@@ -13,9 +13,11 @@ describe('BatchSearchResultsFilters.vue', () => {
   const { index: anotherProject } = esConnectionHelper.build()
 
   const propsDataMultipleQueries = {
-    queryKeys: [{ label: 'query_01', count: 1 },
+    queryKeys: [
+      { label: 'query_01', count: 1 },
       { label: 'query_02', count: 3 },
-      { label: 'query_03', count: 2 }],
+      { label: 'query_03', count: 2 }
+    ],
     indices: [project, anotherProject]
   }
   const propsDataSingleQuery = { queryKeys: [{ label: 'query_04', count: 12 }], indices: project }
@@ -49,7 +51,11 @@ describe('BatchSearchResultsFilters.vue', () => {
       localVue,
       router,
       store,
-      computed: { downloadLink () { return 'mocked-download-link' } },
+      computed: {
+        downloadLink() {
+          return 'mocked-download-link'
+        }
+      },
       propsData: propsDataSingleQuery
     })
     await wrapper.vm.$nextTick()
@@ -64,7 +70,11 @@ describe('BatchSearchResultsFilters.vue', () => {
       localVue,
       router,
       store,
-      computed: { downloadLink () { return 'mocked-download-link' } },
+      computed: {
+        downloadLink() {
+          return 'mocked-download-link'
+        }
+      },
       propsData: propsDataMultipleQueries
     })
     await wrapper.vm.$nextTick()
@@ -80,7 +90,11 @@ describe('BatchSearchResultsFilters.vue', () => {
       localVue,
       router,
       store,
-      computed: { downloadLink () { return 'mocked-download-link' } },
+      computed: {
+        downloadLink() {
+          return 'mocked-download-link'
+        }
+      },
       propsData: propsDataSingleQuery
     })
     await wrapper.vm.$nextTick()
@@ -95,7 +109,11 @@ describe('BatchSearchResultsFilters.vue', () => {
       localVue,
       router,
       store,
-      computed: { downloadLink () { return 'mocked-download-link' } },
+      computed: {
+        downloadLink() {
+          return 'mocked-download-link'
+        }
+      },
       propsData: propsDataMultipleQueries
     })
     await wrapper.vm.$nextTick()
@@ -111,7 +129,11 @@ describe('BatchSearchResultsFilters.vue', () => {
         localVue,
         router,
         store,
-        computed: { downloadLink () { return 'mocked-download-link' } },
+        computed: {
+          downloadLink() {
+            return 'mocked-download-link'
+          }
+        },
         propsData: propsDataMultipleQueries
       })
       await wrapper.vm.$nextTick()
@@ -125,7 +147,11 @@ describe('BatchSearchResultsFilters.vue', () => {
         localVue,
         router,
         store,
-        computed: { downloadLink () { return 'mocked-download-link' } },
+        computed: {
+          downloadLink() {
+            return 'mocked-download-link'
+          }
+        },
         propsData: propsDataMultipleQueries
       })
       await wrapper.vm.$nextTick()
@@ -133,7 +159,10 @@ describe('BatchSearchResultsFilters.vue', () => {
       wrapper.find('.batch-search-results-filters__queries__dropdown__item__search').trigger('click')
 
       expect(wrapper.vm.$router.push).toBeCalled()
-      expect(wrapper.vm.$router.push).toBeCalledWith({ name: 'search', query: { q: 'query_02', indices: project.concat(',', anotherProject) } })
+      expect(wrapper.vm.$router.push).toBeCalledWith({
+        name: 'search',
+        query: { q: 'query_02', indices: project.concat(',', anotherProject) }
+      })
       spy.mockClear()
     })
   })
@@ -145,7 +174,11 @@ describe('BatchSearchResultsFilters.vue', () => {
         localVue,
         router,
         store,
-        computed: { downloadLink () { return 'mocked-download-link' } },
+        computed: {
+          downloadLink() {
+            return 'mocked-download-link'
+          }
+        },
         propsData: propsDataMultipleQueries
       })
 
@@ -158,15 +191,25 @@ describe('BatchSearchResultsFilters.vue', () => {
         localVue,
         router,
         store,
-        computed: { downloadLink () { return 'mocked-download-link' } },
+        computed: {
+          downloadLink() {
+            return 'mocked-download-link'
+          }
+        },
         propsData: propsDataMultipleQueries
       })
       await wrapper.vm.$nextTick()
 
       expect(wrapper.findAll('.batch-search-results-filters__queries__dropdown__item')).toHaveLength(3)
-      expect(wrapper.findAll('.batch-search-results-filters__queries__dropdown__item__label').at(0).text()).toBe('query_02')
-      expect(wrapper.findAll('.batch-search-results-filters__queries__dropdown__item__label').at(1).text()).toBe('query_03')
-      expect(wrapper.findAll('.batch-search-results-filters__queries__dropdown__item__label').at(2).text()).toBe('query_01')
+      expect(wrapper.findAll('.batch-search-results-filters__queries__dropdown__item__label').at(0).text()).toBe(
+        'query_02'
+      )
+      expect(wrapper.findAll('.batch-search-results-filters__queries__dropdown__item__label').at(1).text()).toBe(
+        'query_03'
+      )
+      expect(wrapper.findAll('.batch-search-results-filters__queries__dropdown__item__label').at(2).text()).toBe(
+        'query_01'
+      )
     })
 
     it('should sort queries by "default" order ie. as in database', async () => {
@@ -175,7 +218,11 @@ describe('BatchSearchResultsFilters.vue', () => {
         localVue,
         router,
         store,
-        computed: { downloadLink () { return 'mocked-download-link' } },
+        computed: {
+          downloadLink() {
+            return 'mocked-download-link'
+          }
+        },
         propsData: propsDataMultipleQueries
       })
       const spy = jest.spyOn(wrapper.vm.$router, 'push')
@@ -199,7 +246,11 @@ describe('BatchSearchResultsFilters.vue', () => {
         localVue,
         router,
         store,
-        computed: { downloadLink () { return 'mocked-download-link' } },
+        computed: {
+          downloadLink() {
+            return 'mocked-download-link'
+          }
+        },
         propsData: propsDataMultipleQueries
       })
       await wrapper.vm.$nextTick()

--- a/tests/unit/specs/components/BatchSearchTable.spec.js
+++ b/tests/unit/specs/components/BatchSearchTable.spec.js
@@ -10,25 +10,28 @@ import { Core } from '@/core'
 import BatchSearchTable from '@/components/BatchSearchTable'
 
 const batchSearchMock = {
-  items: [{
-    uuid: '1',
-    projects: [{ name: 'project_01' }, { name: 'project_02' }],
-    name: 'name_01',
-    description: 'description_01',
-    date: '2019-01-01',
-    nbResults: 2,
-    nbQueries: 1,
-    state: 'SUCCESS'
-  }, {
-    uuid: '2',
-    projects: [{ name: 'project_02' }],
-    name: 'name_02',
-    description: 'description_02',
-    date: '2019-01-01',
-    nbResults: 3,
-    nbQueries: 2,
-    state: 'FAILURE'
-  }],
+  items: [
+    {
+      uuid: '1',
+      projects: [{ name: 'project_01' }, { name: 'project_02' }],
+      name: 'name_01',
+      description: 'description_01',
+      date: '2019-01-01',
+      nbResults: 2,
+      nbQueries: 1,
+      state: 'SUCCESS'
+    },
+    {
+      uuid: '2',
+      projects: [{ name: 'project_02' }],
+      name: 'name_02',
+      description: 'description_02',
+      date: '2019-01-01',
+      nbResults: 3,
+      nbQueries: 2,
+      state: 'FAILURE'
+    }
+  ],
   total: 2
 }
 const routerFactory = () => {
@@ -37,7 +40,8 @@ const routerFactory = () => {
       {
         name: 'batch-search',
         path: 'batch-search'
-      }, {
+      },
+      {
         name: 'batch-search.results',
         path: 'batch-search/:index/:uuid'
       }
@@ -99,7 +103,7 @@ describe('BatchSearchTable.vue', () => {
         await wrapper.setData({ perPage: 5 })
         expect(wrapper.find('.pagination.b-pagination').exists()).toBeFalsy()
       })
-      it('should display a \'No result\' message when no items', async () => {
+      it("should display a 'No result' message when no items", async () => {
         const state = { batchSearches: [] }
         const actions = { getBatchSearches: jest.fn() }
         const store = new Vuex.Store({ modules: { batchSearch: { namespaced: true, state, actions } } })
@@ -248,7 +252,7 @@ describe('BatchSearchTable.vue', () => {
         await flushPromises()
 
         expect(wrapper.vm.search).toBe('test')
-        expect(wrapper.vm.field).toBe('name')
+        expect(wrapper.vm.fieldValue).toBe('name')
         expect(wrapper.vm.page).toEqual(2)
         expect(wrapper.vm.order).toEqual('asc')
         expect(wrapper.vm.sort).toEqual('batch_results')
@@ -275,7 +279,7 @@ describe('BatchSearchTable.vue', () => {
         await flushPromises()
 
         expect(wrapper.vm.search).toBe('')
-        expect(wrapper.vm.field).toBe('all')
+        expect(wrapper.vm.fieldValue).toBe('all')
         expect(wrapper.vm.page).toEqual(1)
         expect(wrapper.vm.order).toEqual('desc')
         expect(wrapper.vm.sort).toEqual('batch_date')

--- a/tests/unit/specs/components/DocumentActions.spec.js
+++ b/tests/unit/specs/components/DocumentActions.spec.js
@@ -53,10 +53,12 @@ describe('DocumentActions.vue', () => {
 
     await wrapper.vm.toggleStarDocument()
 
-    expect(wrapper.vm.starredDocuments).toEqual([{
-      id: document.id,
-      index: document.index
-    }])
+    expect(wrapper.vm.starredDocuments).toEqual([
+      {
+        id: document.id,
+        index: document.index
+      }
+    ])
     expect(wrapper.find('.document-actions__star fa-stub').attributes('icon')).toBe('fa,star')
   })
 
@@ -64,10 +66,12 @@ describe('DocumentActions.vue', () => {
     store.commit('starred/pushDocument', document)
     await flushPromises()
 
-    expect(wrapper.vm.starredDocuments).toEqual([{
-      id: document.id,
-      index: document.index
-    }])
+    expect(wrapper.vm.starredDocuments).toEqual([
+      {
+        id: document.id,
+        index: document.index
+      }
+    ])
     expect(wrapper.find('.document-actions__star fa-stub').attributes('icon')).toBe('fa,star')
 
     await wrapper.vm.toggleStarDocument()
@@ -122,8 +126,9 @@ describe('DocumentActions.vue', () => {
 
   it('should display "Download parent" button if document has a parent', async () => {
     await letData(es).have(new IndexedDocument('parent_document', project)).commit()
-    const indexedDocument = await letData(es).have(new IndexedDocument('another_document', project)
-      .withParent('parent_document').withRoot('parent_document')).commit()
+    const indexedDocument = await letData(es)
+      .have(new IndexedDocument('another_document', project).withParent('parent_document').withRoot('parent_document'))
+      .commit()
     document = indexedDocument.document
     wrapper = shallowMount(DocumentActions, {
       i18n,

--- a/tests/unit/specs/components/DocumentContent.spec.js
+++ b/tests/unit/specs/components/DocumentContent.spec.js
@@ -12,7 +12,7 @@ import { flushPromises } from 'tests/unit/tests_utils'
 jest.mock('lodash', () => {
   return {
     ...jest.requireActual('lodash'),
-    throttle: cb => cb
+    throttle: (cb) => cb
   }
 })
 
@@ -31,15 +31,10 @@ describe('DocumentContent.vue', () => {
   const { index, es } = esConnectionHelper.build()
   const id = 'document'
 
-  async function mockDocumentContentSlice (content = '', { language = 'ENGLISH' } = {}) {
-    const contentSlice = letTextContent()
-      .withContent(content)
-      .getResponse()
+  async function mockDocumentContentSlice(content = '', { language = 'ENGLISH' } = {}) {
+    const contentSlice = letTextContent().withContent(content).getResponse()
     // Index the document
-    await letData(es).have(new IndexedDocument(id, index)
-      .withContent(content)
-      .withLanguage(language))
-      .commit()
+    await letData(es).have(new IndexedDocument(id, index).withContent(content).withLanguage(language)).commit()
     // Mock the `getDocumentSlice` method
     api.getDocumentSlice.mockImplementation(async (project, documentId, offset, limit) => {
       // Modify the returned content according to passed parameters
@@ -70,7 +65,8 @@ describe('DocumentContent.vue', () => {
 
   describe('the extracted text content', () => {
     it('should sanitize the HTML in the extracted text', async () => {
-      const content = 'this is a <span>content</span> with some <img src="this.is.a.source" alt="alt" title="title" />images and <a href="this.is.an.href" target="_blank">links</a>'
+      const content =
+        'this is a <span>content</span> with some <img src="this.is.a.source" alt="alt" title="title" />images and <a href="this.is.an.href" target="_blank">links</a>'
       const { document } = await mockDocumentContentSlice(content)
       const propsData = { document }
       const wrapper = shallowMount(DocumentContent, { i18n, localVue, store, propsData })
@@ -92,7 +88,8 @@ describe('DocumentContent.vue', () => {
     })
 
     it('should display the text right to left for arabic', async () => {
-      const content = 'المنال ويتلذذ بالآلام، الألم هو الألم ولكن نتيجة لظروف ما قد تكمن السعاده فيما نتحمله من كد وأسي.'
+      const content =
+        'المنال ويتلذذ بالآلام، الألم هو الألم ولكن نتيجة لظروف ما قد تكمن السعاده فيما نتحمله من كد وأسي.'
       const { document } = await mockDocumentContentSlice(content, { language: 'ARABIC' })
       const propsData = { document }
       const wrapper = shallowMount(DocumentContent, { i18n, localVue, store, propsData })
@@ -153,32 +150,42 @@ describe('DocumentContent.vue', () => {
       it('should highlight the first occurrence of the searched term', async () => {
         const { innerHTML } = wrapper.find('.document-content__body .document-content-slice').element
         expect(wrapper.vm.localSearchIndex).toEqual(1)
-        expect(innerHTML).toEqual('<p>this is a <mark class="local-search-term local-search-term--active" data-offset="10">full</mark> <mark class="local-search-term" data-offset="15">full</mark> content</p>')
+        expect(innerHTML).toEqual(
+          '<p>this is a <mark class="local-search-term local-search-term--active" data-offset="10">full</mark> <mark class="local-search-term" data-offset="15">full</mark> content</p>'
+        )
       })
 
       it('should find the previous and next occurrence, as a loop', async () => {
         const { element } = wrapper.find('.document-content__body  .document-content-slice')
 
         expect(wrapper.vm.localSearchIndex).toEqual(1)
-        expect(element.innerHTML).toEqual('<p>this is a <mark class="local-search-term local-search-term--active" data-offset="10">full</mark> <mark class="local-search-term" data-offset="15">full</mark> content</p>')
+        expect(element.innerHTML).toEqual(
+          '<p>this is a <mark class="local-search-term local-search-term--active" data-offset="10">full</mark> <mark class="local-search-term" data-offset="15">full</mark> content</p>'
+        )
 
         wrapper.vm.findNextLocalSearchTerm()
         await flushPromises()
 
         expect(wrapper.vm.localSearchIndex).toEqual(2)
-        expect(element.innerHTML).toEqual('<p>this is a <mark class="local-search-term" data-offset="10">full</mark> <mark class="local-search-term local-search-term--active" data-offset="15">full</mark> content</p>')
+        expect(element.innerHTML).toEqual(
+          '<p>this is a <mark class="local-search-term" data-offset="10">full</mark> <mark class="local-search-term local-search-term--active" data-offset="15">full</mark> content</p>'
+        )
 
         wrapper.vm.findPreviousLocalSearchTerm()
         await flushPromises()
 
         expect(wrapper.vm.localSearchIndex).toEqual(1)
-        expect(element.innerHTML).toEqual('<p>this is a <mark class="local-search-term local-search-term--active" data-offset="10">full</mark> <mark class="local-search-term" data-offset="15">full</mark> content</p>')
+        expect(element.innerHTML).toEqual(
+          '<p>this is a <mark class="local-search-term local-search-term--active" data-offset="10">full</mark> <mark class="local-search-term" data-offset="15">full</mark> content</p>'
+        )
 
         wrapper.vm.findNextLocalSearchTerm()
         await flushPromises()
 
         expect(wrapper.vm.localSearchIndex).toEqual(2)
-        expect(element.innerHTML).toEqual('<p>this is a <mark class="local-search-term" data-offset="10">full</mark> <mark class="local-search-term local-search-term--active" data-offset="15">full</mark> content</p>')
+        expect(element.innerHTML).toEqual(
+          '<p>this is a <mark class="local-search-term" data-offset="10">full</mark> <mark class="local-search-term local-search-term--active" data-offset="15">full</mark> content</p>'
+        )
       })
     })
 
@@ -249,7 +256,9 @@ describe('DocumentContent.vue', () => {
       await wrapper.vm.loadContentSlice({ offset: 30 })
       // Cook all slices
       await wrapper.vm.cookAllContentSlices()
-      expect(wrapper.vm.getContentSlice({ offset: 0 }).cookedContent).toBe('<p>this is a content from Elastic Search doc which looks huge</p>')
+      expect(wrapper.vm.getContentSlice({ offset: 0 }).cookedContent).toBe(
+        '<p>this is a content from Elastic Search doc which looks huge</p>'
+      )
     })
 
     describe('with 1 occurences', () => {
@@ -273,7 +282,9 @@ describe('DocumentContent.vue', () => {
         await wrapper.vm.loadContentSlice({ offset: 25 })
         // Cook all slices
         await wrapper.vm.cookAllContentSlices()
-        expect(wrapper.vm.getContentSlice({ offset: 0 }).cookedContent).toBe('<p>this is a content and content can be <mark class="local-search-term" data-offset="37">long</mark></p>')
+        expect(wrapper.vm.getContentSlice({ offset: 0 }).cookedContent).toBe(
+          '<p>this is a content and content can be <mark class="local-search-term" data-offset="37">long</mark></p>'
+        )
       })
     })
 
@@ -298,7 +309,9 @@ describe('DocumentContent.vue', () => {
         await wrapper.vm.loadContentSlice({ offset: 25 })
         // Cook all slices
         await wrapper.vm.cookAllContentSlices()
-        expect(wrapper.vm.getContentSlice({ offset: 0 }).cookedContent).toBe('<p>ICIJ: st<mark class="local-search-term" data-offset="8">or</mark>ies that rock the w<mark class="local-search-term" data-offset="29">or</mark>ld</p>')
+        expect(wrapper.vm.getContentSlice({ offset: 0 }).cookedContent).toBe(
+          '<p>ICIJ: st<mark class="local-search-term" data-offset="8">or</mark>ies that rock the w<mark class="local-search-term" data-offset="29">or</mark>ld</p>'
+        )
       })
     })
 

--- a/tests/unit/specs/components/DocumentGlobalSearchTermsTags.spec.js
+++ b/tests/unit/specs/components/DocumentGlobalSearchTermsTags.spec.js
@@ -9,14 +9,14 @@ import { flushPromises } from 'tests/unit/tests_utils'
 import esConnectionHelper from 'tests/unit/specs/utils/esConnectionHelper'
 
 describe('DocumentGlobalSearchTermsTags.vue', () => {
-  function mockedDocumentSearchFactory () {
+  function mockedDocumentSearchFactory() {
     return {
-      terms: { },
-      add ({ term = '', count = 0, offsets = [] } = {}) {
+      terms: {},
+      add({ term = '', count = 0, offsets = [] } = {}) {
         this.terms[term] = { count, offsets }
         return this
       },
-      commit () {
+      commit() {
         api.searchDocument.mockImplementation(async (index, id, term) => {
           if (term in this.terms) {
             return this.terms[term]
@@ -28,9 +28,8 @@ describe('DocumentGlobalSearchTermsTags.vue', () => {
     }
   }
 
-  async function createView (content = '', query = '', metadata = '', tags = []) {
-    const indexedDocument = await IndexedDocument
-      .build('document-id', index)
+  async function createView(content = '', query = '', metadata = '', tags = []) {
+    const indexedDocument = await IndexedDocument.build('document-id', index)
       .withContent(content)
       .withOtherMetadata(metadata)
       .withTags(tags)
@@ -92,10 +91,7 @@ describe('DocumentGlobalSearchTermsTags.vue', () => {
     })
 
     it('should display query terms in tags with specific message and in last position', async () => {
-      mockedDocumentSearchFactory()
-        .add({ term: 'message', count: 1 })
-        .add({ term: 'tag_01', count: 0 })
-        .commit()
+      mockedDocumentSearchFactory().add({ term: 'message', count: 1 }).add({ term: 'tag_01', count: 0 }).commit()
       const wrapper = await createView('message', 'message tag_01', '', ['tag_01', 'tag_02'])
 
       expect(wrapper.findAll('.document-global-search-terms-tags__item')).toHaveLength(2)
@@ -106,10 +102,7 @@ describe('DocumentGlobalSearchTermsTags.vue', () => {
     })
 
     it('should not display the query terms on a specific field but content', async () => {
-      mockedDocumentSearchFactory()
-        .add({ term: 'term_01', count: 1 })
-        .add({ term: 'term_02', count: 0 })
-        .commit()
+      mockedDocumentSearchFactory().add({ term: 'term_01', count: 1 }).add({ term: 'term_02', count: 0 }).commit()
       const wrapper = await createView('term_01', 'content:term_01 field_name:term_02')
 
       expect(wrapper.findAll('.document-global-search-terms-tags__item__label').at(0).text()).toBe('term_01')
@@ -117,10 +110,7 @@ describe('DocumentGlobalSearchTermsTags.vue', () => {
     })
 
     it('should not display the negative query terms', async () => {
-      mockedDocumentSearchFactory()
-        .add({ term: 'term_01', count: 1 })
-        .add({ term: 'term_02', count: 0 })
-        .commit()
+      mockedDocumentSearchFactory().add({ term: 'term_01', count: 1 }).add({ term: 'term_02', count: 0 }).commit()
       const wrapper = await createView('term_01', 'term_01 -term_02')
 
       expect(wrapper.findAll('.document-global-search-terms-tags__item')).toHaveLength(1)
@@ -132,9 +122,17 @@ describe('DocumentGlobalSearchTermsTags.vue', () => {
       const wrapper = await createView('this is a full full content', 'full content')
 
       expect(wrapper.findAll('.document-global-search-terms-tags__item--index-0')).toHaveLength(1)
-      expect(wrapper.find('.document-global-search-terms-tags__item--index-0 .document-global-search-terms-tags__item__label').text()).toBe('full')
+      expect(
+        wrapper
+          .find('.document-global-search-terms-tags__item--index-0 .document-global-search-terms-tags__item__label')
+          .text()
+      ).toBe('full')
       expect(wrapper.findAll('.document-global-search-terms-tags__item--index-1')).toHaveLength(1)
-      expect(wrapper.find('.document-global-search-terms-tags__item--index-1 .document-global-search-terms-tags__item__label').text()).toBe('content')
+      expect(
+        wrapper
+          .find('.document-global-search-terms-tags__item--index-1 .document-global-search-terms-tags__item__label')
+          .text()
+      ).toBe('content')
     })
   })
 })

--- a/tests/unit/specs/components/DocumentLocalSearchInput.spec.js
+++ b/tests/unit/specs/components/DocumentLocalSearchInput.spec.js
@@ -7,7 +7,12 @@ const { localVue, store } = Core.init(createLocalVue()).useAll()
 
 describe('DocumentLocalSearchInput.vue', () => {
   it('should display display search bar, searched term and count of occurrences', () => {
-    const wrapper = shallowMount(DocumentLocalSearchInput, { localVue, store, propsData: { searchTerm: 'document' }, mocks: { $t: msg => msg } })
+    const wrapper = shallowMount(DocumentLocalSearchInput, {
+      localVue,
+      store,
+      propsData: { searchTerm: 'document' },
+      mocks: { $t: (msg) => msg }
+    })
 
     expect(wrapper.find('.document-local-search-input').classes('document-local-search-input--pristine')).toBeTruthy()
     expect(wrapper.find('.document-local-search-input__term').exists()).toBeTruthy()

--- a/tests/unit/specs/components/DocumentTagsForm.spec.js
+++ b/tests/unit/specs/components/DocumentTagsForm.spec.js
@@ -17,12 +17,29 @@ describe('DocumentTagsForm.vue', () => {
   const { index: project, es } = esConnectionHelper.build()
   const id = 'document'
 
-  async function createView ({ es, project, tags = [], documentId = 'document', displayTags = true, displayForm = true }) {
-    mockAxios.request.mockResolvedValue({ data: map(tags, item => { return { label: item, user: { id: 'test-user' } } }) })
+  async function createView({
+    es,
+    project,
+    tags = [],
+    documentId = 'document',
+    displayTags = true,
+    displayForm = true
+  }) {
+    mockAxios.request.mockResolvedValue({
+      data: map(tags, (item) => {
+        return { label: item, user: { id: 'test-user' } }
+      })
+    })
     await letData(es).have(new IndexedDocument(documentId, project).withTags(tags)).commit()
     await store.dispatch('document/get', { id: documentId, index: project })
     await store.dispatch('document/getTags')
-    const wrapper = shallowMount(DocumentTagsForm, { i18n, localVue, store, propsData: { document: store.state.document.doc, tags: store.state.document.tags, displayTags, displayForm }, sync: false })
+    const wrapper = shallowMount(DocumentTagsForm, {
+      i18n,
+      localVue,
+      store,
+      propsData: { document: store.state.document.doc, tags: store.state.document.tags, displayTags, displayForm },
+      sync: false
+    })
     await flushPromises()
     return wrapper
   }
@@ -104,7 +121,9 @@ describe('DocumentTagsForm.vue', () => {
   it('should display a tooltip to a tag', async () => {
     wrapper = await createView({ es, project, tags: ['tag_01'] })
 
-    expect(wrapper.find('.document-tags-form__tags__tag span').attributes('title')).toContain('Created by test-user on ')
+    expect(wrapper.find('.document-tags-form__tags__tag span').attributes('title')).toContain(
+      'Created by test-user on '
+    )
   })
 
   it('should call API endpoint to add a tag', async () => {
@@ -115,14 +134,16 @@ describe('DocumentTagsForm.vue', () => {
     await wrapper.vm.addTag()
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl(`/api/${project}/documents/batchUpdate/tag`),
-      method: 'POST',
-      data: {
-        docIds: [id],
-        tags: ['tag_02']
-      }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl(`/api/${project}/documents/batchUpdate/tag`),
+        method: 'POST',
+        data: {
+          docIds: [id],
+          tags: ['tag_02']
+        }
+      })
+    )
     expect(store.state.document.tags).toHaveLength(2)
     expect(sortBy(store.state.document.tags, ['label'])[0].label).toEqual('tag_01')
     expect(sortBy(store.state.document.tags, ['label'])[1].label).toEqual('tag_02')
@@ -136,14 +157,16 @@ describe('DocumentTagsForm.vue', () => {
     await wrapper.vm.addTag()
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl(`/api/${project}/documents/batchUpdate/tag`),
-      method: 'POST',
-      data: {
-        docIds: [id],
-        tags: ['tag_01', 'tag_02', 'tag_03']
-      }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl(`/api/${project}/documents/batchUpdate/tag`),
+        method: 'POST',
+        data: {
+          docIds: [id],
+          tags: ['tag_01', 'tag_02', 'tag_03']
+        }
+      })
+    )
   })
 
   it('should compact tags to remove empty tags', async () => {
@@ -154,14 +177,16 @@ describe('DocumentTagsForm.vue', () => {
     await wrapper.vm.addTag()
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl(`/api/${project}/documents/batchUpdate/tag`),
-      method: 'POST',
-      data: {
-        docIds: [id],
-        tags: ['tag_01', 'tag_02']
-      }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl(`/api/${project}/documents/batchUpdate/tag`),
+        method: 'POST',
+        data: {
+          docIds: [id],
+          tags: ['tag_01', 'tag_02']
+        }
+      })
+    )
   })
 
   it('should call API endpoint to remove a tag', async () => {
@@ -171,14 +196,16 @@ describe('DocumentTagsForm.vue', () => {
     await wrapper.vm.deleteTag({ label: 'tag_01' })
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl(`/api/${project}/documents/batchUpdate/untag`),
-      method: 'POST',
-      data: {
-        docIds: [id],
-        tags: ['tag_01']
-      }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl(`/api/${project}/documents/batchUpdate/untag`),
+        method: 'POST',
+        data: {
+          docIds: [id],
+          tags: ['tag_01']
+        }
+      })
+    )
   })
 
   it('should emit a filter::refresh event on adding a tag', async () => {
@@ -211,7 +238,7 @@ describe('DocumentTagsForm.vue', () => {
   })
 })
 
-function delay (t, v) {
+function delay(t, v) {
   return new Promise(function (resolve) {
     setTimeout(resolve.bind(null, v), t)
   })

--- a/tests/unit/specs/components/DocumentThread.spec.js
+++ b/tests/unit/specs/components/DocumentThread.spec.js
@@ -12,25 +12,37 @@ describe('DocumentThread.vue', () => {
 
   describe('getThread', () => {
     it('should filter on contentType to retrieve emails only', async () => {
-      await letData(es).have(new IndexedDocument('document_01', index)
-        .withMetadata({
-          tika_metadata_dc_subject: 'subject'
-        })
-        .withCreationDate('2020-12-04T00:00:01Z')
-        .withContentType('application/vnd.ms-outlook')
-      ).commit()
-      await letData(es).have(new IndexedDocument('document_02', index)
-        .withMetadata({ tika_metadata_dc_subject: 'subject' })
-        .withContentType('application/vnd.ms-outlook')
-      ).commit()
-      await letData(es).have(new IndexedDocument('document_03', index)
-        .withMetadata({ tika_metadata_dc_subject: 'subject' })
-        .withContentType('message/rfc822')
-      ).commit()
-      await letData(es).have(new IndexedDocument('document_04', index)
-        .withMetadata({ tika_metadata_dc_subject: 'subject' })
-        .withContentType('application/pdf')
-      ).commit()
+      await letData(es)
+        .have(
+          new IndexedDocument('document_01', index)
+            .withMetadata({
+              tika_metadata_dc_subject: 'subject'
+            })
+            .withCreationDate('2020-12-04T00:00:01Z')
+            .withContentType('application/vnd.ms-outlook')
+        )
+        .commit()
+      await letData(es)
+        .have(
+          new IndexedDocument('document_02', index)
+            .withMetadata({ tika_metadata_dc_subject: 'subject' })
+            .withContentType('application/vnd.ms-outlook')
+        )
+        .commit()
+      await letData(es)
+        .have(
+          new IndexedDocument('document_03', index)
+            .withMetadata({ tika_metadata_dc_subject: 'subject' })
+            .withContentType('message/rfc822')
+        )
+        .commit()
+      await letData(es)
+        .have(
+          new IndexedDocument('document_04', index)
+            .withMetadata({ tika_metadata_dc_subject: 'subject' })
+            .withContentType('application/pdf')
+        )
+        .commit()
       await store.dispatch('document/get', { id: 'document_01', index })
       wrapper = shallowMount(DocumentThread, {
         i18n,
@@ -47,29 +59,44 @@ describe('DocumentThread.vue', () => {
     })
 
     it('should retrieve emails with the exact match of the subject, whatever is before or after', async () => {
-      await letData(es).have(new IndexedDocument('document_01', index)
-        .withMetadata({
-          tika_metadata_dc_subject: 'term_01 term_02'
-        })
-        .withCreationDate('2020-12-04T00:00:01Z')
-        .withContentType('application/vnd.ms-outlook')
-      ).commit()
-      await letData(es).have(new IndexedDocument('document_02', index)
-        .withMetadata({ tika_metadata_dc_subject: 'term_01' })
-        .withContentType('application/vnd.ms-outlook')
-      ).commit()
-      await letData(es).have(new IndexedDocument('document_03', index)
-        .withMetadata({ tika_metadata_dc_subject: 'term_03 term_02' })
-        .withContentType('application/vnd.ms-outlook')
-      ).commit()
-      await letData(es).have(new IndexedDocument('document_04', index)
-        .withMetadata({ tika_metadata_dc_subject: 'term_00 term_01 term_02 term_03' })
-        .withContentType('application/vnd.ms-outlook')
-      ).commit()
-      await letData(es).have(new IndexedDocument('document_05', index)
-        .withMetadata({ tika_metadata_dc_subject: 'term_02 term_01' })
-        .withContentType('application/vnd.ms-outlook')
-      ).commit()
+      await letData(es)
+        .have(
+          new IndexedDocument('document_01', index)
+            .withMetadata({
+              tika_metadata_dc_subject: 'term_01 term_02'
+            })
+            .withCreationDate('2020-12-04T00:00:01Z')
+            .withContentType('application/vnd.ms-outlook')
+        )
+        .commit()
+      await letData(es)
+        .have(
+          new IndexedDocument('document_02', index)
+            .withMetadata({ tika_metadata_dc_subject: 'term_01' })
+            .withContentType('application/vnd.ms-outlook')
+        )
+        .commit()
+      await letData(es)
+        .have(
+          new IndexedDocument('document_03', index)
+            .withMetadata({ tika_metadata_dc_subject: 'term_03 term_02' })
+            .withContentType('application/vnd.ms-outlook')
+        )
+        .commit()
+      await letData(es)
+        .have(
+          new IndexedDocument('document_04', index)
+            .withMetadata({ tika_metadata_dc_subject: 'term_00 term_01 term_02 term_03' })
+            .withContentType('application/vnd.ms-outlook')
+        )
+        .commit()
+      await letData(es)
+        .have(
+          new IndexedDocument('document_05', index)
+            .withMetadata({ tika_metadata_dc_subject: 'term_02 term_01' })
+            .withContentType('application/vnd.ms-outlook')
+        )
+        .commit()
       await store.dispatch('document/get', { id: 'document_01', index })
       wrapper = shallowMount(DocumentThread, {
         i18n,

--- a/tests/unit/specs/components/DocumentTranslatedContent.spec.js
+++ b/tests/unit/specs/components/DocumentTranslatedContent.spec.js
@@ -14,7 +14,7 @@ describe('DocumentTranslatedContent.vue', () => {
   let i18n, localVue, store, api
   const { index, es } = esConnectionHelper.build()
 
-  function mockedDocumentContentFactory (id, content = '') {
+  function mockedDocumentContentFactory(id, content = '') {
     // Index the document
     const contentSlice = letTextContent().withContent(content)
     const indexedDocument = new IndexedDocument(id, index).withContent(content)
@@ -23,7 +23,7 @@ describe('DocumentTranslatedContent.vue', () => {
       indexedDocument,
       content,
       contentSlice,
-      async commit () {
+      async commit() {
         // Mock the `getDocumentSlice` method
         const getDocumentSlideMock = async (project, documentId, offset, limit, targetLanguage) => {
           // Get the translation (if any)
@@ -78,7 +78,7 @@ describe('DocumentTranslatedContent.vue', () => {
     expect(wrapper.find('.document-content__body').text()).toBe('Premier')
   })
 
-  it('shouldn\'t show italian translation', async () => {
+  it("shouldn't show italian translation", async () => {
     const mocked = mockedDocumentContentFactory('document-with-a-translation-in-italian', 'Premier')
     mocked.indexedDocument.withLanguage('FRENCH').withContentTranslated('Primo', 'FRENCH', 'ITALIAN')
     const { document } = await mocked.commit()

--- a/tests/unit/specs/components/DocumentTypeCard.spec.js
+++ b/tests/unit/specs/components/DocumentTypeCard.spec.js
@@ -22,6 +22,8 @@ describe('DocumentTypeCard.vue', () => {
     })
 
     expect(wrapper.findAll('.document-type-card .bg-warning')).toHaveLength(1)
-    expect(wrapper.find('.document-type-card .bg-warning').text()).toBe('This file contains executable code. Ensure you have macros disabled before opening it.')
+    expect(wrapper.find('.document-type-card .bg-warning').text()).toBe(
+      'This file contains executable code. Ensure you have macros disabled before opening it.'
+    )
   })
 })

--- a/tests/unit/specs/components/Extensions.spec.js
+++ b/tests/unit/specs/components/Extensions.spec.js
@@ -58,7 +58,8 @@ describe('Extensions.vue', () => {
         description: 'extension_04_registry_description',
         homepage: null
       }
-    }]
+    }
+  ]
   beforeAll(() => {
     mockAxios = { request: jest.fn() }
     api = new Api(mockAxios, null)
@@ -83,17 +84,27 @@ describe('Extensions.vue', () => {
 
   describe('extension card', () => {
     beforeEach(async () => {
-      wrapper = mount(Extensions, { i18n, localVue, data: () => { return { url: 'this.is.an.url' } } })
+      wrapper = mount(Extensions, {
+        i18n,
+        localVue,
+        data: () => {
+          return { url: 'this.is.an.url' }
+        }
+      })
       await flushPromises()
     })
 
     describe('extension name', () => {
       it('should display name from registry if extension is NOT installed and from registry', () => {
-        expect(wrapper.find('.extensions__card:nth-child(1) .extensions__card__name').text()).toBe('Extension 01 Registry Name')
+        expect(wrapper.find('.extensions__card:nth-child(1) .extensions__card__name').text()).toBe(
+          'Extension 01 Registry Name'
+        )
       })
 
       it('should display name from registry if extension is installed and from registry', () => {
-        expect(wrapper.find('.extensions__card:nth-child(2) .extensions__card__name').text()).toBe('Extension 02 Registry Name')
+        expect(wrapper.find('.extensions__card:nth-child(2) .extensions__card__name').text()).toBe(
+          'Extension 02 Registry Name'
+        )
       })
 
       it('should display extension name if extension is installed and NOT from registry', () => {
@@ -103,15 +114,21 @@ describe('Extensions.vue', () => {
 
     describe('extension description', () => {
       it('should display description from registry if extension is NOT installed and from registry', () => {
-        expect(wrapper.find('.extensions__card:nth-child(1) .extensions__card__description').text()).toBe('extension_01_registry_description')
+        expect(wrapper.find('.extensions__card:nth-child(1) .extensions__card__description').text()).toBe(
+          'extension_01_registry_description'
+        )
       })
 
       it('should display description from registry if extension is installed and from registry', () => {
-        expect(wrapper.find('.extensions__card:nth-child(2) .extensions__card__description').text()).toBe('extension_02_registry_description')
+        expect(wrapper.find('.extensions__card:nth-child(2) .extensions__card__description').text()).toBe(
+          'extension_02_registry_description'
+        )
       })
 
       it('should display plugin description if plugin is installed and NOT from registry', () => {
-        expect(wrapper.find('.extensions__card:nth-child(3) .extensions__card__description').text()).toBe('extension_03_description')
+        expect(wrapper.find('.extensions__card:nth-child(3) .extensions__card__description').text()).toBe(
+          'extension_03_description'
+        )
       })
     })
 
@@ -131,21 +148,29 @@ describe('Extensions.vue', () => {
 
     describe('extension official version', () => {
       it('should display the official version if extension is from registry and has an official version', () => {
-        expect(wrapper.findAll('.extensions__card:nth-child(1) .extensions__card__official-version').exists()).toBeTruthy()
+        expect(
+          wrapper.findAll('.extensions__card:nth-child(1) .extensions__card__official-version').exists()
+        ).toBeTruthy()
       })
 
       it('should NOT display the official version if extension is installed and NOT from registry', () => {
-        expect(wrapper.findAll('.extensions__card:nth-child(3) .extensions__card__official-version').exists()).toBeFalsy()
+        expect(
+          wrapper.findAll('.extensions__card:nth-child(3) .extensions__card__official-version').exists()
+        ).toBeFalsy()
       })
     })
 
     describe('extension homepage', () => {
       it('should display homepage from registry if extension is NOT installed and from registry', () => {
-        expect(wrapper.find('.extensions__card:nth-child(1) .extensions__card__homepage').text()).toBe('extension_01_registry_homepage')
+        expect(wrapper.find('.extensions__card:nth-child(1) .extensions__card__homepage').text()).toBe(
+          'extension_01_registry_homepage'
+        )
       })
 
       it('should display homepage from registry if extension is installed and from registry', () => {
-        expect(wrapper.find('.extensions__card:nth-child(2) .extensions__card__homepage').text()).toBe('extension_02_registry_homepage')
+        expect(wrapper.find('.extensions__card:nth-child(2) .extensions__card__homepage').text()).toBe(
+          'extension_02_registry_homepage'
+        )
       })
 
       it('should NOT display homepage if extension is installed and NOT from registry', () => {
@@ -159,21 +184,29 @@ describe('Extensions.vue', () => {
 
     describe('uninstall button', () => {
       it('should display uninstall button if extension is installed', () => {
-        expect(wrapper.findAll('.extensions__card:nth-child(2) .extensions__card__uninstall-button').exists()).toBeTruthy()
+        expect(
+          wrapper.findAll('.extensions__card:nth-child(2) .extensions__card__uninstall-button').exists()
+        ).toBeTruthy()
       })
 
       it('should NOT display uninstall button if extension is NOT installed', () => {
-        expect(wrapper.findAll('.extensions__card:nth-child(1) .extensions__card__uninstall-button').exists()).toBeFalsy()
+        expect(
+          wrapper.findAll('.extensions__card:nth-child(1) .extensions__card__uninstall-button').exists()
+        ).toBeFalsy()
       })
     })
 
     describe('download button', () => {
       it('should display download button if extension is NOT installed', () => {
-        expect(wrapper.findAll('.extensions__card:nth-child(1) .extensions__card__download-button').exists()).toBeTruthy()
+        expect(
+          wrapper.findAll('.extensions__card:nth-child(1) .extensions__card__download-button').exists()
+        ).toBeTruthy()
       })
 
       it('should NOT display download button if extension is installed', () => {
-        expect(wrapper.findAll('.extensions__card:nth-child(2) .extensions__card__download-button').exists()).toBeFalsy()
+        expect(
+          wrapper.findAll('.extensions__card:nth-child(2) .extensions__card__download-button').exists()
+        ).toBeFalsy()
       })
     })
 
@@ -215,7 +248,13 @@ describe('Extensions.vue', () => {
   })
 
   it('should call for extension installation from extensionUrl', () => {
-    wrapper = mount(Extensions, { i18n, localVue, data: () => { return { url: 'this.is.an.url' } } })
+    wrapper = mount(Extensions, {
+      i18n,
+      localVue,
+      data: () => {
+        return { url: 'this.is.an.url' }
+      }
+    })
     mockAxios.request.mockClear()
 
     wrapper.vm.installExtensionFromUrl()

--- a/tests/unit/specs/components/ExtractingForm.spec.js
+++ b/tests/unit/specs/components/ExtractingForm.spec.js
@@ -31,16 +31,18 @@ describe('ExtractingForm.vue', () => {
     wrapper.vm.submitExtract()
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/task/batchUpdate/index/file'),
-      method: 'POST',
-      data: {
-        options: {
-          ocr: false,
-          filter: true
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/task/batchUpdate/index/file'),
+        method: 'POST',
+        data: {
+          options: {
+            ocr: false,
+            filter: true
+          }
         }
-      }
-    }))
+      })
+    )
   })
 
   it('should call extract action with OCR option and language', () => {
@@ -49,18 +51,20 @@ describe('ExtractingForm.vue', () => {
     wrapper.vm.submitExtract()
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/task/batchUpdate/index/file'),
-      method: 'POST',
-      data: {
-        options: {
-          ocr: true,
-          filter: true,
-          language: 'fra',
-          ocrLanguage: 'fra'
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/task/batchUpdate/index/file'),
+        method: 'POST',
+        data: {
+          options: {
+            ocr: true,
+            filter: true,
+            language: 'fra',
+            ocrLanguage: 'fra'
+          }
         }
-      }
-    }))
+      })
+    )
   })
 
   it('should reset the modal params on submitting the form', async () => {

--- a/tests/unit/specs/components/FindNamedEntitiesForm.spec.js
+++ b/tests/unit/specs/components/FindNamedEntitiesForm.spec.js
@@ -28,20 +28,24 @@ describe('FindNamedEntitiesForm.vue', () => {
     wrapper = shallowMount(FindNamedEntitiesForm, { i18n, localVue, store, wait })
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/ner/pipelines')
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/ner/pipelines')
+      })
+    )
   })
 
   it('should call findNames action with CORENLP pipeline, by default', () => {
     wrapper.vm.submitFindNamedEntities()
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/task/findNames/CORENLP'),
-      method: 'POST',
-      data: { options: { syncModels: true } }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/task/findNames/CORENLP'),
+        method: 'POST',
+        data: { options: { syncModels: true } }
+      })
+    )
   })
 
   it('should call findNames action with ANOTHERNLP pipeline', () => {
@@ -49,11 +53,13 @@ describe('FindNamedEntitiesForm.vue', () => {
     wrapper.vm.submitFindNamedEntities()
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/task/findNames/ANOTHERNLP'),
-      method: 'POST',
-      data: { options: { syncModels: true } }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/task/findNames/ANOTHERNLP'),
+        method: 'POST',
+        data: { options: { syncModels: true } }
+      })
+    )
   })
 
   it('should call findNames action with no models synchronization', () => {
@@ -62,11 +68,13 @@ describe('FindNamedEntitiesForm.vue', () => {
     wrapper.vm.submitFindNamedEntities()
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/task/findNames/CORENLP'),
-      method: 'POST',
-      data: { options: { syncModels: false } }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/task/findNames/CORENLP'),
+        method: 'POST',
+        data: { options: { syncModels: false } }
+      })
+    )
   })
 
   it('should reset the modal params on submitting the form', async () => {

--- a/tests/unit/specs/components/Hook.spec.js
+++ b/tests/unit/specs/components/Hook.spec.js
@@ -23,9 +23,9 @@ const WrappedHook = {
 //
 // Because we use custom component, the runtime-build function must be defined
 // explicitely in the hooked component definition.
-function hookedComponentDefinition (content = '') {
+function hookedComponentDefinition(content = '') {
   return {
-    render (h) {
+    render(h) {
       return h('div', { class: 'hooked-component' }, content)
     }
   }
@@ -78,7 +78,11 @@ describe('Hook.vue', () => {
   })
 
   it('should have two components in reverse order', () => {
-    store.commit('hooks/register', { target: 'test-ordered-components', definition: hookedComponentDefinition('0'), order: 1 })
+    store.commit('hooks/register', {
+      target: 'test-ordered-components',
+      definition: hookedComponentDefinition('0'),
+      order: 1
+    })
     store.commit('hooks/register', { target: 'test-ordered-components', definition: hookedComponentDefinition('1') })
     const propsData = { name: 'test-ordered-components' }
     const wrapper = mount(WrappedHook, { localVue, store, propsData })

--- a/tests/unit/specs/components/NamedEntityInContext.spec.js
+++ b/tests/unit/specs/components/NamedEntityInContext.spec.js
@@ -14,11 +14,14 @@ describe('NamedEntityInContext.vue', () => {
   const defaultPropsData = async function ({ namedEntityIndex = 0, extractLength = 16 } = {}) {
     const category = 'PERSON'
     const id = 'document'
-    await letData(es).have(new IndexedDocument(id, index)
-      .withContent('Lorem Lea ipsum dolor Yassine sit amet')
-      .withNer('Lea', 6, category)
-      .withNer('Yassine', 22, category)
-      .withNer('contact@icij.org', -1, category))
+    await letData(es)
+      .have(
+        new IndexedDocument(id, index)
+          .withContent('Lorem Lea ipsum dolor Yassine sit amet')
+          .withNer('Lea', 6, category)
+          .withNer('Yassine', 22, category)
+          .withNer('contact@icij.org', -1, category)
+      )
       .commit()
     const document = await store.dispatch('document/get', { id, index })
     await store.dispatch('document/getContent')

--- a/tests/unit/specs/components/PageHeader.spec.js
+++ b/tests/unit/specs/components/PageHeader.spec.js
@@ -9,7 +9,10 @@ describe('PageHeader.vue', () => {
   let wrapper = null
 
   beforeEach(() => {
-    wrapper = shallowMount(PageHeader, { localVue, propsData: { description: 'This is my description', title: 'This is my title' } })
+    wrapper = shallowMount(PageHeader, {
+      localVue,
+      propsData: { description: 'This is my description', title: 'This is my title' }
+    })
   })
 
   it('should NOT display a PageIcon', () => {

--- a/tests/unit/specs/components/Pagination.spec.js
+++ b/tests/unit/specs/components/Pagination.spec.js
@@ -10,7 +10,12 @@ describe('Pagination.vue', () => {
   const template = { name: 'router-name', query: { from: 0, size: 10 } }
 
   beforeEach(() => {
-    wrapper = shallowMount(Pagination, { i18n, localVue, propsData: { total: 22, getToTemplate: () => cloneDeep(template) }, sync: false })
+    wrapper = shallowMount(Pagination, {
+      i18n,
+      localVue,
+      propsData: { total: 22, getToTemplate: () => cloneDeep(template) },
+      sync: false
+    })
   })
 
   describe('should display the pagination, or not', () => {
@@ -71,7 +76,10 @@ describe('Pagination.vue', () => {
       const template = { name: 'router-name', query: { from: 20, size: 10 } }
       wrapper.setProps({ total: 22, getToTemplate: () => cloneDeep(template) })
 
-      expect(wrapper.vm.previousPageLinkParameters()).toMatchObject({ name: 'router-name', query: { from: 10, size: 10 } })
+      expect(wrapper.vm.previousPageLinkParameters()).toMatchObject({
+        name: 'router-name',
+        query: { from: 10, size: 10 }
+      })
     })
 
     it('should generate the link to the next page', () => {

--- a/tests/unit/specs/components/Plugins.spec.js
+++ b/tests/unit/specs/components/Plugins.spec.js
@@ -20,7 +20,8 @@ const pluginsMock = [
       description: 'plugin_01_registry_description',
       homepage: 'plugin_01_registry_homepage'
     }
-  }, {
+  },
+  {
     id: 'plugin_02_id',
     name: 'plugin_02_name',
     version: 'plugin_02_version',
@@ -33,14 +34,16 @@ const pluginsMock = [
       description: 'plugin_02_registry_description',
       homepage: 'plugin_02_registry_homepage'
     }
-  }, {
+  },
+  {
     id: 'plugin_03_id',
     name: 'plugin_03_name',
     version: null,
     description: 'plugin_03_description',
     installed: true,
     deliverableFromRegistry: null
-  }, {
+  },
+  {
     id: 'plugin_04_id',
     name: 'plugin_04_name',
     version: 'plugin_04_version',
@@ -53,7 +56,8 @@ const pluginsMock = [
       description: 'plugin_04_registry_description',
       homepage: null
     }
-  }]
+  }
+]
 
 describe('Plugins.vue', () => {
   let wrapper, i18n, localVue, api, mockAxios
@@ -68,7 +72,13 @@ describe('Plugins.vue', () => {
   beforeEach(async () => {
     mockAxios.request.mockClear() // TODO CD suggestion: mock each plugin api function getPlugins, installPlugin, uninstallPlugin instead of mocking axios
     mockAxios.request.mockResolvedValue({ data: pluginsMock })
-    wrapper = shallowMount(Plugins, { i18n, localVue, data: () => { return { url: 'this.is.an.url' } } })
+    wrapper = shallowMount(Plugins, {
+      i18n,
+      localVue,
+      data: () => {
+        return { url: 'this.is.an.url' }
+      }
+    })
     await flushPromises()
   })
 
@@ -91,7 +101,13 @@ describe('Plugins.vue', () => {
 
   describe('plugin card', () => {
     beforeEach(async () => {
-      wrapper = mount(Plugins, { i18n, localVue, data: () => { return { url: 'this.is.an.url' } } })
+      wrapper = mount(Plugins, {
+        i18n,
+        localVue,
+        data: () => {
+          return { url: 'this.is.an.url' }
+        }
+      })
       await flushPromises()
     })
 
@@ -111,15 +127,21 @@ describe('Plugins.vue', () => {
 
     describe('plugin description', () => {
       it('should display description from registry if plugin is NOT installed and from registry', () => {
-        expect(wrapper.find('.plugins__card:nth-child(1) .plugins__card__description').text()).toBe('plugin_01_registry_description')
+        expect(wrapper.find('.plugins__card:nth-child(1) .plugins__card__description').text()).toBe(
+          'plugin_01_registry_description'
+        )
       })
 
       it('should display description from registry if plugin is installed and from registry', () => {
-        expect(wrapper.find('.plugins__card:nth-child(2) .plugins__card__description').text()).toBe('plugin_02_registry_description')
+        expect(wrapper.find('.plugins__card:nth-child(2) .plugins__card__description').text()).toBe(
+          'plugin_02_registry_description'
+        )
       })
 
       it('should display plugin description if plugin is installed and NOT from registry', () => {
-        expect(wrapper.find('.plugins__card:nth-child(3) .plugins__card__description').text()).toBe('plugin_03_description')
+        expect(wrapper.find('.plugins__card:nth-child(3) .plugins__card__description').text()).toBe(
+          'plugin_03_description'
+        )
       })
     })
 
@@ -149,11 +171,15 @@ describe('Plugins.vue', () => {
 
     describe('plugin homepage', () => {
       it('should display homepage from registry if plugin is NOT installed and from registry', () => {
-        expect(wrapper.find('.plugins__card:nth-child(1) .plugins__card__homepage').text()).toBe('plugin_01_registry_homepage')
+        expect(wrapper.find('.plugins__card:nth-child(1) .plugins__card__homepage').text()).toBe(
+          'plugin_01_registry_homepage'
+        )
       })
 
       it('should display homepage from registry if plugin is installed and from registry', () => {
-        expect(wrapper.find('.plugins__card:nth-child(2) .plugins__card__homepage').text()).toBe('plugin_02_registry_homepage')
+        expect(wrapper.find('.plugins__card:nth-child(2) .plugins__card__homepage').text()).toBe(
+          'plugin_02_registry_homepage'
+        )
       })
 
       it('should NOT display homepage if plugin is installed and NOT from registry', () => {
@@ -222,7 +248,13 @@ describe('Plugins.vue', () => {
   })
 
   it('should call for plugin installation from pluginUrl', () => {
-    wrapper = mount(Plugins, { i18n, localVue, data: () => { return { url: 'this.is.an.url' } } })
+    wrapper = mount(Plugins, {
+      i18n,
+      localVue,
+      data: () => {
+        return { url: 'this.is.an.url' }
+      }
+    })
     mockAxios.request.mockClear()
 
     wrapper.vm.installPluginFromUrl()

--- a/tests/unit/specs/components/ProjectSelector.spec.js
+++ b/tests/unit/specs/components/ProjectSelector.spec.js
@@ -10,15 +10,22 @@ describe('ProjectSelector.vue', () => {
     let wrapper
 
     beforeEach(() => {
-      Murmur.config.merge({ defaultProject: 'first-index', groups_by_applications: { datashare: ['second-index', 'third-index'] } })
+      Murmur.config.merge({
+        defaultProject: 'first-index',
+        groups_by_applications: { datashare: ['second-index', 'third-index'] }
+      })
       wrapper = shallowMount(ProjectSelector, { localVue, store, propsData: { value: 'first-index' } })
     })
 
     it('should load projects list from config, not including the default project', () => {
       const { projectOptions } = wrapper.vm
       expect(projectOptions).toHaveLength(2)
-      expect(projectOptions).toEqual(expect.arrayContaining([{ disabled: false, value: 'second-index', text: 'Second Index' }]))
-      expect(projectOptions).toEqual(expect.arrayContaining([{ disabled: false, value: 'third-index', text: 'Third Index' }]))
+      expect(projectOptions).toEqual(
+        expect.arrayContaining([{ disabled: false, value: 'second-index', text: 'Second Index' }])
+      )
+      expect(projectOptions).toEqual(
+        expect.arrayContaining([{ disabled: false, value: 'third-index', text: 'Third Index' }])
+      )
     })
 
     it('should create a select box', () => {
@@ -31,15 +38,25 @@ describe('ProjectSelector.vue', () => {
 
     beforeEach(() => {
       Murmur.config.merge({ groups_by_applications: { datashare: ['first-index', 'second-index', 'third-index'] } })
-      wrapper = shallowMount(ProjectSelector, { localVue, store, propsData: { value: ['first-index'], multiple: true } })
+      wrapper = shallowMount(ProjectSelector, {
+        localVue,
+        store,
+        propsData: { value: ['first-index'], multiple: true }
+      })
     })
 
     it('should load projects list from config with one disabled option', () => {
       const { projectOptions } = wrapper.vm
       expect(projectOptions).toHaveLength(3)
-      expect(projectOptions).toEqual(expect.arrayContaining([{ disabled: true, value: 'first-index', text: 'First Index' }]))
-      expect(projectOptions).toEqual(expect.arrayContaining([{ disabled: false, value: 'second-index', text: 'Second Index' }]))
-      expect(projectOptions).toEqual(expect.arrayContaining([{ disabled: false, value: 'third-index', text: 'Third Index' }]))
+      expect(projectOptions).toEqual(
+        expect.arrayContaining([{ disabled: true, value: 'first-index', text: 'First Index' }])
+      )
+      expect(projectOptions).toEqual(
+        expect.arrayContaining([{ disabled: false, value: 'second-index', text: 'Second Index' }])
+      )
+      expect(projectOptions).toEqual(
+        expect.arrayContaining([{ disabled: false, value: 'third-index', text: 'Third Index' }])
+      )
     })
 
     it('should create a checkbox froup', () => {
@@ -49,9 +66,15 @@ describe('ProjectSelector.vue', () => {
     it('should  have no disable option', async () => {
       await wrapper.setProps({ value: ['first-index', 'second-index'] })
       const { projectOptions } = wrapper.vm
-      expect(projectOptions).toEqual(expect.arrayContaining([{ disabled: false, value: 'first-index', text: 'First Index' }]))
-      expect(projectOptions).toEqual(expect.arrayContaining([{ disabled: false, value: 'second-index', text: 'Second Index' }]))
-      expect(projectOptions).toEqual(expect.arrayContaining([{ disabled: false, value: 'third-index', text: 'Third Index' }]))
+      expect(projectOptions).toEqual(
+        expect.arrayContaining([{ disabled: false, value: 'first-index', text: 'First Index' }])
+      )
+      expect(projectOptions).toEqual(
+        expect.arrayContaining([{ disabled: false, value: 'second-index', text: 'Second Index' }])
+      )
+      expect(projectOptions).toEqual(
+        expect.arrayContaining([{ disabled: false, value: 'third-index', text: 'Third Index' }])
+      )
     })
   })
 })

--- a/tests/unit/specs/components/ResetFiltersButton.spec.js
+++ b/tests/unit/specs/components/ResetFiltersButton.spec.js
@@ -33,7 +33,7 @@ describe('ResetFiltersButton.vue', function () {
     expect(wrapper.find('.btn').attributes('disabled')).toBeUndefined()
   })
 
-  it('shouldn\'t have filters', () => {
+  it("shouldn't have filters", () => {
     expect(wrapper.vm.hasFiltersOrQuery).toBeFalsy()
   })
 

--- a/tests/unit/specs/components/SearchBar.spec.js
+++ b/tests/unit/specs/components/SearchBar.spec.js
@@ -76,29 +76,29 @@ describe('SearchBar.vue', function () {
   describe('search suggestions', () => {
     it('should retrieve suggestions in NamedEntities and tags for default search', async () => {
       wrapper = shallowMountFactory()
-      await letData(es).have(new IndexedDocument('document', project)
-        .withNer('ne_01')
-        .withTags(['ne_tag'])
-      ).commit()
+      await letData(es)
+        .have(new IndexedDocument('document', project).withNer('ne_01').withTags(['ne_tag']))
+        .commit()
 
       const suggestions = await wrapper.vm.suggestTerms([{ field: '<implicit>', term: 'ne_' }])
 
-      expect(suggestions.suggestions).toEqual([{ key: 'ne_01', doc_count: 1 }, { key: 'ne_tag', doc_count: 1 }])
+      expect(suggestions.suggestions).toEqual([
+        { key: 'ne_01', doc_count: 1 },
+        { key: 'ne_tag', doc_count: 1 }
+      ])
     })
 
     it('should order suggestions by doc_count descending', async () => {
       wrapper = shallowMountFactory()
-      await letData(es).have(new IndexedDocument('document_01', project)
-        .withNer('ne_01')
-        .withNer('ne_02')
-      ).commit()
-      await letData(es).have(new IndexedDocument('document_02', project)
-        .withNer('ne_02')
-      ).commit()
+      await letData(es).have(new IndexedDocument('document_01', project).withNer('ne_01').withNer('ne_02')).commit()
+      await letData(es).have(new IndexedDocument('document_02', project).withNer('ne_02')).commit()
 
       const suggestions = await wrapper.vm.suggestTerms([{ field: '<implicit>', term: 'ne_' }])
 
-      expect(suggestions.suggestions).toEqual([{ key: 'ne_02', doc_count: 2 }, { key: 'ne_01', doc_count: 1 }])
+      expect(suggestions.suggestions).toEqual([
+        { key: 'ne_02', doc_count: 2 },
+        { key: 'ne_01', doc_count: 1 }
+      ])
     })
   })
 })

--- a/tests/unit/specs/components/SearchResultsHeader.spec.js
+++ b/tests/unit/specs/components/SearchResultsHeader.spec.js
@@ -52,9 +52,9 @@ describe('SearchResultsHeader.vue', () => {
   })
 
   it('should display an applied filters component on top position', async () => {
-    await letData(es).have(
-      new IndexedDocuments().setBaseName('doc').withContent('document').withIndex(index).count(3)
-    ).commit()
+    await letData(es)
+      .have(new IndexedDocuments().setBaseName('doc').withContent('document').withIndex(index).count(3))
+      .commit()
 
     await store.dispatch('search/query', { query: '*', from: 0, size: 3 })
     wrapper.setProps({ position: 'top' })
@@ -63,9 +63,9 @@ describe('SearchResultsHeader.vue', () => {
   })
 
   it('should not display an applied filters component on bottom position', async () => {
-    await letData(es).have(
-      new IndexedDocuments().setBaseName('doc').withContent('document').withIndex(index).count(3)
-    ).commit()
+    await letData(es)
+      .have(new IndexedDocuments().setBaseName('doc').withContent('document').withIndex(index).count(3))
+      .commit()
 
     await store.dispatch('search/query', { query: '*', from: 0, size: 3 })
     await wrapper.setProps({ position: 'bottom' })
@@ -122,25 +122,27 @@ describe('SearchResultsHeader.vue', () => {
 
     await wrapper.vm.batchDownload()
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/task/batchDownload'),
-      method: 'POST',
-      data: {
-        options: {
-          projectIds: [index, anotherIndex],
-          uri: expect.any(String),
-          query: {
-            bool: {
-              must: [
-                { match_all: {} },
-                { bool: { should: [{ query_string: { query: 'bar' } }] } },
-                { match: { type: 'Document' } }
-              ]
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/task/batchDownload'),
+        method: 'POST',
+        data: {
+          options: {
+            projectIds: [index, anotherIndex],
+            uri: expect.any(String),
+            query: {
+              bool: {
+                must: [
+                  { match_all: {} },
+                  { bool: { should: [{ query_string: { query: 'bar' } }] } },
+                  { match: { type: 'Document' } }
+                ]
+              }
             }
           }
         }
-      }
-    }))
+      })
+    )
   })
 
   describe('firstDocument', () => {

--- a/tests/unit/specs/components/SearchResultsList.spec.js
+++ b/tests/unit/specs/components/SearchResultsList.spec.js
@@ -8,7 +8,7 @@ import SearchResultsList from '@/components/SearchResultsList'
 
 const { localVue, i18n, store } = Core.init(createLocalVue()).useAll()
 
-async function createView (query = '*', from = 0, size = 25) {
+async function createView(query = '*', from = 0, size = 25) {
   await store.dispatch('search/query', { query, from, size })
   return shallowMount(SearchResultsList, {
     localVue,
@@ -38,26 +38,27 @@ describe('SearchResultsList.vue', () => {
     })
 
     it('should return 2 documents', async () => {
-      await letData(es).have(new IndexedDocuments().setBaseName('doc').withContent('document').withIndex(index).count(4)).commit()
+      await letData(es)
+        .have(new IndexedDocuments().setBaseName('doc').withContent('document').withIndex(index).count(4))
+        .commit()
       wrapper = await createView('document', 0, 2)
 
       expect(wrapper.findAll('.search-results-list__items__item__link')).toHaveLength(2)
     })
 
     it('should return 3 documents', async () => {
-      await letData(es).have(new IndexedDocuments().setBaseName('doc').withContent('document').withIndex(index).count(4)).commit()
+      await letData(es)
+        .have(new IndexedDocuments().setBaseName('doc').withContent('document').withIndex(index).count(4))
+        .commit()
       wrapper = await createView('document', 0, 3)
 
       expect(wrapper.findAll('.search-results-list__items__item__link')).toHaveLength(3)
     })
 
     it('should display all the documents that have a NE person Paris', async () => {
-      await letData(es).have(new IndexedDocument('doc_01', index)
-        .withNer('paris', 1, 'LOCATION')).commit()
-      await letData(es).have(new IndexedDocument('doc_02', index)
-        .withNer('paris')).commit()
-      await letData(es).have(new IndexedDocument('doc_03', index)
-        .withNer('paris')).commit()
+      await letData(es).have(new IndexedDocument('doc_01', index).withNer('paris', 1, 'LOCATION')).commit()
+      await letData(es).have(new IndexedDocument('doc_02', index).withNer('paris')).commit()
+      await letData(es).have(new IndexedDocument('doc_03', index).withNer('paris')).commit()
 
       store.commit('search/addFilterValue', { name: 'namedEntityPerson', value: 'paris' })
       wrapper = await createView()
@@ -66,14 +67,14 @@ describe('SearchResultsList.vue', () => {
     })
 
     it('should display all the documents between the creation dates', async () => {
-      await letData(es).have(new IndexedDocument('doc_01', index)
-        .withCreationDate('2019-08-19T00:00:00.000Z')).commit()
-      await letData(es).have(new IndexedDocument('doc_02', index)
-        .withCreationDate('2019-08-20T00:00:00.000Z')).commit()
-      await letData(es).have(new IndexedDocument('doc_03', index)
-        .withCreationDate('2019-08-21T00:00:00.000Z')).commit()
+      await letData(es).have(new IndexedDocument('doc_01', index).withCreationDate('2019-08-19T00:00:00.000Z')).commit()
+      await letData(es).have(new IndexedDocument('doc_02', index).withCreationDate('2019-08-20T00:00:00.000Z')).commit()
+      await letData(es).have(new IndexedDocument('doc_03', index).withCreationDate('2019-08-21T00:00:00.000Z')).commit()
 
-      store.commit('search/setFilterValue', { name: 'creationDate', value: [new Date('2019-08-20').getTime(), new Date('2019-08-21').getTime()] })
+      store.commit('search/setFilterValue', {
+        name: 'creationDate',
+        value: [new Date('2019-08-20').getTime(), new Date('2019-08-21').getTime()]
+      })
       wrapper = await createView()
 
       expect(wrapper.findAll('.search-results-list__items__item__link')).toHaveLength(2)
@@ -121,9 +122,15 @@ describe('SearchResultsList.vue', () => {
 
   describe('lucene querying', () => {
     it('should search with field names', async () => {
-      await letData(es).have(new IndexedDocument('doc_01', index).withContent('first').withContentType('type_01')).commit()
-      await letData(es).have(new IndexedDocument('doc_02', index).withContent('firs').withContentType('type_01')).commit()
-      await letData(es).have(new IndexedDocument('doc_03', index).withContent('foxes').withContentType('type_02')).commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_01', index).withContent('first').withContentType('type_01'))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_02', index).withContent('firs').withContentType('type_01'))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_03', index).withContent('foxes').withContentType('type_02'))
+        .commit()
 
       wrapper = await createView('contentType:type_01')
       expect(wrapper.findAll('.search-results-list__items__item__link')).toHaveLength(2)
@@ -145,8 +152,12 @@ describe('SearchResultsList.vue', () => {
     })
 
     it('should search with exact query', async () => {
-      await letData(es).have(new IndexedDocument('doc_01', index).withContent('this should be an exact content')).commit()
-      await letData(es).have(new IndexedDocument('doc_02', index).withContent('this should be an approximate content')).commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_01', index).withContent('this should be an exact content'))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_02', index).withContent('this should be an approximate content'))
+        .commit()
       await letData(es).have(new IndexedDocument('doc_03', index).withContent('this is an exact content')).commit()
 
       wrapper = await createView('"exact content"')

--- a/tests/unit/specs/components/SearchResultsListLink.spec.js
+++ b/tests/unit/specs/components/SearchResultsListLink.spec.js
@@ -108,6 +108,10 @@ describe('SearchResultsListLink.vue', () => {
         })
       }
     })
-    expect(wrapper.find('.search-results-list-link .search-results-list-link__basename .document-sliced-name__item__single').text()).toBe(documentName)
+    expect(
+      wrapper
+        .find('.search-results-list-link .search-results-list-link__basename .document-sliced-name__item__single')
+        .text()
+    ).toBe(documentName)
   })
 })

--- a/tests/unit/specs/components/SearchResultsTable.spec.js
+++ b/tests/unit/specs/components/SearchResultsTable.spec.js
@@ -29,10 +29,7 @@ describe('SearchResultsTable.vue', () => {
     mockAxios.request.mockClear()
     mockAxios.request.mockResolvedValue({ data: {} })
 
-    await letData(es).have(new IndexedDocuments()
-      .setBaseName('document')
-      .withIndex(index)
-      .count(4)).commit()
+    await letData(es).have(new IndexedDocuments().setBaseName('document').withIndex(index).count(4)).commit()
     await store.dispatch('search/query', { query: '*', from: 0, size: 25 })
     wrapper = shallowMount(SearchResultsTable, { i18n, localVue, store, wait })
   })
@@ -47,10 +44,7 @@ describe('SearchResultsTable.vue', () => {
 
   it('should display 3 action buttons', async () => {
     await wrapper.setData({
-      selected: [
-        { id: 'document_01' },
-        { id: 'document_02' }
-      ]
+      selected: [{ id: 'document_01' }, { id: 'document_02' }]
     })
 
     expect(wrapper.findAll('b-list-group-stub > b-list-group-item-stub')).toHaveLength(3)
@@ -68,11 +62,13 @@ describe('SearchResultsTable.vue', () => {
     wrapper.findAll('.list-group-item-action').at(1).trigger('click')
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/' + index + '/documents/batchUpdate/star'),
-      method: 'POST',
-      data: ['document_01', 'document_02']
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/' + index + '/documents/batchUpdate/star'),
+        method: 'POST',
+        data: ['document_01', 'document_02']
+      })
+    )
   })
 
   it('should translate an unknown size', () => {
@@ -88,7 +84,9 @@ describe('SearchResultsTable.vue', () => {
   })
 
   it('should select all documents', async () => {
-    mockAxios.request.mockResolvedValue({ data: [{ id: 'document_01' }, { id: 'document_03' }, { id: 'document_03' }, { id: 'document_04' }] })
+    mockAxios.request.mockResolvedValue({
+      data: [{ id: 'document_01' }, { id: 'document_03' }, { id: 'document_03' }, { id: 'document_04' }]
+    })
     wrapper = mount(SearchResultsTable, { i18n, localVue, router, store, wait })
     await wrapper.setData({ selected: [{ id: 'document_01' }] })
     await wrapper.vm.$nextTick()

--- a/tests/unit/specs/components/ServerSettings.spec.js
+++ b/tests/unit/specs/components/ServerSettings.spec.js
@@ -34,21 +34,25 @@ describe('ServerSettings.vue', () => {
 
   it('should load the settings on component creation', () => {
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/settings')
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/settings')
+      })
+    )
   })
 
   it('should submit the settings modifications', () => {
     wrapper.vm.onSubmit()
 
     expect(mockAxios.request).toBeCalledTimes(2)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/settings'),
-      method: 'PATCH',
-      data: { data: {} },
-      headers: { 'Content-Type': 'application/json' }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/settings'),
+        method: 'PATCH',
+        data: { data: {} },
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
   })
 
   it('should restore master settings if submit fails', async () => {

--- a/tests/unit/specs/components/ShortkeysModal.spec.js
+++ b/tests/unit/specs/components/ShortkeysModal.spec.js
@@ -80,28 +80,49 @@ describe('ShortkeysModal', () => {
   it('should extract shortkeys keys and action on component creation', () => {
     expect(wrapper.vm.shortkeys).toHaveLength(4)
     expect(wrapper.vm.shortkeys).toEqual([
-      { keys: { mac: ['meta', 'key_01'], default: ['ctrl', 'key_01'] }, action: 'action_01', icon: 'icon_01', page: '' },
+      {
+        keys: { mac: ['meta', 'key_01'], default: ['ctrl', 'key_01'] },
+        action: 'action_01',
+        icon: 'icon_01',
+        page: ''
+      },
       { keys: { mac: ['meta', 'key_02'], default: ['ctrl', 'key_02'] }, action: 'action_02', page: '' },
-      { keys: { mac: ['meta', 'key_03'], default: ['ctrl', 'key_03'] }, action: 'action_03', icon: 'icon_03', label: 'This is a translation' },
+      {
+        keys: { mac: ['meta', 'key_03'], default: ['ctrl', 'key_03'] },
+        action: 'action_03',
+        icon: 'icon_03',
+        label: 'This is a translation'
+      },
       { keys: { mac: ['meta', 'key_04'], default: ['ctrl', 'key_04'] }, action: 'action_04', icon: 'icon_04' }
     ])
   })
 
   describe('Shortkey label', () => {
     it('should return the translation of the label if there is one', () => {
-      label = wrapper.vm.getLabel({ keys: { mac: ['meta', 'key_01'], default: ['ctrl', 'key_01'] }, action: 'action_01', label: 'key.subkey' })
+      label = wrapper.vm.getLabel({
+        keys: { mac: ['meta', 'key_01'], default: ['ctrl', 'key_01'] },
+        action: 'action_01',
+        label: 'key.subkey'
+      })
 
       expect(label).toBe('key.subkey')
     })
 
     it('should return the label if there is one', () => {
-      label = wrapper.vm.getLabel({ keys: { mac: ['meta', 'key_01'], default: ['ctrl', 'key_01'] }, action: 'action_01', label: 'There is no translation' })
+      label = wrapper.vm.getLabel({
+        keys: { mac: ['meta', 'key_01'], default: ['ctrl', 'key_01'] },
+        action: 'action_01',
+        label: 'There is no translation'
+      })
 
       expect(label).toBe('There is no translation')
     })
 
     it('should return the action of a key if there is no label', () => {
-      label = wrapper.vm.getLabel({ keys: { mac: ['meta', 'key_01'], default: ['ctrl', 'key_01'] }, action: 'action_01' })
+      label = wrapper.vm.getLabel({
+        keys: { mac: ['meta', 'key_01'], default: ['ctrl', 'key_01'] },
+        action: 'action_01'
+      })
 
       expect(label).toBe('action_01')
     })

--- a/tests/unit/specs/components/TreeView.spec.js
+++ b/tests/unit/specs/components/TreeView.spec.js
@@ -49,8 +49,12 @@ describe('TreeView.vue', () => {
   })
 
   it('should display 2 directories', async () => {
-    await letData(es).have(new IndexedDocuments().setBaseName('/home/foo/bar/doc_01').withIndex(index).count(5)).commit()
-    await letData(es).have(new IndexedDocuments().setBaseName('/home/foo/baz/doc_02').withIndex(index).count(5)).commit()
+    await letData(es)
+      .have(new IndexedDocuments().setBaseName('/home/foo/bar/doc_01').withIndex(index).count(5))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocuments().setBaseName('/home/foo/baz/doc_02').withIndex(index).count(5))
+      .commit()
     await wrapper.vm.loadData()
 
     expect(wrapper.find('.tree-view__header__hits').exists()).toBeTruthy()
@@ -60,8 +64,12 @@ describe('TreeView.vue', () => {
 
   it('should display 3 directories including one from the tree', async () => {
     wrapper.vm.$core.api.tree = jest.fn().mockResolvedValue(HOME_TREE)
-    await letData(es).have(new IndexedDocuments().setBaseName('/home/foo/bar/doc_01').withIndex(index).count(5)).commit()
-    await letData(es).have(new IndexedDocuments().setBaseName('/home/foo/baz/doc_02').withIndex(index).count(5)).commit()
+    await letData(es)
+      .have(new IndexedDocuments().setBaseName('/home/foo/bar/doc_01').withIndex(index).count(5))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocuments().setBaseName('/home/foo/baz/doc_02').withIndex(index).count(5))
+      .commit()
     await wrapper.vm.loadData({ clearPages: true })
 
     expect(wrapper.find('.tree-view__header__hits').exists()).toBeTruthy()

--- a/tests/unit/specs/components/UserDisplay.spec.js
+++ b/tests/unit/specs/components/UserDisplay.spec.js
@@ -4,7 +4,7 @@ import UserDisplay from '@/components/UserDisplay'
 import { Core } from '@/core'
 
 describe('UserDisplay.vue', () => {
-  const flushPromises = () => new Promise(resolve => setImmediate(resolve))
+  const flushPromises = () => new Promise((resolve) => setImmediate(resolve))
   let wrapper = null
   let api, i18n, localVue, store, wait
 
@@ -48,7 +48,7 @@ describe('UserDisplay.vue', () => {
     store.commit('pipelines/register', {
       name: 'username-to-uppercase',
       category: wrapper.vm.usernamePipeline,
-      type: username => username.toUpperCase()
+      type: (username) => username.toUpperCase()
     })
     await flushPromises()
     expect(wrapper.find('.user-display__username').text()).toBe('FOO')

--- a/tests/unit/specs/components/document/DocumentNavbar.spec.js
+++ b/tests/unit/specs/components/document/DocumentNavbar.spec.js
@@ -54,19 +54,23 @@ describe('DocumentNavbar.vue', () => {
       await wrapper.vm.toggleAsRecommended()
 
       expect(mockAxios.request).toBeCalledTimes(2)
-      expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-        url: Api.getFullUrl(`/api/${index}/documents/batchUpdate/recommend`),
-        method: 'POST',
-        data: ['doc_01']
-      }))
+      expect(mockAxios.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl(`/api/${index}/documents/batchUpdate/recommend`),
+          method: 'POST',
+          data: ['doc_01']
+        })
+      )
       expect(wrapper.vm.isRecommended).toBeTruthy()
-      expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-        url: Api.getFullUrl('/api/users/recommendations'),
-        method: 'GET',
-        params: {
-          project: index
-        }
-      }))
+      expect(mockAxios.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl('/api/users/recommendations'),
+          method: 'GET',
+          params: {
+            project: index
+          }
+        })
+      )
       expect(store.state.recommended.byUsers).toEqual([{ user: 'Jean-Michel', count: 1 }])
     })
 
@@ -77,19 +81,23 @@ describe('DocumentNavbar.vue', () => {
       await wrapper.vm.toggleAsRecommended()
 
       expect(mockAxios.request).toBeCalledTimes(2)
-      expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-        url: Api.getFullUrl(`/api/${index}/documents/batchUpdate/unrecommend`),
-        method: 'POST',
-        data: ['doc_01']
-      }))
+      expect(mockAxios.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl(`/api/${index}/documents/batchUpdate/unrecommend`),
+          method: 'POST',
+          data: ['doc_01']
+        })
+      )
       expect(wrapper.vm.isRecommended).toBeFalsy()
-      expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-        url: Api.getFullUrl('/api/users/recommendations'),
-        method: 'GET',
-        params: {
-          project: index
-        }
-      }))
+      expect(mockAxios.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl('/api/users/recommendations'),
+          method: 'GET',
+          params: {
+            project: index
+          }
+        })
+      )
       expect(store.state.recommended.byUsers).toEqual([])
     })
   })

--- a/tests/unit/specs/components/document/DocumentNotes.spec.js
+++ b/tests/unit/specs/components/document/DocumentNotes.spec.js
@@ -21,7 +21,12 @@ describe('DocumentNotes.vue', () => {
   })
 
   it('should display 2 notes on document', async () => {
-    await wrapper.setData({ notes: [{ note: 'This is a note', variant: 'warning' }, { note: 'Another note', variant: 'danger' }] })
+    await wrapper.setData({
+      notes: [
+        { note: 'This is a note', variant: 'warning' },
+        { note: 'Another note', variant: 'danger' }
+      ]
+    })
     expect(wrapper.findAll('b-alert-stub')).toHaveLength(2)
   })
 

--- a/tests/unit/specs/components/document/DocumentTabDetails.spec.js
+++ b/tests/unit/specs/components/document/DocumentTabDetails.spec.js
@@ -30,7 +30,12 @@ describe('DocumentTabDetails.vue', () => {
     const id = '/home/datashare/data/foo.txt'
     await letData(es).have(new IndexedDocument(id, index)).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, { i18n, localVue, store, propsData: { document: store.state.document.doc } })
+    wrapper = shallowMount(DocumentTabDetails, {
+      i18n,
+      localVue,
+      store,
+      propsData: { document: store.state.document.doc }
+    })
 
     expect(wrapper.find('.document__content__path').text()).toBe('C:/Users/ds/docs/foo.txt')
   })
@@ -38,7 +43,12 @@ describe('DocumentTabDetails.vue', () => {
   it('should display the document type', async () => {
     await letData(es).have(new IndexedDocument(id, index).withContentType('application/pdf')).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, { i18n, localVue, store, propsData: { document: store.state.document.doc } })
+    wrapper = shallowMount(DocumentTabDetails, {
+      i18n,
+      localVue,
+      store,
+      propsData: { document: store.state.document.doc }
+    })
 
     expect(wrapper.find('.document__content__content-type').text()).toBe('Portable Document Format (PDF)')
   })
@@ -47,8 +57,15 @@ describe('DocumentTabDetails.vue', () => {
     const parentDocument = 'parentDocument'
     await letData(es).have(new IndexedDocument(parentDocument, index)).commit()
     await letData(es).have(new IndexedDocument(id, index).withParent(parentDocument)).commit()
-    await store.dispatch('document/get', { index, id, routing: parentDocument }).then(() => store.dispatch('document/getParent'))
-    wrapper = shallowMount(DocumentTabDetails, { i18n, localVue, store, propsData: { document: store.state.document.doc, parentDocument: store.state.document.parentDocument } })
+    await store
+      .dispatch('document/get', { index, id, routing: parentDocument })
+      .then(() => store.dispatch('document/getParent'))
+    wrapper = shallowMount(DocumentTabDetails, {
+      i18n,
+      localVue,
+      store,
+      propsData: { document: store.state.document.doc, parentDocument: store.state.document.parentDocument }
+    })
 
     expect(wrapper.find('.document__content__basename').text()).toBe(id)
     expect(wrapper.find('.document__content__tree-level').text()).toBe('1st')
@@ -58,7 +75,12 @@ describe('DocumentTabDetails.vue', () => {
   it('should not display the creation date if it is missing', async () => {
     await letData(es).have(new IndexedDocument(id, index)).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, { i18n, localVue, store, propsData: { document: store.state.document.doc } })
+    wrapper = shallowMount(DocumentTabDetails, {
+      i18n,
+      localVue,
+      store,
+      propsData: { document: store.state.document.doc }
+    })
 
     expect(wrapper.find('.document__content__creation-date').exists()).toBeFalsy()
   })
@@ -66,7 +88,12 @@ describe('DocumentTabDetails.vue', () => {
   it('should display the creation date if it is defined', async () => {
     await letData(es).have(new IndexedDocument(id, index).withCreationDate('2020-12-04T00:00:01Z')).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, { i18n, localVue, store, propsData: { document: store.state.document.doc } })
+    wrapper = shallowMount(DocumentTabDetails, {
+      i18n,
+      localVue,
+      store,
+      propsData: { document: store.state.document.doc }
+    })
 
     expect(wrapper.find('.document__content__creation-date').exists()).toBeTruthy()
   })
@@ -74,7 +101,12 @@ describe('DocumentTabDetails.vue', () => {
   it('should not display the author if it is missing', async () => {
     await letData(es).have(new IndexedDocument(id, index)).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, { i18n, localVue, store, propsData: { document: store.state.document.doc } })
+    wrapper = shallowMount(DocumentTabDetails, {
+      i18n,
+      localVue,
+      store,
+      propsData: { document: store.state.document.doc }
+    })
 
     expect(wrapper.find('.document__content__author').exists()).toBeFalsy()
   })
@@ -82,7 +114,12 @@ describe('DocumentTabDetails.vue', () => {
   it('should display the author date if it is defined', async () => {
     await letData(es).have(new IndexedDocument(id, index).withAuthor('local')).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, { i18n, localVue, store, propsData: { document: store.state.document.doc } })
+    wrapper = shallowMount(DocumentTabDetails, {
+      i18n,
+      localVue,
+      store,
+      propsData: { document: store.state.document.doc }
+    })
 
     expect(wrapper.find('.document__content__author').exists()).toBeTruthy()
   })
@@ -90,7 +127,12 @@ describe('DocumentTabDetails.vue', () => {
   it('should display a link to the list of children documents', async () => {
     await letData(es).have(new IndexedDocument(id, index)).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, { i18n, localVue, store, propsData: { document: store.state.document.doc } })
+    wrapper = shallowMount(DocumentTabDetails, {
+      i18n,
+      localVue,
+      store,
+      propsData: { document: store.state.document.doc }
+    })
 
     expect(wrapper.find('.document__content__shortcuts__children').exists()).toBeTruthy()
   })
@@ -98,7 +140,12 @@ describe('DocumentTabDetails.vue', () => {
   it('should display a link to the search in the folder of the document', async () => {
     await letData(es).have(new IndexedDocument(id, index)).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, { i18n, localVue, store, propsData: { document: store.state.document.doc } })
+    wrapper = shallowMount(DocumentTabDetails, {
+      i18n,
+      localVue,
+      store,
+      propsData: { document: store.state.document.doc }
+    })
 
     expect(wrapper.find('.document__content__shortcuts__folder').exists()).toBeTruthy()
   })
@@ -106,7 +153,12 @@ describe('DocumentTabDetails.vue', () => {
   it('should display an "Unknown" file size', async () => {
     await letData(es).have(new IndexedDocument(id, index)).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, { i18n, localVue, store, propsData: { document: store.state.document.doc } })
+    wrapper = shallowMount(DocumentTabDetails, {
+      i18n,
+      localVue,
+      store,
+      propsData: { document: store.state.document.doc }
+    })
 
     expect(wrapper.find('.document__content__content-length').exists()).toBeTruthy()
     expect(wrapper.find('.document__content__content-length').text()).toBe('Unknown')
@@ -115,7 +167,12 @@ describe('DocumentTabDetails.vue', () => {
   it('should display an file size', async () => {
     await letData(es).have(new IndexedDocument(id, index).withContentLength('123456')).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, { i18n, localVue, store, propsData: { document: store.state.document.doc } })
+    wrapper = shallowMount(DocumentTabDetails, {
+      i18n,
+      localVue,
+      store,
+      propsData: { document: store.state.document.doc }
+    })
 
     expect(wrapper.find('.document__content__content-length').exists()).toBeTruthy()
     expect(wrapper.find('.document__content__content-length').text()).toBe('120.56 KB (123456 B)')

--- a/tests/unit/specs/components/document/DocumentTabNamedEntities.spec.js
+++ b/tests/unit/specs/components/document/DocumentTabNamedEntities.spec.js
@@ -20,15 +20,25 @@ describe('DocumentTabNamedEntities.vue', () => {
   })
 
   it('should display named entities in the dedicated tab', async () => {
-    await letData(es).have(new IndexedDocument(id, index)
-      .withPipeline('CORENLP')
-      .withNer('mention_01', 0, 'PERSON')
-      .withNer('mention_02', 0, 'ORGANIZATION')
-      .withNer('mention_03', 0, 'LOCATION'))
+    await letData(es)
+      .have(
+        new IndexedDocument(id, index)
+          .withPipeline('CORENLP')
+          .withNer('mention_01', 0, 'PERSON')
+          .withNer('mention_02', 0, 'ORGANIZATION')
+          .withNer('mention_03', 0, 'LOCATION')
+      )
       .commit()
     document = await store.dispatch('document/get', { id, index })
     await store.dispatch('document/getFirstPageForNamedEntityInAllCategories')
-    wrapper = shallowMount(DocumentTabNamedEntities, { i18n, localVue, store, wait, propsData: { document }, sync: false })
+    wrapper = shallowMount(DocumentTabNamedEntities, {
+      i18n,
+      localVue,
+      store,
+      wait,
+      propsData: { document },
+      sync: false
+    })
 
     const pills = wrapper.findAll('b-badge-stub')
     expect(pills).toHaveLength(3)
@@ -41,15 +51,25 @@ describe('DocumentTabNamedEntities.vue', () => {
   })
 
   it('should display filtered named entities', async () => {
-    await letData(es).have(new IndexedDocument(id, index)
-      .withPipeline('DUCKNLP')
-      .withNer('riri', 0, 'PERSON')
-      .withNer('fifi', 0, 'PERSON')
-      .withNer('loulou', 0, 'PERSON'))
+    await letData(es)
+      .have(
+        new IndexedDocument(id, index)
+          .withPipeline('DUCKNLP')
+          .withNer('riri', 0, 'PERSON')
+          .withNer('fifi', 0, 'PERSON')
+          .withNer('loulou', 0, 'PERSON')
+      )
       .commit()
     document = await store.dispatch('document/get', { id, index })
     await store.dispatch('document/getFirstPageForNamedEntityInAllCategories')
-    wrapper = shallowMount(DocumentTabNamedEntities, { i18n, localVue, store, wait, propsData: { document }, sync: false })
+    wrapper = shallowMount(DocumentTabNamedEntities, {
+      i18n,
+      localVue,
+      store,
+      wait,
+      propsData: { document },
+      sync: false
+    })
     wrapper.setData({ filterToken: 'lou' })
     await wrapper.vm.getFirstPageInAllCategories()
 
@@ -63,7 +83,14 @@ describe('DocumentTabNamedEntities.vue', () => {
     await letData(es).have(new IndexedDocument(id, index)).commit()
     document = await store.dispatch('document/get', { id, index })
     await store.dispatch('document/getFirstPageForNamedEntityInAllCategories')
-    wrapper = shallowMount(DocumentTabNamedEntities, { i18n, localVue, store, wait, propsData: { document }, sync: false })
+    wrapper = shallowMount(DocumentTabNamedEntities, {
+      i18n,
+      localVue,
+      store,
+      wait,
+      propsData: { document },
+      sync: false
+    })
 
     expect(wrapper.findAll('.document__named-entities--not--searched')).toHaveLength(1)
   })
@@ -72,7 +99,14 @@ describe('DocumentTabNamedEntities.vue', () => {
     await letData(es).have(new IndexedDocument(id, index).withPipeline('CORENLP')).commit()
     document = await store.dispatch('document/get', { id, index })
     await store.dispatch('document/getFirstPageForNamedEntityInAllCategories')
-    wrapper = shallowMount(DocumentTabNamedEntities, { i18n, localVue, store, wait, propsData: { document }, sync: false })
+    wrapper = shallowMount(DocumentTabNamedEntities, {
+      i18n,
+      localVue,
+      store,
+      wait,
+      propsData: { document },
+      sync: false
+    })
 
     expect(wrapper.findAll('.document__named-entities--not--found')).toHaveLength(1)
   })

--- a/tests/unit/specs/components/document/DocumentTabPreview.spec.js
+++ b/tests/unit/specs/components/document/DocumentTabPreview.spec.js
@@ -12,38 +12,58 @@ describe('DocumentTabPreview.vue', () => {
   const disabled = true
 
   it('should call the LegacySpreadsheetViewer component for XLSX document', async () => {
-    const document = await letData(es).have(new IndexedDocument(id, index)
-      .withContentType('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'))
+    const document = await letData(es)
+      .have(
+        new IndexedDocument(id, index).withContentType(
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        )
+      )
       .commitAndGetLastDocument()
 
-    const wrapper = shallowMount(DocumentTabPreview, { localVue, propsData: { document, disabled }, mocks: { $t: msg => msg } })
+    const wrapper = shallowMount(DocumentTabPreview, {
+      localVue,
+      propsData: { document, disabled },
+      mocks: { $t: (msg) => msg }
+    })
     expect(wrapper.vm.previewComponent).toBe('LegacySpreadsheetViewer')
   })
 
   it('should call the LegacySpreadsheetViewer component for CSV document', async () => {
-    const document = await letData(es).have(new IndexedDocument(id, index)
-      .withContentType('text/csv'))
+    const document = await letData(es)
+      .have(new IndexedDocument(id, index).withContentType('text/csv'))
       .commitAndGetLastDocument()
 
-    const wrapper = shallowMount(DocumentTabPreview, { localVue, propsData: { document, disabled }, mocks: { $t: msg => msg } })
+    const wrapper = shallowMount(DocumentTabPreview, {
+      localVue,
+      propsData: { document, disabled },
+      mocks: { $t: (msg) => msg }
+    })
     expect(wrapper.vm.previewComponent).toBe('LegacySpreadsheetViewer')
   })
 
   it('should call the PaginatedViewer component for PDF document', async () => {
-    const document = await letData(es).have(new IndexedDocument(id, index)
-      .withContentType('application/pdf'))
+    const document = await letData(es)
+      .have(new IndexedDocument(id, index).withContentType('application/pdf'))
       .commitAndGetLastDocument()
 
-    const wrapper = shallowMount(DocumentTabPreview, { localVue, propsData: { document, disabled }, mocks: { $t: msg => msg } })
+    const wrapper = shallowMount(DocumentTabPreview, {
+      localVue,
+      propsData: { document, disabled },
+      mocks: { $t: (msg) => msg }
+    })
     expect(wrapper.vm.previewComponent).toBe('PaginatedViewer')
   })
 
   it('should call the TiffViewer component for TIFF document', async () => {
-    const document = await letData(es).have(new IndexedDocument(id, index)
-      .withContentType('image/tiff'))
+    const document = await letData(es)
+      .have(new IndexedDocument(id, index).withContentType('image/tiff'))
       .commitAndGetLastDocument()
 
-    const wrapper = shallowMount(DocumentTabPreview, { localVue, propsData: { document, disabled }, mocks: { $t: msg => msg } })
+    const wrapper = shallowMount(DocumentTabPreview, {
+      localVue,
+      propsData: { document, disabled },
+      mocks: { $t: (msg) => msg }
+    })
     expect(wrapper.vm.previewComponent).toBe('TiffViewer')
   })
 })

--- a/tests/unit/specs/components/document/viewers/LegacySpreadsheetViewer.spec.js
+++ b/tests/unit/specs/components/document/viewers/LegacySpreadsheetViewer.spec.js
@@ -34,12 +34,39 @@ describe('LegacySpreadsheetViewer.vue', () => {
     await wrapper.vm.getWorkbook()
     await flushPromises()
 
-    expect(wrapper.find('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content > div table').element).toBeTruthy()
-    expect(wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content > div table td').at(0).text()).toBe('this')
-    expect(wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content > div table td').at(1).text()).toBe('is')
-    expect(wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content > div table td').at(2).text()).toBe('a')
-    expect(wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content > div table td').at(3).text()).toBe('CSV')
-    expect(wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content > div table td').at(4).text()).toBe('spreadsheet')
+    expect(
+      wrapper.find('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content > div table').element
+    ).toBeTruthy()
+    expect(
+      wrapper
+        .findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content > div table td')
+        .at(0)
+        .text()
+    ).toBe('this')
+    expect(
+      wrapper
+        .findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content > div table td')
+        .at(1)
+        .text()
+    ).toBe('is')
+    expect(
+      wrapper
+        .findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content > div table td')
+        .at(2)
+        .text()
+    ).toBe('a')
+    expect(
+      wrapper
+        .findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content > div table td')
+        .at(3)
+        .text()
+    ).toBe('CSV')
+    expect(
+      wrapper
+        .findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content > div table td')
+        .at(4)
+        .text()
+    ).toBe('spreadsheet')
   })
 
   it('should load a xlsx content file', async () => {
@@ -47,22 +74,41 @@ describe('LegacySpreadsheetViewer.vue', () => {
     await wrapper.vm.getWorkbook()
     await flushPromises()
 
-    expect(wrapper.find('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content > div table').element).toBeTruthy()
-    expect(wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content table td').at(0).text()).toBe('this')
-    expect(wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content table td').at(1).text()).toBe('is')
-    expect(wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content table td').at(2).text()).toBe('a')
-    expect(wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content table td').at(3).text()).toBe('XLSX')
-    expect(wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content table td').at(4).text()).toBe('spreadsheet')
+    expect(
+      wrapper.find('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content > div table').element
+    ).toBeTruthy()
+    expect(
+      wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content table td').at(0).text()
+    ).toBe('this')
+    expect(
+      wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content table td').at(1).text()
+    ).toBe('is')
+    expect(
+      wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content table td').at(2).text()
+    ).toBe('a')
+    expect(
+      wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content table td').at(3).text()
+    ).toBe('XLSX')
+    expect(
+      wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content table td').at(4).text()
+    ).toBe('spreadsheet')
   })
 
   it('should change the displayed sheet', async () => {
     wrapper = mount(LegacySpreadsheetViewer, { i18n, localVue, propsData: { document: { url: 'spreadsheet.xlsx' } } })
     await wrapper.vm.getWorkbook()
     await flushPromises()
-    await wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__header option').at(1).setSelected()
+    await wrapper
+      .findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__header option')
+      .at(1)
+      .setSelected()
 
-    expect(wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content table td').at(0).text()).toBe('second')
-    expect(wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content table td').at(1).text()).toBe('sheet')
+    expect(
+      wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content table td').at(0).text()
+    ).toBe('second')
+    expect(
+      wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__preview__content table td').at(1).text()
+    ).toBe('sheet')
   })
 
   it('should display a thumbnail by page', async () => {
@@ -70,7 +116,17 @@ describe('LegacySpreadsheetViewer.vue', () => {
     await wrapper.vm.getWorkbook()
     await flushPromises()
 
-    expect(wrapper.find('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__header .legacy-spreadsheet-viewer__header__thumbnails').exists()).toBeTruthy()
-    expect(wrapper.findAll('.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__header .legacy-spreadsheet-viewer__header__thumbnails .img-thumbnail')).toHaveLength(2)
+    expect(
+      wrapper
+        .find(
+          '.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__header .legacy-spreadsheet-viewer__header__thumbnails'
+        )
+        .exists()
+    ).toBeTruthy()
+    expect(
+      wrapper.findAll(
+        '.legacy-spreadsheet-viewer .legacy-spreadsheet-viewer__header .legacy-spreadsheet-viewer__header__thumbnails .img-thumbnail'
+      )
+    ).toHaveLength(2)
   })
 })

--- a/tests/unit/specs/components/filter/FilterBoilerplate.spec.js
+++ b/tests/unit/specs/components/filter/FilterBoilerplate.spec.js
@@ -72,7 +72,14 @@ describe('FilterBoilerplate.vue', () => {
   })
 
   it('should cast items into string', () => {
-    const computed = { itemsWithExcludedValues () { return [{ key: 0, doc_count: 12 }, { key: 1, doc_count: 15 }] } }
+    const computed = {
+      itemsWithExcludedValues() {
+        return [
+          { key: 0, doc_count: 12 },
+          { key: 1, doc_count: 15 }
+        ]
+      }
+    }
     wrapper = shallowMount(FilterBoilerplate, { i18n, localVue, router, store, wait, propsData: { filter }, computed })
 
     expect(wrapper.vm.options).toEqual([

--- a/tests/unit/specs/components/filter/types/FilterDate.spec.js
+++ b/tests/unit/specs/components/filter/types/FilterDate.spec.js
@@ -28,12 +28,9 @@ describe('FilterDate.vue', () => {
   afterEach(() => store.commit('search/reset'))
 
   it('should display a creation date filter with 2 months', async () => {
-    await letData(es).have(new IndexedDocument('doc_01', index)
-      .withIndexingDate('2018-04-01T00:00:00.000Z')).commit()
-    await letData(es).have(new IndexedDocument('doc_02', index)
-      .withIndexingDate('2018-05-01T00:00:00.000Z')).commit()
-    await letData(es).have(new IndexedDocument('doc_03', index)
-      .withIndexingDate('2018-05-01T00:00:00.000Z')).commit()
+    await letData(es).have(new IndexedDocument('doc_01', index).withIndexingDate('2018-04-01T00:00:00.000Z')).commit()
+    await letData(es).have(new IndexedDocument('doc_02', index).withIndexingDate('2018-05-01T00:00:00.000Z')).commit()
+    await letData(es).have(new IndexedDocument('doc_03', index).withIndexingDate('2018-05-01T00:00:00.000Z')).commit()
 
     await wrapper.vm.root.aggregate()
 

--- a/tests/unit/specs/components/filter/types/FilterNamedEntity.spec.js
+++ b/tests/unit/specs/components/filter/types/FilterNamedEntity.spec.js
@@ -55,12 +55,12 @@ describe('FilterNamedEntity.vue', () => {
   })
 
   it('should filter items according to the content type filter search', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('type_01')
-      .withNer('person_01')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContentType('type_02')
-      .withNer('person_02')).commit()
+    await letData(es)
+      .have(new IndexedDocument('document_01', index).withContentType('type_01').withNer('person_01'))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('document_02', index).withContentType('type_02').withNer('person_02'))
+      .commit()
 
     store.commit('search/setFilterValue', { name: 'contentType', value: 'type_01' })
     await wrapper.vm.root.aggregate({ clearPages: true })
@@ -69,12 +69,12 @@ describe('FilterNamedEntity.vue', () => {
   })
 
   it('should filter items according to the date filter search', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withNer('person_01')
-      .withIndexingDate('2018-10-19T10:11:12.001Z')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withNer('person_02')
-      .withIndexingDate('2018-09-19T10:11:12.001Z')).commit()
+    await letData(es)
+      .have(new IndexedDocument('document_01', index).withNer('person_01').withIndexingDate('2018-10-19T10:11:12.001Z'))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('document_02', index).withNer('person_02').withIndexingDate('2018-09-19T10:11:12.001Z'))
+      .commit()
 
     const value = [new Date('2018-09-01T00:00:00.000Z').getTime().toString()]
     store.commit('search/setFilterValue', { name: 'indexingDate', value })
@@ -84,15 +84,15 @@ describe('FilterNamedEntity.vue', () => {
   })
 
   it('should filter items according to the content type reverse filter search', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('type_01')
-      .withNer('person_01')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContentType('type_02')
-      .withNer('person_02')).commit()
-    await letData(es).have(new IndexedDocument('document_03', index)
-      .withContentType('type_03')
-      .withNer('person_03')).commit()
+    await letData(es)
+      .have(new IndexedDocument('document_01', index).withContentType('type_01').withNer('person_01'))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('document_02', index).withContentType('type_02').withNer('person_02'))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('document_03', index).withContentType('type_03').withNer('person_03'))
+      .commit()
 
     store.commit('search/setFilterValue', { name: 'contentType', value: ['type_01'] })
     store.commit('search/toggleFilter', 'contentType')
@@ -104,12 +104,9 @@ describe('FilterNamedEntity.vue', () => {
   })
 
   it('should filter items according to the named entity filter search', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withNer('person_01')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withNer('person_02')).commit()
-    await letData(es).have(new IndexedDocument('document_03', index)
-      .withNer('person_03')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withNer('person_01')).commit()
+    await letData(es).have(new IndexedDocument('document_02', index).withNer('person_02')).commit()
+    await letData(es).have(new IndexedDocument('document_03', index).withNer('person_03')).commit()
 
     store.commit('search/setFilterValue', { name: 'namedEntityPerson', value: ['person_01'] })
     await wrapper.vm.root.aggregate({ clearPages: true })
@@ -119,24 +116,29 @@ describe('FilterNamedEntity.vue', () => {
   })
 
   it('should display the only namedEntityPerson selected', async () => {
-    await letData(es).have(new IndexedDocument('doc_01', index)
-      .withNer('person_01')
-      .withNer('person_02')
-      .withNer('person_03')
-      .withNer('organization_01', 1, 'ORGANIZATION')
-      .withNer('organization_02', 1, 'ORGANIZATION')
-    ).commit()
-    await letData(es).have(new IndexedDocument('doc_02', index)
-      .withNer('person_03')
-      .withNer('organization_03', 1, 'ORGANIZATION')
-    ).commit()
-    await letData(es).have(new IndexedDocument('doc_03', index)
-      .withNer('person_02')
-      .withNer('person_04')
-      .withNer('organization_02', 1, 'ORGANIZATION')
-      .withNer('organization_03', 1, 'ORGANIZATION')
-      .withNer('organization_04', 1, 'ORGANIZATION')
-    ).commit()
+    await letData(es)
+      .have(
+        new IndexedDocument('doc_01', index)
+          .withNer('person_01')
+          .withNer('person_02')
+          .withNer('person_03')
+          .withNer('organization_01', 1, 'ORGANIZATION')
+          .withNer('organization_02', 1, 'ORGANIZATION')
+      )
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('doc_02', index).withNer('person_03').withNer('organization_03', 1, 'ORGANIZATION'))
+      .commit()
+    await letData(es)
+      .have(
+        new IndexedDocument('doc_03', index)
+          .withNer('person_02')
+          .withNer('person_04')
+          .withNer('organization_02', 1, 'ORGANIZATION')
+          .withNer('organization_03', 1, 'ORGANIZATION')
+          .withNer('organization_04', 1, 'ORGANIZATION')
+      )
+      .commit()
 
     store.commit('search/setFilterValue', { name: 'namedEntityPerson', value: ['person_02'] })
     await wrapper.vm.root.aggregate({ clearPages: true })
@@ -146,24 +148,29 @@ describe('FilterNamedEntity.vue', () => {
   })
 
   it('should filter items of namedEntityPerson according to the namedEntityOrganization selected', async () => {
-    await letData(es).have(new IndexedDocument('doc_01', index)
-      .withNer('person_01')
-      .withNer('person_02')
-      .withNer('person_03')
-      .withNer('organization_01', 1, 'ORGANIZATION')
-      .withNer('organization_02', 1, 'ORGANIZATION')
-    ).commit()
-    await letData(es).have(new IndexedDocument('doc_02', index)
-      .withNer('person_03')
-      .withNer('organization_03', 1, 'ORGANIZATION')
-    ).commit()
-    await letData(es).have(new IndexedDocument('doc_03', index)
-      .withNer('person_02')
-      .withNer('person_04')
-      .withNer('organization_02', 1, 'ORGANIZATION')
-      .withNer('organization_03', 1, 'ORGANIZATION')
-      .withNer('organization_04', 1, 'ORGANIZATION')
-    ).commit()
+    await letData(es)
+      .have(
+        new IndexedDocument('doc_01', index)
+          .withNer('person_01')
+          .withNer('person_02')
+          .withNer('person_03')
+          .withNer('organization_01', 1, 'ORGANIZATION')
+          .withNer('organization_02', 1, 'ORGANIZATION')
+      )
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('doc_02', index).withNer('person_03').withNer('organization_03', 1, 'ORGANIZATION'))
+      .commit()
+    await letData(es)
+      .have(
+        new IndexedDocument('doc_03', index)
+          .withNer('person_02')
+          .withNer('person_04')
+          .withNer('organization_02', 1, 'ORGANIZATION')
+          .withNer('organization_03', 1, 'ORGANIZATION')
+          .withNer('organization_04', 1, 'ORGANIZATION')
+      )
+      .commit()
 
     store.commit('search/setFilterValue', { name: 'namedEntityOrganization', value: ['organization_03'] })
     await wrapper.vm.root.aggregate({ clearPages: true })
@@ -175,10 +182,8 @@ describe('FilterNamedEntity.vue', () => {
   })
 
   it('should prepend a selected and excluded Named Entity in the items, and show it in the list of filter items', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withNer('anne')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withNer('bruno')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withNer('anne')).commit()
+    await letData(es).have(new IndexedDocument('document_02', index).withNer('bruno')).commit()
 
     store.commit('search/setFilterValue', { name: 'namedEntityPerson', value: ['anne'] })
     store.commit('search/toggleFilter', 'namedEntityPerson')
@@ -191,14 +196,17 @@ describe('FilterNamedEntity.vue', () => {
   })
 
   it('should filter filters items on 2 named entities from different categories', async () => {
-    await letData(es).have(new IndexedDocument(id, index)
-      .withNer('person_01')
-      .withNer('person_02')
-      .withNer('organization_01', 1, 'ORGANIZATION')
-      .withNer('organization_02', 1, 'ORGANIZATION')
-      .withNer('location_01', 1, 'LOCATION')
-      .withNer('location_02', 1, 'LOCATION')
-    ).commit()
+    await letData(es)
+      .have(
+        new IndexedDocument(id, index)
+          .withNer('person_01')
+          .withNer('person_02')
+          .withNer('organization_01', 1, 'ORGANIZATION')
+          .withNer('organization_02', 1, 'ORGANIZATION')
+          .withNer('location_01', 1, 'LOCATION')
+          .withNer('location_02', 1, 'LOCATION')
+      )
+      .commit()
 
     store.commit('search/setFilterValue', { name: 'namedEntityPerson', value: ['person_01'] })
     store.commit('search/setFilterValue', { name: 'namedEntityOrganization', value: ['organization_01'] })
@@ -208,15 +216,17 @@ describe('FilterNamedEntity.vue', () => {
   })
 
   it('should display the correct number of occurrences if named entity filter is excluded', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withNer('person_01')
-      .withNer('organization_01', 1, 'ORGANIZATION')
-    ).commit()
+    await letData(es)
+      .have(
+        new IndexedDocument('document_01', index).withNer('person_01').withNer('organization_01', 1, 'ORGANIZATION')
+      )
+      .commit()
 
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withNer('person_02')
-      .withNer('organization_02', 1, 'ORGANIZATION')
-    ).commit()
+    await letData(es)
+      .have(
+        new IndexedDocument('document_02', index).withNer('person_02').withNer('organization_02', 1, 'ORGANIZATION')
+      )
+      .commit()
 
     store.commit('search/setFilterValue', { name: 'namedEntityOrganization', value: ['organization_01'] })
     store.commit('search/toggleFilter', 'namedEntityOrganization')
@@ -226,9 +236,7 @@ describe('FilterNamedEntity.vue', () => {
   })
 
   it('should display an "All" item on top of others items, and this item should be active by default', async () => {
-    await letData(es).have(new IndexedDocument(id, index)
-      .withContent('person_01')
-      .withNer('person_01')).commit()
+    await letData(es).have(new IndexedDocument(id, index).withContent('person_01').withNer('person_01')).commit()
 
     await wrapper.vm.root.aggregate({ clearPages: true })
     await store.dispatch('search/query', '*')
@@ -266,8 +274,7 @@ describe('FilterNamedEntity.vue', () => {
     })
 
     it('should display 1 named entity', async () => {
-      await letData(es).have(new IndexedDocument(id, index)
-        .withNer('person_01')).commit()
+      await letData(es).have(new IndexedDocument(id, index).withNer('person_01')).commit()
 
       await wrapper.vm.root.aggregate({ clearPages: true })
 
@@ -275,9 +282,7 @@ describe('FilterNamedEntity.vue', () => {
     })
 
     it('should display 2 named entities in one document', async () => {
-      await letData(es).have(new IndexedDocument(id, index)
-        .withNer('person_01')
-        .withNer('person_02')).commit()
+      await letData(es).have(new IndexedDocument(id, index).withNer('person_01').withNer('person_02')).commit()
 
       await wrapper.vm.root.aggregate({ clearPages: true })
 
@@ -285,10 +290,10 @@ describe('FilterNamedEntity.vue', () => {
     })
 
     it('should display 1 named entity in 2 documents', async () => {
-      await letData(es).have(new IndexedDocument('document_01', index)
-        .withNer('person_01', [2, 25])).commit()
-      await letData(es).have(new IndexedDocument('document_02', index)
-        .withNer('person_01')).commit()
+      await letData(es)
+        .have(new IndexedDocument('document_01', index).withNer('person_01', [2, 25]))
+        .commit()
+      await letData(es).have(new IndexedDocument('document_02', index).withNer('person_01')).commit()
 
       await wrapper.vm.root.aggregate({ clearPages: true })
 
@@ -296,12 +301,15 @@ describe('FilterNamedEntity.vue', () => {
     })
 
     it('should display 3 named entities in 2 documents in correct order', async () => {
-      await letData(es).have(new IndexedDocument('document_01', index)
-        .withNer('someone_01', 2)).commit()
-      await letData(es).have(new IndexedDocument('document_02', index)
-        .withNer('someone_01', 26)
-        .withNer('someone_02', [2, 16, 21])
-        .withNer('someone_03', 35)).commit()
+      await letData(es).have(new IndexedDocument('document_01', index).withNer('someone_01', 2)).commit()
+      await letData(es)
+        .have(
+          new IndexedDocument('document_02', index)
+            .withNer('someone_01', 26)
+            .withNer('someone_02', [2, 16, 21])
+            .withNer('someone_03', 35)
+        )
+        .commit()
 
       await wrapper.vm.root.aggregate({ clearPages: true })
 
@@ -312,12 +320,15 @@ describe('FilterNamedEntity.vue', () => {
     })
 
     it('should display 3 named entities in 2 documents alphabeticaly', async () => {
-      await letData(es).have(new IndexedDocument('document_01', index)
-        .withNer('paul', 2)).commit()
-      await letData(es).have(new IndexedDocument('document_02', index)
-        .withNer('ines', [2, 16, 21])
-        .withNer('paul', 26)
-        .withNer('anita', 35)).commit()
+      await letData(es).have(new IndexedDocument('document_01', index).withNer('paul', 2)).commit()
+      await letData(es)
+        .have(
+          new IndexedDocument('document_02', index)
+            .withNer('ines', [2, 16, 21])
+            .withNer('paul', 26)
+            .withNer('anita', 35)
+        )
+        .commit()
 
       wrapper.findComponent({ ref: 'filter' }).setData({ sortBy: '_key', sortByOrder: 'asc' })
       await wrapper.vm.root.aggregate({ clearPages: true })
@@ -331,14 +342,10 @@ describe('FilterNamedEntity.vue', () => {
 
   describe('Filtering on named entities', () => {
     it('should filter on named entity filter and return no items', async () => {
-      await letData(es).have(new IndexedDocument('document_01', index)
-        .withNer('person_01')).commit()
-      await letData(es).have(new IndexedDocument('document_02', index)
-        .withNer('person_02')).commit()
-      await letData(es).have(new IndexedDocument('document_03', index)
-        .withNer('person_03')).commit()
-      await letData(es).have(new IndexedDocument('document_04', index)
-        .withNer('person_04')).commit()
+      await letData(es).have(new IndexedDocument('document_01', index).withNer('person_01')).commit()
+      await letData(es).have(new IndexedDocument('document_02', index).withNer('person_02')).commit()
+      await letData(es).have(new IndexedDocument('document_03', index).withNer('person_03')).commit()
+      await letData(es).have(new IndexedDocument('document_04', index).withNer('person_04')).commit()
 
       wrapper.vm.root.query = 'Windows'
       await wrapper.vm.root.aggregate({ clearPages: true })
@@ -347,14 +354,10 @@ describe('FilterNamedEntity.vue', () => {
     })
 
     it('should filter on named entity filter and return all items', async () => {
-      await letData(es).have(new IndexedDocument('document_01', index)
-        .withNer('person_01')).commit()
-      await letData(es).have(new IndexedDocument('document_02', index)
-        .withNer('person_02')).commit()
-      await letData(es).have(new IndexedDocument('document_03', index)
-        .withNer('person_03')).commit()
-      await letData(es).have(new IndexedDocument('document_04', index)
-        .withNer('person_04')).commit()
+      await letData(es).have(new IndexedDocument('document_01', index).withNer('person_01')).commit()
+      await letData(es).have(new IndexedDocument('document_02', index).withNer('person_02')).commit()
+      await letData(es).have(new IndexedDocument('document_03', index).withNer('person_03')).commit()
+      await letData(es).have(new IndexedDocument('document_04', index).withNer('person_04')).commit()
 
       wrapper.vm.root.query = 'person'
       await wrapper.vm.root.aggregate({ clearPages: true })
@@ -363,14 +366,10 @@ describe('FilterNamedEntity.vue', () => {
     })
 
     it('should filter on named entity filter and return only 1 item', async () => {
-      await letData(es).have(new IndexedDocument('document_01', index)
-        .withNer('person_01')).commit()
-      await letData(es).have(new IndexedDocument('document_02', index)
-        .withNer('person_02')).commit()
-      await letData(es).have(new IndexedDocument('document_03', index)
-        .withNer('person_03')).commit()
-      await letData(es).have(new IndexedDocument('document_04', index)
-        .withNer('person_04')).commit()
+      await letData(es).have(new IndexedDocument('document_01', index).withNer('person_01')).commit()
+      await letData(es).have(new IndexedDocument('document_02', index).withNer('person_02')).commit()
+      await letData(es).have(new IndexedDocument('document_03', index).withNer('person_03')).commit()
+      await letData(es).have(new IndexedDocument('document_04', index).withNer('person_04')).commit()
 
       wrapper.vm.root.query = 'person_01'
       await wrapper.vm.root.aggregate({ clearPages: true })
@@ -381,8 +380,7 @@ describe('FilterNamedEntity.vue', () => {
 
   describe('Deletion', () => {
     it('should display the "delete" button', async () => {
-      await letData(es).have(new IndexedDocument(id, index)
-        .withNer('person_01')).commit()
+      await letData(es).have(new IndexedDocument(id, index).withNer('person_01')).commit()
 
       await wrapper.vm.root.aggregate({ clearPages: true })
 

--- a/tests/unit/specs/components/filter/types/FilterProject.spec.js
+++ b/tests/unit/specs/components/filter/types/FilterProject.spec.js
@@ -25,7 +25,7 @@ describe('FilterProject.vue', () => {
 
     const mergeCreatedStrategy = localVue.config.optionMergeStrategies.created
     localVue.config.optionMergeStrategies.created = (parent, _) => mergeCreatedStrategy(parent)
-    localVue.mixin({ created () {} })
+    localVue.mixin({ created() {} })
 
     Murmur.config.merge({ groups_by_applications: { datashare: JSON.stringify([project, anotherProject]) } })
     store.commit('search/index', project)
@@ -34,11 +34,23 @@ describe('FilterProject.vue', () => {
   beforeEach(() => {
     mockAxios.request.mockClear()
     mockAxios.request.mockResolvedValue({ data: [] })
-    wrapper = shallowMount(FilterProject, { i18n, localVue, store, wait, propsData: { filter: find(store.getters['search/instantiatedFilters'], { name: 'language' }) } })
+    wrapper = shallowMount(FilterProject, {
+      i18n,
+      localVue,
+      store,
+      wait,
+      propsData: { filter: find(store.getters['search/instantiatedFilters'], { name: 'language' }) }
+    })
   })
 
-  it('should not display a dropdown if we aren\'t in server mode', () => {
-    wrapper = shallowMount(FilterProject, { i18n, localVue, store, wait, propsData: { filter: find(store.getters['search/instantiatedFilters'], { name: 'language' }) } })
+  it("should not display a dropdown if we aren't in server mode", () => {
+    wrapper = shallowMount(FilterProject, {
+      i18n,
+      localVue,
+      store,
+      wait,
+      propsData: { filter: find(store.getters['search/instantiatedFilters'], { name: 'language' }) }
+    })
 
     expect(wrapper.findAll('option')).toHaveLength(0)
   })
@@ -49,7 +61,14 @@ describe('FilterProject.vue', () => {
 
   describe('on project change', () => {
     beforeEach(() => {
-      wrapper = shallowMount(FilterProject, { i18n, localVue, store, router: new VueRouter(), wait, propsData: { filter: find(store.getters['search/instantiatedFilters'], { name: 'language' }) } })
+      wrapper = shallowMount(FilterProject, {
+        i18n,
+        localVue,
+        store,
+        router: new VueRouter(),
+        wait,
+        propsData: { filter: find(store.getters['search/instantiatedFilters'], { name: 'language' }) }
+      })
       store.commit('downloads/clear')
     })
 
@@ -76,22 +95,26 @@ describe('FilterProject.vue', () => {
       await wrapper.vm.select(anotherProject)
 
       expect(mockAxios.request).toBeCalledTimes(3)
-      expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-        url: Api.getFullUrl(`/api/project/isDownloadAllowed/${anotherProject}`)
-      }))
+      expect(mockAxios.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl(`/api/project/isDownloadAllowed/${anotherProject}`)
+        })
+      )
     })
 
     it('should refresh the recommendedByUsers', async () => {
       await wrapper.vm.select(anotherProject)
 
       expect(mockAxios.request).toBeCalledTimes(3)
-      expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-        url: Api.getFullUrl('/api/users/recommendations'),
-        method: 'GET',
-        params: {
-          project: anotherProject
-        }
-      }))
+      expect(mockAxios.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl('/api/users/recommendations'),
+          method: 'GET',
+          params: {
+            project: anotherProject
+          }
+        })
+      )
     })
 
     it('should refresh the route', async () => {

--- a/tests/unit/specs/components/filter/types/FilterRecommendedBy.spec.js
+++ b/tests/unit/specs/components/filter/types/FilterRecommendedBy.spec.js
@@ -19,7 +19,7 @@ jest.mock('@/api/resources/Auth', () => {
 FilterRecommendedBy.methods.refreshRouteAndSearch = jest.fn()
 
 describe('FilterRecommendedBy.vue', () => {
-  const flushPromises = () => new Promise(resolve => setImmediate(resolve))
+  const flushPromises = () => new Promise((resolve) => setImmediate(resolve))
   let i18n, localVue, router, store, wait, wrapper, api, mockAxios
   const project = toLower('FilterRecommendedBy')
 
@@ -74,13 +74,15 @@ describe('FilterRecommendedBy.vue', () => {
 
   it('should load users who recommended documents in this project', () => {
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/users/recommendations'),
-      method: 'GET',
-      params: {
-        project: project
-      }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/users/recommendations'),
+        method: 'GET',
+        params: {
+          project: project
+        }
+      })
+    )
     expect(wrapper.vm.recommendedByUsers).toEqual([
       { user: 'user_00', count: 2 },
       { user: 'user_01', count: 1 },
@@ -107,13 +109,15 @@ describe('FilterRecommendedBy.vue', () => {
     mockAxios.request.mockClear()
     await wrapper.vm.selectUsers(['user_01', 'user_02'])
 
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl(`/api/${project}/documents/recommendations`),
-      method: 'GET',
-      params: {
-        userids: 'user_01,user_02'
-      }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl(`/api/${project}/documents/recommendations`),
+        method: 'GET',
+        params: {
+          userids: 'user_01,user_02'
+        }
+      })
+    )
     expect(store.state.recommended.documents).toEqual(documents)
     expect(wrapper.vm.selected).toEqual(['user_01', 'user_02'])
     expect(wrapper.findComponent({ ref: 'filter' }).vm.isAllSelected).toBeFalsy()

--- a/tests/unit/specs/components/filter/types/FilterText.spec.js
+++ b/tests/unit/specs/components/filter/types/FilterText.spec.js
@@ -48,16 +48,11 @@ describe('FilterText.vue', () => {
   })
 
   it('should display 2 items for the contentType filter', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('text/javascript')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContentType('text/javascript')).commit()
-    await letData(es).have(new IndexedDocument('document_03', index)
-      .withContentType('text/javascript')).commit()
-    await letData(es).have(new IndexedDocument('document_04', index)
-      .withContentType('text/html')).commit()
-    await letData(es).have(new IndexedDocument('document_05', index)
-      .withContentType('text/html')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withContentType('text/javascript')).commit()
+    await letData(es).have(new IndexedDocument('document_02', index).withContentType('text/javascript')).commit()
+    await letData(es).have(new IndexedDocument('document_03', index).withContentType('text/javascript')).commit()
+    await letData(es).have(new IndexedDocument('document_04', index).withContentType('text/html')).commit()
+    await letData(es).have(new IndexedDocument('document_05', index).withContentType('text/html')).commit()
 
     await wrapper.findComponent({ ref: 'filter' }).vm.aggregate({ clearPages: true })
 
@@ -66,12 +61,12 @@ describe('FilterText.vue', () => {
   })
 
   it('should filter according to the others filters if contextualized search', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('type_01')
-      .withLanguage('ENGLISH')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContentType('type_02')
-      .withLanguage('FRENCH')).commit()
+    await letData(es)
+      .have(new IndexedDocument('document_01', index).withContentType('type_01').withLanguage('ENGLISH'))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('document_02', index).withContentType('type_02').withLanguage('FRENCH'))
+      .commit()
 
     store.commit('search/contextualizeFilter', name)
     store.commit('search/setFilterValue', { name: 'language', value: 'ENGLISH' })
@@ -82,20 +77,13 @@ describe('FilterText.vue', () => {
   })
 
   it('should display 3 items for the contentType filter', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('text/javascript')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContentType('text/javascript')).commit()
-    await letData(es).have(new IndexedDocument('document_03', index)
-      .withContentType('text/javascript')).commit()
-    await letData(es).have(new IndexedDocument('document_04', index)
-      .withContentType('text/html')).commit()
-    await letData(es).have(new IndexedDocument('document_05', index)
-      .withContentType('text/html')).commit()
-    await letData(es).have(new IndexedDocument('document_06', index)
-      .withContentType('text/stylesheet')).commit()
-    await letData(es).have(new IndexedDocument('document_07', index)
-      .withContentType('text/stylesheet')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withContentType('text/javascript')).commit()
+    await letData(es).have(new IndexedDocument('document_02', index).withContentType('text/javascript')).commit()
+    await letData(es).have(new IndexedDocument('document_03', index).withContentType('text/javascript')).commit()
+    await letData(es).have(new IndexedDocument('document_04', index).withContentType('text/html')).commit()
+    await letData(es).have(new IndexedDocument('document_05', index).withContentType('text/html')).commit()
+    await letData(es).have(new IndexedDocument('document_06', index).withContentType('text/stylesheet')).commit()
+    await letData(es).have(new IndexedDocument('document_07', index).withContentType('text/stylesheet')).commit()
 
     await wrapper.findComponent({ ref: 'filter' }).vm.aggregate({ clearPages: true })
 
@@ -104,12 +92,9 @@ describe('FilterText.vue', () => {
   })
 
   it('should display 3 items for the contentType filter alphabeticaly', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('text/javascript')).commit()
-    await letData(es).have(new IndexedDocument('document_05', index)
-      .withContentType('text/html')).commit()
-    await letData(es).have(new IndexedDocument('document_06', index)
-      .withContentType('text/stylesheet')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withContentType('text/javascript')).commit()
+    await letData(es).have(new IndexedDocument('document_05', index).withContentType('text/html')).commit()
+    await letData(es).have(new IndexedDocument('document_06', index).withContentType('text/stylesheet')).commit()
 
     wrapper.findComponent({ ref: 'filter' }).setData({ sortBy: '_key', sortByOrder: 'asc' })
     await wrapper.findComponent({ ref: 'filter' }).vm.aggregate({ clearPages: true })
@@ -123,18 +108,24 @@ describe('FilterText.vue', () => {
   })
 
   it('should display X filter items after applying the relative search', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContent('INDEX').withContentType('text/javascript')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContent('LIST').withContentType('text/javascript')).commit()
-    await letData(es).have(new IndexedDocument('document_03', index)
-      .withContent('SHOW').withContentType('text/javascript')).commit()
-    await letData(es).have(new IndexedDocument('document_04', index)
-      .withContent('INDEX').withContentType('text/html')).commit()
-    await letData(es).have(new IndexedDocument('document_05', index)
-      .withContent('LIST').withContentType('text/html')).commit()
-    await letData(es).have(new IndexedDocument('document_06', index)
-      .withContent('LIST').withContentType('text/stylesheet')).commit()
+    await letData(es)
+      .have(new IndexedDocument('document_01', index).withContent('INDEX').withContentType('text/javascript'))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('document_02', index).withContent('LIST').withContentType('text/javascript'))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('document_03', index).withContent('SHOW').withContentType('text/javascript'))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('document_04', index).withContent('INDEX').withContentType('text/html'))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('document_05', index).withContent('LIST').withContentType('text/html'))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('document_06', index).withContent('LIST').withContentType('text/stylesheet'))
+      .commit()
 
     store.commit('search/query', 'SHOW')
     store.commit('search/decontextualizeFilter', name)
@@ -152,10 +143,12 @@ describe('FilterText.vue', () => {
   })
 
   it('should apply relative filter and get back to global filter', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContent('Lorem').withContentType('text/javascript')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContent('Ipsum').withContentType('text/html')).commit()
+    await letData(es)
+      .have(new IndexedDocument('document_01', index).withContent('Lorem').withContentType('text/javascript'))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('document_02', index).withContent('Ipsum').withContentType('text/html'))
+      .commit()
 
     store.commit('search/query', 'Lorem')
     store.commit('search/decontextualizeFilter', name)
@@ -173,12 +166,9 @@ describe('FilterText.vue', () => {
   })
 
   it('should display an item for excluded filter', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('text/javascript')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContentType('text/html')).commit()
-    await letData(es).have(new IndexedDocument('document_03', index)
-      .withContentType('text/javascript')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withContentType('text/javascript')).commit()
+    await letData(es).have(new IndexedDocument('document_02', index).withContentType('text/html')).commit()
+    await letData(es).have(new IndexedDocument('document_03', index).withContentType('text/javascript')).commit()
 
     store.commit('search/addFilterValue', { name: 'contentType', value: 'text/javascript' })
     store.commit('search/excludeFilter', 'contentType')
@@ -190,16 +180,11 @@ describe('FilterText.vue', () => {
   })
 
   it('should filter filter values', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('text/type_01')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContentType('text/type_02')).commit()
-    await letData(es).have(new IndexedDocument('document_03', index)
-      .withContentType('text/type_03')).commit()
-    await letData(es).have(new IndexedDocument('document_12', index)
-      .withContentType('text/type_12')).commit()
-    await letData(es).have(new IndexedDocument('document_13', index)
-      .withContentType('text/type_13')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withContentType('text/type_01')).commit()
+    await letData(es).have(new IndexedDocument('document_02', index).withContentType('text/type_02')).commit()
+    await letData(es).have(new IndexedDocument('document_03', index).withContentType('text/type_03')).commit()
+    await letData(es).have(new IndexedDocument('document_12', index).withContentType('text/type_12')).commit()
+    await letData(es).have(new IndexedDocument('document_13', index).withContentType('text/type_13')).commit()
 
     wrapper.findComponent({ ref: 'filter' }).vm.query = 'text/type_0'
 
@@ -210,18 +195,12 @@ describe('FilterText.vue', () => {
   })
 
   it('should filter filter values with no results', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('text/type_01')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContentType('text/type_02')).commit()
-    await letData(es).have(new IndexedDocument('document_03', index)
-      .withContentType('text/type_02')).commit()
-    await letData(es).have(new IndexedDocument('document_04', index)
-      .withContentType('text/type_03')).commit()
-    await letData(es).have(new IndexedDocument('document_05', index)
-      .withContentType('text/type_03')).commit()
-    await letData(es).have(new IndexedDocument('document_06', index)
-      .withContentType('text/type_03')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withContentType('text/type_01')).commit()
+    await letData(es).have(new IndexedDocument('document_02', index).withContentType('text/type_02')).commit()
+    await letData(es).have(new IndexedDocument('document_03', index).withContentType('text/type_02')).commit()
+    await letData(es).have(new IndexedDocument('document_04', index).withContentType('text/type_03')).commit()
+    await letData(es).have(new IndexedDocument('document_05', index).withContentType('text/type_03')).commit()
+    await letData(es).have(new IndexedDocument('document_06', index).withContentType('text/type_03')).commit()
 
     wrapper.findComponent({ ref: 'filter' }).vm.query = 'yolo'
 
@@ -232,10 +211,8 @@ describe('FilterText.vue', () => {
   })
 
   it('should filter filter values - Uppercase situation', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('text/csv')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContentType('plain/text')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withContentType('text/csv')).commit()
+    await letData(es).have(new IndexedDocument('document_02', index).withContentType('plain/text')).commit()
 
     wrapper.findComponent({ ref: 'filter' }).vm.query = 'TEX'
 
@@ -246,14 +223,16 @@ describe('FilterText.vue', () => {
   })
 
   it('should filter filter values on filter item', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('application/pdf')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContentType('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')).commit()
-    await letData(es).have(new IndexedDocument('document_03', index)
-      .withContentType('image/wmf')).commit()
-    await letData(es).have(new IndexedDocument('document_04', index)
-      .withContentType('image/emf')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withContentType('application/pdf')).commit()
+    await letData(es)
+      .have(
+        new IndexedDocument('document_02', index).withContentType(
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        )
+      )
+      .commit()
+    await letData(es).have(new IndexedDocument('document_03', index).withContentType('image/wmf')).commit()
+    await letData(es).have(new IndexedDocument('document_04', index).withContentType('image/emf')).commit()
 
     wrapper.findComponent({ ref: 'filter' }).vm.query = 'image'
 
@@ -264,12 +243,9 @@ describe('FilterText.vue', () => {
   })
 
   it('should filter filter values on filter label', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('message/rfc822')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContentType('another_type')).commit()
-    await letData(es).have(new IndexedDocument('document_03', index)
-      .withContentType('message/rfc822')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withContentType('message/rfc822')).commit()
+    await letData(es).have(new IndexedDocument('document_02', index).withContentType('another_type')).commit()
+    await letData(es).have(new IndexedDocument('document_03', index).withContentType('message/rfc822')).commit()
 
     wrapper.findComponent({ ref: 'filter' }).vm.query = 'Internet'
 
@@ -281,12 +257,9 @@ describe('FilterText.vue', () => {
   })
 
   it('should filter filter values on filter label in capital letters', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('message/rfc822')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContentType('another_type')).commit()
-    await letData(es).have(new IndexedDocument('document_03', index)
-      .withContentType('message/rfc822')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withContentType('message/rfc822')).commit()
+    await letData(es).have(new IndexedDocument('document_02', index).withContentType('another_type')).commit()
+    await letData(es).have(new IndexedDocument('document_03', index).withContentType('message/rfc822')).commit()
 
     wrapper.findComponent({ ref: 'filter' }).vm.query = 'EMAIL'
 
@@ -300,8 +273,7 @@ describe('FilterText.vue', () => {
   it('should fire 2 events on click on filter item', async () => {
     const rootWrapper = createWrapper(wrapper.vm.$root)
     const spyRefreshRoute = jest.spyOn(wrapper.findComponent({ ref: 'filter' }).vm, 'refreshRoute')
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('type_01')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withContentType('type_01')).commit()
     await wrapper.findComponent({ ref: 'filter' }).vm.aggregate({ clearPages: true })
     await wrapper.find('.filter__items__item:nth-child(1) input').trigger('click')
 
@@ -312,8 +284,7 @@ describe('FilterText.vue', () => {
 
   it('should reset the from query on click on filter item', async () => {
     store.commit('search/from', 25)
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('type_01')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withContentType('type_01')).commit()
     await wrapper.findComponent({ ref: 'filter' }).vm.aggregate({ clearPages: true })
     await wrapper.find('.filter__items__item:nth-child(1) input').trigger('click')
 
@@ -321,12 +292,9 @@ describe('FilterText.vue', () => {
   })
 
   it('should return filters from another index', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('text/javascript')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContentType('text/html')).commit()
-    await letData(es).have(new IndexedDocument('document_03', anotherIndex)
-      .withContentType('text/javascript')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withContentType('text/javascript')).commit()
+    await letData(es).have(new IndexedDocument('document_02', index).withContentType('text/html')).commit()
+    await letData(es).have(new IndexedDocument('document_03', anotherIndex).withContentType('text/javascript')).commit()
     await wrapper.findComponent({ ref: 'filter' }).vm.aggregate({ clearPages: true })
 
     expect(wrapper.findAll('.filter__items__item')).toHaveLength(2)
@@ -340,10 +308,8 @@ describe('FilterText.vue', () => {
   })
 
   it('should display an "All" item on top of others items, and this item should be active by default', async () => {
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('type_01')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContentType('type_02')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withContentType('type_01')).commit()
+    await letData(es).have(new IndexedDocument('document_02', index).withContentType('type_02')).commit()
 
     await wrapper.findComponent({ ref: 'filter' }).vm.aggregate({ clearPages: true })
 
@@ -358,18 +324,12 @@ describe('FilterText.vue', () => {
     const rootWrapper = createWrapper(wrapper.vm.$root)
     const spyRefreshRoute = jest.spyOn(wrapper.findComponent({ ref: 'filter' }).vm, 'refreshRoute')
 
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withContentType('type_01')).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withContentType('type_02')).commit()
-    await letData(es).have(new IndexedDocument('document_03', index)
-      .withContentType('type_02')).commit()
-    await letData(es).have(new IndexedDocument('document_04', index)
-      .withContentType('type_03')).commit()
-    await letData(es).have(new IndexedDocument('document_05', index)
-      .withContentType('type_03')).commit()
-    await letData(es).have(new IndexedDocument('document_06', index)
-      .withContentType('type_03')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withContentType('type_01')).commit()
+    await letData(es).have(new IndexedDocument('document_02', index).withContentType('type_02')).commit()
+    await letData(es).have(new IndexedDocument('document_03', index).withContentType('type_02')).commit()
+    await letData(es).have(new IndexedDocument('document_04', index).withContentType('type_03')).commit()
+    await letData(es).have(new IndexedDocument('document_05', index).withContentType('type_03')).commit()
+    await letData(es).have(new IndexedDocument('document_06', index).withContentType('type_03')).commit()
 
     await wrapper.findComponent({ ref: 'filter' }).vm.aggregate({ clearPages: true })
     await wrapper.find('.filter__items__item:nth-child(2) input').trigger('click')
@@ -394,8 +354,7 @@ describe('FilterText.vue', () => {
         filter: store.getters['search/getFilter']({ name: 'language' })
       }
     })
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withLanguage('ENGLISH')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withLanguage('ENGLISH')).commit()
     await wrapper.findComponent({ ref: 'filter' }).vm.aggregate({ clearPages: true })
 
     expect(wrapper.findAll('.filter__items__item')).toHaveLength(1)
@@ -414,8 +373,7 @@ describe('FilterText.vue', () => {
         filter: store.getters['search/getFilter']({ name: 'language' })
       }
     })
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withLanguage('WELSH')).commit()
+    await letData(es).have(new IndexedDocument('document_01', index).withLanguage('WELSH')).commit()
     await wrapper.findComponent({ ref: 'filter' }).vm.aggregate({ clearPages: true })
 
     expect(wrapper.findAll('.filter__items__item')).toHaveLength(1)
@@ -426,8 +384,7 @@ describe('FilterText.vue', () => {
     wrapper.setProps({ filter: find(store.getters['search/instantiatedFilters'], { name: 'extractionLevel' }) })
 
     await letData(es).have(new IndexedDocument('document_01', index)).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withParent('document_01')).commit()
+    await letData(es).have(new IndexedDocument('document_02', index).withParent('document_01')).commit()
     await wrapper.findComponent({ ref: 'filter' }).vm.aggregate({ clearPages: true })
 
     expect(wrapper.findAll('.filter__items__item')).toHaveLength(2)
@@ -448,8 +405,7 @@ describe('FilterText.vue', () => {
     })
 
     await letData(es).have(new IndexedDocument('document_01', index)).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withParent('document_01')).commit()
+    await letData(es).have(new IndexedDocument('document_02', index).withParent('document_01')).commit()
     await wrapper.findComponent({ ref: 'filter' }).vm.aggregate({ clearPages: true })
 
     expect(wrapper.findAll('.filter__items__item')).toHaveLength(2)
@@ -467,12 +423,15 @@ describe('FilterText.vue', () => {
   it('should remove "tag_01" from the tags filter on event "filter::delete"', async () => {
     wrapper.setProps({ filter: find(store.getters['search/instantiatedFilters'], { name: 'tags' }) })
 
-    await letData(es).have(new IndexedDocument('document_01', index)
-      .withTags(['tag_01'])).commit()
-    await letData(es).have(new IndexedDocument('document_02', index)
-      .withTags(['tag_02'])).commit()
-    await letData(es).have(new IndexedDocument('document_03', index)
-      .withTags(['tag_03'])).commit()
+    await letData(es)
+      .have(new IndexedDocument('document_01', index).withTags(['tag_01']))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('document_02', index).withTags(['tag_02']))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('document_03', index).withTags(['tag_03']))
+      .commit()
 
     await wrapper.findComponent({ ref: 'filter' }).vm.aggregate({ clearPages: true })
     expect(wrapper.findComponent({ ref: 'filter' }).vm.items).toHaveLength(3)

--- a/tests/unit/specs/components/filter/types/FilterYesNo.spec.js
+++ b/tests/unit/specs/components/filter/types/FilterYesNo.spec.js
@@ -12,10 +12,7 @@ import { Api } from '@/api'
 FilterStarred.methods.refreshRouteAndSearch = jest.fn()
 
 describe('FilterStarred.vue', () => {
-  const {
-    index,
-    es
-  } = esConnectionHelper.build()
+  const { index, es } = esConnectionHelper.build()
   let filter, mockAxios, api, store, i18n, localVue, router, wait
   let wrapper
 
@@ -64,8 +61,12 @@ describe('FilterStarred.vue', () => {
     await wrapper.findComponent({ ref: 'filter' }).vm.aggregate()
 
     expect(wrapper.findAll('.filter__items__item .custom-control-label .filter__items__item__label')).toHaveLength(2)
-    expect(wrapper.findAll('.filter__items__item').at(0).find('.custom-control-label .filter__items__item__label').text()).toBe('Starred')
-    expect(wrapper.findAll('.filter__items__item').at(1).find('.custom-control-label .filter__items__item__label').text()).toBe('Not starred')
+    expect(
+      wrapper.findAll('.filter__items__item').at(0).find('.custom-control-label .filter__items__item__label').text()
+    ).toBe('Starred')
+    expect(
+      wrapper.findAll('.filter__items__item').at(1).find('.custom-control-label .filter__items__item__label').text()
+    ).toBe('Not starred')
   })
 
   it('should change the selected value', async () => {
@@ -91,15 +92,19 @@ describe('FilterStarred.vue', () => {
 
   it('should fetch the starred documents', async () => {
     await letData(es).have(new IndexedDocument('document', index)).commit()
-    store.commit('starred/documents', [{
-      index,
-      id: 'document'
-    }])
+    store.commit('starred/documents', [
+      {
+        index,
+        id: 'document'
+      }
+    ])
     await flushPromises()
-    expect(wrapper.vm.starredDocuments).toEqual([{
-      index,
-      id: 'document'
-    }])
+    expect(wrapper.vm.starredDocuments).toEqual([
+      {
+        index,
+        id: 'document'
+      }
+    ])
   })
 
   it('should display the results count', async () => {

--- a/tests/unit/specs/components/widget/WidgetDocumentsByCreationDate.spec.js
+++ b/tests/unit/specs/components/widget/WidgetDocumentsByCreationDate.spec.js
@@ -24,12 +24,15 @@ describe('WidgetDocumentsByCreationDate.vue', () => {
   })
 
   it('should filter data where creation date < 1970', async () => {
-    await letData(es).have(new IndexedDocument('document_01', project)
-      .withCreationDate('2019-08-19T00:00:00.000Z')).commit()
-    await letData(es).have(new IndexedDocument('document_02', project)
-      .withCreationDate('0000-01-01T00:00:00.000Z')).commit()
-    await letData(es).have(new IndexedDocument('document_03', project)
-      .withCreationDate('1968-01-01T00:00:00.000Z')).commit()
+    await letData(es)
+      .have(new IndexedDocument('document_01', project).withCreationDate('2019-08-19T00:00:00.000Z'))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('document_02', project).withCreationDate('0000-01-01T00:00:00.000Z'))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('document_03', project).withCreationDate('1968-01-01T00:00:00.000Z'))
+      .commit()
 
     await wrapper.vm.loadData()
 
@@ -56,12 +59,15 @@ describe('WidgetDocumentsByCreationDate.vue', () => {
     })
 
     it('should change the value of the selectedInterval and reload data', async () => {
-      await letData(es).have(new IndexedDocument('document_01', project)
-        .withCreationDate('2019-08-01T00:00:00.000Z')).commit()
-      await letData(es).have(new IndexedDocument('document_02', project)
-        .withCreationDate('2019-07-01T00:00:00.000Z')).commit()
-      await letData(es).have(new IndexedDocument('document_03', project)
-        .withCreationDate('2019-06-01T00:00:00.000Z')).commit()
+      await letData(es)
+        .have(new IndexedDocument('document_01', project).withCreationDate('2019-08-01T00:00:00.000Z'))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('document_02', project).withCreationDate('2019-07-01T00:00:00.000Z'))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('document_03', project).withCreationDate('2019-06-01T00:00:00.000Z'))
+        .commit()
 
       await wrapper.vm.setSelectedInterval('year')
 
@@ -73,7 +79,10 @@ describe('WidgetDocumentsByCreationDate.vue', () => {
   describe('missing data', () => {
     it('should display no message if no data are missing', async () => {
       await wrapper.setData({
-        data: [{ date: new Date('2012-02'), doc_count: 2 }, { date: new Date('2012-03'), doc_count: 4 }],
+        data: [
+          { date: new Date('2012-02'), doc_count: 2 },
+          { date: new Date('2012-03'), doc_count: 4 }
+        ],
         missing: 0
       })
 
@@ -82,7 +91,10 @@ describe('WidgetDocumentsByCreationDate.vue', () => {
 
     it('should display a message if data are missing', async () => {
       await wrapper.setData({
-        data: [{ date: new Date('2012-02'), doc_count: 2 }, { date: new Date('2012-03'), doc_count: 4 }],
+        data: [
+          { date: new Date('2012-02'), doc_count: 2 },
+          { date: new Date('2012-03'), doc_count: 4 }
+        ],
         missing: 2
       })
 
@@ -90,12 +102,15 @@ describe('WidgetDocumentsByCreationDate.vue', () => {
     })
 
     it('should count missing creation dates while loading data', async () => {
-      await letData(es).have(new IndexedDocument('document_01', project)
-        .withCreationDate('2019-08-19T00:00:00.000Z')).commit()
-      await letData(es).have(new IndexedDocument('document_02', project)
-        .withCreationDate('0000-01-01T00:00:00.000Z')).commit()
-      await letData(es).have(new IndexedDocument('document_03', project)
-        .withCreationDate('1968-01-01T00:00:00.000Z')).commit()
+      await letData(es)
+        .have(new IndexedDocument('document_01', project).withCreationDate('2019-08-19T00:00:00.000Z'))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('document_02', project).withCreationDate('0000-01-01T00:00:00.000Z'))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('document_03', project).withCreationDate('1968-01-01T00:00:00.000Z'))
+        .commit()
 
       await wrapper.vm.loadData()
       await flushPromises()

--- a/tests/unit/specs/components/widget/WidgetListGroup.spec.js
+++ b/tests/unit/specs/components/widget/WidgetListGroup.spec.js
@@ -13,7 +13,7 @@ describe('WidgetListGroup.vue', () => {
   it('should be a Vue instance', async () => {
     const propsData = { widget: { content: '' } }
     const wrapper = shallowMount(WidgetListGroup, { localVue, store, propsData })
-    await new Promise(resolve => setImmediate(resolve))
+    await new Promise((resolve) => setImmediate(resolve))
 
     expect(wrapper).toBeTruthy()
   })
@@ -21,7 +21,7 @@ describe('WidgetListGroup.vue', () => {
   it('should have a `widget--list-group` class', async () => {
     const propsData = { widget: { content: '' } }
     const wrapper = shallowMount(WidgetListGroup, { localVue, store, propsData })
-    await new Promise(resolve => setImmediate(resolve))
+    await new Promise((resolve) => setImmediate(resolve))
 
     expect(wrapper.attributes('class')).toContain('widget--list-group')
   })
@@ -29,7 +29,7 @@ describe('WidgetListGroup.vue', () => {
   it('should contain a title with a `card-header` class', async () => {
     const propsData = { widget: { title: 'Hello world', card: true } }
     const wrapper = shallowMount(WidgetListGroup, { localVue, store, propsData })
-    await new Promise(resolve => setImmediate(resolve))
+    await new Promise((resolve) => setImmediate(resolve))
 
     expect(wrapper.find('.widget__header').attributes('class')).toContain('card-header')
   })
@@ -37,20 +37,16 @@ describe('WidgetListGroup.vue', () => {
   it('should contain a title without `card-header` class', async () => {
     const propsData = { widget: { title: 'Hello world', card: false } }
     const wrapper = shallowMount(WidgetListGroup, { localVue, store, propsData })
-    await new Promise(resolve => setImmediate(resolve))
+    await new Promise((resolve) => setImmediate(resolve))
 
     expect(wrapper.find('.widget__header').attributes('class')).not.toContain('card-header')
   })
 
   it('should contain a 3 items', async () => {
-    const items = [
-      { label: 'foo' },
-      { label: 'bar' },
-      { label: 'buz', description: 'a short description' }
-    ]
+    const items = [{ label: 'foo' }, { label: 'bar' }, { label: 'buz', description: 'a short description' }]
     const propsData = { widget: { title: 'Hello world', card: false, items } }
     const wrapper = shallowMount(WidgetListGroup, { localVue, store, propsData })
-    await new Promise(resolve => setImmediate(resolve))
+    await new Promise((resolve) => setImmediate(resolve))
 
     expect(wrapper.findAll('.widget__list__item')).toHaveLength(3)
     expect(wrapper.findAll('.widget__list__item').at(0).element.tagName).toBe('DIV')
@@ -60,12 +56,10 @@ describe('WidgetListGroup.vue', () => {
   })
 
   it('should contain a link', async () => {
-    const items = [
-      { label: 'foo', href: 'https://www.icij.org' }
-    ]
+    const items = [{ label: 'foo', href: 'https://www.icij.org' }]
     const propsData = { widget: { title: 'Hello world', card: false, items } }
     const wrapper = shallowMount(WidgetListGroup, { localVue, store, propsData })
-    await new Promise(resolve => setImmediate(resolve))
+    await new Promise((resolve) => setImmediate(resolve))
 
     expect(wrapper.findAll('.widget__list__item')).toHaveLength(1)
     expect(wrapper.findAll('.widget__list__item').at(0).element.tagName).toBe('A')
@@ -75,14 +69,14 @@ describe('WidgetListGroup.vue', () => {
 
   it('should reverse the list using a pipeline', async () => {
     const pipeline = 'widget-list-group-test-reverse'
-    store.commit('pipelines/register', { category: pipeline, type: items => items.reverse() })
+    store.commit('pipelines/register', { category: pipeline, type: (items) => items.reverse() })
     const items = [
       { label: 'foo', href: 'https://www.icij.org' },
       { label: 'bar', href: 'https://www.icij.org' }
     ]
     const propsData = { widget: { title: 'Hello world', card: false, items, pipeline } }
     const wrapper = shallowMount(WidgetListGroup, { localVue, store, propsData })
-    await new Promise(resolve => setImmediate(resolve))
+    await new Promise((resolve) => setImmediate(resolve))
 
     expect(wrapper.findAll('.widget__list__item').at(0).text()).toBe('bar')
     expect(wrapper.findAll('.widget__list__item').at(1).text()).toBe('foo')
@@ -96,7 +90,7 @@ describe('WidgetListGroup.vue', () => {
     })
     const propsData = { widget: { title: 'Hello world', card: false, pipeline } }
     const wrapper = shallowMount(WidgetListGroup, { localVue, store, propsData })
-    await new Promise(resolve => setImmediate(resolve))
+    await new Promise((resolve) => setImmediate(resolve))
 
     expect(wrapper.findAll('.widget__list__item').at(0).text()).toBe('foo')
     expect(wrapper.findAll('.widget__list__item').at(1).text()).toBe('bar')

--- a/tests/unit/specs/components/widget/WidgetText.spec.js
+++ b/tests/unit/specs/components/widget/WidgetText.spec.js
@@ -26,7 +26,7 @@ describe('WidgetText.vue', () => {
     const widget = { content: 'Hello world' }
     const propsData = { widget }
     const wrapper = shallowMount(WidgetText, { localVue, store, propsData })
-    await new Promise(resolve => setImmediate(resolve))
+    await new Promise((resolve) => setImmediate(resolve))
     expect(wrapper.find('.widget__content').text()).toBe('Hello world')
   })
 

--- a/tests/unit/specs/components/widget/WidgetTreeMap.spec.js
+++ b/tests/unit/specs/components/widget/WidgetTreeMap.spec.js
@@ -5,7 +5,9 @@ import WidgetTreeMap from '@/components/widget/WidgetTreeMap'
 
 jest.mock('@/api/elasticsearch', () => {
   return {
-    search: () => { return { aggregations: { byDirname: { buckets: [{ key: '/home/dev/data/folders', doc_count: 50 }] } } } }
+    search: () => {
+      return { aggregations: { byDirname: { buckets: [{ key: '/home/dev/data/folders', doc_count: 50 }] } } }
+    }
   }
 })
 
@@ -24,7 +26,9 @@ describe('WidgetTreeMap.vue', () => {
       localVue,
       store,
       propsData: { widget: {} },
-      data () { return { id: 'widget_tree_map' } }
+      data() {
+        return { id: 'widget_tree_map' }
+      }
     })
   })
 
@@ -45,7 +49,9 @@ describe('WidgetTreeMap.vue', () => {
       localVue,
       store,
       propsData,
-      data () { return { id: 'widget_tree_map' } }
+      data() {
+        return { id: 'widget_tree_map' }
+      }
     })
     expect(wrapper.find('.widget__header').text()).toBe('Hello world')
   })

--- a/tests/unit/specs/core/Core.spec.js
+++ b/tests/unit/specs/core/Core.spec.js
@@ -73,11 +73,15 @@ describe('Core', () => {
     expect(vm).toBeInstanceOf(Vue)
   })
 
-  it('should call a global event "datashare:ready" after the core is configured', done => {
-    document.addEventListener('datashare:ready', ({ detail }) => {
-      expect(Core.isInstanceOfCore(detail.core)).toBe(true)
-      done()
-    }, { once: true })
+  it('should call a global event "datashare:ready" after the core is configured', (done) => {
+    document.addEventListener(
+      'datashare:ready',
+      ({ detail }) => {
+        expect(Core.isInstanceOfCore(detail.core)).toBe(true)
+        done()
+      },
+      { once: true }
+    )
     // Create and configure the core
     Core.init(localVue, api).useAll().configure()
   })
@@ -97,9 +101,11 @@ describe('Core', () => {
     await core.configure()
 
     expect(mockAxios.request).toBeCalledTimes(4)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl(`/api/project/isDownloadAllowed/${project}`)
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl(`/api/project/isDownloadAllowed/${project}`)
+      })
+    )
   })
 
   it('should install the internal `VueCore` plugin', () => {
@@ -122,7 +128,7 @@ describe('Core', () => {
     expect(core.getDefaultProject()).toEqual('my_project')
   })
 
-  it('should return first user project when user doesn\'t have the default project', () => {
+  it("should return first user project when user doesn't have the default project", () => {
     const core = Core.init(localVue).useAll()
     core.config.set('groups_by_applications.datashare', ['user_project'])
     core.config.set('defaultProject', 'default_project')

--- a/tests/unit/specs/core/ProjectsMixin.spec.js
+++ b/tests/unit/specs/core/ProjectsMixin.spec.js
@@ -107,8 +107,10 @@ describe('ProjectsMixin', () => {
     core.config.set('defaultProject', defaultProject)
     core.createDefaultProject()
 
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl(`/api/index/${defaultProject}`)
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl(`/api/index/${defaultProject}`)
+      })
+    )
   })
 })

--- a/tests/unit/specs/mixins/polling.spec.js
+++ b/tests/unit/specs/mixins/polling.spec.js
@@ -2,9 +2,15 @@ import { createLocalVue, shallowMount } from '@vue/test-utils'
 import polling from '@/mixins/polling'
 
 // A few helper functions
-const flushPromises = () => new Promise(resolve => setImmediate(resolve))
-const flushPromisesAndPendingTimers = async () => { jest.runOnlyPendingTimers(); await flushPromises() }
-const flushPromisesAndAdvanceTimers = async time => { jest.advanceTimersByTime(time); await flushPromises() }
+const flushPromises = () => new Promise((resolve) => setImmediate(resolve))
+const flushPromisesAndPendingTimers = async () => {
+  jest.runOnlyPendingTimers()
+  await flushPromises()
+}
+const flushPromisesAndAdvanceTimers = async (time) => {
+  jest.advanceTimersByTime(time)
+  await flushPromises()
+}
 
 // Use fake timers to control times!
 // @see https://jestjs.io/fr/docs/timer-mocks

--- a/tests/unit/specs/mixins/shortkeys.spec.js
+++ b/tests/unit/specs/mixins/shortkeys.spec.js
@@ -37,11 +37,14 @@ describe('shortkeys mixin', () => {
   let wrapper
 
   beforeEach(() => {
-    wrapper = shallowMount(SearchDocumentNavbar, { localVue, store, router, mocks: { $t: msg => msg } })
+    wrapper = shallowMount(SearchDocumentNavbar, { localVue, store, router, mocks: { $t: (msg) => msg } })
   })
 
   it('should return the getShortkey object for "goToPreviousDocument" action', () => {
-    const result = { keys: { mac: ['meta', 'arrowleft'], default: ['ctrl', 'arrowleft'] }, action: 'goToPreviousDocument' }
+    const result = {
+      keys: { mac: ['meta', 'arrowleft'], default: ['ctrl', 'arrowleft'] },
+      action: 'goToPreviousDocument'
+    }
     expect(wrapper.vm.getShortkey('goToPreviousDocument')).toEqual(result)
   })
 

--- a/tests/unit/specs/pages/BatchDownload.spec.js
+++ b/tests/unit/specs/pages/BatchDownload.spec.js
@@ -20,97 +20,101 @@ describe('BatchDownload.vue', () => {
   })
   beforeEach(async () => {
     mockAxios.request.mockResolvedValue({
-      data: [{
-        name: 'BatchDownloadTask_01_name',
-        result: 'BatchDownloadTask_01_result',
-        progress: 1,
-        state: 'DONE',
-        user: {
-          id: 'test',
-          provider: 'test',
-          email: null,
-          name: null
+      data: [
+        {
+          name: 'BatchDownloadTask_01_name',
+          result: 'BatchDownloadTask_01_result',
+          progress: 1,
+          state: 'DONE',
+          user: {
+            id: 'test',
+            provider: 'test',
+            email: null,
+            name: null
+          },
+          properties: {
+            batchDownload: {
+              uuid: 'uuid_01',
+              encrypted: false,
+              filename: 'filename_01_2021-01-01T12:45:25',
+              query: 'query_01',
+              zipSize: 150,
+              exists: true,
+              project: {
+                name: 'project',
+                sourcePath: 'source'
+              },
+              user: {
+                id: 'test',
+                provider: 'test',
+                email: null,
+                name: null
+              }
+            }
+          }
         },
-        properties: {
-          batchDownload: {
-            uuid: 'uuid_01',
-            encrypted: false,
-            filename: 'filename_01_2021-01-01T12:45:25',
-            query: 'query_01',
-            zipSize: 150,
-            exists: true,
-            project: {
-              name: 'project',
-              sourcePath: 'source'
-            },
-            user: {
-              id: 'test',
-              provider: 'test',
-              email: null,
-              name: null
+        {
+          name: 'BatchDownloadTask_02_name',
+          result: 'BatchDownloadTask_02_result',
+          progress: 1,
+          state: 'DONE',
+          user: {
+            id: 'test',
+            provider: 'test',
+            email: null,
+            name: null
+          },
+          properties: {
+            batchDownload: {
+              uuid: 'uuid_02',
+              encrypted: true,
+              exists: false,
+              filename: 'filename_02_2020-01-01T19:50:00',
+              query: 'query_02',
+              project: {
+                name: 'project',
+                sourcePath: 'source'
+              },
+              user: {
+                id: 'test',
+                provider: 'test',
+                email: null,
+                name: null
+              }
+            }
+          }
+        },
+        {
+          name: 'BatchDownloadTask_03_name',
+          result: 'BatchDownloadTask_03_result',
+          progress: 0.5,
+          state: 'RUNNING',
+          user: {
+            id: 'test',
+            provider: 'test',
+            email: null,
+            name: null
+          },
+          properties: {
+            batchDownload: {
+              uuid: 'uuid_03',
+              encrypted: false,
+              filename: 'filename_03_2020-12-07T17:35:20',
+              query: 'query_03',
+              project: {
+                name: 'project',
+                sourcePath: 'source'
+              },
+              user: {
+                id: 'test',
+                provider: 'test',
+                email: null,
+                name: null
+              }
             }
           }
         }
-      }, {
-        name: 'BatchDownloadTask_02_name',
-        result: 'BatchDownloadTask_02_result',
-        progress: 1,
-        state: 'DONE',
-        user: {
-          id: 'test',
-          provider: 'test',
-          email: null,
-          name: null
-        },
-        properties: {
-          batchDownload: {
-            uuid: 'uuid_02',
-            encrypted: true,
-            exists: false,
-            filename: 'filename_02_2020-01-01T19:50:00',
-            query: 'query_02',
-            project: {
-              name: 'project',
-              sourcePath: 'source'
-            },
-            user: {
-              id: 'test',
-              provider: 'test',
-              email: null,
-              name: null
-            }
-          }
-        }
-      }, {
-        name: 'BatchDownloadTask_03_name',
-        result: 'BatchDownloadTask_03_result',
-        progress: 0.5,
-        state: 'RUNNING',
-        user: {
-          id: 'test',
-          provider: 'test',
-          email: null,
-          name: null
-        },
-        properties: {
-          batchDownload: {
-            uuid: 'uuid_03',
-            encrypted: false,
-            filename: 'filename_03_2020-12-07T17:35:20',
-            query: 'query_03',
-            project: {
-              name: 'project',
-              sourcePath: 'source'
-            },
-            user: {
-              id: 'test',
-              provider: 'test',
-              email: null,
-              name: null
-            }
-          }
-        }
-      }]
+      ]
     })
     wrapper = mount(BatchDownload, { i18n, localVue, store, wait })
     mockAxios.request.mockClear()
@@ -134,7 +138,9 @@ describe('BatchDownload.vue', () => {
   })
 
   it('should a message when zip is encrypted', async () => {
-    expect(wrapper.find('.tasks-list__tasks__item:nth-child(3) .tasks-list__tasks__item__encrypted').exists()).toBeTruthy()
+    expect(
+      wrapper.find('.tasks-list__tasks__item:nth-child(3) .tasks-list__tasks__item__encrypted').exists()
+    ).toBeTruthy()
   })
 
   it('should sort the list with pending tasks first then sort by datetime descending', async () => {

--- a/tests/unit/specs/pages/BatchSearch.spec.js
+++ b/tests/unit/specs/pages/BatchSearch.spec.js
@@ -16,25 +16,28 @@ describe('BatchSearch.vue', () => {
   beforeAll(async () => {
     api = new Api(null, null)
     api.getBatchSearches = jest.fn().mockResolvedValue({
-      items: [{
-        uuid: '1',
-        projects: [{ name: 'project_01' }, { name: 'project_02' }],
-        name: 'name_01',
-        description: 'description_01',
-        date: '2019-01-01',
-        nbResults: 2,
-        nbQueries: 1,
-        state: 'SUCCESS'
-      }, {
-        uuid: '2',
-        projects: [{ name: 'project_02' }],
-        name: 'name_02',
-        description: 'description_02',
-        date: '2019-01-01',
-        nbResults: 3,
-        nbQueries: 2,
-        state: 'FAILURE'
-      }],
+      items: [
+        {
+          uuid: '1',
+          projects: [{ name: 'project_01' }, { name: 'project_02' }],
+          name: 'name_01',
+          description: 'description_01',
+          date: '2019-01-01',
+          nbResults: 2,
+          nbQueries: 1,
+          state: 'SUCCESS'
+        },
+        {
+          uuid: '2',
+          projects: [{ name: 'project_02' }],
+          name: 'name_02',
+          description: 'description_02',
+          date: '2019-01-01',
+          nbResults: 3,
+          nbQueries: 2,
+          state: 'FAILURE'
+        }
+      ],
       total: 2
     })
     const core = Core.init(createLocalVue(), api).useAll()
@@ -70,7 +73,7 @@ describe('BatchSearch.vue', () => {
     expect(button.attributes().disabled).toBeTruthy()
   })
 
-  it('should display a \'No filtered result\' message when no items and filter is on', async () => {
+  it("should display a 'No filtered result' message when no items and filter is on", async () => {
     const state = { batchSearches: [] }
     const actions = { hasBatchSearch: jest.fn() }
     const store = new Vuex.Store({ modules: { batchSearch: { namespaced: true, state, actions } } })

--- a/tests/unit/specs/pages/BatchSearchResults.spec.js
+++ b/tests/unit/specs/pages/BatchSearchResults.spec.js
@@ -17,7 +17,8 @@ describe('BatchSearchResults.vue', () => {
       {
         name: 'batch-search.results',
         path: 'batch-search/:indices/:uuid'
-      }, {
+      },
+      {
         name: 'document-standalone',
         path: '/ds/:indices/:id/:routing?'
       }
@@ -40,7 +41,8 @@ describe('BatchSearchResults.vue', () => {
         query: 'query_01',
         project: 'batchsearchresults',
         rootId: 42
-      }, {
+      },
+      {
         creationDate: '2011-10-11T04:12:49.000+0000',
         documentId: 43,
         documentNumber: 1,
@@ -49,7 +51,8 @@ describe('BatchSearchResults.vue', () => {
         query: 'query_01',
         project: 'anotherbatchsearchresults',
         rootId: 43
-      }, {
+      },
+      {
         creationDate: '2011-10-11T04:12:49.000+0000',
         documentId: 44,
         documentNumber: 2,
@@ -177,17 +180,20 @@ describe('BatchSearchResults.vue', () => {
 
   it('should redirect to document including the search query', async () => {
     wrapper = mount(BatchSearchResults, { i18n, localVue, store, router, wait, propsData })
-    await wrapper.vm.$router.push({
-      name: 'batch-search.results',
-      params: { indices: project.concat(',', anotherProject), uuid: '12' },
-      query: { page: 1 }
-    }).catch(() => {})
+    await wrapper.vm.$router
+      .push({
+        name: 'batch-search.results',
+        params: { indices: project.concat(',', anotherProject), uuid: '12' },
+        query: { page: 1 }
+      })
+      .catch(() => {})
 
     await wrapper.vm.fetch()
 
     expect(wrapper.findAll('.batch-search-results__queries__query')).toHaveLength(3)
-    expect(wrapper.find('.batch-search-results__queries__query__link').attributes('href'))
-      .toBe(`#/ds/${project.concat(',', anotherProject)}/42/42?q=query_01`)
+    expect(wrapper.find('.batch-search-results__queries__query__link').attributes('href')).toBe(
+      `#/ds/${project.concat(',', anotherProject)}/42/42?q=query_01`
+    )
   })
 
   it('should cast queries param into array on beforeRouteEnter and beforeRouteUpdate', async () => {
@@ -198,7 +204,7 @@ describe('BatchSearchResults.vue', () => {
       query: { page: 1, queries: 'simple_text' }
     }
 
-    BatchSearchResults.beforeRouteEnter.call(wrapper.vm, toObject, undefined, fn => fn(wrapper.vm))
+    BatchSearchResults.beforeRouteEnter.call(wrapper.vm, toObject, undefined, (fn) => fn(wrapper.vm))
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.queries).toEqual(['simple_text'])
 
@@ -216,7 +222,7 @@ describe('BatchSearchResults.vue', () => {
       query: { page: 1, queries: 'simple_text' }
     }
 
-    BatchSearchResults.beforeRouteEnter.call(wrapper.vm, to, undefined, fn => fn(wrapper.vm))
+    BatchSearchResults.beforeRouteEnter.call(wrapper.vm, to, undefined, (fn) => fn(wrapper.vm))
     expect(wrapper.vm.$store.state.batchSearch.selectedQueries).toEqual([{ label: 'simple_text' }])
 
     wrapper.vm.$store.commit('batchSearch/selectedQueries', [])

--- a/tests/unit/specs/pages/DocumentView.spec.js
+++ b/tests/unit/specs/pages/DocumentView.spec.js
@@ -104,8 +104,9 @@ describe('DocumentView.vue', () => {
     await wrapper.vm.getDoc()
 
     expect(wrapper.findAll('.document .document__header__nav__item')).toHaveLength(4)
-    expect(wrapper.findAll('.document .document__header__nav__item').at(3).attributes('title'))
-      .toContain('Named Entities')
+    expect(wrapper.findAll('.document .document__header__nav__item').at(3).attributes('title')).toContain(
+      'Named Entities'
+    )
   })
 
   it('should NOT display the named entities tab', async () => {
@@ -115,8 +116,9 @@ describe('DocumentView.vue', () => {
     await wrapper.vm.getDoc()
 
     expect(wrapper.findAll('.document .document__header__nav__item')).toHaveLength(3)
-    expect(wrapper.findAll('.document .document__header__nav__item').at(2).attributes('title'))
-      .not.toContain('Named Entities')
+    expect(wrapper.findAll('.document .document__header__nav__item').at(2).attributes('title')).not.toContain(
+      'Named Entities'
+    )
   })
 
   it('should call the API to add document to history', async () => {
@@ -168,7 +170,7 @@ describe('DocumentView.vue', () => {
       core.registerPipeline({
         name: temporaryPipelineName,
         category: 'document-view-tabs',
-        type (tabs, document) {
+        type(tabs, document) {
           const tab = { name: 'tmp', label: 'Temporary' }
           return [...tabs, tab]
         }

--- a/tests/unit/specs/pages/Error.spec.js
+++ b/tests/unit/specs/pages/Error.spec.js
@@ -29,7 +29,7 @@ describe('Error.vue local mode', () => {
     const computed = { isServer: () => true }
     wrapper = shallowMount(Error, { i18n, localVue, computed })
     // Flush promises
-    await (new Promise(resolve => setImmediate(resolve)))
+    await new Promise((resolve) => setImmediate(resolve))
     // Render again
     expect(wrapper.find('.error__header').exists()).toBeTruthy()
   })
@@ -50,7 +50,7 @@ describe('Error.vue server mode', () => {
     // Mock the isServer property
     wrapper = shallowMount(Error, { i18n, localVue })
     // Flush promises
-    await (new Promise(resolve => setImmediate(resolve)))
+    await new Promise((resolve) => setImmediate(resolve))
     // Render again
     expect(wrapper.find('.error__header').exists()).toBeFalsy()
   })

--- a/tests/unit/specs/pages/Indexing.spec.js
+++ b/tests/unit/specs/pages/Indexing.spec.js
@@ -6,8 +6,11 @@ import Indexing from '@/pages/Indexing'
 
 // We use a custom flushPromises function with s`setImmediate`
 // which is not mocked by jest when using fake timers
-const flushPromises = () => new Promise(resolve => setImmediate(resolve))
-const flushPromisesAndPendingTimers = async () => { jest.runOnlyPendingTimers(); await flushPromises() }
+const flushPromises = () => new Promise((resolve) => setImmediate(resolve))
+const flushPromisesAndPendingTimers = async () => {
+  jest.runOnlyPendingTimers()
+  await flushPromises()
+}
 
 // Polling task list uses timers
 // @see https://jestjs.io/fr/docs/timer-mocks
@@ -116,16 +119,14 @@ describe('Indexing.vue', () => {
     const wrapper = mount(Indexing, { i18n, localVue, store, wait })
     await flushPromisesAndPendingTimers()
     await wrapper.vm.unregisteredPools()
-    store.commit('indexing/updateTasks', [
-      { name: 'foo.bar@123', progress: 0.5, state: 'RUNNING' }
-    ])
+    store.commit('indexing/updateTasks', [{ name: 'foo.bar@123', progress: 0.5, state: 'RUNNING' }])
     await flushPromises()
 
     mockAxios.request.mockClear()
     wrapper.find('.indexing__actions__stop-pending-tasks').trigger('click')
     await flushPromisesAndPendingTimers()
 
-    const calledUrls = mockAxios.request.mock.calls.map(call => call[0].url)
+    const calledUrls = mockAxios.request.mock.calls.map((call) => call[0].url)
     expect(calledUrls).toContain(Api.getFullUrl('/api/task/stopAll'))
   })
 
@@ -133,16 +134,14 @@ describe('Indexing.vue', () => {
     const wrapper = mount(Indexing, { i18n, localVue, store, wait })
     await flushPromisesAndPendingTimers()
     await wrapper.vm.unregisteredPools()
-    store.commit('indexing/updateTasks', [
-      { name: 'foo.bar@123', progress: 0.5, state: 'DONE' }
-    ])
+    store.commit('indexing/updateTasks', [{ name: 'foo.bar@123', progress: 0.5, state: 'DONE' }])
     await flushPromises()
 
     mockAxios.request.mockClear()
     wrapper.find('.indexing__actions__delete-done-tasks').trigger('click')
     await flushPromisesAndPendingTimers()
 
-    const calledUrls = mockAxios.request.mock.calls.map(call => call[0].url)
+    const calledUrls = mockAxios.request.mock.calls.map((call) => call[0].url)
     expect(calledUrls).toContain(Api.getFullUrl('/api/task/clean'))
   })
 
@@ -160,7 +159,7 @@ describe('Indexing.vue', () => {
     mockAxios.request.mockClear()
     wrapper.find('.tasks-list__tasks__item__stop').trigger('click')
     await flushPromisesAndPendingTimers()
-    const calledUrls = mockAxios.request.mock.calls.map(call => call[0].url)
+    const calledUrls = mockAxios.request.mock.calls.map((call) => call[0].url)
     const stopUrl = Api.getFullUrl('/api/task/stop/' + encodeURIComponent('foo.baz@456'))
     expect(calledUrls).toContain(stopUrl)
   })

--- a/tests/unit/specs/pages/Search.spec.js
+++ b/tests/unit/specs/pages/Search.spec.js
@@ -8,8 +8,11 @@ import Vuex from 'vuex'
 import { Core } from '@/core'
 import Search from '@/pages/Search'
 import { state, getters, mutations } from '@/store/modules/search'
-const flushPromises = () => new Promise(resolve => setImmediate(resolve))
-const flushPromisesAndAdvanceTimers = async time => { jest.advanceTimersByTime(time); await flushPromises() }
+const flushPromises = () => new Promise((resolve) => setImmediate(resolve))
+const flushPromisesAndAdvanceTimers = async (time) => {
+  jest.advanceTimersByTime(time)
+  await flushPromises()
+}
 
 describe('Search.vue', () => {
   let store

--- a/tests/unit/specs/pages/UserHistory.spec.js
+++ b/tests/unit/specs/pages/UserHistory.spec.js
@@ -35,33 +35,36 @@ describe('UserHistory.vue', () => {
   beforeEach(() => {
     mockAxios.request.mockClear()
     mockAxios.request.mockResolvedValue({
-      data: [{
-        id: 'id_01',
-        user: {
-          id: 'user',
-          name: null,
-          email: null,
-          provider: 'local'
+      data: [
+        {
+          id: 'id_01',
+          user: {
+            id: 'user',
+            name: null,
+            email: null,
+            provider: 'local'
+          },
+          creationDate: 'creation_date_01',
+          modificationDate: 'modification_date_01',
+          type: 'DOCUMENT',
+          name: 'name_01',
+          uri: 'uri_01'
         },
-        creationDate: 'creation_date_01',
-        modificationDate: 'modification_date_01',
-        type: 'DOCUMENT',
-        name: 'name_01',
-        uri: 'uri_01'
-      }, {
-        id: 'id_02',
-        user: {
-          id: 'user',
-          name: null,
-          email: null,
-          provider: 'local'
-        },
-        creationDate: 'creation_date_02',
-        modificationDate: 'modification_date_02',
-        type: 'SEARCH',
-        name: 'name_02',
-        uri: 'uri_02'
-      }]
+        {
+          id: 'id_02',
+          user: {
+            id: 'user',
+            name: null,
+            email: null,
+            provider: 'local'
+          },
+          creationDate: 'creation_date_02',
+          modificationDate: 'modification_date_02',
+          type: 'SEARCH',
+          name: 'name_02',
+          uri: 'uri_02'
+        }
+      ]
     })
   })
 
@@ -76,15 +79,17 @@ describe('UserHistory.vue', () => {
     wrapper = await shallowMount(UserHistory, { i18n, localVue, router, store, wait })
     await wrapper.vm.$nextTick()
     expect(mockAxios.request).toBeCalledTimes(2)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/users/me/history'),
-      method: 'GET',
-      params: {
-        from: 0,
-        size: 100,
-        type: 'document'
-      }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/users/me/history'),
+        method: 'GET',
+        params: {
+          from: 0,
+          size: 100,
+          type: 'document'
+        }
+      })
+    )
   })
 
   it('should call delete user history api function is called', async () => {
@@ -94,12 +99,14 @@ describe('UserHistory.vue', () => {
     await wrapper.vm.$nextTick()
 
     expect(mockAxios.request).toBeCalledTimes(2)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/users/me/history'),
-      method: 'DELETE',
-      params: {
-        type: 'document'
-      }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/users/me/history'),
+        method: 'DELETE',
+        params: {
+          type: 'document'
+        }
+      })
+    )
   })
 })

--- a/tests/unit/specs/pages/UserHistoryDocument.spec.js
+++ b/tests/unit/specs/pages/UserHistoryDocument.spec.js
@@ -7,33 +7,36 @@ import UserHistoryDocument from '@/pages/UserHistoryDocument'
 describe('UserHistoryDocument.vue', () => {
   const { i18n, localVue, router } = Core.init(createLocalVue()).useAll()
   const propsData = {
-    events: [{
-      id: 'id_01',
-      user: {
-        id: 'user',
-        name: null,
-        email: null,
-        provider: 'local'
+    events: [
+      {
+        id: 'id_01',
+        user: {
+          id: 'user',
+          name: null,
+          email: null,
+          provider: 'local'
+        },
+        creationDate: 'creation_date_01',
+        modificationDate: 'modification_date_01',
+        type: 'DOCUMENT',
+        name: 'name_01',
+        uri: 'uri_01'
       },
-      creationDate: 'creation_date_01',
-      modificationDate: 'modification_date_01',
-      type: 'DOCUMENT',
-      name: 'name_01',
-      uri: 'uri_01'
-    }, {
-      id: 'id_02',
-      user: {
-        id: 'user',
-        name: null,
-        email: null,
-        provider: 'local'
-      },
-      creationDate: 'creation_date_02',
-      modificationDate: 'modification_date_02',
-      type: 'DOCUMENT',
-      name: 'name_02',
-      uri: 'uri_02'
-    }]
+      {
+        id: 'id_02',
+        user: {
+          id: 'user',
+          name: null,
+          email: null,
+          provider: 'local'
+        },
+        creationDate: 'creation_date_02',
+        modificationDate: 'modification_date_02',
+        type: 'DOCUMENT',
+        name: 'name_02',
+        uri: 'uri_02'
+      }
+    ]
   }
   let wrapper = null
 

--- a/tests/unit/specs/pages/UserHistorySearch.spec.js
+++ b/tests/unit/specs/pages/UserHistorySearch.spec.js
@@ -4,33 +4,36 @@ import { Core } from '@/core'
 import UserHistorySearch from '@/pages/UserHistorySearch'
 
 const propsData = {
-  events: [{
-    id: 'id_01',
-    user: {
-      id: 'user',
-      name: null,
-      email: null,
-      provider: 'local'
+  events: [
+    {
+      id: 'id_01',
+      user: {
+        id: 'user',
+        name: null,
+        email: null,
+        provider: 'local'
+      },
+      creationDate: 'creation_date_01',
+      modificationDate: 'modification_date_01',
+      type: 'SEARCH',
+      name: 'name_01',
+      uri: 'uri_01'
     },
-    creationDate: 'creation_date_01',
-    modificationDate: 'modification_date_01',
-    type: 'SEARCH',
-    name: 'name_01',
-    uri: 'uri_01'
-  }, {
-    id: 'id_02',
-    user: {
-      id: 'user',
-      name: null,
-      email: null,
-      provider: 'local'
-    },
-    creationDate: 'creation_date_02',
-    modificationDate: 'modification_date_02',
-    type: 'SEARCH',
-    name: 'name_02',
-    uri: 'uri_02'
-  }]
+    {
+      id: 'id_02',
+      user: {
+        id: 'user',
+        name: null,
+        email: null,
+        provider: 'local'
+      },
+      creationDate: 'creation_date_02',
+      modificationDate: 'modification_date_02',
+      type: 'SEARCH',
+      name: 'name_02',
+      uri: 'uri_02'
+    }
+  ]
 }
 
 describe('UserHistorySearch.vue', () => {
@@ -78,12 +81,14 @@ describe('UserHistorySearch.vue', () => {
     await wrapper.vm.$nextTick()
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/users/me/history/event'),
-      method: 'DELETE',
-      params: {
-        id: event.id
-      }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/users/me/history/event'),
+        method: 'DELETE',
+        params: {
+          id: event.id
+        }
+      })
+    )
   })
 })

--- a/tests/unit/specs/store/filters/FilterNamedEntity.spec.js
+++ b/tests/unit/specs/store/filters/FilterNamedEntity.spec.js
@@ -4,7 +4,11 @@ import bodybuilder from 'bodybuilder'
 describe('FilterNamedEntity.js', () => {
   it('should filter on existing category', () => {
     const filter = new FilterNamedEntity({})
-    const q = filter.queryBuilder(bodybuilder(), { name: 'namedEntityLocation', reverse: false, values: ['luxembourg'] }, 'query')
+    const q = filter.queryBuilder(
+      bodybuilder(),
+      { name: 'namedEntityLocation', reverse: false, values: ['luxembourg'] },
+      'query'
+    )
     expect(JSON.stringify(q.build())).toContain('{"query_string":{"default_field":"category","query":"LOCATION"}}')
   })
 

--- a/tests/unit/specs/store/filters/FilterPath.spec.js
+++ b/tests/unit/specs/store/filters/FilterPath.spec.js
@@ -5,12 +5,16 @@ describe('FilterPath.js', () => {
   it('should add slash to path in json if path doesnt have one', () => {
     const filter = new FilterPath({})
     const q = filter.queryBuilder(bodybuilder(), { name: 'path', values: ['/home/foo/bar'] }, 'query')
-    expect(JSON.stringify(q.build())).toContain('{\"query\":{\"bool\":{\"query\":{\"term\":{\"dirname.tree\":\"/home/foo/bar\"}}}}}')
+    expect(JSON.stringify(q.build())).toContain(
+      '{"query":{"bool":{"query":{"term":{"dirname.tree":"/home/foo/bar"}}}}}'
+    )
   })
 
   it('should NOT add slash to path in json if path already have one', () => {
     const filter = new FilterPath({})
     const q = filter.queryBuilder(bodybuilder(), { name: 'path', values: ['/home/foo/bar/'] }, 'query')
-    expect(JSON.stringify(q.build())).toContain('{\"query\":{\"bool\":{\"query\":{\"term\":{\"dirname.tree\":\"/home/foo/bar\"}}}}}')
+    expect(JSON.stringify(q.build())).toContain(
+      '{"query":{"bool":{"query":{"term":{"dirname.tree":"/home/foo/bar"}}}}}'
+    )
   })
 })

--- a/tests/unit/specs/store/index.spec.js
+++ b/tests/unit/specs/store/index.spec.js
@@ -5,7 +5,7 @@ describe('store', () => {
     expect(store).toBeInstanceOf(Object)
   })
 
-  it('shouldn\'t be in strict mode', () => {
+  it("shouldn't be in strict mode", () => {
     expect(store.strict).toBeFalsy()
   })
 

--- a/tests/unit/specs/store/modules/batchSearch.spec.js
+++ b/tests/unit/specs/store/modules/batchSearch.spec.js
@@ -31,9 +31,11 @@ describe('BatchSearchStore', () => {
       await store.dispatch('batchSearch/getBatchSearch', 12)
 
       expect(mockAxiosApi.request).toBeCalledTimes(1)
-      expect(mockAxiosApi.request).toBeCalledWith(expect.objectContaining({
-        url: Api.getFullUrl('/api/batch/search/12')
-      }))
+      expect(mockAxiosApi.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl('/api/batch/search/12')
+        })
+      )
       expect(store.state.batchSearch.batchSearch.name).toBe('This is my batchSearch')
 
       mockAxiosApi.request.mockReturnValue({ data: {} })
@@ -63,28 +65,54 @@ describe('BatchSearchStore', () => {
       expect(store.getters['batchSearch/queryKeys']).toEqual([
         { label: 'query1', count: 0 },
         { label: 'query2', count: 2 },
-        { label: 'query3', count: 1 }])
+        { label: 'query3', count: 1 }
+      ])
     })
 
     it('should retrieve all the batchSearches', async () => {
-      mockAxiosApi.request.mockResolvedValue({ data: { items: ['batchSearch_01', 'batchSearch_02', 'batchSearch_03'], total: 3 } })
-      const data = { from: 0, size: 10, sort: 'batch_date', order: 'asc', query: '*', field: 'all', batchDate: [], project: [], state: [], publishState: null }
+      mockAxiosApi.request.mockResolvedValue({
+        data: { items: ['batchSearch_01', 'batchSearch_02', 'batchSearch_03'], total: 3 }
+      })
+      const data = {
+        from: 0,
+        size: 10,
+        sort: 'batch_date',
+        order: 'asc',
+        query: '*',
+        field: 'all',
+        batchDate: [],
+        project: [],
+        state: [],
+        publishState: null
+      }
 
       await store.dispatch('batchSearch/getBatchSearches', data)
 
       expect(mockAxiosApi.request).toBeCalledTimes(1)
-      expect(mockAxiosApi.request).toBeCalledWith(expect.objectContaining({
-        data,
-        method: 'POST',
-        url: Api.getFullUrl('/api/batch/search')
-      }))
+      expect(mockAxiosApi.request).toBeCalledWith(
+        expect.objectContaining({
+          data,
+          method: 'POST',
+          url: Api.getFullUrl('/api/batch/search')
+        })
+      )
       expect(store.state.batchSearch.batchSearches).toHaveLength(3)
 
       mockAxiosApi.request.mockResolvedValue({ data: {} })
     })
 
     it('should submit the new batchSearch form with complete information', async () => {
-      await store.dispatch('batchSearch/onSubmit', { name: 'name', csvFile: 'csvFile', description: 'description', projects: ['project1', 'project2'], phraseMatch: false, fuzziness: 2, fileTypes: [{ mime: 'pdf' }, { mime: 'csv' }], paths: ['/a/path/to/home', '/another/path'], published: false })
+      await store.dispatch('batchSearch/onSubmit', {
+        name: 'name',
+        csvFile: 'csvFile',
+        description: 'description',
+        projects: ['project1', 'project2'],
+        phraseMatch: false,
+        fuzziness: 2,
+        fileTypes: [{ mime: 'pdf' }, { mime: 'csv' }],
+        paths: ['/a/path/to/home', '/another/path'],
+        published: false
+      })
 
       const data = new FormData()
       data.append('name', 'name')
@@ -100,16 +128,31 @@ describe('BatchSearchStore', () => {
       data.append('paths', '/another/path')
       data.append('published', false)
       expect(mockAxiosApi.request).toBeCalledTimes(2)
-      expect(mockAxiosApi.request).toBeCalledWith(expect.objectContaining({
-        data,
-        method: 'POST',
-        url: Api.getFullUrl('/api/batch/search/project1,project2')
-      }))
-      expect(mockAxiosApi.request).toBeCalledWith(expect.objectContaining({
-        data: { from: 0, size: 100, sort: 'batch_date', order: 'asc', query: '*', field: 'all', batchDate: null, project: [], state: [], publishState: null },
-        method: 'POST',
-        url: Api.getFullUrl('/api/batch/search')
-      }))
+      expect(mockAxiosApi.request).toBeCalledWith(
+        expect.objectContaining({
+          data,
+          method: 'POST',
+          url: Api.getFullUrl('/api/batch/search/project1,project2')
+        })
+      )
+      expect(mockAxiosApi.request).toBeCalledWith(
+        expect.objectContaining({
+          data: {
+            from: 0,
+            size: 100,
+            sort: 'batch_date',
+            order: 'asc',
+            query: '*',
+            field: 'all',
+            batchDate: null,
+            project: [],
+            state: [],
+            publishState: null
+          },
+          method: 'POST',
+          url: Api.getFullUrl('/api/batch/search')
+        })
+      )
     })
 
     it('should retrieve a batchSearch results according to its id', async () => {
@@ -118,10 +161,12 @@ describe('BatchSearchStore', () => {
       await store.dispatch('batchSearch/getBatchSearchResults', { batchId: 12 })
 
       expect(mockAxiosApi.request).toBeCalledTimes(1)
-      expect(mockAxiosApi.request).toBeCalledWith(expect.objectContaining({
-        url: Api.getFullUrl('/api/batch/search/result/12'),
-        method: 'POST'
-      }))
+      expect(mockAxiosApi.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl('/api/batch/search/result/12'),
+          method: 'POST'
+        })
+      )
       expect(store.state.batchSearch.results).toHaveLength(1)
       expect(store.state.batchSearch.results[0].documentId).toBe(12)
       expect(store.state.batchSearch.results[0].rootId).toBe(42)
@@ -131,15 +176,21 @@ describe('BatchSearchStore', () => {
     })
 
     it('should delete a specific batchSearch', async () => {
-      store.state.batchSearch.batchSearches = [{ uuid: 'batchSearch_01' }, { uuid: 'batchSearch_02' }, { uuid: 'batchSearch_03' }]
+      store.state.batchSearch.batchSearches = [
+        { uuid: 'batchSearch_01' },
+        { uuid: 'batchSearch_02' },
+        { uuid: 'batchSearch_03' }
+      ]
 
       await store.dispatch('batchSearch/deleteBatchSearch', { batchId: 'batchSearch_01' })
 
       expect(mockAxiosApi.request).toBeCalledTimes(1)
-      expect(mockAxiosApi.request).toBeCalledWith(expect.objectContaining({
-        url: Api.getFullUrl('/api/batch/search/batchSearch_01'),
-        method: 'DELETE'
-      }))
+      expect(mockAxiosApi.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl('/api/batch/search/batchSearch_01'),
+          method: 'DELETE'
+        })
+      )
       expect(store.state.batchSearch.batchSearches).toEqual([{ uuid: 'batchSearch_02' }, { uuid: 'batchSearch_03' }])
     })
 
@@ -149,10 +200,12 @@ describe('BatchSearchStore', () => {
       await store.dispatch('batchSearch/deleteBatchSearches')
 
       expect(mockAxiosApi.request).toBeCalledTimes(1)
-      expect(mockAxiosApi.request).toBeCalledWith(expect.objectContaining({
-        url: Api.getFullUrl('/api/batch/search'),
-        method: 'DELETE'
-      }))
+      expect(mockAxiosApi.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl('/api/batch/search'),
+          method: 'DELETE'
+        })
+      )
       expect(store.state.batchSearch.batchSearches).toEqual([])
     })
   })

--- a/tests/unit/specs/store/modules/document.spec.js
+++ b/tests/unit/specs/store/modules/document.spec.js
@@ -60,7 +60,7 @@ describe('DocumentStore', () => {
     expect(store.state.document.parentDocument.id).toBe(routing)
   })
 
-  it('should get the document\'s named entities', async () => {
+  it("should get the document's named entities", async () => {
     await letData(es).have(new IndexedDocument(id, index).withNer('naz')).commit()
     await store.dispatch('document/get', { id, index })
     await store.dispatch('document/getFirstPageForNamedEntityInAllCategories')
@@ -69,11 +69,15 @@ describe('DocumentStore', () => {
     expect(store.getters['document/namedEntities'][0].raw._routing).toBe(id)
   })
 
-  it('should get only the not hidden document\'s named entities', async () => {
-    await letData(es).have(new IndexedDocument(id, index)
-      .withNer('entity_01', 42, 'ORGANIZATION', false)
-      .withNer('entity_02', 43, 'ORGANIZATION', true)
-      .withNer('entity_03', 44, 'ORGANIZATION', false)).commit()
+  it("should get only the not hidden document's named entities", async () => {
+    await letData(es)
+      .have(
+        new IndexedDocument(id, index)
+          .withNer('entity_01', 42, 'ORGANIZATION', false)
+          .withNer('entity_02', 43, 'ORGANIZATION', true)
+          .withNer('entity_03', 44, 'ORGANIZATION', false)
+      )
+      .commit()
     await store.dispatch('document/get', { id, index })
 
     await store.dispatch('document/getFirstPageForNamedEntityInAllCategories')
@@ -86,7 +90,7 @@ describe('DocumentStore', () => {
   })
 
   describe('Manage tags', () => {
-    it('should get the document\'s tags', async () => {
+    it("should get the document's tags", async () => {
       const tags = ['tag_01', 'tag_02']
       mockAxiosApi.request.mockReturnValue({ data: tags })
       await letData(es).have(new IndexedDocument(id, index).withTags(tags)).commit()
@@ -104,17 +108,22 @@ describe('DocumentStore', () => {
 
       mockAxiosApi.request.mockClear()
 
-      await store.dispatch('document/tag', { documents: [{ id: 'doc_01' }, { id: 'doc_02' }], tag: 'tag_01 tag_02 tag_03' })
+      await store.dispatch('document/tag', {
+        documents: [{ id: 'doc_01' }, { id: 'doc_02' }],
+        tag: 'tag_01 tag_02 tag_03'
+      })
 
       expect(mockAxiosApi.request).toBeCalledTimes(1)
-      expect(mockAxiosApi.request).toBeCalledWith(expect.objectContaining({
-        url: Api.getFullUrl(`/api/${index}/documents/batchUpdate/tag`),
-        method: 'POST',
-        data: {
-          docIds: ['doc_01', 'doc_02'],
-          tags: ['tag_01', 'tag_02', 'tag_03']
-        }
-      }))
+      expect(mockAxiosApi.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl(`/api/${index}/documents/batchUpdate/tag`),
+          method: 'POST',
+          data: {
+            docIds: ['doc_01', 'doc_02'],
+            tags: ['tag_01', 'tag_02', 'tag_03']
+          }
+        })
+      )
     })
 
     it('should tag multiple documents and not refresh and no document is selected in the store', async () => {
@@ -134,14 +143,16 @@ describe('DocumentStore', () => {
       await store.dispatch('document/tag', { documents: [document01, document02], tag: 'tag_01 tag_02 tag_03' })
 
       expect(mockAxiosApi.request).toBeCalledTimes(1)
-      expect(mockAxiosApi.request).toBeCalledWith(expect.objectContaining({
-        url: Api.getFullUrl(`/api/${index}/documents/batchUpdate/tag`),
-        method: 'POST',
-        data: {
-          docIds: ['doc_01', 'doc_02'],
-          tags: ['tag_01', 'tag_02', 'tag_03']
-        }
-      }))
+      expect(mockAxiosApi.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl(`/api/${index}/documents/batchUpdate/tag`),
+          method: 'POST',
+          data: {
+            docIds: ['doc_01', 'doc_02'],
+            tags: ['tag_01', 'tag_02', 'tag_03']
+          }
+        })
+      )
     })
     it('should tag a single doc with a userId user', async () => {
       await store.dispatch('document/tag', { documents: [{ id: 'doc_01' }], tag: 'tag_01', userId: 'user' })
@@ -161,14 +172,16 @@ describe('DocumentStore', () => {
       await store.dispatch('document/deleteTag', { documents: [{ id: 'doc_01' }], tag: { label: 'tag_01' } })
 
       expect(mockAxiosApi.request).toBeCalledTimes(1)
-      expect(mockAxiosApi.request).toBeCalledWith(expect.objectContaining({
-        url: Api.getFullUrl(`/api/${index}/documents/batchUpdate/untag`),
-        method: 'POST',
-        data: {
-          docIds: ['doc_01'],
-          tags: ['tag_01']
-        }
-      }))
+      expect(mockAxiosApi.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl(`/api/${index}/documents/batchUpdate/untag`),
+          method: 'POST',
+          data: {
+            docIds: ['doc_01'],
+            tags: ['tag_01']
+          }
+        })
+      )
     })
 
     it('should add tags to the store', () => {
@@ -220,11 +233,13 @@ describe('DocumentStore', () => {
       await store.dispatch('document/toggleAsRecommended', userId)
 
       expect(mockAxiosApi.request).toBeCalledTimes(1)
-      expect(mockAxiosApi.request).toBeCalledWith(expect.objectContaining({
-        url: Api.getFullUrl(`/api/${index}/documents/batchUpdate/recommend`),
-        method: 'POST',
-        data: ['doc_01']
-      }))
+      expect(mockAxiosApi.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl(`/api/${index}/documents/batchUpdate/recommend`),
+          method: 'POST',
+          data: ['doc_01']
+        })
+      )
       expect(store.state.document.isRecommended).toBeTruthy()
       expect(store.state.document.recommendedBy).toEqual([userId])
     })
@@ -241,31 +256,46 @@ describe('DocumentStore', () => {
       await store.dispatch('document/toggleAsRecommended')
 
       expect(mockAxiosApi.request).toBeCalledTimes(1)
-      expect(mockAxiosApi.request).toBeCalledWith(expect.objectContaining({
-        url: Api.getFullUrl(`/api/${index}/documents/batchUpdate/unrecommend`),
-        method: 'POST',
-        data: ['doc_01']
-      }))
+      expect(mockAxiosApi.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl(`/api/${index}/documents/batchUpdate/unrecommend`),
+          method: 'POST',
+          data: ['doc_01']
+        })
+      )
       expect(store.state.document.isRecommended).toBeFalsy()
       expect(indexOf(store.state.document.recommendedBy, userId)).toBe(-1)
     })
 
     it('should retrieve the list of users who recommended it and set it to the store', async () => {
-      const users = { aggregates: [{ item: { id: 'user_01' }, doc_count: 1 }, { item: { id: 'user_02' }, doc_count: 1 }] }
+      const users = {
+        aggregates: [
+          { item: { id: 'user_01' }, doc_count: 1 },
+          { item: { id: 'user_02' }, doc_count: 1 }
+        ]
+      }
       mockAxiosApi.request.mockReturnValue({ data: users })
       await letData(es).have(new IndexedDocument('doc_01', index)).commit()
       await store.dispatch('document/get', { id: 'doc_01', index })
       await store.dispatch('document/getRecommendationsByDocuments')
 
       expect(mockAxiosApi.request).toBeCalledTimes(1)
-      expect(mockAxiosApi.request).toBeCalledWith(expect.objectContaining({
-        url: Api.getFullUrl(`/api/users/recommendationsby?project=${index}&docIds=doc_01`)
-      }))
+      expect(mockAxiosApi.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl(`/api/users/recommendationsby?project=${index}&docIds=doc_01`)
+        })
+      )
       expect(store.state.document.recommendedBy).toEqual(['user_01', 'user_02'])
     })
 
     it('should sort users by alphabetical order of id', async () => {
-      const users = { aggregates: [{ item: { id: 'user_01' }, doc_count: 1 }, { item: { id: 'user_03' }, doc_count: 1 }, { item: { id: 'user_02' }, doc_count: 1 }] }
+      const users = {
+        aggregates: [
+          { item: { id: 'user_01' }, doc_count: 1 },
+          { item: { id: 'user_03' }, doc_count: 1 },
+          { item: { id: 'user_02' }, doc_count: 1 }
+        ]
+      }
       mockAxiosApi.request.mockReturnValue({ data: users })
       await letData(es).have(new IndexedDocument('doc_01', index)).commit()
       await store.dispatch('document/get', { id: 'doc_01', index })

--- a/tests/unit/specs/store/modules/documentNotes.spec.js
+++ b/tests/unit/specs/store/modules/documentNotes.spec.js
@@ -1,4 +1,3 @@
-
 import { Api } from '@/api'
 import { storeBuilder } from '@/store/storeBuilder'
 
@@ -48,7 +47,10 @@ describe('DocumentNotesStore', () => {
       ]
     })
 
-    const notes = await store.dispatch('documentNotes/filterNotesByPath', { project, path: '/this/is/a/path/to/document.txt' })
+    const notes = await store.dispatch('documentNotes/filterNotesByPath', {
+      project,
+      path: '/this/is/a/path/to/document.txt'
+    })
 
     expect(notes).toHaveLength(3)
   })

--- a/tests/unit/specs/store/modules/indexing.spec.js
+++ b/tests/unit/specs/store/modules/indexing.spec.js
@@ -36,26 +36,30 @@ describe('IndexingStore', () => {
     await store.dispatch('indexing/submitExtract')
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/task/batchUpdate/index/file'),
-      method: 'POST',
-      data: {
-        options: expect.objectContaining({ ocr: false, filter: true })
-      }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/task/batchUpdate/index/file'),
+        method: 'POST',
+        data: {
+          options: expect.objectContaining({ ocr: false, filter: true })
+        }
+      })
+    )
   })
 
   it('should execute a default find named entities action', async () => {
     await store.dispatch('indexing/submitFindNamedEntities')
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/task/findNames/CORENLP'),
-      method: 'POST',
-      data: {
-        options: expect.objectContaining({ syncModels: true })
-      }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/task/findNames/CORENLP'),
+        method: 'POST',
+        data: {
+          options: expect.objectContaining({ syncModels: true })
+        }
+      })
+    )
   })
 
   it('should stop pending tasks', async () => {
@@ -66,25 +70,31 @@ describe('IndexingStore', () => {
 
     expect(store.state.indexing.tasks).toHaveLength(0)
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/task/stopAll'),
-      method: 'PUT'
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/task/stopAll'),
+        method: 'PUT'
+      })
+    )
   })
 
   it('should stop the task named 456', async () => {
-    store.commit('indexing/updateTasks', [{ name: 'foo.bar@123', progress: 0.5, state: 'RUNNING' },
-      { name: 'foo.bar@456', progress: 0.7, state: 'RUNNING' }])
+    store.commit('indexing/updateTasks', [
+      { name: 'foo.bar@123', progress: 0.5, state: 'RUNNING' },
+      { name: 'foo.bar@456', progress: 0.7, state: 'RUNNING' }
+    ])
     expect(store.state.indexing.tasks).toHaveLength(2)
 
     await store.dispatch('indexing/stopTask', 'foo.bar@123')
 
     expect(store.state.indexing.tasks).toHaveLength(1)
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl(`/api/task/stop/${encodeURIComponent('foo.bar@123')}`),
-      method: 'PUT'
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl(`/api/task/stop/${encodeURIComponent('foo.bar@123')}`),
+        method: 'PUT'
+      })
+    )
   })
 
   it('should delete done tasks', async () => {
@@ -95,10 +105,12 @@ describe('IndexingStore', () => {
 
     expect(store.state.indexing.tasks).toHaveLength(0)
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/task/clean'),
-      method: 'POST'
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/task/clean'),
+        method: 'POST'
+      })
+    )
   })
 
   it('should reset the extracting form', () => {
@@ -125,18 +137,22 @@ describe('IndexingStore', () => {
     await store.dispatch('indexing/deleteAll')
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl(`/api/project/${project}`),
-      method: 'DELETE'
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl(`/api/project/${project}`),
+        method: 'DELETE'
+      })
+    )
   })
 
   it('should retrieve the NER pipelines', async () => {
     await store.dispatch('indexing/getNerPipelines')
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/ner/pipelines')
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/ner/pipelines')
+      })
+    )
   })
 })

--- a/tests/unit/specs/store/modules/pipelines.spec.js
+++ b/tests/unit/specs/store/modules/pipelines.spec.js
@@ -24,7 +24,7 @@ describe('PipelinesStore', () => {
 
   it('should register a pipeline with a function', () => {
     const name = 'test-pl-with-function'
-    const type = value => value.toUpperCase()
+    const type = (value) => value.toUpperCase()
     store.commit('pipelines/register', { name, type })
     const pipeline = store.getters['pipelines/getInstantiatedPipelineByName'](name)
     expect(pipeline).toBeInstanceOf(SimplePipeline)
@@ -33,7 +33,7 @@ describe('PipelinesStore', () => {
 
   it('should register a pipeline with a function', () => {
     class Type {
-      apply (value) {
+      apply(value) {
         return value.toUpperCase()
       }
     }
@@ -111,8 +111,8 @@ describe('PipelinesStore', () => {
 
   it('should have ordered pipelines', () => {
     const category = 'test-category-ordered-case'
-    store.commit('pipelines/register', { category, type: s => s.toLowerCase() })
-    store.commit('pipelines/register', { category, type: s => s.toUpperCase() })
+    store.commit('pipelines/register', { category, type: (s) => s.toLowerCase() })
+    store.commit('pipelines/register', { category, type: (s) => s.toUpperCase() })
     const pipelines = store.getters['pipelines/getPipelineChainByCategory'](category)
     expect(pipelines).toHaveLength(2)
     expect(pipelines.reduce((res, fn) => fn(res), 'foo BAR')).toBe('FOO BAR')
@@ -121,8 +121,8 @@ describe('PipelinesStore', () => {
 
   it('should have ordered pipelines', () => {
     const category = 'test-category-ordered-case-with-property'
-    store.commit('pipelines/register', { category, type: s => s.toLowerCase(), order: 10 })
-    store.commit('pipelines/register', { category, type: s => s.toUpperCase(), order: 5 })
+    store.commit('pipelines/register', { category, type: (s) => s.toLowerCase(), order: 10 })
+    store.commit('pipelines/register', { category, type: (s) => s.toUpperCase(), order: 5 })
     const pipelines = store.getters['pipelines/getPipelineChainByCategory'](category)
     expect(pipelines).toHaveLength(2)
     expect(pipelines.reduce((res, fn) => fn(res), 'foo BAR')).toBe('foo bar')

--- a/tests/unit/specs/store/modules/recommended.spec.js
+++ b/tests/unit/specs/store/modules/recommended.spec.js
@@ -39,13 +39,15 @@ describe('RecommendedStore', () => {
     await store.dispatch('recommended/getDocumentsRecommendedBy', ['user_01', 'user_02'])
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl(`/api/${index}/documents/recommendations`),
-      method: 'GET',
-      params: {
-        userids: 'user_01,user_02'
-      }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl(`/api/${index}/documents/recommendations`),
+        method: 'GET',
+        params: {
+          userids: 'user_01,user_02'
+        }
+      })
+    )
     expect(store.state.recommended.documents).toEqual(['document_01', 'document_02', 'document_03'])
   })
 
@@ -69,18 +71,29 @@ describe('RecommendedStore', () => {
   })
 
   it('should return users who recommended documents from this project', async () => {
-    mockAxios.request.mockResolvedValue({ data: { aggregates: [{ item: { id: 'user_01' }, count: 1 }, { item: { id: 'user_02' }, count: 1 }] } })
+    mockAxios.request.mockResolvedValue({
+      data: {
+        aggregates: [
+          { item: { id: 'user_01' }, count: 1 },
+          { item: { id: 'user_02' }, count: 1 }
+        ]
+      }
+    })
     mockAxios.request.mockClear()
     await store.dispatch('recommended/fetchIndicesRecommendations')
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/users/recommendations'),
-      method: 'GET',
-      params: { project: index }
-    }))
-    expect(store.state.recommended.byUsers)
-      .toEqual([{ user: 'user_01', count: 1 }, { user: 'user_02', count: 1 }])
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/users/recommendations'),
+        method: 'GET',
+        params: { project: index }
+      })
+    )
+    expect(store.state.recommended.byUsers).toEqual([
+      { user: 'user_01', count: 1 },
+      { user: 'user_02', count: 1 }
+    ])
   })
 
   it('should return the total of documents recommended for this project', async () => {
@@ -89,11 +102,13 @@ describe('RecommendedStore', () => {
     await store.dispatch('recommended/fetchIndicesRecommendations')
 
     expect(mockAxios.request).toBeCalledTimes(1)
-    expect(mockAxios.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/users/recommendations'),
-      method: 'GET',
-      params: { project: index }
-    }))
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/users/recommendations'),
+        method: 'GET',
+        params: { project: index }
+      })
+    )
     expect(store.state.recommended.total).toBe(42)
   })
 })

--- a/tests/unit/specs/store/modules/search.spec.js
+++ b/tests/unit/specs/store/modules/search.spec.js
@@ -260,8 +260,9 @@ describe('SearchStore', () => {
   })
 
   it('should return 2 documents', async () => {
-    await letData(es).have(new IndexedDocuments().setBaseName('doc').withContent('this is a document')
-      .withIndex(project).count(4)).commit()
+    await letData(es)
+      .have(new IndexedDocuments().setBaseName('doc').withContent('this is a document').withIndex(project).count(4))
+      .commit()
 
     await store.dispatch('search/query', { query: 'document', from: 0, size: 2 })
     expect(store.state.search.response.hits).toHaveLength(2)
@@ -269,8 +270,9 @@ describe('SearchStore', () => {
   })
 
   it('should return 3 documents', async () => {
-    await letData(es).have(new IndexedDocuments().setBaseName('doc').withContent('this is a document')
-      .withIndex(project).count(4)).commit()
+    await letData(es)
+      .have(new IndexedDocuments().setBaseName('doc').withContent('this is a document').withIndex(project).count(4))
+      .commit()
 
     await store.dispatch('search/query', { query: 'document', from: 0, size: 3 })
     expect(store.state.search.response.hits).toHaveLength(3)
@@ -278,8 +280,9 @@ describe('SearchStore', () => {
   })
 
   it('should return 1 document (1/3)', async () => {
-    await letData(es).have(new IndexedDocuments().setBaseName('doc').withContent('this is a document')
-      .withIndex(project).count(4)).commit()
+    await letData(es)
+      .have(new IndexedDocuments().setBaseName('doc').withContent('this is a document').withIndex(project).count(4))
+      .commit()
 
     await store.dispatch('search/query', { query: 'document', from: 3, size: 3 })
     expect(store.state.search.response.hits).toHaveLength(1)
@@ -292,8 +295,9 @@ describe('SearchStore', () => {
   })
 
   it('should return 5 documents in total', async () => {
-    await letData(es).have(new IndexedDocuments().setBaseName('doc').withContent('this is a document')
-      .withIndex(project).count(5)).commit()
+    await letData(es)
+      .have(new IndexedDocuments().setBaseName('doc').withContent('this is a document').withIndex(project).count(5))
+      .commit()
 
     await store.dispatch('search/query', { query: 'document', from: 0, size: 2 })
     expect(store.state.search.response.total).toBe(5)
@@ -301,8 +305,13 @@ describe('SearchStore', () => {
   })
 
   it('should return the default query parameters', () => {
-    expect(store.getters['search/toRouteQuery']())
-      .toMatchObject({ field: 'all', indices: project, q: '', size: 25, from: 0 })
+    expect(store.getters['search/toRouteQuery']()).toMatchObject({
+      field: 'all',
+      indices: project,
+      q: '',
+      size: 25,
+      from: 0
+    })
   })
 
   it('should return an advanced and filtered query parameters', () => {
@@ -312,8 +321,14 @@ describe('SearchStore', () => {
     store.commit('search/sort', 'randomOrder')
     store.commit('search/addFilterValue', { name: 'contentType', value: 'TXT' })
 
-    expect(store.getters['search/toRouteQuery']())
-      .toMatchObject({ indices: project, q: 'datashare', from: 0, size: 12, sort: 'randomOrder', 'f[contentType]': ['TXT'] })
+    expect(store.getters['search/toRouteQuery']()).toMatchObject({
+      indices: project,
+      q: 'datashare',
+      from: 0,
+      size: 12,
+      sort: 'randomOrder',
+      'f[contentType]': ['TXT']
+    })
 
     store.commit('search/size', 25)
   })
@@ -389,7 +404,7 @@ describe('SearchStore', () => {
     })
   })
 
-  it('should not delete the term from the query if it doesn\'t exist', async () => {
+  it("should not delete the term from the query if it doesn't exist", async () => {
     store.commit('search/query', '*')
     await store.dispatch('search/deleteQueryTerm', 'term')
 
@@ -454,138 +469,137 @@ describe('SearchStore', () => {
     it('should retrieve 1 applied filter', () => {
       store.commit('search/query', 'term_01')
 
-      expect(store.getters['search/retrieveQueryTerms'])
-        .toEqual([{ field: '', label: 'term_01', negation: false, regex: false }])
+      expect(store.getters['search/retrieveQueryTerms']).toEqual([
+        { field: '', label: 'term_01', negation: false, regex: false }
+      ])
     })
 
     it('should retrieve 2 applied filters', () => {
       store.commit('search/query', 'term_01 term_02')
 
-      expect(store.getters['search/retrieveQueryTerms'])
-        .toEqual([
-          { field: '', label: 'term_01', negation: false, regex: false },
-          { field: '', label: 'term_02', negation: false, regex: false }
-        ])
+      expect(store.getters['search/retrieveQueryTerms']).toEqual([
+        { field: '', label: 'term_01', negation: false, regex: false },
+        { field: '', label: 'term_02', negation: false, regex: false }
+      ])
     })
 
     it('should retrieve 3 applied filters', () => {
       store.commit('search/query', 'term_01 term_02 term_03')
 
-      expect(store.getters['search/retrieveQueryTerms'])
-        .toEqual([
-          { field: '', label: 'term_01', negation: false, regex: false },
-          { field: '', label: 'term_02', negation: false, regex: false },
-          { field: '', label: 'term_03', negation: false, regex: false }
-        ])
+      expect(store.getters['search/retrieveQueryTerms']).toEqual([
+        { field: '', label: 'term_01', negation: false, regex: false },
+        { field: '', label: 'term_02', negation: false, regex: false },
+        { field: '', label: 'term_03', negation: false, regex: false }
+      ])
     })
 
     it('should merge 2 identical terms', () => {
       store.commit('search/query', 'term_01 term_01')
 
-      expect(store.getters['search/retrieveQueryTerms'])
-        .toEqual([{ field: '', label: 'term_01', negation: false, regex: false }])
+      expect(store.getters['search/retrieveQueryTerms']).toEqual([
+        { field: '', label: 'term_01', negation: false, regex: false }
+      ])
     })
 
     it('should filter on boolean operators "AND" and "OR"', () => {
       store.commit('search/query', 'term_01 AND term_02 OR term_03')
 
-      expect(store.getters['search/retrieveQueryTerms'])
-        .toEqual([
-          { field: '', label: 'term_01', negation: false, regex: false },
-          { field: '', label: 'term_02', negation: false, regex: false },
-          { field: '', label: 'term_03', negation: false, regex: false }
-        ])
+      expect(store.getters['search/retrieveQueryTerms']).toEqual([
+        { field: '', label: 'term_01', negation: false, regex: false },
+        { field: '', label: 'term_02', negation: false, regex: false },
+        { field: '', label: 'term_03', negation: false, regex: false }
+      ])
     })
 
     it('should not split an exact search sentence', () => {
       store.commit('search/query', 'term_01 "and an exact term" term_02')
 
-      expect(store.getters['search/retrieveQueryTerms'])
-        .toEqual([
-          { field: '', label: 'term_01', negation: false, regex: false },
-          { field: '', label: 'and an exact term', negation: false, regex: false },
-          { field: '', label: 'term_02', negation: false, regex: false }
-        ])
+      expect(store.getters['search/retrieveQueryTerms']).toEqual([
+        { field: '', label: 'term_01', negation: false, regex: false },
+        { field: '', label: 'and an exact term', negation: false, regex: false },
+        { field: '', label: 'term_02', negation: false, regex: false }
+      ])
     })
 
     it('should display field name', () => {
       store.commit('search/query', 'field_name:term_01')
 
-      expect(store.getters['search/retrieveQueryTerms'])
-        .toEqual([{ field: 'field_name', label: 'term_01', negation: false, regex: false }])
+      expect(store.getters['search/retrieveQueryTerms']).toEqual([
+        { field: 'field_name', label: 'term_01', negation: false, regex: false }
+      ])
     })
 
     it('should return a negation parameter according to the prefix', () => {
       store.commit('search/query', '-term_01 +term_02 !term_03')
 
-      expect(store.getters['search/retrieveQueryTerms'])
-        .toEqual([
-          { field: '', label: 'term_01', negation: true, regex: false },
-          { field: '', label: 'term_02', negation: false, regex: false },
-          { field: '', label: 'term_03', negation: true, regex: false }
-        ])
+      expect(store.getters['search/retrieveQueryTerms']).toEqual([
+        { field: '', label: 'term_01', negation: true, regex: false },
+        { field: '', label: 'term_02', negation: false, regex: false },
+        { field: '', label: 'term_03', negation: true, regex: false }
+      ])
     })
 
     it('should return a negation parameter if query starts by "NOT"', () => {
       store.commit('search/query', 'NOT term_01')
 
-      expect(store.getters['search/retrieveQueryTerms'])
-        .toEqual([{ field: '', label: 'term_01', negation: true, regex: false }])
+      expect(store.getters['search/retrieveQueryTerms']).toEqual([
+        { field: '', label: 'term_01', negation: true, regex: false }
+      ])
     })
 
     it('should return a negation parameter if query contains "AND NOT" or "OR NOT"', () => {
       store.commit('search/query', 'term_01 AND NOT term_02 NOT term_03')
 
-      expect(store.getters['search/retrieveQueryTerms'])
-        .toEqual([
-          { field: '', label: 'term_01', negation: false, regex: false },
-          { field: '', label: 'term_02', negation: true, regex: false },
-          { field: '', label: 'term_03', negation: true, regex: false }
-        ])
+      expect(store.getters['search/retrieveQueryTerms']).toEqual([
+        { field: '', label: 'term_01', negation: false, regex: false },
+        { field: '', label: 'term_02', negation: true, regex: false },
+        { field: '', label: 'term_03', negation: true, regex: false }
+      ])
     })
 
     it('should remove escaped slash', () => {
       store.commit('search/query', 'term\\:other')
 
-      expect(store.getters['search/retrieveQueryTerms'])
-        .toEqual([{ field: '', label: 'term:other', negation: false, regex: false }])
+      expect(store.getters['search/retrieveQueryTerms']).toEqual([
+        { field: '', label: 'term:other', negation: false, regex: false }
+      ])
     })
 
     it('should grab terms between brackets', () => {
       store.commit('search/query', 'term_01 (term_02 AND -term_03) term_04')
 
-      expect(store.getters['search/retrieveQueryTerms'])
-        .toEqual([
-          { field: '', label: 'term_01', negation: false, regex: false },
-          { field: '', label: 'term_02', negation: false, regex: false },
-          { field: '', label: 'term_03', negation: true, regex: false },
-          { field: '', label: 'term_04', negation: false, regex: false }
-        ])
+      expect(store.getters['search/retrieveQueryTerms']).toEqual([
+        { field: '', label: 'term_01', negation: false, regex: false },
+        { field: '', label: 'term_02', negation: false, regex: false },
+        { field: '', label: 'term_03', negation: true, regex: false },
+        { field: '', label: 'term_04', negation: false, regex: false }
+      ])
     })
 
     it('should apply the negation only to the second group', () => {
       store.commit('search/query', '(term_01 term_02) NOT term_03')
 
-      expect(store.getters['search/retrieveQueryTerms'])
-        .toEqual([
-          { field: '', label: 'term_01', negation: false, regex: false },
-          { field: '', label: 'term_02', negation: false, regex: false },
-          { field: '', label: 'term_03', negation: true, regex: false }
-        ])
+      expect(store.getters['search/retrieveQueryTerms']).toEqual([
+        { field: '', label: 'term_01', negation: false, regex: false },
+        { field: '', label: 'term_02', negation: false, regex: false },
+        { field: '', label: 'term_03', negation: true, regex: false }
+      ])
     })
 
     it('should detect regex and return it as true', () => {
       store.commit('search/query', '/test and.*/')
 
-      expect(store.getters['search/retrieveQueryTerms'])
-        .toEqual([{ field: '', label: 'test and.*', negation: false, regex: true }])
+      expect(store.getters['search/retrieveQueryTerms']).toEqual([
+        { field: '', label: 'test and.*', negation: false, regex: true }
+      ])
     })
 
     it('should replace escaped arobase in regex', () => {
       store.commit('search/query', '/.*\\@.*/')
 
-      expect(store.getters['search/retrieveQueryTerms'])
-        .toEqual([{ field: '', label: '.*@.*', negation: false, regex: true }])
+      expect(store.getters['search/retrieveQueryTerms']).toEqual([
+        { field: '', label: '.*@.*', negation: false, regex: true }
+      ])
     })
   })
 
@@ -678,8 +692,12 @@ describe('SearchStore', () => {
   })
 
   it('should find document on querying the NamedEntity with a complex query', async () => {
-    await letData(es).have(new IndexedDocument('doc_01', project).withContent('test of ner_01').withNer('ner_01')).commit()
-    await letData(es).have(new IndexedDocument('doc_02', project).withContent('test of ner_02').withNer('ner_02')).commit()
+    await letData(es)
+      .have(new IndexedDocument('doc_01', project).withContent('test of ner_01').withNer('ner_01'))
+      .commit()
+    await letData(es)
+      .have(new IndexedDocument('doc_02', project).withContent('test of ner_02').withNer('ner_02'))
+      .commit()
     await letData(es).have(new IndexedDocument('doc_03', project).withContent('no content').withNer('test')).commit()
 
     await store.dispatch('search/query', '(test AND ner_*) OR test')

--- a/tests/unit/specs/store/modules/searchfilters.spec.js
+++ b/tests/unit/specs/store/modules/searchfilters.spec.js
@@ -55,7 +55,7 @@ describe('SearchFilters', () => {
     })
 
     it('should find a "contentType" filter using function', () => {
-      expect(store.getters['search/getFilter'](f => f.name === 'contentType')).toBeDefined()
+      expect(store.getters['search/getFilter']((f) => f.name === 'contentType')).toBeDefined()
     })
 
     it('should count 2 documents of type "type_01"', async () => {
@@ -69,7 +69,9 @@ describe('SearchFilters', () => {
     })
 
     it('should use contentType (without charset)', async () => {
-      await letData(es).have(new IndexedDocument('document', project).withContentType('text/plain; charset=UTF-8')).commit()
+      await letData(es)
+        .have(new IndexedDocument('document', project).withContentType('text/plain; charset=UTF-8'))
+        .commit()
 
       const response = await store.dispatch('search/queryFilter', { name: 'contentType' })
 
@@ -145,9 +147,15 @@ describe('SearchFilters', () => {
     })
 
     it('should return the indexing date buckets', async () => {
-      await letData(es).have(new IndexedDocument('doc_01.txt', project).withIndexingDate('2018-04-04T20:20:20.001Z')).commit()
-      await letData(es).have(new IndexedDocument('doc_02.txt', project).withIndexingDate('2018-04-06T20:20:20.001Z')).commit()
-      await letData(es).have(new IndexedDocument('doc_03.txt', project).withIndexingDate('2018-05-04T20:20:20.001Z')).commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_01.txt', project).withIndexingDate('2018-04-04T20:20:20.001Z'))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_02.txt', project).withIndexingDate('2018-04-06T20:20:20.001Z'))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_03.txt', project).withIndexingDate('2018-05-04T20:20:20.001Z'))
+        .commit()
 
       const response = await store.dispatch('search/queryFilter', { name, options: { size: 8 } })
 
@@ -170,10 +178,18 @@ describe('SearchFilters', () => {
     })
 
     it('should aggregate only the not hidden named entities for PERSON category', async () => {
-      await letData(es).have(new IndexedDocument('doc_01.csv', project).withNer('entity_01', 42, 'PERSON', false)).commit()
-      await letData(es).have(new IndexedDocument('doc_02.csv', project).withNer('entity_01', 43, 'PERSON', false)).commit()
-      await letData(es).have(new IndexedDocument('doc_03.csv', project).withNer('entity_02', 44, 'PERSON', true)).commit()
-      await letData(es).have(new IndexedDocument('doc_04.csv', project).withNer('entity_03', 45, 'PERSON', false)).commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_01.csv', project).withNer('entity_01', 42, 'PERSON', false))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_02.csv', project).withNer('entity_01', 43, 'PERSON', false))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_03.csv', project).withNer('entity_02', 44, 'PERSON', true))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_04.csv', project).withNer('entity_03', 45, 'PERSON', false))
+        .commit()
 
       const response = await store.dispatch('search/queryFilter', { name: 'namedEntityPerson' })
 
@@ -185,9 +201,15 @@ describe('SearchFilters', () => {
     })
 
     it('should aggregate named entities for LOCATION category', async () => {
-      await letData(es).have(new IndexedDocument('doc_01.csv', project).withNer('entity_01', 42, 'LOCATION', false)).commit()
-      await letData(es).have(new IndexedDocument('doc_02.csv', project).withNer('entity_02', 43, 'LOCATION', false)).commit()
-      await letData(es).have(new IndexedDocument('doc_03.csv', project).withNer('entity_03', 44, 'ORGANIZATION', true)).commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_01.csv', project).withNer('entity_01', 42, 'LOCATION', false))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_02.csv', project).withNer('entity_02', 43, 'LOCATION', false))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_03.csv', project).withNer('entity_03', 44, 'ORGANIZATION', true))
+        .commit()
 
       const response = await store.dispatch('search/queryFilter', { name: 'namedEntityLocation', category: 'LOCATION' })
 
@@ -195,11 +217,20 @@ describe('SearchFilters', () => {
     })
 
     it('should aggregate named entities for ORGANIZATION category', async () => {
-      await letData(es).have(new IndexedDocument('doc_01.csv', project).withNer('entity_01', 42, 'ORGANIZATION', false)).commit()
-      await letData(es).have(new IndexedDocument('doc_02.csv', project).withNer('entity_02', 43, 'ORGANIZATION', false)).commit()
-      await letData(es).have(new IndexedDocument('doc_03.csv', project).withNer('entity_03', 44, 'PERSON', true)).commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_01.csv', project).withNer('entity_01', 42, 'ORGANIZATION', false))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_02.csv', project).withNer('entity_02', 43, 'ORGANIZATION', false))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_03.csv', project).withNer('entity_03', 44, 'PERSON', true))
+        .commit()
 
-      const response = await store.dispatch('search/queryFilter', { name: 'namedEntityOrganization', category: 'ORGANIZATION' })
+      const response = await store.dispatch('search/queryFilter', {
+        name: 'namedEntityOrganization',
+        category: 'ORGANIZATION'
+      })
 
       expect(response.aggregations.byMentions.buckets).toHaveLength(2)
     })
@@ -209,10 +240,12 @@ describe('SearchFilters', () => {
     const name = 'creationDate'
 
     it('should merge all missing data', async () => {
-      await letData(es).have(new IndexedDocument('doc_01', project)
-        .withCreationDate('2018-04-01T00:00:00.001Z')).commit()
-      await letData(es).have(new IndexedDocument('doc_02', project)
-        .withCreationDate('2018-05-01T00:00:00.001Z')).commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_01', project).withCreationDate('2018-04-01T00:00:00.001Z'))
+        .commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_02', project).withCreationDate('2018-05-01T00:00:00.001Z'))
+        .commit()
       await letData(es).have(new IndexedDocument('doc_03', project)).commit()
       await letData(es).have(new IndexedDocument('doc_04', project)).commit()
 
@@ -228,8 +261,9 @@ describe('SearchFilters', () => {
     })
 
     it('should count only Document types and not the NamedEntities', async () => {
-      await letData(es).have(new IndexedDocument('doc_01', project)
-        .withCreationDate('2018-04-01T00:00:00.001Z').withNer('term_01')).commit()
+      await letData(es)
+        .have(new IndexedDocument('doc_01', project).withCreationDate('2018-04-01T00:00:00.001Z').withNer('term_01'))
+        .commit()
 
       const response = await store.dispatch('search/queryFilter', { name, options: { size: 8 } })
 

--- a/tests/unit/specs/store/modules/settings.spec.js
+++ b/tests/unit/specs/store/modules/settings.spec.js
@@ -18,20 +18,24 @@ describe('SettingsStore', () => {
     store.dispatch('settings/getSettings')
 
     expect(mockAxiosApi.request).toBeCalledTimes(1)
-    expect(mockAxiosApi.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/settings')
-    }))
+    expect(mockAxiosApi.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/settings')
+      })
+    )
   })
 
   it('should send the settings modifications', () => {
     store.dispatch('settings/onSubmit', { foo: 'bar' })
 
     expect(mockAxiosApi.request).toBeCalledTimes(1)
-    expect(mockAxiosApi.request).toBeCalledWith(expect.objectContaining({
-      url: Api.getFullUrl('/api/settings'),
-      method: 'PATCH',
-      data: { data: { foo: 'bar' } },
-      headers: { 'Content-Type': 'application/json' }
-    }))
+    expect(mockAxiosApi.request).toBeCalledWith(
+      expect.objectContaining({
+        url: Api.getFullUrl('/api/settings'),
+        method: 'PATCH',
+        data: { data: { foo: 'bar' } },
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
   })
 })

--- a/tests/unit/specs/store/modules/starred.spec.js
+++ b/tests/unit/specs/store/modules/starred.spec.js
@@ -67,13 +67,9 @@ describe('StarredStore', () => {
       { index, id: 12 },
       { index, id: 42 }
     ])
-    store.commit('starred/removeDocuments', [
-      { index, id: 42 }
-    ])
+    store.commit('starred/removeDocuments', [{ index, id: 42 }])
 
-    expect(store.state.starred.documents).toEqual([
-      { index, id: 12 }
-    ])
+    expect(store.state.starred.documents).toEqual([{ index, id: 12 }])
   })
 
   it('should push a documentId from the list of the starredDocuments', () => {
@@ -153,11 +149,8 @@ describe('StarredStore', () => {
       { index, id: 'doc_03' }
     ])
 
-    await store.dispatch('starred/unstarDocuments', [
-      { index, id: 'doc_01' }])
+    await store.dispatch('starred/unstarDocuments', [{ index, id: 'doc_01' }])
 
-    expect(store.state.starred.documents).toEqual([
-      { index, id: 'doc_03' }
-    ])
+    expect(store.state.starred.documents).toEqual([{ index, id: 'doc_03' }])
   })
 })

--- a/tests/unit/specs/utils/esConnectionHelper.js
+++ b/tests/unit/specs/utils/esConnectionHelper.js
@@ -4,7 +4,7 @@ import elasticsearch from 'elasticsearch-browser'
 import esMapping from './datashare_index_mappings.json'
 import esSettings from './datashare_index_settings.json'
 
-function slugger (value) {
+function slugger(value) {
   return value
     .toLowerCase()
     .trim()
@@ -12,14 +12,14 @@ function slugger (value) {
     .replace(/\s/g, '-')
 }
 
-function esConnectionHelper (indexOrIndices = []) {
+function esConnectionHelper(indexOrIndices = []) {
   jest.setTimeout(1e4)
   const indices = castArray(indexOrIndices)
 
   beforeAll(async () => {
     await Promise.all(
-      map(indices, async index => {
-        if (!await es.indices.exists({ index })) {
+      map(indices, async (index) => {
+        if (!(await es.indices.exists({ index }))) {
           await es.indices.create({ index, body: { settings: esSettings, mappings: esMapping } })
         }
       })
@@ -27,7 +27,12 @@ function esConnectionHelper (indexOrIndices = []) {
   })
 
   beforeEach(async () => {
-    await es.deleteByQuery({ index: join(indices), conflicts: 'proceed', refresh: true, body: { query: { match_all: {} } } })
+    await es.deleteByQuery({
+      index: join(indices),
+      conflicts: 'proceed',
+      refresh: true,
+      body: { query: { match_all: {} } }
+    })
     // Easy Tiger! Elasticsearch can hardly follow
     await setTimeout(noop, 5000)
   })
@@ -39,7 +44,7 @@ function esConnectionHelper (indexOrIndices = []) {
   return indices
 }
 
-function build (prefix = 'spec') {
+function build(prefix = 'spec') {
   const randomKey = Math.random().toString(36).slice(2)
   const randomIndex = [prefix, randomKey, uniqueId()].map(slugger).join('-')
   const [index] = esConnectionHelper(randomIndex)

--- a/tests/unit/specs/utils/highlight.spec.js
+++ b/tests/unit/specs/utils/highlight.spec.js
@@ -21,13 +21,20 @@ describe('Highlight', () => {
 
   it('should hightlight "foo" and "bar"', () => {
     const content = 'foo, bar, baz'
-    const highlighted = Highlight.create({ content }).ranges([{ start: 0, length: 3 }, { start: 5, length: 3 }])
+    const highlighted = Highlight.create({ content }).ranges([
+      { start: 0, length: 3 },
+      { start: 5, length: 3 }
+    ])
     expect(highlighted).toBe('<mark>foo</mark>, <mark>bar</mark>, baz')
   })
 
   it('should hightlight "foo", "bar" and "baz"', () => {
     const content = 'foo, bar, baz'
-    const highlighted = Highlight.create({ content }).ranges([{ start: 0, length: 3 }, { start: 5, length: 3 }, { start: 10, length: 3 }])
+    const highlighted = Highlight.create({ content }).ranges([
+      { start: 0, length: 3 },
+      { start: 5, length: 3 },
+      { start: 10, length: 3 }
+    ])
     expect(highlighted).toBe('<mark>foo</mark>, <mark>bar</mark>, <mark>baz</mark>')
   })
 
@@ -39,14 +46,14 @@ describe('Highlight', () => {
 
   it('should hightlight one "bar" with a custom class', () => {
     const content = 'foo, bar, baz'
-    const each = m => `<mark class="local-mark">${m.content}</mark>`
+    const each = (m) => `<mark class="local-mark">${m.content}</mark>`
     const highlighted = Highlight.create({ content, each }).ranges([{ start: 5, length: 3 }])
     expect(highlighted).toBe('foo, <mark class="local-mark">bar</mark>, baz')
   })
 
   it('should hightlight "foo" and "bar" with a category class', () => {
     const content = 'foo, bar, baz'
-    const each = m => `<mark class="${m.category}">${m.content}</mark>`
+    const each = (m) => `<mark class="${m.category}">${m.content}</mark>`
     const highlighted = Highlight.create({ content, each }).ranges([
       { start: 0, length: 3, category: 'person' },
       { start: 5, length: 3, category: 'location' }

--- a/tests/unit/specs/utils/strings.spec.js
+++ b/tests/unit/specs/utils/strings.spec.js
@@ -7,7 +7,7 @@ describe('strings', () => {
       expect(content).toBe('Lorem ipsum <mark class="local-search-term">dolor</mark>')
     })
 
-    it('shouldn\'t wrap anything', () => {
+    it("shouldn't wrap anything", () => {
       const { content } = addLocalSearchMarksClass('Lorem ipsum dolor', { label: 'sit amet' })
       expect(content).toBe('Lorem ipsum dolor')
     })
@@ -48,28 +48,45 @@ describe('strings', () => {
     })
 
     it('should wrap "ipsum" with tags in string with HTML, wrapped with a span', () => {
-      const { content } = addLocalSearchMarksClass('<span>Lorem <strong>ipsum</strong> dolor</span>', { label: 'ipsum' })
+      const { content } = addLocalSearchMarksClass('<span>Lorem <strong>ipsum</strong> dolor</span>', {
+        label: 'ipsum'
+      })
       expect(content).toBe('<span>Lorem <strong><mark class="local-search-term">ipsum</mark></strong> dolor</span>')
     })
 
     it('should wrap "dolor" in a deeply nested string', () => {
-      const { content } = addLocalSearchMarksClass('<i>Lorem</i> <strong>ipsum <span>dolor</span></strong>', { label: 'dolor' })
-      expect(content).toBe('<i>Lorem</i> <strong>ipsum <span><mark class="local-search-term">dolor</mark></span></strong>')
+      const { content } = addLocalSearchMarksClass('<i>Lorem</i> <strong>ipsum <span>dolor</span></strong>', {
+        label: 'dolor'
+      })
+      expect(content).toBe(
+        '<i>Lorem</i> <strong>ipsum <span><mark class="local-search-term">dolor</mark></span></strong>'
+      )
     })
 
     it('should wrap "Lorem" in a deeply nested string', () => {
-      const { content } = addLocalSearchMarksClass('<i>Lorem</i> <strong>ipsum <span>dolor</span></strong>', { label: 'lorem' })
-      expect(content).toBe('<i><mark class="local-search-term">Lorem</mark></i> <strong>ipsum <span>dolor</span></strong>')
+      const { content } = addLocalSearchMarksClass('<i>Lorem</i> <strong>ipsum <span>dolor</span></strong>', {
+        label: 'lorem'
+      })
+      expect(content).toBe(
+        '<i><mark class="local-search-term">Lorem</mark></i> <strong>ipsum <span>dolor</span></strong>'
+      )
     })
 
     it('shouldn\'t wrap "Lorem ipsum" in different tags', () => {
-      const { content } = addLocalSearchMarksClass('<i>Lorem</i> <strong>ipsum <span>dolor</span></strong>', { label: 'Lorem ipsum' })
+      const { content } = addLocalSearchMarksClass('<i>Lorem</i> <strong>ipsum <span>dolor</span></strong>', {
+        label: 'Lorem ipsum'
+      })
       expect(content).toBe('<i>Lorem</i> <strong>ipsum <span>dolor</span></strong>')
     })
 
     it('should wrap regex', () => {
-      const { content } = addLocalSearchMarksClass('France is not a tax heaven.\nBut most probably a taxidermists country.', { label: 'tax.*', regex: true })
-      expect(content).toBe('France is not a <mark class="local-search-term">tax heaven. But most probably a taxidermists country.</mark>')
+      const { content } = addLocalSearchMarksClass(
+        'France is not a tax heaven.\nBut most probably a taxidermists country.',
+        { label: 'tax.*', regex: true }
+      )
+      expect(content).toBe(
+        'France is not a <mark class="local-search-term">tax heaven. But most probably a taxidermists country.</mark>'
+      )
     })
 
     it('should display HTML characters', () => {
@@ -83,7 +100,9 @@ describe('strings', () => {
     })
 
     it('should ignore carriage return', () => {
-      const { content, localSearchOccurrences } = addLocalSearchMarksClass('content content Donald \nTrump content', { label: 'Donald Trump' })
+      const { content, localSearchOccurrences } = addLocalSearchMarksClass('content content Donald \nTrump content', {
+        label: 'Donald Trump'
+      })
 
       expect(localSearchOccurrences).toBe(1)
       expect(content).toBe('content content <mark class="local-search-term">Donald Trump</mark> content')
@@ -112,7 +131,9 @@ describe('strings', () => {
       const term = 'i'
       const offsets = [0, 2]
       const marked = addLocalSearchMarksClassByOffsets({ content, offsets, term })
-      expect(marked).toBe('<mark class="local-search-term" data-offset="0">I</mark>C<mark class="local-search-term" data-offset="2">I</mark>J')
+      expect(marked).toBe(
+        '<mark class="local-search-term" data-offset="0">I</mark>C<mark class="local-search-term" data-offset="2">I</mark>J'
+      )
     })
 
     it('should replace "dolor" using its offset minus the given delta', () => {

--- a/tests/unit/specs/utils/utils.spec.js
+++ b/tests/unit/specs/utils/utils.spec.js
@@ -1,4 +1,10 @@
-import { getDocumentTypeLabel, getExtractionLevelTranslationKey, getOS, getShortkeyOS, objectIncludes } from '@/utils/utils'
+import {
+  getDocumentTypeLabel,
+  getExtractionLevelTranslationKey,
+  getOS,
+  getShortkeyOS,
+  objectIncludes
+} from '@/utils/utils'
 
 describe('utils', () => {
   let languageGetter = null
@@ -89,21 +95,41 @@ describe('utils', () => {
     })
 
     it('should filter on a simple object of strings', () => {
-      expect(objectIncludes({ id: 'obj_01', name: 'this is an object', description: 'this is a complex description' }, 'compl')).toBeTruthy()
-      expect(objectIncludes({ id: 'obj_02', name: 'this is an object', description: 'this is a simple description' }, 'compl')).toBeFalsy()
+      expect(
+        objectIncludes(
+          { id: 'obj_01', name: 'this is an object', description: 'this is a complex description' },
+          'compl'
+        )
+      ).toBeTruthy()
+      expect(
+        objectIncludes(
+          { id: 'obj_02', name: 'this is an object', description: 'this is a simple description' },
+          'compl'
+        )
+      ).toBeFalsy()
     })
 
     it('should filter on a complex object of strings', () => {
-      expect(objectIncludes({
-        id: 'obj_01',
-        name: ['this has multiple', 'and some complex', 'names'],
-        description: 'this is a description'
-      }, 'compl')).toBeTruthy()
-      expect(objectIncludes({
-        id: 'obj_01',
-        name: ['this has multiple', 'and some simple', 'names'],
-        description: 'this is a description'
-      }, 'compl')).toBeFalsy()
+      expect(
+        objectIncludes(
+          {
+            id: 'obj_01',
+            name: ['this has multiple', 'and some complex', 'names'],
+            description: 'this is a description'
+          },
+          'compl'
+        )
+      ).toBeTruthy()
+      expect(
+        objectIncludes(
+          {
+            id: 'obj_01',
+            name: ['this has multiple', 'and some simple', 'names'],
+            description: 'this is a description'
+          },
+          'compl'
+        )
+      ).toBeFalsy()
     })
   })
 })

--- a/tests/unit/tests_utils.js
+++ b/tests/unit/tests_utils.js
@@ -2,11 +2,11 @@ import { merge } from 'lodash'
 import fs from 'fs'
 import { join } from 'path'
 
-export function flushPromises () {
-  return new Promise(resolve => setTimeout(resolve, 0))
+export function flushPromises() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
 }
 
-export function responseWithJson (body = {}, status = 200, headers = {}) {
+export function responseWithJson(body = {}, status = 200, headers = {}) {
   const mockResponse = new Response(JSON.stringify(body), {
     status,
     headers: merge(headers, { 'Content-type': 'application/json' })
@@ -14,7 +14,7 @@ export function responseWithJson (body = {}, status = 200, headers = {}) {
   return Promise.resolve(mockResponse)
 }
 
-export function responseWithArrayBuffer (path, returnBuffer = true) {
+export function responseWithArrayBuffer(path, returnBuffer = true) {
   try {
     const arrayBuffer = fs.readFileSync(join(__dirname, `resources/${path}`))
     const status = 200

--- a/yarn.lock
+++ b/yarn.lock
@@ -5871,6 +5871,11 @@ escodegen@^1.11.1, escodegen@^1.8.1, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-prettier@^8.6.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz#dec1d29ab728f4fa63061774e1672ac4e363d207"
+  integrity sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==
+
 eslint-config-standard@^16.0.3:
   version "16.0.3"
   resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz#6c8761e544e96c531ff92642eeb87842b8488516"
@@ -5958,6 +5963,13 @@ eslint-plugin-node@^11.0.0:
     minimatch "^3.0.4"
     resolve "^1.10.1"
     semver "^6.1.0"
+
+eslint-plugin-prettier@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"
+  integrity sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
 
 eslint-plugin-promise@^5.1.0:
   version "5.2.0"
@@ -6357,6 +6369,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.2.6:
   version "2.2.7"
@@ -11249,6 +11266,13 @@ prepend-http@^1.0.0, prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
 
 "prettier@^1.18.2 || ^2.0.0":
   version "2.7.1"


### PR DESCRIPTION
## What

This PR adds Prettier for code formatting and reconfigured ESLint for code style rules. 

- ESLint was already present, this PR merges config files that were located in 2 places (in package.json, and inside the test folder), and harmonises rules with rules defined in the Xemx codebase. Feel free to comment and make requests about any fomatting or style rules you would like us to agree on. 
- Finally, this PR adds a lint step in the CI. 

## What to check
- .eslintrc.js holds the eslint config
- .prettierrc holds the prttier config
- .eslintignore holds a list of files not to run linters on
- .circleci/config.yml for the ci step

Most changes on other files were made automatically, but you can check the commit history for manual fixes. 
Main two offenses to fix manually were:
- [no shadow](https://eslint.org/docs/latest/rules/no-shadow)
- r[equire-default-prop](https://eslint.vuejs.org/rules/require-default-prop.html) --> I think this one is a really good rule, but I ended up turning it off, because it was too much refactor to implement it. I tried marking the props required or adding defaults where I could, but tests were failing and there is about 100 occurrences to fix, which is too much without prior knowledge of the codebase. 

## How to use
To run ESLint in autocorrect mode, run `yarn lint:fix`, this will also autocorrect prettier offences. 
You can also configure your own editor tu run this automatically. 

## Why
fixes https://github.com/ICIJ/datashare/issues/977 and https://github.com/ICIJ/datashare/issues/976