### PR TITLE
fix: path filter links color

### DIFF
--- a/src/components/filter/FilterBoilerplate.vue
+++ b/src/components/filter/FilterBoilerplate.vue
@@ -6,6 +6,7 @@
       'filter--hide-show-more': hideShowMore,
       'filter--hide-search': hideSearch,
       'filter--hide-header': hideHeader,
+      'filter--dark': dark,
       'filter--has-values': hasValues()
     }"
   >

--- a/src/components/filter/types/FilterPath.vue
+++ b/src/components/filter/types/FilterPath.vue
@@ -113,13 +113,13 @@ export default {
         display: none;
       }
     }
+  }
 
-    .filter--dark & .list-group-item {
-      border-bottom: 0;
+  &--dark &__tree-view :deep(.tree-view) .list-group-item {
+    border-bottom: 0;
 
-      a {
-        color: $light;
-      }
+    a {
+      color: $light;
     }
   }
 }


### PR DESCRIPTION
For some reason the class indicating "dark mode" on a filter was removed. This PR restore it and fix the class of tree view link with a deep selector.