### PR TITLE
fix: incorrect document basename on Windows

### DIFF
--- a/src/api/resources/Document.js
+++ b/src/api/resources/Document.js
@@ -78,17 +78,18 @@ export default class Document extends EsDoc {
   }
   get folder() {
     // Extract location parts
-    const parts = this.path.split(_separator)
+    const pathSeparator = Murmur.config.get('pathSeparator', _separator)
+    const parts = this.path.split(pathSeparator)
     // Remove the file name
     parts.splice(-1, 1)
     // And return the new path
-    return parts.join(_separator) + _separator
+    return parts.join(pathSeparator) + pathSeparator
   }
   get location() {
     return this.folder.split(Murmur.config.get('dataDir', process.env.VUE_APP_DATA_PREFIX)).pop()
   }
   get basename() {
-    return last(this.path.split(_separator))
+    return last(this.path.split(Murmur.config.get('pathSeparator', _separator)))
   }
   get extension() {
     return extname(this.basename).toLowerCase()

--- a/tests/unit/specs/api/resources/Document.spec.js
+++ b/tests/unit/specs/api/resources/Document.spec.js
@@ -1,3 +1,4 @@
+import Murmur from '@icij/murmur'
 import Document from '@/api/resources/Document'
 
 describe('Document', () => {
@@ -175,5 +176,12 @@ describe('Document', () => {
     const doc = new Document({ _id: '42', _index: 'project', _routing: '12' })
 
     expect(doc.fullRootUrl).toBe('http://localhost:9009/api/project/documents/src/12?routing=12')
+  })
+
+  it('should return the correct basename on Windows', () => {
+    Murmur.config.set('pathSeparator', '\\')
+    const doc = new Document({ _source: { path: 'C:\\this\\is\\a\\specific.file' } })
+
+    expect(doc.basename).toBe('specific.file')
   })
 })


### PR DESCRIPTION
On Windows, documents have the full path in their names which add difficulty for users to identify their documents.
![Windocname](https://user-images.githubusercontent.com/35509100/221195063-5c1eab78-2863-413c-9974-17d5e2b27768.png)

This PR fixes this issue with the following result
![Docnamescorrected](https://user-images.githubusercontent.com/35509100/221195199-31b5b8d5-d18c-4378-8329-e394f32a1533.png)

