### PR TITLE
bug: add published dropdown filter selected on publish state update #234

### DIFF
--- a/src/components/BatchSearchFilterDropdown.vue
+++ b/src/components/BatchSearchFilterDropdown.vue
@@ -6,6 +6,7 @@
         :items="items"
         deactivate-keys
         :multiple="multiple"
+        :eq="eq"
         class="shadow-none border-0"
       >
         <template #item-label="{ item }">
@@ -19,6 +20,7 @@
 <script>
 import BatchSearchFilter from '@/components/BatchSearchFilter'
 import { isEqual } from 'lodash'
+import eq from 'lodash/eq'
 
 export default {
   name: 'BatchSearchFilterDropdown',
@@ -31,6 +33,10 @@ export default {
     id: {
       type: String,
       required: true
+    },
+    eq: {
+      type: Function,
+      default: eq
     },
     name: {
       type: String,
@@ -50,7 +56,7 @@ export default {
   },
   computed: {
     isActive() {
-      return this.values?.length > 0 || this.values?.value !== undefined
+      return this.values?.length > 0 || !!this.values?.value
     },
     selectedValues: {
       get() {

--- a/src/components/BatchSearchTable.vue
+++ b/src/components/BatchSearchTable.vue
@@ -54,7 +54,13 @@
         />
       </template>
       <template #head(published)="{ field }">
-        <batch-search-filter-dropdown :id="field.key" v-model="selectedStatus" :items="status" :name="field.label">
+        <batch-search-filter-dropdown
+          :id="field.key"
+          v-model="selectedStatus"
+          :items="status"
+          :eq="isSelected"
+          :name="field.label"
+        >
           <template #label="{ item }">
             {{ $t(`batchSearch.${item.label}`) }}
           </template>
@@ -445,7 +451,9 @@ export default {
     getProjectsNames(item) {
       return item.projects?.map((project) => project.name).join(', ') ?? ''
     },
-
+    isSelected(item) {
+      return item?.value === this.selectedStatus?.value
+    },
     linkGen(page) {
       return this.createBatchSearchRoute({ page })
     },

--- a/tests/unit/specs/components/BatchSearchTable.spec.js
+++ b/tests/unit/specs/components/BatchSearchTable.spec.js
@@ -225,6 +225,16 @@ describe('BatchSearchTable.vue', () => {
         wrapper.vm.selectedStates = []
         expect(router.push).toBeCalledWith(routeFactory())
       })
+
+      it('set selectedStatus', () => {
+        expect(wrapper.vm.selectedStatus).toEqual(null)
+        jest.spyOn(router, 'push')
+        wrapper.vm.selectedStatus = { label: 'published', value: '1' }
+        expect(router.push).toBeCalledTimes(1)
+        expect(router.push).toBeCalledWith(routeFactory({ publishState: '1' }))
+        wrapper.vm.selectedStatus = null
+        expect(router.push).toBeCalledWith(routeFactory())
+      })
     })
 
     describe('Retrieve values from search params', () => {


### PR DESCRIPTION
related to #234 
before:
publicationStatus dropdown list item was not highlighted when updated (selected/unselected)

after:
publicationStatus dropdown list item is highlighted when updated

why: we use the same dropdown for single value selection and multiple selection. the single value is an object with label/value therefore we need to handle the selected callback differently

:v: add test on publication status router update