### PR TITLE
feat: adds alert informing tesseract is missing

### DIFF
--- a/src/components/ExtractingFormOcrControl.vue
+++ b/src/components/ExtractingFormOcrControl.vue
@@ -30,11 +30,14 @@ export default {
       }
       return 'default'
     },
+    isLanguageAvailable() {
+      return !!find(this.ocrLanguages, (language) => language.iso6392 === this.isoLang)
+    },
     isOcrLanguage() {
-      return (
-        (this.hasTesseract && !this.isoLang) ||
-        !!find(this.ocrLanguages, (language) => language.iso6392 === this.isoLang)
-      )
+      return !this.isoLang || this.isLanguageAvailable
+    },
+    shouldDisplayLanguageMessage() {
+      return this.hasTesseract && !this.isOcrLanguage
     },
     waitIdentifier() {
       return uniqueId('extracting-form-ocr-control-')
@@ -60,9 +63,9 @@ export default {
         this.textLanguages = textLanguages
         this.ocrLanguages = ocrLanguages
       } catch (e) {
-        if (e.response.status === 503) {
-          this.$set(this, 'hasTesseract', false)
-        } else {
+        this.hasTesseract = e.response.status !== 503
+
+        if (this.hasTesseract) {
           this.$root.$bvToast.toast(this.$t('extractingLanguageFormControl.failedToRetrieveLanguages'), {
             noCloseButton: true,
             variant: 'danger'
@@ -84,7 +87,7 @@ export default {
       >{{ $t('extractingFormOcrControl.tesseractNotInstalled') }}
     </b-alert>
     <b-alert
-      :show="!isOcrLanguage"
+      :show="shouldDisplayLanguageMessage"
       variant="warning"
       class="extracting_language_form_control__install_ocr_language mt-3"
       >{{ $t('extractingFormOcrControl.isMissing', { language: languageName }) }}

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -516,7 +516,8 @@
   "extractingFormOcrControl": {
     "useDefault": "Default OCR language is used.",
     "isMissing": " OCR for '{language}' is not installed.",
-    "installOcr": "Choose among {availableLanguages} languages to install."
+    "installOcrLanguage": "Choose among {availableLanguages} languages to install.",
+    "tesseractNotInstalled": "Tesseract OCR is not installed."
   },
   "indexing": {
     "title": "Analyze your documents",

--- a/tests/unit/specs/components/ExtractingFormOcrControl.spec.js
+++ b/tests/unit/specs/components/ExtractingFormOcrControl.spec.js
@@ -45,8 +45,15 @@ describe('ExtractingFormOcrControl.vue', () => {
     it('should display an alert indicating that no ocr are installed', async () => {
       wrapper = mount(ExtractingFormOcrControl, { wait, store, i18n, localVue, propsData: { isoLang: 'ita' } })
       await flushPromises()
-      expect(wrapper.find('.extracting_language_form_control__install_ocr').exists()).toBe(true)
-      expect(wrapper.find('.extracting_language_form_control__install_ocr').text()).toContain("'Italian'")
+      expect(wrapper.find('.extracting_language_form_control__install_ocr_language').exists()).toBe(true)
+      expect(wrapper.find('.extracting_language_form_control').text()).not.toContain('Tesseract OCR is not installed.')
+    })
+
+    it('should display an alert indicating that tesseract is not installed', async () => {
+      wrapper = mount(ExtractingFormOcrControl, { wait, store, i18n, localVue, propsData: { isoLang: 'ita' } })
+      wrapper.setData({ hasTesseract: false })
+      await flushPromises()
+      expect(wrapper.find('.extracting_language_form_control').text()).toContain('Tesseract OCR is not installed.')
     })
   })
 })


### PR DESCRIPTION
Related to [this issue](https://github.com/ICIJ/datashare/issues/1013)
This PR adds an alert when OCR is check in indexation form.

Possible improvement : disable/grey out check button