### PR TITLE
Fix: add modern greek key to lang

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,4 @@ VUE_APP_DS_AUTH_SIGNIN=/auth/signin
 VUE_APP_DS_COOKIE_NAME=_ds_session_id
 VUE_APP_DS_AUTH_SIGNOUT=/auth/signout
 VUE_APP_DS_PREVIEW_HOST=
+VUE_APP_DEV_PROXY=http://localhost:8080

--- a/src/lang/ach.json
+++ b/src/lang/ach.json
@@ -234,6 +234,7 @@
       "GEORGIAN": "crwdns1497:0crwdne1497:0",
       "GERMAN": "crwdns1499:0crwdne1499:0",
       "GREEK": "crwdns1501:0crwdne1501:0",
+      "MODERN GREEK (1453-)": "crwdns1501:0crwdne1501:0",
       "GUARANI": "crwdns1503:0crwdne1503:0",
       "GUJARATI": "crwdns1505:0crwdne1505:0",
       "HAITIAN": "crwdns1507:0crwdne1507:0",

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -234,6 +234,7 @@
       "GEORGIAN": "Georgisch",
       "GERMAN": "Deutsch",
       "GREEK": "Griechisch",
+      "MODERN GREEK (1453-)": "Griechisch",
       "GUARANI": "Guarani",
       "GUJARATI": "Gujarati",
       "HAITIAN": "Haitianisch",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -237,6 +237,7 @@
       "GEORGIAN": "Georgian",
       "GERMAN": "German",
       "GREEK": "Greek",
+      "MODERN GREEK (1453-)": "Greek",
       "GUARANI": "Guarani",
       "GUJARATI": "Gujarati",
       "HAITIAN": "Haitian",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -234,6 +234,7 @@
       "GEORGIAN": "Georgiano",
       "GERMAN": "Alemán",
       "GREEK": "Griego",
+      "MODERN GREEK (1453-)": "Griego",
       "GUARANI": "Guaraní",
       "GUJARATI": "Guyaratí",
       "HAITIAN": "Haitiano",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -234,6 +234,7 @@
       "GEORGIAN": "Géorgien",
       "GERMAN": "Allemand",
       "GREEK": "Grec",
+      "MODERN GREEK (1453-)": "Grec",
       "GUARANI": "Guarani",
       "GUJARATI": "Gujarati",
       "HAITIAN": "Haïtien",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -234,6 +234,7 @@
       "GEORGIAN": "グルジア語",
       "GERMAN": "ドイツ語",
       "GREEK": "ギリシャ語",
+      "MODERN GREEK (1453-)": "ギリシャ語",
       "GUARANI": "パラグアイ グアラニー",
       "GUJARATI": "グジャラート語",
       "HAITIAN": "ハイチ語",

--- a/vue.config.js
+++ b/vue.config.js
@@ -80,7 +80,7 @@ module.exports = {
     port: 9009,
     proxy: {
       '^/': {
-        target: 'http://localhost:8008'
+        target: process.env.VUE_APP_DEV_PROXY
       }
     }
   },


### PR DESCRIPTION
Related to https://github.com/ICIJ/datashare/issues/1069

Feat:
- Add MODERN GREEK (1453-) to `filter.lang`array to have allow proper display of the Greek language name in the UI

Enhancement:
- Add proxy url as environment variable