### PR TITLE
feat: preview audio video

### DIFF
--- a/src/api/resources/Document.js
+++ b/src/api/resources/Document.js
@@ -300,6 +300,12 @@ export default class Document extends EsDoc {
   get isImage() {
     return this.contentType.indexOf('image/') === 0
   }
+  get isVideo() {
+    return this.contentType.indexOf('video/') === 0
+  }
+  get isAudio() {
+    return this.contentType.indexOf('audio/') === 0
+  }
   get isJson() {
     return this.contentType.indexOf('application/json') === 0
   }

--- a/src/components/document/DocumentTabPreview.vue
+++ b/src/components/document/DocumentTabPreview.vue
@@ -63,6 +63,10 @@ export default {
           return 'LegacySpreadsheetViewer'
         case this.document.isImage:
           return 'ImageViewer'
+        case this.document.isAudio:
+          return 'AudioViewer'
+        case this.document.isVideo:
+          return 'VideoViewer'
         default:
           return null
       }

--- a/src/components/document/viewers/AudioViewer.vue
+++ b/src/components/document/viewers/AudioViewer.vue
@@ -1,0 +1,67 @@
+<template>
+  <b-card class="audio-viewer my-auto w-100 m-3" overflow-hidden :border-variant="cardVariant">
+    <audio controls :autoplay="autoplay" :loop="loop" class="audio-viewer__player w-100 d-inline-block">
+      <source :src="document.inlineFullUrl" :type="document.contentType" />
+    </audio>
+    <template #footer>
+      <div class="d-lg-flex">
+        <div switches class="my-auto d-flex">
+          <b-form-checkbox v-model="autoplay" switch class="my-2 mr-3">
+            {{ $t('document.player.autoplay') }}
+          </b-form-checkbox>
+          <b-form-checkbox v-model="loop" switch class="my-2 mr-3">
+            {{ $t('document.player.loop') }}
+          </b-form-checkbox>
+        </div>
+        <b-alert :show="cannotPlayAudioFormat" variant="warning" class="ml-auto mt-3 mb-0 my-lg-auto">
+          <fa icon="warning" class="mr-2" />
+          {{ $t('document.player.audio.unknownFormat') }}
+        </b-alert>
+      </div>
+    </template>
+  </b-card>
+</template>
+
+<script>
+/**
+ * Display a preview video of the document.
+ */
+export default {
+  name: 'AudioViewer',
+  props: {
+    /**
+     * The selected document
+     */
+    document: {
+      type: Object
+    }
+  },
+  computed: {
+    cannotPlayAudioFormat() {
+      return !this.canPlayAudioFormat
+    },
+    canPlayAudioFormat() {
+      return document.createElement('audio').canPlayType(this.document.contentType) !== ''
+    },
+    cardVariant() {
+      return this.cannotPlayAudioFormat ? 'warning' : null
+    },
+    autoplay: {
+      get() {
+        return this.$store.state.player.autoplay
+      },
+      set(autoplay) {
+        return this.$store.commit('player/autoplay', autoplay)
+      }
+    },
+    loop: {
+      get() {
+        return this.$store.state.player.loop
+      },
+      set(loop) {
+        return this.$store.commit('player/loop', loop)
+      }
+    }
+  }
+}
+</script>

--- a/src/components/document/viewers/VideoViewer.vue
+++ b/src/components/document/viewers/VideoViewer.vue
@@ -70,3 +70,12 @@ export default {
   }
 }
 </script>
+
+<style scoped lang="scss">
+.video-viewer {
+  &__player {
+    // Quick and dirty solution to ensure the video is not taking to much space
+    max-height: calc(100vh - 300px);
+  }
+}
+</style>

--- a/src/components/document/viewers/VideoViewer.vue
+++ b/src/components/document/viewers/VideoViewer.vue
@@ -1,0 +1,72 @@
+<template>
+  <b-card
+    class="video-viewer my-3 align-self-center w-100 m-3 overflow-hidden"
+    :footer-bg-variant="cardVariant"
+    :border-variant="cardVariant"
+    no-body
+  >
+    <video controls :autoplay="autoplay" :loop="loop" class="video-viewer__player w-100">
+      <source :src="document.inlineFullUrl" :type="document.contentType" />
+    </video>
+    <template #footer>
+      <div class="d-lg-flex">
+        <div switches class="my-auto d-flex">
+          <b-form-checkbox v-model="autoplay" switch class="my-2 mr-3">
+            {{ $t('document.player.autoplay') }}
+          </b-form-checkbox>
+          <b-form-checkbox v-model="loop" switch class="my-2 mr-3">
+            {{ $t('document.player.loop') }}
+          </b-form-checkbox>
+        </div>
+        <b-alert :show="cannotPlayVideoFormat" variant="warning" class="ml-auto mt-3 mb-0 my-lg-auto">
+          <fa icon="warning" class="mr-2" />
+          {{ $t('document.player.video.unknownFormat') }}
+        </b-alert>
+      </div>
+    </template>
+  </b-card>
+</template>
+
+<script>
+/**
+ * Display a preview video of the document.
+ */
+export default {
+  name: 'VideoViewer',
+  props: {
+    /**
+     * The selected document
+     */
+    document: {
+      type: Object
+    }
+  },
+  computed: {
+    cannotPlayVideoFormat() {
+      return !this.canPlayVideoFormat
+    },
+    canPlayVideoFormat() {
+      return document.createElement('video').canPlayType(this.document.contentType) !== ''
+    },
+    cardVariant() {
+      return this.cannotPlayVideoFormat ? 'warning' : null
+    },
+    autoplay: {
+      get() {
+        return this.$store.state.player.autoplay
+      },
+      set(autoplay) {
+        return this.$store.commit('player/autoplay', autoplay)
+      }
+    },
+    loop: {
+      get() {
+        return this.$store.state.player.loop
+      },
+      set(loop) {
+        return this.$store.commit('player/loop', loop)
+      }
+    }
+  }
+}
+</script>

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -469,6 +469,16 @@
       "preview": "Preview of the PDF active page",
       "thumbnail": "Thumbnail of the PDF page"
     },
+    "player": {
+      "autoplay": "Play automatically",
+      "loop": "Play in loop",
+      "audio": {
+        "unknownFormat": "Unsupported audio format"
+      },
+      "video": {
+        "unknownFormat": "Unsupported video format"
+      }
+    },
     "attachments": {
       "heading": "No attachments | One attachment | {total} attachments",
       "more": "More attachments..."

--- a/src/pages/Search.vue
+++ b/src/pages/Search.vue
@@ -30,7 +30,7 @@
           </div>
         </div>
         <search-results v-else-if="isReady" :layout="layout" />
-        <content-placeholder v-else class="bg-white p-3 mb-3" v-for="n in 3" :key="n" />
+        <content-placeholder v-for="n in 3" v-else :key="n" class="bg-white p-3 mb-3" />
       </component>
       <div v-if="showDocument" class="search__body__document">
         <search-document-navbar class="search__body__document__navbar" :is-shrinked="isShrinked" />

--- a/src/store/modules/player.js
+++ b/src/store/modules/player.js
@@ -1,0 +1,19 @@
+export const state = () => ({
+  autoplay: true,
+  loop: true
+})
+
+export const mutations = {
+  autoplay(state, autoplay) {
+    state.autoplay = autoplay
+  },
+  loop(state, loop) {
+    state.loop = loop
+  }
+}
+
+export default {
+  namespaced: true,
+  mutations,
+  state
+}

--- a/src/store/storeBuilder.js
+++ b/src/store/storeBuilder.js
@@ -3,19 +3,20 @@ import Vue from 'vue'
 import Vuex from 'vuex'
 import createPersistedState from 'vuex-persistedstate'
 
-import app from './modules/app'
-import { documentStoreBuilder } from './modules/document'
 import { batchStoreBuilder } from './modules/batchSearch'
 import { documentNotesStoreBuilder } from './modules/documentNotes'
+import { documentStoreBuilder } from './modules/document'
 import { downloadsBuilder } from './modules/downloads'
-import hooks from './modules/hooks'
 import { indexingStoreBuilder } from './modules/indexing'
-import insights from './modules/insights'
-import pipelines from './modules/pipelines'
 import { recommendedStoreBuilder } from './modules/recommended'
 import { searchStoreBuilder } from './modules/search'
 import { settingsStoreBuilder } from './modules/settings'
 import { starredStoreBuilder } from './modules/starred'
+import app from './modules/app'
+import hooks from './modules/hooks'
+import insights from './modules/insights'
+import pipelines from './modules/pipelines'
+import player from './modules/player'
 import treeView from './modules/treeView'
 
 Vue.use(Vuex)
@@ -30,6 +31,7 @@ export function storeBuilder(api) {
       hooks,
       indexing: indexingStoreBuilder(api),
       insights,
+      player,
       pipelines,
       recommended: recommendedStoreBuilder(api),
       search: searchStoreBuilder(api),
@@ -43,6 +45,8 @@ export function storeBuilder(api) {
         paths: [
           'app.redirectAfterLogin',
           'document.showTranslatedContent',
+          'player.autoplay',
+          'player.loop',
           'search.query',
           'search.size',
           'search.values',
@@ -57,7 +61,7 @@ export function storeBuilder(api) {
         ],
         filter(mutation) {
           // Only for some mutations
-          return some(['search/', 'app/', 'doc/'], (k) => mutation.type.indexOf(k) === 0)
+          return some(['search/', 'app/', 'doc/', 'player/'], (k) => mutation.type.indexOf(k) === 0)
         }
       })
     ]

--- a/tests/unit/specs/api/resources/Document.spec.js
+++ b/tests/unit/specs/api/resources/Document.spec.js
@@ -24,14 +24,36 @@ describe('Document', () => {
   describe('check if document is of JSON type', () => {
     it('should be a JSON file', () => {
       const doc = new Document({ _source: { contentType: 'application/json' } })
-
       expect(doc.isJson).toBeTruthy()
     })
 
     it('should NOT be a JSON file', () => {
       const doc = new Document({ _source: { contentType: 'application/pdf' } })
-
       expect(doc.isJson).toBeFalsy()
+    })
+  })
+
+  describe('check if document is of audio type', () => {
+    it('should be an audio file', () => {
+      const doc = new Document({ _source: { contentType: 'audio/mp3' } })
+      expect(doc.isAudio).toBeTruthy()
+    })
+
+    it('should NOT be an audio file', () => {
+      const doc = new Document({ _source: { contentType: 'application/pdf' } })
+      expect(doc.isAudio).toBeFalsy()
+    })
+  })
+
+  describe('check if document is of video type', () => {
+    it('should be an video file', () => {
+      const doc = new Document({ _source: { contentType: 'video/mp4' } })
+      expect(doc.isVideo).toBeTruthy()
+    })
+
+    it('should NOT be an video file', () => {
+      const doc = new Document({ _source: { contentType: 'application/pdf' } })
+      expect(doc.isVideo).toBeFalsy()
     })
   })
 

--- a/tests/unit/specs/components/document/DocumentTabPreview.spec.js
+++ b/tests/unit/specs/components/document/DocumentTabPreview.spec.js
@@ -66,4 +66,30 @@ describe('DocumentTabPreview.vue', () => {
     })
     expect(wrapper.vm.previewComponent).toBe('TiffViewer')
   })
+
+  it('should call the AudioViewer component for audio document', async () => {
+    const document = await letData(es)
+      .have(new IndexedDocument(id, index).withContentType('audio/ogg'))
+      .commitAndGetLastDocument()
+
+    const wrapper = shallowMount(DocumentTabPreview, {
+      localVue,
+      propsData: { document, disabled },
+      mocks: { $t: (msg) => msg }
+    })
+    expect(wrapper.vm.previewComponent).toBe('AudioViewer')
+  })
+
+  it('should call the VideoViewer component for video document', async () => {
+    const document = await letData(es)
+      .have(new IndexedDocument(id, index).withContentType('video/mp4'))
+      .commitAndGetLastDocument()
+
+    const wrapper = shallowMount(DocumentTabPreview, {
+      localVue,
+      propsData: { document, disabled },
+      mocks: { $t: (msg) => msg }
+    })
+    expect(wrapper.vm.previewComponent).toBe('VideoViewer')
+  })
 })

--- a/tests/unit/specs/store/modules/player.spec.js
+++ b/tests/unit/specs/store/modules/player.spec.js
@@ -1,0 +1,31 @@
+import { Api } from '@/api'
+import { storeBuilder } from '@/store/storeBuilder'
+
+describe('PlayerStore', () => {
+  let store
+
+  beforeAll(() => {
+    const api = new Api(null, null)
+    store = storeBuilder(api)
+  })
+
+  it('should change the autoplay value to true', () => {
+    store.commit('player/autoplay', true)
+    expect(store.state.player.autoplay).toBeTruthy()
+  })
+
+  it('should change the loop value to true', () => {
+    store.commit('player/loop', true)
+    expect(store.state.player.loop).toBeTruthy()
+  })
+
+  it('should change the autoplay value to false', () => {
+    store.commit('player/autoplay', false)
+    expect(store.state.player.autoplay).toBeFalsy()
+  })
+
+  it('should change the loop value to false', () => {
+    store.commit('player/loop', false)
+    expect(store.state.player.loop).toBeFalsy()
+  })
+})


### PR DESCRIPTION
This feature add the support for audio player:

![Screenshot 2023-01-13 at 18-34-33 Document - Datashare](https://user-images.githubusercontent.com/471176/212382977-4c927071-f23f-4a9a-8bc6-1da2f6ce4926.png)

And a video player:

![Screenshot 2023-01-13 at 18-34-51 Document - Datashare](https://user-images.githubusercontent.com/471176/212382980-f09fa85a-b47a-49f9-8a6c-fe37e64a30c5.png)

To persit the "autoplay" and "loop" options I created a `Player` store module.
