### PR TITLE
fix: ensure changing target language is reactive

### DIFF
--- a/src/components/DocumentContent.vue
+++ b/src/components/DocumentContent.vue
@@ -74,7 +74,7 @@ export default {
     }, 300),
     async targetLanguage(value) {
       await this.loadMaxOffset(value)
-      await this.cookAllContentSlices()
+      await this.activateContentSlice({ offset: 0 })
     },
     async page() {
       const offset = this.activeContentSliceOffset


### PR DESCRIPTION
This fix this bug: https://github.com/ICIJ/datashare/issues/1063

The watcher on `targetLanguage` was "recooking" extract text because we used to load content in the recooking method. Since we moved the loading to a higher level method (`activateContentSlice`) we needed to call this new method instead.