### PR TITLE
fix(history/search): display one badge per filter value

### DIFF
--- a/src/components/BatchSearchTable.vue
+++ b/src/components/BatchSearchTable.vue
@@ -156,9 +156,6 @@ export default {
       ]
     }
   },
-  mounted() {
-    this.fetchAndRegisterPollWithLoader()
-  },
   watch: {
     $route() {
       return this.fetchWithLoader()
@@ -166,6 +163,9 @@ export default {
     total() {
       this.fetchAndRegisterPollWithLoader()
     }
+  },
+  mounted() {
+    this.fetchAndRegisterPollWithLoader()
   },
   computed: {
     ...mapState('batchSearch', ['total']),

--- a/src/pages/UserHistorySearch.vue
+++ b/src/pages/UserHistorySearch.vue
@@ -66,13 +66,10 @@ export default {
     },
     createFiltersFromURI(uri) {
       const urlSearchParams = new URLSearchParams(uri.split('?').slice(1).pop())
-      const params = Object.fromEntries(urlSearchParams.entries())
-      // Reduce params list into an array
-      return Object.keys(params).reduce((filters, name) => {
-        let value = params[name]
-        // Skip ignored param
+      const filters = []
+      for (let [name, value] of urlSearchParams.entries()) {
         if (this.isIgnoredFilter({ name, value })) {
-          return filters
+          continue
         }
         // Filter value is a Date
         if (name.includes('Date')) {
@@ -83,10 +80,10 @@ export default {
         if (name.includes('indices')) {
           name = 'projects'
         }
-        // Finally, add the filter to the list of displayed filters
+
         filters.push({ name, value, label: value })
-        return filters
-      }, [])
+      }
+      return filters
     },
     async deleteUserEvent(event) {
       try {

--- a/tests/unit/specs/pages/UserHistorySearch.spec.js
+++ b/tests/unit/specs/pages/UserHistorySearch.spec.js
@@ -91,4 +91,12 @@ describe('UserHistorySearch.vue', () => {
       })
     )
   })
+
+  it('should parse uri with multiple fields with the same filter name', () => {
+    const uri = '/?q=*&indices=cantina,local-datashare&f[language]=FRENCH&f[language]=ENGLISH'
+    const filters = wrapper.vm.createFiltersFromURI(uri)
+    expect(filters[0].name).toBe('projects')
+    expect(filters[1].name).toBe('f[language]')
+    expect(filters[2].name).toBe('f[language]')
+  })
 })


### PR DESCRIPTION
fixes https://github.com/ICIJ/datashare/issues/1032

Before This PR, when a filter had several value, the history for this search would display only one badge with one value.

After this PR, one badge per value for one filter is displayed (a filter with n values is displayed in n badges): 

![image](https://user-images.githubusercontent.com/39140360/221915631-34b33194-a9e6-4751-ba6b-c1142c6395e1.png)
