### PR TITLE
fix: language ignored in modals

### DIFF
--- a/src/components/LocalesMenu.vue
+++ b/src/components/LocalesMenu.vue
@@ -18,7 +18,7 @@
           :key="locale.key"
           href="#"
           class="dropdown-item"
-          :class="{ active: locale === currentLocale }"
+          :class="{ active: locale.key === currentLocale.key }"
           @click.prevent="chooseLocale(locale.key)"
         >
           {{ locale.label }}
@@ -55,44 +55,29 @@ export default {
   },
   data() {
     return {
-      locales: settings.locales,
-      loadedLocales: [settings.defaultLocale]
+      locales: settings.locales
     }
   },
   computed: {
     currentLocale() {
-      const key = localStorage.getItem('locale') ? localStorage.getItem('locale') : this.$i18n.locale
-      this.loadLocale(key)
+      const key = this.$i18n.locale
       return find(this.locales, { key })
     },
     uniqueId() {
       return uniqueId('locales-menu')
     }
   },
+  watch: {
+    currentLocale({ key }) {
+      return this.$core.loadI18Locale(key)
+    }
+  },
   methods: {
     async chooseLocale(locale) {
-      await this.loadLocale(locale)
+      await this.$core.loadI18Locale(locale)
       if (this.$refs.popover) {
         this.$refs.popover.$emit('close')
       }
-    },
-    setI18nLanguage(locale) {
-      localStorage.setItem('locale', locale)
-      this.$i18n.locale = locale
-      return locale
-    },
-    loadLocale(locale) {
-      if (this.$i18n.locale !== locale) {
-        if (!this.loadedLocales.includes(locale)) {
-          return import(/* webpackChunkName: "[request]" */ '@/lang/' + locale + '.json').then((messages) => {
-            this.$i18n.setLocaleMessage(locale, messages.default)
-            this.loadedLocales.push(locale)
-            return this.setI18nLanguage(locale)
-          })
-        }
-        return Promise.resolve(this.setI18nLanguage(locale))
-      }
-      return Promise.resolve(locale)
     }
   }
 }

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -16,6 +16,7 @@ import VueEllipseProgress from 'vue-ellipse-progress'
 
 import FiltersMixin from './FiltersMixin'
 import HooksMixin from './HooksMixin'
+import I18nMixin from './I18nMixin'
 import PipelinesMixin from './PipelinesMixin'
 import ProjectsMixin from './ProjectsMixin'
 import WidgetsMixin from './WidgetsMixin'
@@ -31,13 +32,14 @@ import settings from '@/utils/settings'
 import { Api } from '@/api'
 
 class Base {}
-const Behaviors = compose(FiltersMixin, HooksMixin, PipelinesMixin, ProjectsMixin, WidgetsMixin)(Base)
+const Behaviors = compose(FiltersMixin, HooksMixin, I18nMixin, PipelinesMixin, ProjectsMixin, WidgetsMixin)(Base)
 
 /**
   @class
   @classdesc Class representing the core application with public methods for plugins.
   @mixes FiltersMixin
   @mixes HooksMixin
+  @mixes I18nMixin
   @mixes PipelinesMixin
   @mixes ProjectsMixin
   @mixes WidgetsMixin
@@ -195,6 +197,8 @@ class Core extends Behaviors {
       // Check if "Download" functionality is available for the selected project
       // Because otherwise, if the FilterPanel is closed, it is never called
       await this.store.dispatch('downloads/fetchIndicesStatus')
+      // Initialize current locale
+      await this.initializeI18n()
       // Hold a promise that is resolved when the core is configured
       return this.ready && this._readyResolve(this)
     } catch (error) {

--- a/src/core/I18nMixin.js
+++ b/src/core/I18nMixin.js
@@ -1,0 +1,60 @@
+import { isEmpty } from 'lodash'
+import settings from '@/utils/settings'
+
+/**
+  Mixin class extending the core to add helpers for i18n.
+  @mixin I18nMixin
+  @typicalname datashare
+*/
+const I18nMixin = (superclass) =>
+  class extends superclass {
+    /**
+     * Initialize i18N using the local storage and load
+     * the necessary locale's messages
+     * @memberof I18nMixin.prototype
+     * @returns {Promise}
+     */
+    initializeI18n() {
+      const locale = localStorage.getItem('locale') ?? this.i18n.locale
+      return this.loadI18Locale(locale)
+    }
+
+    /**
+     * Set the active locale both in local stoage and VueI18n.
+     * @memberof I18nMixin.prototype
+     * @param {String} locale - Key of the local (fr, de, en, ja, ...)
+     * @returns {String}
+     */
+    setI18nLocale(locale = settings.defaultLocale) {
+      localStorage.setItem('locale', locale)
+      this.i18n.locale = locale
+      return locale
+    }
+
+    /**
+     * Check the given locale storage was loaded.
+     * @memberof I18nMixin.prototype
+     * @param {String} locale - Key of the local (fr, de, en, ja, ...)
+     * @returns {Boolean}
+     */
+    hasI18Locale(locale) {
+      return !isEmpty(this.i18n.getLocaleMessage(locale))
+    }
+
+    /**
+     * Load i18n messages for the given locale (if needed)
+     * and set it as the current locale.
+     * @memberof I18nMixin.prototype
+     * @returns {Promise}
+     */
+    async loadI18Locale(locale) {
+      if (!this.hasI18Locale(locale)) {
+        const messages = await import(/* webpackChunkName: "[request]" */ '@/lang/' + locale + '.json')
+        this.i18n.setLocaleMessage(locale, messages.default)
+        return this.setI18nLocale(locale)
+      }
+      return this.setI18nLocale(locale)
+    }
+  }
+
+export default I18nMixin

--- a/src/core/I18nMixin.js
+++ b/src/core/I18nMixin.js
@@ -45,6 +45,7 @@ const I18nMixin = (superclass) =>
      * Load i18n messages for the given locale (if needed)
      * and set it as the current locale.
      * @memberof I18nMixin.prototype
+     * @param {String} locale - Key of the local (fr, de, en, ja, ...)
      * @returns {Promise}
      */
     async loadI18Locale(locale) {

--- a/src/pages/App.vue
+++ b/src/pages/App.vue
@@ -30,12 +30,12 @@
 
 <script>
 import { compact, get, some } from 'lodash'
+import VuePerfectScrollbar from 'vue-perfect-scrollbar'
 
 import AppSidebar from '@/components/AppSidebar'
 import Hook from '@/components/Hook'
 import ScrollTracker from '@/components/ScrollTracker'
 import { EventBus } from '@/utils/event-bus'
-import VuePerfectScrollbar from 'vue-perfect-scrollbar'
 
 export default {
   name: 'App',

--- a/tests/unit/specs/components/LocalesMenu.spec.js
+++ b/tests/unit/specs/components/LocalesMenu.spec.js
@@ -5,30 +5,30 @@ import LocalesMenu from '@/components/LocalesMenu'
 import { Core } from '@/core'
 
 describe('LocalesMenu', () => {
-  const { localVue, i18n } = Core.init(createLocalVue()).useAll()
+  const core = Core.init(createLocalVue()).useAll()
+  const { localVue, i18n } = core
   let wrapper = null
 
-  afterEach(() => {
-    localStorage.removeItem('locale')
-    i18n.locale = 'en'
+  beforeEach(async () => {
+    await core.loadI18Locale('en')
   })
 
-  describe('should change the interface language according to localStorage', () => {
+  describe('should change the interface language according to configuration', () => {
     it('should display the interfaces in English by default', () => {
       wrapper = shallowMount(LocalesMenu, { localVue, i18n })
 
       expect(wrapper.find('.locales-menu__button').text()).toBe('English')
     })
 
-    it('should display the interface in French if localStorage says so', () => {
-      localStorage.setItem('locale', 'fr')
+    it('should display the interface in French if configuration says so', () => {
+      core.setI18nLocale('fr')
       wrapper = shallowMount(LocalesMenu, { localVue, i18n })
 
       expect(wrapper.find('.locales-menu__button').text()).toBe('Français')
     })
 
-    it('should display the interface in Spanish if localStorage says so', () => {
-      localStorage.setItem('locale', 'es')
+    it('should display the interface in Spanish if configuration says so', () => {
+      core.setI18nLocale('es')
       wrapper = shallowMount(LocalesMenu, { localVue, i18n })
 
       expect(wrapper.find('.locales-menu__button').text()).toBe('Español')

--- a/tests/unit/specs/components/LocalesMenu.spec.js
+++ b/tests/unit/specs/components/LocalesMenu.spec.js
@@ -13,6 +13,10 @@ describe('LocalesMenu', () => {
     await core.loadI18Locale('en')
   })
 
+  afterAll(async () => {
+    await core.loadI18Locale('en')
+  })
+
   describe('should change the interface language according to configuration', () => {
     it('should display the interfaces in English by default', () => {
       wrapper = shallowMount(LocalesMenu, { localVue, i18n })

--- a/tests/unit/specs/core/I18nMixin.spec.js
+++ b/tests/unit/specs/core/I18nMixin.spec.js
@@ -71,7 +71,7 @@ describe('I18nMixin', () => {
       expect(core.i18n.locale).toBe('ja')
     })
 
-    it('should have "ja" mjasage', async () => {
+    it('should have "ja" messages', async () => {
       await core.loadI18Locale('ja')
       expect(core.hasI18Locale('ja')).toBeTruthy()
     })

--- a/tests/unit/specs/core/I18nMixin.spec.js
+++ b/tests/unit/specs/core/I18nMixin.spec.js
@@ -1,0 +1,84 @@
+import { createLocalVue } from '@vue/test-utils'
+import { Core } from '@/core'
+
+describe('I18nMixin', () => {
+  let core
+
+  describe('without language in local storage', () => {
+    beforeEach(async () => {
+      localStorage.removeItem('locale')
+      core = Core.init(createLocalVue()).useAll()
+      await core.initializeI18n()
+    })
+
+    afterEach(async () => {
+      await core.loadI18Locale('en')
+    })
+
+    it('should use "en" as default language', () => {
+      expect(core.i18n.locale).toBe('en')
+    })
+
+    it('should have "en" messages', () => {
+      expect(core.hasI18Locale('en')).toBeTruthy()
+    })
+
+    it('should save the "en" local in local storage by default', async () => {
+      expect(localStorage.getItem('locale')).toBe('en')
+    })
+
+    it('should not have "fr" messages', () => {
+      expect(core.hasI18Locale('fr')).toBeFalsy()
+    })
+
+    it('should switch to Spanish (es)', async () => {
+      await core.loadI18Locale('es')
+      expect(core.i18n.locale).toBe('es')
+    })
+
+    it('should have "es" message', async () => {
+      await core.loadI18Locale('es')
+      expect(core.hasI18Locale('es')).toBeTruthy()
+    })
+
+    it('should save the "es" local in local storage', async () => {
+      await core.loadI18Locale('es')
+      expect(localStorage.getItem('locale')).toBe('es')
+    })
+  })
+
+  describe('with german language in local storage', () => {
+    beforeEach(async () => {
+      localStorage.setItem('locale', 'de')
+      core = Core.init(createLocalVue()).useAll()
+      await core.initializeI18n()
+    })
+
+    afterEach(async () => {
+      await core.loadI18Locale('de')
+    })
+
+    it('should use "de" as default language', () => {
+      expect(core.i18n.locale).toBe('de')
+    })
+
+    it('should have "de" messages', () => {
+      expect(core.hasI18Locale('de')).toBeTruthy()
+    })
+
+    it('should switch to Japanese (ja)', async () => {
+      await core.loadI18Locale('ja')
+      expect(core.i18n.locale).toBe('ja')
+    })
+
+    it('should have "ja" mjasage', async () => {
+      await core.loadI18Locale('ja')
+      expect(core.hasI18Locale('ja')).toBeTruthy()
+    })
+
+    it('should save the "ja" local in local storage', async () => {
+      await core.loadI18Locale('ja')
+      expect(localStorage.getItem('locale')).toBe('ja')
+    })
+  })
+})

--- a/tests/unit/specs/core/I18nMixin.spec.js
+++ b/tests/unit/specs/core/I18nMixin.spec.js
@@ -4,6 +4,10 @@ import { Core } from '@/core'
 describe('I18nMixin', () => {
   let core
 
+  afterAll(async () => {
+    localStorage.removeItem('locale')
+  })
+
   describe('without language in local storage', () => {
     beforeEach(async () => {
       localStorage.removeItem('locale')


### PR DESCRIPTION
This PR aims at fixing the persistence of the selected locale.

I used this opportunity to move the logic of loading/settings the current locale into a proper core mixin called `I18nMixin`. This mixin is now used by the `LocalesMenu` component and by the `Core` instance when configuring the app.

The non-persisting state was due to the fact that the current locale was loaded directly within the `LocalesMenu` component at mount time. So for routes where there was no `LocalesMenu` (like the modal, or the login screen), the locale was never loaded. It is now done at the `Core` level, so for every route.