### PR TITLE
fix: ensure store is reseted when URL query change

### DIFF
--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -392,6 +392,7 @@ function actionsBuilder(api) {
       }
     },
     updateFromRouteQuery({ commit, getters }, query) {
+      commit('reset', ['field'])
       ;['q', 'index', 'indices', 'from', 'size', 'sort', 'field'].forEach((key) => {
         if (key in query) {
           // Add the query to the state with a mutation to avoid triggering a search


### PR DESCRIPTION
The error described in https://github.com/ICIJ/datashare/issues/1022 is caused by the method that read search filter from the URL.

This PR takes care of resetting the search filter every time an attempt to read route parameters is done.