### PR TITLE
fix: launch polling when total changes ICIJ/datashare#1010

### DIFF
--- a/src/components/BatchSearchTable.vue
+++ b/src/components/BatchSearchTable.vue
@@ -352,6 +352,9 @@ export default {
   watch: {
     $route() {
       return this.fetchWithLoader()
+    },
+    total() {
+      this.fetchAndRegisterPollWithLoader()
     }
   },
   mounted() {

--- a/src/pages/BatchSearch.vue
+++ b/src/pages/BatchSearch.vue
@@ -19,7 +19,6 @@
 </template>
 
 <script>
-import polling from '@/mixins/polling'
 import utils from '@/mixins/utils'
 import BatchSearchTable from '@/components/BatchSearchTable'
 import BatchSearchClearFilters from '@/components/BatchSearchClearFilters'
@@ -33,7 +32,7 @@ export default {
     BatchSearchClearFilters,
     BatchSearchTable
   },
-  mixins: [polling, utils],
+  mixins: [utils],
   computed: {
     ...mapState('batchSearch', ['hasBatchSearch']),
     howToLink() {


### PR DESCRIPTION
This is a "quick" fix.

Problem is : batchsearch polling was working when there was no batchsearch. But when there is at least one batch search, it fails. 

The root cause is because when there is no batch search, there is no `BatchSearchTable` component. When the form is submitted the store value `hasBatchSearch` is commited, and as it is mapped with the state of `BatchSearch` page, then it creates the  `BatchSearchTable` calling `mounted()` that triggers `this.fetchAndRegisterPollWithLoader()`.

When  a second BatchSearch is created, the component is not mounted another time. The inner state of `BatchSearchTable` changes because it is mapped with `total` property of the store. But it doesn't trigger the polling.

It raises several points :

- with this quick fix, when there is no batch search, the polling is launched twice (but as it is idempotent in the `polling` mixin it doesn't matter much)
- if we would like to remove this, we could remove the `hasBatchSearch` mutation/state in the store : it is a kind of duplication with `total` isn't it? Could we make a  `hasBatchSearch` getter that would return `state.total > 0` ? 
- the store action `hasBatchSearch(...)` looks like a getter but it is not : it is making a batchSearch ajax call and eventually change the store state. Could it be a good reason to remove this action, and delegate to `getBatchSearches(...)` ?