### PR TITLE
feat: hide pagination frame when there is no pagination

### DIFF
--- a/src/components/DocumentContent.vue
+++ b/src/components/DocumentContent.vue
@@ -108,6 +108,9 @@ export default {
       // Find the active search term according to `localSearchIndex`
       return this.localSearchIndexes[this.localSearchIndex - 1] // renvoie undefined si le tableau est vide
     },
+    isPaginated () {
+      return this.nbPages > 1
+    },
     contentPipeline() {
       return this.getPipelineChain('extracted-text', this.addLocalSearchMarks)
     },
@@ -334,7 +337,7 @@ export default {
 </script>
 
 <template>
-  <div class="document-content">
+  <div class="document-content" :class="{ 'document-content--paginated': isPaginated  }">
     <hook name="document.content:before"></hook>
     <div class="document-content__toolbox d-flex" :class="{ 'document-content__toolbox--sticky': hasStickyToolbox }">
       <hook name="document.content.toolbox:before"></hook>
@@ -370,8 +373,8 @@ export default {
       <hook name="document.content.ner:after" class="d-flex flex-row justify-content-end align-items-center"></hook>
     </div>
 
-    <div class="document-content__wrapper border shadow-sm m-3">
-      <div v-if="nbPages > 1" class="document-content__wrapper__pagination p-1 bg-lighter">
+    <div class="document-content__wrapper">
+      <div v-if="isPaginated" class="document-content__wrapper__pagination p-1 bg-lighter">
         <b-pagination
           v-model="page"
           align="center"
@@ -441,6 +444,12 @@ export default {
     color: inherit;
     border-bottom: 2px solid transparent;
     padding: 0;
+  }
+
+  &--paginated &__wrapper {
+     border: $border-color 1px soldid;
+     box-shadow: $box-shadow-sm;
+     margin: $spacer;
   }
 }
 </style>

--- a/src/components/DocumentContent.vue
+++ b/src/components/DocumentContent.vue
@@ -108,7 +108,7 @@ export default {
       // Find the active search term according to `localSearchIndex`
       return this.localSearchIndexes[this.localSearchIndex - 1] // renvoie undefined si le tableau est vide
     },
-    isPaginated () {
+    isPaginated() {
       return this.nbPages > 1
     },
     contentPipeline() {
@@ -337,7 +337,7 @@ export default {
 </script>
 
 <template>
-  <div class="document-content" :class="{ 'document-content--paginated': isPaginated  }">
+  <div class="document-content" :class="{ 'document-content--paginated': isPaginated }">
     <hook name="document.content:before"></hook>
     <div class="document-content__toolbox d-flex" :class="{ 'document-content__toolbox--sticky': hasStickyToolbox }">
       <hook name="document.content.toolbox:before"></hook>
@@ -447,9 +447,9 @@ export default {
   }
 
   &--paginated &__wrapper {
-     border: $border-color 1px soldid;
-     box-shadow: $box-shadow-sm;
-     margin: $spacer;
+    border: $border-color 1px soldid;
+    box-shadow: $box-shadow-sm;
+    margin: $spacer;
   }
 }
 </style>


### PR DESCRIPTION
This simply remove the pagination frame around the extracted text when there is no pagination.

![Screenshot 2023-04-05 at 18-02-54 Document - Datashare](https://user-images.githubusercontent.com/471176/230141248-497f249e-f2be-4b15-822d-cab110dc2f7d.png)
![Screenshot 2023-04-05 at 18-03-00 Document - Datashare](https://user-images.githubusercontent.com/471176/230141252-48ee478c-2f60-4bb2-84b2-254b8bf5bf10.png)
