### PR TITLE
fix: make accents insensitive

### DIFF
--- a/tests/unit/specs/utils/datashare_index_mappings.json
+++ b/tests/unit/specs/utils/datashare_index_mappings.json
@@ -2,7 +2,22 @@
   "properties": {
     "content": {
       "type": "text",
-      "index_options": "offsets"
+      "index_options": "offsets",
+      "analyzer": "folding"
+    },
+    "metadata" : {
+      "properties": {
+        "tika_metadata_resourcename": {
+          "type": "text",
+          "analyzer": "folding",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        }
+      }
     },
     "extractionDate": {
       "type": "date",
@@ -54,9 +69,6 @@
     "tags": {
       "type": "keyword",
       "normalizer": "keyword_lowercase"
-    },
-    "metadata": {
-      "type": "object"
     },
     "type": {
       "type": "keyword"

--- a/tests/unit/specs/utils/datashare_index_settings.json
+++ b/tests/unit/specs/utils/datashare_index_settings.json
@@ -18,6 +18,10 @@
     "analyzer": {
       "path_analyzer": {
         "tokenizer": "path_tokenizer"
+      },
+      "folding": {
+        "tokenizer": "standard",
+        "filter":  [ "lowercase", "asciifolding" ]
       }
     },
     "tokenizer": {

--- a/tests/unit/specs/utils/datashare_index_settings_windows.json
+++ b/tests/unit/specs/utils/datashare_index_settings_windows.json
@@ -18,6 +18,10 @@
     "analyzer": {
       "path_analyzer": {
         "tokenizer": "path_tokenizer"
+      },
+      "folding": {
+        "tokenizer": "standard",
+        "filter":  [ "lowercase", "asciifolding" ]
       }
     },
     "tokenizer": {


### PR DESCRIPTION
This PR aims to modify the settings and mappings for index creation in order to make accents insensitive in document content and titles. Related to [this PR](https://github.com/ICIJ/datashare/pull/1073)