### PR TITLE
refactor: add two inputs for date range filter

### DIFF
--- a/src/components/filter/types/FilterDateRange.vue
+++ b/src/components/filter/types/FilterDateRange.vue
@@ -68,8 +68,8 @@ export default {
         if (values.length < 2) {
           return null
         }
-        const start = min(values)
-        const end = max(values)
+        const start = parseInt(min(values))
+        const end = parseInt(max(values))
         return { start, end }
       },
       set(range) {

--- a/src/components/filter/types/FilterDateRange.vue
+++ b/src/components/filter/types/FilterDateRange.vue
@@ -81,9 +81,12 @@ export default {
       return [
         {
           key: 'today',
-          contentStyle: {
-            fontWeight: '700',
-            fontSize: '.9 rem'
+          highlight: {
+            style: {
+              backgroundColor: 'var(--yellow-900)',
+              opacity: '0.3',
+              borderRadius: 'var(--rounded-full)'
+            }
           },
           dates: new Date()
         }
@@ -147,46 +150,6 @@ export default {
     flex: 0 1 100%;
     input {
       width: 45%;
-    }
-  }
-  .date-picker {
-    --yellow-500: #{$tertiary};
-    --yellow-400: #{lighten($tertiary, 5)};
-    --yellow-300: #{lighten($tertiary, 10)};
-    --yellow-200: #{lighten($tertiary, 15)};
-    --yellow-100: #{lighten($tertiary, 20)};
-
-    font-family: $font-family-base;
-    border: 0;
-    font-size: 0.8rem;
-    color: inherit;
-    padding: 0;
-    margin: 0;
-    background: transparent;
-
-    .vc-popover-content-wrapper {
-      z-index: $zindex-tooltip !important;
-    }
-
-    .vc-grid-cell {
-      .vc-highlights {
-        .vc-day-layer {
-          .vc-highlight-base-start,
-          .vc-highlight-base-middle,
-          .vc-highlight-base-end {
-            background-color: rgba($tertiary, 0.4);
-          }
-
-          .vc-rounded-full {
-            background-color: $tertiary;
-            border-color: $tertiary;
-          }
-        }
-      }
-
-      .vc-day-content:hover {
-        background-color: rgba($tertiary, 0.1);
-      }
     }
   }
 }

--- a/src/components/filter/types/FilterDateRange.vue
+++ b/src/components/filter/types/FilterDateRange.vue
@@ -10,18 +10,43 @@
     <template #items>
       <div class="m-2">
         <date-picker
+          ref="calendar"
           :key="locale"
           v-model="selectedDate"
-          class="date-picker"
+          class="date-picker d-flex flex-grow-1"
+          :popover="{ visibility: 'focus' }"
           is-range
           is-dark
-          is-expanded
           color="yellow"
-          show-caps
           :model-config="{ type: 'number' }"
           :attributes="attributes"
           :locale="locale"
+          :update-on-input="false"
+          @dayclick="updateFocus"
         >
+          <template #default="{ inputValue, inputEvents }">
+            <div class="filter--date-range__inputs d-inline-flex justify-content-between align-items-center">
+              <input
+                ref="dateStart"
+                :title="$t('filter.dateRange.from', { dateFormat: placeholderMask })"
+                :alt="$t('filter.dateRange.startingDate')"
+                :placeholder="placeholderMask"
+                :value="inputValue.start"
+                class="filter--date-range__inputs__start"
+                v-on="inputEvents.start"
+              />
+              <fa icon="arrow-right" fixed-width />
+              <input
+                ref="dateEnd"
+                :title="$t('filter.dateRange.to', { dateFormat: placeholderMask })"
+                :alt="$t('filter.dateRange.endingDate')"
+                :placeholder="placeholderMask"
+                :value="inputValue.end"
+                class="filter--date-range__inputs__end"
+                v-on="inputEvents.end"
+              />
+            </div>
+          </template>
         </date-picker>
       </div>
     </template>
@@ -46,6 +71,11 @@ export default {
     FilterBoilerplate
   },
   extends: FilterAbstract,
+  data() {
+    return {
+      placeholderMask: ''
+    }
+  },
   computed: {
     attributes() {
       return [
@@ -84,12 +114,41 @@ export default {
         this.refreshRouteAndSearch()
       }
     }
+  },
+  watch: {
+    locale() {
+      this.updatePlaceholder()
+    }
+  },
+  async mounted() {
+    this.updatePlaceholder()
+  },
+  methods: {
+    updatePlaceholder() {
+      if (this.$refs.calendar && this.placeholderMask !== this.$refs.calendar.$locale?.masks?.L) {
+        this.placeholderMask = this.$refs.calendar.$locale?.masks?.L
+      }
+    },
+    async updateFocus(e) {
+      await this.$nextTick()
+      const start = this.$refs.dateStart
+      const end = this.$refs.dateEnd
+      if (start.value?.trim().length && start.value === end.value) {
+        end.focus()
+      }
+    }
   }
 }
 </script>
 
 <style lang="scss">
 .filter.filter--date-range {
+  .filter--date-range__inputs {
+    flex: 0 1 100%;
+    input {
+      width: 45%;
+    }
+  }
   .date-picker {
     --yellow-500: #{$tertiary};
     --yellow-400: #{lighten($tertiary, 5)};

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -383,6 +383,12 @@
       "level10": "10th"
     },
     "tags": "Tags",
+    "dateRange": {
+      "from": "From {dateFormat}",
+      "to": "To {dateFormat}",
+      "startingDate": "Starting date",
+      "endingDate": "Ending date"
+    },
     "selectDateRange": "Select a date range"
   },
   "document": {

--- a/src/main.scss
+++ b/src/main.scss
@@ -210,3 +210,35 @@ $value in $theme-colors {
     }
   }
 }
+
+.vc-popover-content-wrapper {
+  z-index: $zindex-tooltip !important;
+  .vc-container {
+    --yellow-500: #{$tertiary};
+    --yellow-400: #{lighten($tertiary, 5)};
+    --yellow-300: #{lighten($tertiary, 10)};
+    --yellow-200: #{lighten($tertiary, 15)};
+    --yellow-100: #{lighten($tertiary, 20)};
+    --gray-900: #{$app-sidebar-bg};
+
+    font-size: 0.8rem;
+    color: inherit;
+    padding: 0;
+    margin: 0;
+    font-family: $font-family-base;
+
+    .vc-highlights {
+      .vc-day-layer {
+        .vc-highlight-base-start,
+        .vc-highlight-base-middle,
+        .vc-highlight-base-end {
+          background-color: rgba($tertiary, 0.4) !important;
+        }
+      }
+    }
+
+    .vc-day-content:hover {
+      background-color: rgba($tertiary, 0.1) !important;
+    }
+  }
+}

--- a/tests/unit/specs/components/filter/types/FilterDateRange.spec.js
+++ b/tests/unit/specs/components/filter/types/FilterDateRange.spec.js
@@ -59,4 +59,38 @@ describe('FilterDateRange.vue', () => {
     const existingFilter = find(store.getters['search/instantiatedFilters'], { name })
     expect(existingFilter.values).toEqual([expectedStart, expectedEnd])
   })
+  it('has two inputs containing the date range', () => {
+    const elementStart = wrapper.find('.filter--date-range__inputs__start')
+    expect(elementStart.exists()).toBeTruthy()
+    const startAttr = elementStart.attributes()
+    expect(startAttr.title).toBe('From MM/DD/YYYY')
+    expect(startAttr.alt).toBe('Starting date')
+    expect(startAttr.placeholder).toBe('MM/DD/YYYY')
+
+    const elementEnd = wrapper.find('.filter--date-range__inputs__end')
+    expect(elementEnd.exists()).toBeTruthy()
+    const endAttr = elementEnd.attributes()
+    expect(endAttr.title).toBe('To MM/DD/YYYY')
+    expect(endAttr.alt).toBe('Ending date')
+    expect(endAttr.placeholder).toBe('MM/DD/YYYY')
+  })
+  it('changes date format to DD/MM/YYYY according to FR locale', async () => {
+    expect(i18n.locale).toBe('en')
+    const startAttr = wrapper.find('.filter--date-range__inputs__start').attributes()
+    expect(startAttr.placeholder).toBe('MM/DD/YYYY')
+    i18n.locale = 'fr'
+    const wrapper2 = mount(FilterDateRange, {
+      localVue,
+      i18n,
+      store,
+      router,
+      wait,
+      propsData: {
+        filter
+      }
+    })
+    await wrapper2.vm.$nextTick()
+    const startAttrFr = wrapper2.find('.filter--date-range__inputs__start').attributes()
+    expect(startAttrFr.placeholder).toBe('DD/MM/YYYY')
+  })
 })


### PR DESCRIPTION
This PR is related to ICIJ/datashare#981

Added 2 inputs for start/end date range picking. The date format changes according to the locale. 
UX: 
- title / alt / placeholder for helping on date format
- when fields are empty and start is filled, the ui focuses on the end field.
Fix: 
- date filters where not loaded on page load 

Screenshots:
![Screenshot from 2023-01-17 15-14-49](https://user-images.githubusercontent.com/4643139/212924820-0f9bcdf4-57e2-4d94-8032-c503e14aec86.png)

![Screenshot from 2023-01-17 15-13-27](https://user-images.githubusercontent.com/4643139/212924758-e44dec86-0873-44a3-aa38-8c315a8fca1f.png)
