### PR TITLE
fix: avoid startTask for batchSearch ICIJ/datashare#1005

### DIFF
--- a/src/components/BatchSearchForm.vue
+++ b/src/components/BatchSearchForm.vue
@@ -395,21 +395,13 @@ export default {
           published: this.published
         })
         this.resetForm()
-        if (this.$config.is('manageDocuments')) {
-          try {
-            await this.$store.dispatch('indexing/runBatchSearch')
-            this.$root.$bvToast.toast(this.$t('batchSearch.success'), {
-              noCloseButton: true,
-              variant: 'success'
-            })
-          } catch (_) {
-            this.manageError(_.response.status, true)
-          }
-        } else {
-          this.$root.$bvToast.toast(this.$t('batchSearch.submitSuccess'), {
+        try {
+          this.$root.$bvToast.toast(this.$t('batchSearch.success'), {
             noCloseButton: true,
             variant: 'success'
           })
+        } catch (_) {
+          this.manageError(_.response.status, true)
         }
       } catch (_) {
         this.manageError(_.response.status, false)

--- a/src/mode/index.js
+++ b/src/mode/index.js
@@ -1,11 +1,17 @@
 export const MODE_NAME = Object.freeze({
   LOCAL: 'LOCAL',
+  EMBEDDED: 'EMBEDDED',
   SERVER: 'SERVER'
 })
 
 const MODES = Object.freeze({
   [MODE_NAME.LOCAL]: {
     modeName: 'local',
+    multipleProjects: false,
+    manageDocuments: true
+  },
+  [MODE_NAME.EMBEDDED]: {
+    modeName: 'embedded',
     multipleProjects: false,
     manageDocuments: true
   },
@@ -18,5 +24,5 @@ const MODES = Object.freeze({
 
 export const getMode = (modeName = MODE_NAME.LOCAL) => {
   // Return the right values according to the mode or fallback to `local`
-  return MODES[modeName.toLowerCase()] || MODES[MODE_NAME.LOCAL]
+  return MODES[modeName.toUpperCase()] || MODES[MODE_NAME.LOCAL]
 }


### PR DESCRIPTION
[cf ICIJ/datashare](https://github.com/ICIJ/datashare/pull/1006)

We changed how the batchsearches are handled by datashare :
- for LOCAL/EMBEDDED modes we create a batchsearchloop with a memory queue
- we don't need to make difference between local/server mode

This PR also fixes a bug : when refactoring with IoC, we introduced a lower/upper case bug in the mode module.