### PR TITLE
refactor: remove ne delete button

### DIFF
--- a/src/components/filter/FilterBoilerplate.vue
+++ b/src/components/filter/FilterBoilerplate.vue
@@ -219,6 +219,13 @@ export default {
     dark: {
       type: Boolean,
       default: true
+    },
+    /**
+     * Disable the attempt to translate an item value
+     */
+    noItemTranslation: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -257,8 +264,8 @@ export default {
       return map(this.itemsWithExcludedValues, (item) => {
         return {
           item,
-          value: item.key.toString(),
-          label: this.labelToHuman(this.filter.itemLabel(item))
+          value: item?.key?.toString(),
+          label: this.itemTranslation(item)
         }
       })
     },
@@ -561,6 +568,12 @@ export default {
       this.$store.commit('search/from', 0)
       this.$emit('add-filter-values', this.filter, this.selected)
       this.refreshRouteAndSearch()
+    },
+    itemTranslation(item) {
+      if (this.noItemTranslation) {
+        return item?.key?.toString()
+      }
+      return this.labelToHuman(this.filter.itemLabel(item))
     }
   }
 }

--- a/src/components/filter/types/FilterNamedEntity.vue
+++ b/src/components/filter/types/FilterNamedEntity.vue
@@ -13,24 +13,11 @@
             <span class="filter__items__item__label px-1 flex-grow-1">
               {{ value }}
             </span>
-            <span
-              class="filter__items__item__count badge badge-pill badge-light align-self-start"
-              :class="{ hideOnHover: $config.is('manageDocuments') }"
-            >
+            <span class="filter__items__item__count badge badge-pill badge-light align-self-start">
               {{ $n(item.doc_count) }}
             </span>
           </span>
         </b-form-checkbox>
-        <confirm-button
-          v-if="$config.is('manageDocuments')"
-          class="align-self-start btn btn-link btn-sm p-0 mr-2 mt-1 filter__items__item__delete"
-          :confirmed="() => deleteNamedEntitiesByMentionNorm(value)"
-          :label="$t('filter.deleteNamedEntity')"
-          :yes="$t('global.yes')"
-          :no="$t('global.no')"
-        >
-          <fa icon="trash-alt"></fa>
-        </confirm-button>
       </div>
     </template>
   </filter-boilerplate>
@@ -40,7 +27,6 @@
 import FilterAbstract from '@/components/filter/types/FilterAbstract'
 import FilterBoilerplate from '@/components/filter/FilterBoilerplate'
 import ner from '@/mixins/ner'
-import utils from '@/mixins/utils'
 
 /**
  * A Filter component to list named entities for a specific type.
@@ -51,36 +37,6 @@ export default {
     FilterBoilerplate
   },
   extends: FilterAbstract,
-  mixins: [ner, utils],
-  methods: {
-    async deleteNamedEntitiesByMentionNorm(mentionNorm) {
-      const promises = []
-      for (const index in this.$store.state.search.indices) {
-        promises.push(this.$core.api.deleteNamedEntitiesByMentionNorm(index, mentionNorm))
-      }
-      await Promise.all(promises)
-      this.$root.$emit('filter::hide::named-entities')
-      await this.root?.aggregate()
-    }
-  }
+  mixins: [ner]
 }
 </script>
-
-<style lang="scss" scoped>
-.filter--named-entity {
-  .filter__items__item {
-    &__delete:not([aria-describedby]) {
-      display: none;
-    }
-
-    &:hover .filter__items__item__delete {
-      color: inherit;
-      display: block;
-    }
-
-    &:hover .hideOnHover {
-      display: none;
-    }
-  }
-}
-</style>

--- a/src/components/filter/types/FilterNamedEntity.vue
+++ b/src/components/filter/types/FilterNamedEntity.vue
@@ -1,24 +1,10 @@
 <template>
-  <filter-boilerplate v-bind="$props" ref="filter" class="filter--named-entity">
+  <filter-boilerplate v-bind="$props" ref="filter" class="filter--named-entity" no-item-translation>
     <template #title>
       <span class="col-2 filter__items__item__icon pl-0 pr-1" :class="getCategoryClass(filter.category, 'text-')">
         <fa :icon="getCategoryIcon(filter.category)" fixed-width></fa>
       </span>
       {{ $t(`filter.${filter.name}`) }}
-    </template>
-    <template #item="{ item, value }">
-      <div class="d-flex filter__items__item">
-        <b-form-checkbox :value="value" class="flex-grow-1 w-100">
-          <span class="d-flex">
-            <span class="filter__items__item__label px-1 flex-grow-1">
-              {{ value }}
-            </span>
-            <span class="filter__items__item__count badge badge-pill badge-light align-self-start">
-              {{ $n(item.doc_count) }}
-            </span>
-          </span>
-        </b-form-checkbox>
-      </div>
     </template>
   </filter-boilerplate>
 </template>

--- a/tests/unit/specs/components/filter/FilterBoilerplate.spec.js
+++ b/tests/unit/specs/components/filter/FilterBoilerplate.spec.js
@@ -12,25 +12,34 @@ describe('FilterBoilerplate.vue', () => {
   const name = 'contentType'
   const filter = store.getters['search/getFilter']({ name })
   const propsData = { filter }
-  let wrapper = null
 
-  beforeEach(() => {
-    wrapper = shallowMount(FilterBoilerplate, { i18n, localVue, router, store, wait, propsData })
-  })
+  describe('setting a filter value', () => {
+    let wrapper = null
 
-  it('should commit a setFilterValue and then refresh the route and the search', () => {
-    jest.spyOn(wrapper.vm, 'refreshRouteAndSearch')
-    wrapper.vm.setValue(['42'])
-    expect(wrapper.vm.refreshRouteAndSearch).toBeCalled()
-  })
+    beforeEach(() => {
+      wrapper = shallowMount(FilterBoilerplate, { i18n, localVue, router, store, wait, propsData })
+    })
 
-  it('should refresh the route', () => {
-    jest.spyOn(router, 'push')
-    wrapper.vm.refreshRoute()
-    expect(router.push).toBeCalled()
+    it('should commit a setFilterValue and then refresh the route and the search', () => {
+      jest.spyOn(wrapper.vm, 'refreshRouteAndSearch')
+      wrapper.vm.setValue(['42'])
+      expect(wrapper.vm.refreshRouteAndSearch).toBeCalled()
+    })
+
+    it('should refresh the route', () => {
+      jest.spyOn(router, 'push')
+      wrapper.vm.refreshRoute()
+      expect(router.push).toBeCalled()
+    })
   })
 
   describe('on resetFilterValues', () => {
+    let wrapper = null
+
+    beforeEach(() => {
+      wrapper = shallowMount(FilterBoilerplate, { i18n, localVue, router, store, wait, propsData })
+    })
+
     it('should empty "selected" value', () => {
       wrapper.vm.$set(wrapper.vm, 'selected', ['item'])
       wrapper.vm.resetFilterValues()
@@ -71,20 +80,132 @@ describe('FilterBoilerplate.vue', () => {
     })
   })
 
-  it('should cast items into string', () => {
-    const computed = {
-      itemsWithExcludedValues() {
-        return [
-          { key: 0, doc_count: 12 },
-          { key: 1, doc_count: 15 }
-        ]
-      }
-    }
-    wrapper = shallowMount(FilterBoilerplate, { i18n, localVue, router, store, wait, propsData: { filter }, computed })
+  describe('with integers keys', () => {
+    let wrapper = null
 
-    expect(wrapper.vm.options).toEqual([
-      { item: { key: 0, doc_count: 12 }, value: '0', label: '0' },
-      { item: { key: 1, doc_count: 15 }, value: '1', label: '1' }
-    ])
+    beforeEach(() => {
+      const computed = {
+        itemsWithExcludedValues() {
+          return [
+            { key: 0, doc_count: 12 },
+            { key: 1, doc_count: 15 }
+          ]
+        }
+      }
+
+      wrapper = shallowMount(FilterBoilerplate, {
+        i18n,
+        localVue,
+        router,
+        store,
+        wait,
+        propsData: { filter },
+        computed
+      })
+    })
+
+    it('should cast items into string', () => {
+      expect(wrapper.vm.options).toEqual([
+        { item: { key: 0, doc_count: 12 }, value: '0', label: '0' },
+        { item: { key: 1, doc_count: 15 }, value: '1', label: '1' }
+      ])
+    })
+  })
+
+  describe('with integers keys', () => {
+    let wrapper = null
+
+    beforeEach(() => {
+      const computed = {
+        itemsWithExcludedValues() {
+          return [
+            { key: 0, doc_count: 12 },
+            { key: 1, doc_count: 15 }
+          ]
+        }
+      }
+
+      wrapper = shallowMount(FilterBoilerplate, {
+        i18n,
+        localVue,
+        router,
+        store,
+        wait,
+        propsData: { filter },
+        computed
+      })
+    })
+
+    it('should cast items into string', () => {
+      expect(wrapper.vm.options).toEqual([
+        { item: { key: 0, doc_count: 12 }, value: '0', label: '0' },
+        { item: { key: 1, doc_count: 15 }, value: '1', label: '1' }
+      ])
+    })
+  })
+
+  describe('with translated keys', () => {
+    let wrapper = null
+
+    beforeEach(() => {
+      const computed = {
+        itemsWithExcludedValues() {
+          return [
+            { key: 'lang.CATALAN', doc_count: 12 },
+            { key: 'lang.FRENCH', doc_count: 15 }
+          ]
+        }
+      }
+
+      wrapper = shallowMount(FilterBoilerplate, {
+        i18n,
+        localVue,
+        router,
+        store,
+        wait,
+        propsData: { filter },
+        computed
+      })
+    })
+
+    it('should show the translation', () => {
+      expect(wrapper.vm.options).toEqual([
+        { item: { key: 'lang.CATALAN', doc_count: 12 }, value: 'lang.CATALAN', label: 'Catalan' },
+        { item: { key: 'lang.FRENCH', doc_count: 15 }, value: 'lang.FRENCH', label: 'French' }
+      ])
+    })
+  })
+
+  describe('without translated keys', () => {
+    let wrapper = null
+
+    beforeEach(() => {
+      const noItemTranslation = true
+      const computed = {
+        itemsWithExcludedValues() {
+          return [
+            { key: 'lang.CATALAN', doc_count: 12 },
+            { key: 'lang.FRENCH', doc_count: 15 }
+          ]
+        }
+      }
+
+      wrapper = shallowMount(FilterBoilerplate, {
+        i18n,
+        localVue,
+        router,
+        store,
+        wait,
+        propsData: { filter, noItemTranslation },
+        computed
+      })
+    })
+
+    it('should show the orinal key value', () => {
+      expect(wrapper.vm.options).toEqual([
+        { item: { key: 'lang.CATALAN', doc_count: 12 }, value: 'lang.CATALAN', label: 'lang.CATALAN' },
+        { item: { key: 'lang.FRENCH', doc_count: 15 }, value: 'lang.FRENCH', label: 'lang.FRENCH' }
+      ])
+    })
   })
 })

--- a/tests/unit/specs/components/filter/types/FilterNamedEntity.spec.js
+++ b/tests/unit/specs/components/filter/types/FilterNamedEntity.spec.js
@@ -24,7 +24,6 @@ describe('FilterNamedEntity.vue', () => {
 
   beforeAll(() => {
     api = new Api(null, null)
-    api.deleteNamedEntitiesByMentionNorm = jest.fn()
     api.fetchIndicesStarredDocuments = jest.fn()
     const core = Core.init(createLocalVue(), api).useAll()
     localVue = core.localVue
@@ -38,7 +37,6 @@ describe('FilterNamedEntity.vue', () => {
   })
 
   beforeEach(() => {
-    api.deleteNamedEntitiesByMentionNorm.mockReturnValue(jsonResp())
     api.fetchIndicesStarredDocuments.mockReturnValue(jsonResp())
 
     const filter = store.getters['search/getFilter']({ name })
@@ -51,7 +49,6 @@ describe('FilterNamedEntity.vue', () => {
 
   afterEach(() => {
     api.fetchIndicesStarredDocuments.mockClear()
-    api.deleteNamedEntitiesByMentionNorm.mockClear()
   })
 
   it('should filter items according to the content type filter search', async () => {
@@ -375,25 +372,6 @@ describe('FilterNamedEntity.vue', () => {
       await wrapper.vm.root.aggregate({ clearPages: true })
 
       expect(wrapper.findAll('.filter__items__item')).toHaveLength(1)
-    })
-  })
-
-  describe('Deletion', () => {
-    it('should display the "delete" button', async () => {
-      await letData(es).have(new IndexedDocument(id, index).withNer('person_01')).commit()
-
-      await wrapper.vm.root.aggregate({ clearPages: true })
-
-      expect(wrapper.findAll('.filter__items__item .filter__items__item__delete')).toHaveLength(1)
-    })
-
-    it('should emit an event filter::hide::named-entities on delete named entity', async () => {
-      const mockCallback = jest.fn()
-      wrapper.vm.$root.$on('filter::hide::named-entities', mockCallback)
-
-      await wrapper.vm.deleteNamedEntitiesByMentionNorm('ner_01')
-
-      expect(mockCallback.mock.calls).toHaveLength(1)
     })
   })
 })


### PR DESCRIPTION
Mostly remove code from the `FilterNamedEntities` component.

I also took this opportunity to add an option to `FilterBoilerplate` to disable the translation of the aggregation key (example: `FRENCH -> Français`, etc) including new tests. This allows to remove even more code from  `FilterNamedEntities` component which add to implement its own "items" slot  to avoid translating named entities.