### PR TITLE
fix: handle long extracted text and search occurences

### DIFF
--- a/src/components/DocumentActions.vue
+++ b/src/components/DocumentActions.vue
@@ -37,7 +37,11 @@
           >
             {{ $t('document.downloadWithoutMetadata') }}
           </b-dropdown-item>
-          <b-dropdown-item @click="documentOriginalExtractedText">
+          <b-dropdown-item
+            v-if="hasContentLength"
+            class="document-actions__download--extracted-text"
+            @click="documentOriginalExtractedText"
+          >
             {{ $t('document.downloadExtractedText') }}
           </b-dropdown-item>
         </b-dropdown>
@@ -259,6 +263,9 @@ export default {
     },
     hasRootCleanableContentType() {
       return this.hasRoot && this.cleanableContentTypes.includes(this.document.root.contentType)
+    },
+    hasContentLength() {
+      return this.document?.contentLength > 0
     }
   },
   methods: {

--- a/src/components/DocumentActions.vue
+++ b/src/components/DocumentActions.vue
@@ -30,14 +30,15 @@
             {{ $t('document.downloadButton') }}
           </span>
         </a>
-        <b-dropdown
-          v-if="displayDownloadWithoutMetadata && hasCleanableContentType"
-          right
-          toggle-class="py-0"
-          size="sm"
-        >
-          <b-dropdown-item :href="documentFullUrlWithoutMetadata">
+        <b-dropdown right toggle-class="py-0" size="sm">
+          <b-dropdown-item
+            v-if="displayDownloadWithoutMetadata && hasCleanableContentType"
+            :href="documentFullUrlWithoutMetadata"
+          >
             {{ $t('document.downloadWithoutMetadata') }}
+          </b-dropdown-item>
+          <b-dropdown-item @click="documentOriginalExtractedText">
+            {{ $t('document.downloadExtractedText') }}
           </b-dropdown-item>
         </b-dropdown>
       </b-btn-group>
@@ -261,6 +262,15 @@ export default {
     }
   },
   methods: {
+    async documentOriginalExtractedText() {
+      if (!this.document.content) {
+        await this.$store.dispatch('document/getContent')
+      }
+      const a = document.createElement('a')
+      a.href = URL.createObjectURL(new Blob([this.document.content], { type: 'text/plain;charset=UTF-8' }))
+      a.download = `${this.document.title}.txt`
+      a.click()
+    },
     classAttributeToObject(str) {
       const list = str.split(' ')
       return Object.assign({}, ...list.map((key) => ({ [key]: true })))

--- a/src/components/DocumentContent.vue
+++ b/src/components/DocumentContent.vue
@@ -216,7 +216,7 @@ export default {
       // Add the missing tailing content (if any)
       const organicContent = truncatedTailContent + missingTailingContent
       // The offset of the content is not the same anymore
-      const organicOffset = organicHead ? Number(offset) : 1 + Number(offset) + content.split('\n').shift().length
+      const organicOffset = organicHead ? Number(offset) : 1 + offset + content.split('\n').shift().length
       return { organicContent, organicHead, organicTail, organicOffset }
     },
     async cookContentSlice({
@@ -251,7 +251,7 @@ export default {
       }
     },
     getContentSlice(
-      { offset = 0, endOffset = this.pageSize, targetLanguage = this.targetLanguage } = {},
+      { offset = 0, endOffset = offset + this.pageSize, targetLanguage = this.targetLanguage } = {},
       defaultValue = null
     ) {
       const targetLanguageKey = targetLanguage || 'original'
@@ -263,10 +263,13 @@ export default {
     hasContentSlice({ offset = 0, endOffset = this.pageSize, targetLanguage = this.targetLanguage } = {}) {
       return !!this.getContentSlice({ offset, endOffset, targetLanguage })
     },
-    async loadContentSlice({ offset = 0, endOffset = this.pageSize, targetLanguage = this.targetLanguage } = {}) {
+    async loadContentSlice({
+      offset = 0,
+      endOffset = offset + this.pageSize,
+      targetLanguage = this.targetLanguage
+    } = {}) {
       // Ensure the limit is not beyond limit
       const limit = Math.max(Math.min(endOffset, this.maxOffset) - offset, 0)
-
       const { content } = await this.$store.dispatch('document/getContentSlice', { offset, limit, targetLanguage })
       return this.setContentSlice({ offset, endOffset, targetLanguage, content })
     },

--- a/src/components/DocumentContent.vue
+++ b/src/components/DocumentContent.vue
@@ -104,12 +104,16 @@ export default {
     }
   },
   watch: {
-    localSearchTerm: throttle(async function () {
-      await this.retrieveTotalOccurrences()
-      await this.cookAllContentSlices()
-      await this.$nextTick()
-      await this.jumpToActiveLocalSearchTerm()
-    }, 300),
+    localSearchTerm: throttle(
+      async function () {
+        await this.retrieveTotalOccurrences()
+        await this.cookAllContentSlices()
+        await this.$nextTick()
+        await this.jumpToActiveLocalSearchTerm()
+      },
+      300,
+      { leading: false }
+    ),
     async targetLanguage(value) {
       await this.loadMaxOffset(value)
       await this.cookAllContentSlices()

--- a/src/components/DocumentContent.vue
+++ b/src/components/DocumentContent.vue
@@ -402,8 +402,15 @@ export default {
     </div>
 
     <div class="border shadow-sm m-3">
-      <div class="p-1 bg-lighter">
-        <custom-pagination v-model="page" compact size="sm" :pages="nbPages"></custom-pagination>
+      <div class="p-1 bg-lighter" v-if="nbPages > 1">
+        <b-pagination
+          v-model="page"
+          align="center"
+          class="m-0"
+          size="sm"
+          :per-page="1"
+          :total-rows="nbPages"
+        ></b-pagination>
       </div>
       <b-overlay :show="$wait.is('loadContentSlice')" opacity="0.6" rounded spinner-small>
         <hook name="document.content.body:before"></hook>

--- a/src/components/DocumentLocalSearchInput.vue
+++ b/src/components/DocumentLocalSearchInput.vue
@@ -41,6 +41,12 @@ export default {
      */
     loading: {
       type: Boolean
+    },
+    /**
+     * Disable input
+     */
+    disabled: {
+      type: Boolean
     }
   },
   data() {
@@ -61,6 +67,9 @@ export default {
     },
     searchLabel() {
       return `${this.searchIndex} ${this.$t('document.of')} ${this.searchOccurrences}`
+    },
+    searchTermIsEmpty() {
+      return this.searchTerm?.length === 0
     }
   },
   watch: {
@@ -115,7 +124,7 @@ export default {
     class="document-local-search-input form-inline px-3"
     :class="{
       'document-local-search-input--active': isActive,
-      'document-local-search-input--pristine': searchTerm.length > 0
+      'document-local-search-input--pristine': !searchTermIsEmpty
     }"
   >
     <div class="form-group py-2 mr-2">
@@ -128,12 +137,13 @@ export default {
           v-shortkey="getKeys('findInDocument')"
           type="search"
           :value="searchTerm"
+          :disabled="disabled"
           :placeholder="$t('document.find')"
           class="form-control document-local-search-input__term"
           @input="$emit('input', $event.target.value)"
           @shortkey="getAction('findInDocument')"
         />
-        <div v-if="searchTerm.length > 0" class="document-local-search-input__count input-group-append w-25">
+        <div v-if="!searchTermIsEmpty" class="document-local-search-input__count input-group-append w-25">
           <span v-if="loading" class="input-group-text w-100 text-center d-inline-block">
             <fa icon="circle-notch" spin></fa>
           </span>
@@ -152,14 +162,14 @@ export default {
     <div class="form-group">
       <button
         class="document-local-search-input__previous btn btn-sm p-2"
-        :disabled="searchOccurrences === 0 || searchTerm.length === 0"
+        :disabled="searchOccurrences === 0 || searchTermIsEmpty"
         @click="previous"
       >
         <fa icon="angle-up"></fa>
       </button>
       <button
         class="document-local-search-input__next btn btn-sm p-2"
-        :disabled="searchOccurrences === 0 || searchTerm.length === 0"
+        :disabled="searchOccurrences === 0 || searchTermIsEmpty"
         @click="next"
       >
         <fa icon="angle-down"></fa>

--- a/src/components/DocumentTranslatedContent.vue
+++ b/src/components/DocumentTranslatedContent.vue
@@ -97,7 +97,7 @@ export default {
   },
   methods: {
     toggleTranslatedContent() {
-      this.$store.commit('document/toogleShowTransatedContent')
+      this.$store.commit('document/toggleShowTranslatedContent')
     },
     async loadAvailableTranslations() {
       const _source = join([

--- a/src/components/SearchResultsHeader.vue
+++ b/src/components/SearchResultsHeader.vue
@@ -292,7 +292,7 @@ export default {
         width: 172px;
       }
 
-      &:deep(&__toogler__hits) {
+      &:deep(&__toggler__hits) {
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;

--- a/src/components/SearchResultsList.vue
+++ b/src/components/SearchResultsList.vue
@@ -117,7 +117,7 @@ export default {
     }
 
     .nav-link {
-      color: mix($tertiary, text-contrast($tertiary), 0.7);
+      color: mix($tertiary, text-contrast($tertiary), 70%);
     }
   }
 

--- a/src/components/document/DocumentNavbar.vue
+++ b/src/components/document/DocumentNavbar.vue
@@ -95,7 +95,7 @@ import utils from '@/mixins/utils'
  * Document navbar in the context of a search.
  */
 export default {
-  name: 'SearchDocumentNavbar',
+  name: 'DocumentNavbar',
   components: {
     DocumentActions,
     UserDisplay

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -136,6 +136,9 @@
     "viewOriginal": "View original text",
     "viewTranslated": "View translated text"
   },
+  "documentContent": {
+    "noContent": "No content extracted for this document"
+  },
   "filter": {
     "none": "No values",
     "noMatches": "No matches.<br />Hit <kbd>Enter</kbd> to search in every documents",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -415,6 +415,7 @@
     "downloadButton": "Download",
     "downloadRootButton": "Download parent",
     "downloadWithoutMetadata": "Download without metadata",
+    "downloadExtractedText": "Download extracted text",
     "externalWindow": "Open in a new window",
     "copyLink": "Copy link",
     "selectAll": "Select all",

--- a/src/store/modules/document.js
+++ b/src/store/modules/document.js
@@ -114,7 +114,7 @@ export const mutations = {
     }
     return state.rootDocument
   },
-  toogleShowTransatedContent(state, toggle = null) {
+  toggleShowTranslatedContent(state, toggle = null) {
     Vue.set(state, 'showTranslatedContent', toggle !== null ? toggle : !state.showTranslatedContent)
   },
   addTag(state, { tag, userId }) {

--- a/src/store/pipelines/index.js
+++ b/src/store/pipelines/index.js
@@ -1,7 +1,6 @@
 export { default as IdentityPipeline } from './IdentityPipeline'
 export { default as SimplePipeline } from './SimplePipeline'
 export { default as AddGlobalSearchMarks } from './AddGlobalSearchMarks'
-export { default as AddNamedEntitiesPipeline } from './AddNamedEntitiesPipeline'
 export { default as AddLineBreaksPipeline } from './AddLineBreaksPipeline'
 export { default as DeleteEmptyParagraphsPipeline } from './DeleteEmptyParagraphsPipeline'
 export { default as AddLabelComponents } from './AddLabelComponents'

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -13,8 +13,8 @@ export function addLocalSearchMarksClassByOffsets({ content = '', term = '', off
   const chunks = content.split('')
   // Add mark tag to the corresponding letters
   offsets.forEach((offset) => {
-    const start = offset - delta
-    const end = start + term.length - 1
+    const start = offset - Number(delta)
+    const end = Math.min(start + term.length - 1, chunks.length - 1)
     // Only replace by offset in existing chunk
     if (chunks[start] && chunks[end]) {
       chunks[start] = `<mark class="local-search-term" data-offset="${offset}">${chunks[start]}`
@@ -23,32 +23,6 @@ export function addLocalSearchMarksClassByOffsets({ content = '', term = '', off
   })
   // Then merge letters again
   return chunks.join('')
-}
-
-export function addLocalSearchMarksClassSensitive(content = '<div></div>', localSearchTerm = { label: '' }) {
-  const escapedLocalSearchTerm = localSearchTerm.regex ? localSearchTerm.label : escapeRegExp(localSearchTerm.label)
-  // In case the searched term is split on 2 lines in the content
-  const escapedLocalSearchTermAsRegex = escapedLocalSearchTerm.replace(' ', '( |  |.|..| .)')
-  const regex = new RegExp(`(?![^<]*>)${escapedLocalSearchTermAsRegex}`, 'gms')
-  const localSearchOccurrences = (content.match(regex) || []).length
-  const localSearchIndex = Number(!!localSearchOccurrences)
-  try {
-    if (localSearchOccurrences === 0) throw new Error()
-    const needle = new RegExp(`(${escapedLocalSearchTermAsRegex})`, 'gms')
-    const replacedContent = content.replace(needle, (m) => {
-      const term = m.replace(/(\r\n|\n|\r)/gm, ' ').replace('  ', ' ')
-      return `<mark class="local-search-term">${term}</mark>`
-    })
-
-    return {
-      content: replacedContent,
-      localSearchIndex,
-      localSearchOccurrences
-    }
-    // Silently fails
-  } catch (error) {
-    return { content, localSearchIndex, localSearchOccurrences }
-  }
 }
 
 export function addLocalSearchMarksClass(content = '<div></div>', localSearchTerm = { label: '' }) {

--- a/tests/unit/specs/components/DocumentActions.spec.js
+++ b/tests/unit/specs/components/DocumentActions.spec.js
@@ -107,6 +107,17 @@ describe('DocumentActions.vue', () => {
     expect(wrapper.find('.document-actions__download').exists()).toBeTruthy()
   })
 
+  it('should display "Download extracted text" button if there is content available', () => {
+    const options = { i18n, localVue, store, propsData: { document, isDownloadAllowed: true }, sync: false }
+    wrapper = shallowMount(DocumentActions, options)
+
+    expect(wrapper.find('.document-actions__download--extracted-text').exists()).toBe(false)
+    document.contentLength = 10
+
+    wrapper = shallowMount(DocumentActions, options)
+    expect(wrapper.find('.document-actions__download--extracted-text').exists()).toBe(true)
+  })
+
   it('should NOT display "Download parent" button if document has no parent', () => {
     wrapper = shallowMount(DocumentActions, {
       i18n,

--- a/tests/unit/specs/components/DocumentContent.spec.js
+++ b/tests/unit/specs/components/DocumentContent.spec.js
@@ -45,7 +45,7 @@ describe('DocumentContent.vue', () => {
     await store.dispatch('document/get', { id, index })
     const document = store.state.document.doc
     // Finally flush all promises and return all necessary values
-    flushPromises()
+    await flushPromises()
     return { content, contentSlice, document }
   }
 
@@ -86,13 +86,7 @@ describe('DocumentContent.vue', () => {
       const content = 'this is a <mark>document</mark>'
       const { document } = await mockDocumentContentSlice(content)
       const propsData = { document }
-      const wrapper = shallowMount(DocumentContent, {
-        i18n,
-        localVue,
-        store,
-        propsData,
-        wait
-      })
+      const wrapper = shallowMount(DocumentContent, { i18n, localVue, store, propsData, wait })
       await flushPromises()
       await wrapper.vm.loadContentSlice()
       await wrapper.vm.cookAllContentSlices()
@@ -131,6 +125,20 @@ describe('DocumentContent.vue', () => {
       await flushPromises()
       await wrapper.vm.loadContentSlice()
       expect(wrapper.find('.document-content__body--rtl').exists()).toBeFalsy()
+    })
+
+    it('should display "No content extracted for this document" and disable the search input when the extracted text is empty', async () => {
+      const { document } = await mockDocumentContentSlice('')
+      const propsData = { document }
+      const wrapper = shallowMount(DocumentContent, { i18n, localVue, store, propsData, wait })
+      await flushPromises()
+      await wrapper.vm.loadContentSlice()
+      const element = wrapper.find('.document-content__body--no-content')
+      expect(element.exists()).toBe(true)
+      expect(element.text()).toBe('No content extracted for this document')
+      const input = wrapper.find('document-local-search-input-stub')
+      expect(input.exists()).toBe(true)
+      expect(input.attributes('disabled')).toBe('true')
     })
   })
 

--- a/tests/unit/specs/components/DocumentContent.spec.js
+++ b/tests/unit/specs/components/DocumentContent.spec.js
@@ -27,7 +27,7 @@ window.HTMLElement.prototype.scrollIntoView = jest.fn()
 
 describe('DocumentContent.vue', () => {
   const api = new Api(null, null)
-  const { i18n, localVue, store } = Core.init(createLocalVue(), api).useAll()
+  const { i18n, localVue, store, wait } = Core.init(createLocalVue(), api).useAll()
   const { index, es } = esConnectionHelper.build()
   const id = 'document'
 
@@ -69,7 +69,13 @@ describe('DocumentContent.vue', () => {
         'this is a <span>content</span> with some <img src="this.is.a.source" alt="alt" title="title" />images and <a href="this.is.an.href" target="_blank">links</a>'
       const { document } = await mockDocumentContentSlice(content)
       const propsData = { document }
-      const wrapper = shallowMount(DocumentContent, { i18n, localVue, store, propsData })
+      const wrapper = shallowMount(DocumentContent, {
+        i18n,
+        localVue,
+        store,
+        propsData,
+        wait
+      })
       await flushPromises()
       await wrapper.vm.loadContentSlice()
       await wrapper.vm.cookAllContentSlices()
@@ -80,7 +86,13 @@ describe('DocumentContent.vue', () => {
       const content = 'this is a <mark>document</mark>'
       const { document } = await mockDocumentContentSlice(content)
       const propsData = { document }
-      const wrapper = shallowMount(DocumentContent, { i18n, localVue, store, propsData })
+      const wrapper = shallowMount(DocumentContent, {
+        i18n,
+        localVue,
+        store,
+        propsData,
+        wait
+      })
       await flushPromises()
       await wrapper.vm.loadContentSlice()
       await wrapper.vm.cookAllContentSlices()
@@ -90,9 +102,17 @@ describe('DocumentContent.vue', () => {
     it('should display the text right to left for arabic', async () => {
       const content =
         'المنال ويتلذذ بالآلام، الألم هو الألم ولكن نتيجة لظروف ما قد تكمن السعاده فيما نتحمله من كد وأسي.'
-      const { document } = await mockDocumentContentSlice(content, { language: 'ARABIC' })
+      const { document } = await mockDocumentContentSlice(content, {
+        language: 'ARABIC'
+      })
       const propsData = { document }
-      const wrapper = shallowMount(DocumentContent, { i18n, localVue, store, propsData })
+      const wrapper = shallowMount(DocumentContent, {
+        i18n,
+        localVue,
+        store,
+        propsData,
+        wait
+      })
       await flushPromises()
       await wrapper.vm.loadContentSlice()
       expect(wrapper.find('.document-content__body--rtl').exists()).toBeTruthy()
@@ -101,7 +121,13 @@ describe('DocumentContent.vue', () => {
     it('should NOT display the text right to left for english', async () => {
       const { document } = await mockDocumentContentSlice('foo')
       const propsData = { document }
-      const wrapper = shallowMount(DocumentContent, { i18n, localVue, store, propsData })
+      const wrapper = shallowMount(DocumentContent, {
+        i18n,
+        localVue,
+        store,
+        propsData,
+        wait
+      })
       await flushPromises()
       await wrapper.vm.loadContentSlice()
       expect(wrapper.find('.document-content__body--rtl').exists()).toBeFalsy()
@@ -119,7 +145,13 @@ describe('DocumentContent.vue', () => {
       it('should not sticky the toolbox by default', async () => {
         const { document } = await mockDocumentContentSlice('')
         const propsData = { document }
-        const wrapper = shallowMount(DocumentContent, { i18n, localVue, store, propsData })
+        const wrapper = shallowMount(DocumentContent, {
+          i18n,
+          localVue,
+          store,
+          propsData,
+          wait
+        })
         await flushPromises()
         expect(wrapper.find('.document-content__toolbox--sticky').exists()).toBeFalsy()
       })
@@ -135,7 +167,13 @@ describe('DocumentContent.vue', () => {
           return { count: 2, offsets: [10, 15] }
         })
         const propsData = { document }
-        wrapper = mount(DocumentContent, { i18n, localVue, store, propsData })
+        wrapper = mount(DocumentContent, {
+          i18n,
+          localVue,
+          store,
+          propsData,
+          wait
+        })
         await flushPromises()
         await wrapper.vm.loadContentSlice()
         // Use vm.$set method to set nested value reactivly
@@ -148,7 +186,7 @@ describe('DocumentContent.vue', () => {
       })
 
       it('should highlight the first occurrence of the searched term', async () => {
-        const { innerHTML } = wrapper.find('.document-content__body .document-content-slice').element
+        const { innerHTML } = wrapper.find('.document-content__body').element
         expect(wrapper.vm.localSearchIndex).toEqual(1)
         expect(innerHTML).toEqual(
           '<p>this is a <mark class="local-search-term local-search-term--active" data-offset="10">full</mark> <mark class="local-search-term" data-offset="15">full</mark> content</p>'
@@ -156,7 +194,7 @@ describe('DocumentContent.vue', () => {
       })
 
       it('should find the previous and next occurrence, as a loop', async () => {
-        const { element } = wrapper.find('.document-content__body  .document-content-slice')
+        const { element } = wrapper.find('.document-content__body')
 
         expect(wrapper.vm.localSearchIndex).toEqual(1)
         expect(element.innerHTML).toEqual(
@@ -199,7 +237,13 @@ describe('DocumentContent.vue', () => {
           return { count: 3, offsets: [10, 15, 28] }
         })
         const propsData = { document }
-        wrapper = mount(DocumentContent, { i18n, localVue, store, propsData })
+        wrapper = mount(DocumentContent, {
+          i18n,
+          localVue,
+          store,
+          propsData,
+          wait
+        })
         await flushPromises()
         await wrapper.vm.loadContentSlice()
       })
@@ -219,7 +263,13 @@ describe('DocumentContent.vue', () => {
       const content = 'this is a content'
       const { document } = await mockDocumentContentSlice(content)
       const propsData = { document }
-      const wrapper = mount(DocumentContent, { i18n, localVue, store, propsData })
+      const wrapper = mount(DocumentContent, {
+        i18n,
+        localVue,
+        store,
+        propsData,
+        wait
+      })
       await flushPromises()
       await wrapper.vm.loadContentSlice()
       expect(wrapper.vm.getContentSlice().content).toBe('this is a content')
@@ -231,7 +281,13 @@ describe('DocumentContent.vue', () => {
       const { document } = await mockDocumentContentSlice(content)
       const pageSize = 10
       const propsData = { document, pageSize }
-      const wrapper = mount(DocumentContent, { i18n, localVue, store, propsData })
+      const wrapper = mount(DocumentContent, {
+        i18n,
+        localVue,
+        store,
+        propsData,
+        wait
+      })
       await flushPromises()
       // Load the first slice
       await wrapper.vm.loadContentSlice({ offset: 0 })
@@ -249,7 +305,13 @@ describe('DocumentContent.vue', () => {
       const { document } = await mockDocumentContentSlice(content)
       const pageSize = 30
       const propsData = { document, pageSize }
-      const wrapper = mount(DocumentContent, { i18n, localVue, store, propsData })
+      const wrapper = mount(DocumentContent, {
+        i18n,
+        localVue,
+        store,
+        propsData,
+        wait
+      })
       await flushPromises()
       // Load two slices
       await wrapper.vm.loadContentSlice({ offset: 0 })
@@ -274,7 +336,13 @@ describe('DocumentContent.vue', () => {
         const { document } = await mockDocumentContentSlice(content)
         const pageSize = 25
         const propsData = { document, pageSize }
-        const wrapper = mount(DocumentContent, { i18n, localVue, store, propsData })
+        const wrapper = mount(DocumentContent, {
+          i18n,
+          localVue,
+          store,
+          propsData,
+          wait
+        })
         wrapper.vm.$set(wrapper.vm, 'localSearchTerm', 'long')
         await flushPromises()
         // Load two slices
@@ -301,7 +369,13 @@ describe('DocumentContent.vue', () => {
         const { document } = await mockDocumentContentSlice(content)
         const pageSize = 25
         const propsData = { document, pageSize }
-        const wrapper = mount(DocumentContent, { i18n, localVue, store, propsData })
+        const wrapper = mount(DocumentContent, {
+          i18n,
+          localVue,
+          store,
+          propsData,
+          wait
+        })
         wrapper.vm.$set(wrapper.vm, 'localSearchTerm', 'or')
         await flushPromises()
         // Load two slices
@@ -321,7 +395,13 @@ describe('DocumentContent.vue', () => {
       const { document } = await mockDocumentContentSlice(content)
       const pageSize = 11
       const propsData = { document, pageSize }
-      const wrapper = mount(DocumentContent, { i18n, localVue, store, propsData })
+      const wrapper = mount(DocumentContent, {
+        i18n,
+        localVue,
+        store,
+        propsData,
+        wait
+      })
       await flushPromises()
       // Load the first slice
       // Load two slices

--- a/tests/unit/specs/components/DocumentLocalSearchInput.spec.js
+++ b/tests/unit/specs/components/DocumentLocalSearchInput.spec.js
@@ -18,4 +18,16 @@ describe('DocumentLocalSearchInput.vue', () => {
     expect(wrapper.find('.document-local-search-input__term').exists()).toBeTruthy()
     expect(wrapper.find('.document-local-search-input__count').exists()).toBeTruthy()
   })
+
+  it('should disable input when disabled props is true', async () => {
+    const wrapper = shallowMount(DocumentLocalSearchInput, {
+      localVue,
+      store,
+      propsData: { disabled: false },
+      mocks: { $t: (msg) => msg }
+    })
+    expect(wrapper.find('.document-local-search-input__term').attributes('disabled')).toBeUndefined()
+    await wrapper.setProps({ disabled: true })
+    expect(wrapper.find('.document-local-search-input__term').attributes('disabled')).toBe('disabled')
+  })
 })

--- a/tests/unit/specs/components/DocumentTranslatedContent.spec.js
+++ b/tests/unit/specs/components/DocumentTranslatedContent.spec.js
@@ -9,7 +9,7 @@ import { Core } from '@/core'
 import DocumentTranslatedContent from '@/components/DocumentTranslatedContent'
 
 describe('DocumentTranslatedContent.vue', () => {
-  let i18n, localVue, store, api
+  let i18n, localVue, store, wait, api
   const { index, es } = esConnectionHelper.build()
 
   function mockedDocumentContentFactory(id, content = '') {
@@ -50,6 +50,7 @@ describe('DocumentTranslatedContent.vue', () => {
     i18n = core.i18n
     localVue = core.localVue
     store = core.store
+    wait = core.wait
   })
   beforeEach(() => {
     api.getDocumentSlice.mockClear()
@@ -67,7 +68,7 @@ describe('DocumentTranslatedContent.vue', () => {
     const mocked = mockedDocumentContentFactory('document-without-translation', 'Premier')
     mocked.indexedDocument.withLanguage('FRENCH').withNoContentTranslated()
     const { document } = await mocked.commit()
-    const wrapper = mount(DocumentTranslatedContent, { i18n, localVue, store, propsData: { document } })
+    const wrapper = mount(DocumentTranslatedContent, { i18n, localVue, store, wait, propsData: { document } })
     await wrapper.vm.loadAvailableTranslations()
     await wrapper.vm.$refs.content.loadMaxOffset()
     await wrapper.vm.$refs.content.loadContentSlice()
@@ -80,7 +81,7 @@ describe('DocumentTranslatedContent.vue', () => {
     const mocked = mockedDocumentContentFactory('document-with-a-translation-in-italian', 'Premier')
     mocked.indexedDocument.withLanguage('FRENCH').withContentTranslated('Primo', 'FRENCH', 'ITALIAN')
     const { document } = await mocked.commit()
-    const wrapper = mount(DocumentTranslatedContent, { i18n, localVue, store, propsData: { document } })
+    const wrapper = mount(DocumentTranslatedContent, { i18n, localVue, store, wait, propsData: { document } })
     await wrapper.vm.loadAvailableTranslations()
     await wrapper.vm.$refs.content.loadMaxOffset()
     await wrapper.vm.$refs.content.loadContentSlice()
@@ -93,7 +94,7 @@ describe('DocumentTranslatedContent.vue', () => {
     const mocked = mockedDocumentContentFactory('document-with-a-translation-in-english', 'Premier')
     mocked.indexedDocument.withLanguage('FRENCH').withContentTranslated('First', 'FRENCH', 'ENGLISH')
     const { document } = await mocked.commit()
-    const wrapper = mount(DocumentTranslatedContent, { i18n, localVue, store, propsData: { document } })
+    const wrapper = mount(DocumentTranslatedContent, { i18n, localVue, store, wait, propsData: { document } })
     await wrapper.vm.loadAvailableTranslations()
     await wrapper.vm.$refs.content.loadMaxOffset()
     await wrapper.vm.$refs.content.loadContentSlice()

--- a/tests/unit/specs/components/DocumentTranslatedContent.spec.js
+++ b/tests/unit/specs/components/DocumentTranslatedContent.spec.js
@@ -53,7 +53,7 @@ describe('DocumentTranslatedContent.vue', () => {
   })
   beforeEach(() => {
     api.getDocumentSlice.mockClear()
-    store.commit('document/toogleShowTransatedContent', true)
+    store.commit('document/toggleShowTranslatedContent', true)
   })
 
   afterEach(async () => {


### PR DESCRIPTION
Related to the bug: ICIJ/datashare#1033
And related to modifications here: https://github.com/ICIJ/datashare/pull/1043

Fixed:
- Replace virtual scroller by paginated extracted text

Added:
- Extracted text download as text file is now available under Download document

Improvement suggestions:
- Refactor document content component (DRY)
- Prevent download or display when extracted text is empty.
- Propose a better pagination UX
- Propose a better download extracted text UX

Misc: 
- when merging, I'll try to squash the PR in 2 commits: 1 for the "fixed", 1 for the "added"