### PR TITLE
ci: move documentation to a different repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,5 +153,5 @@ jobs:
             git -C ~/datashare-docs add -A
             git -C ~/datashare-docs commit -am "doc: update client documentation [${CIRCLE_SHA1}]" || true
       - run:
-          name: Push changes to the Wiki (if any)
+          name: Push changes to the Documentation (if any)
           command: git -C ~/datashare-docs push origin master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,28 +129,29 @@ jobs:
              chmod 700 ~/.ssh
       - add_ssh_keys:
           fingerprints:
-            # This deploy key has read-write permission on Datashare repository
+            # This deploy key has read-write permission on ICIJ/datashare-docs repository
             # @see https://app.circleci.com/settings/project/github/ICIJ/datashare-client/ssh
-            - "ee:80:dd:ca:56:91:b8:9b:ee:b4:f8:53:63:77:e4:8a"
+            # @see https://github.com/ICIJ/datashare-docs/settings/keys
+            - "d0:5d:4a:ba:8a:55:2e:1f:6f:ad:57:c5:e0:21:ce:34"
       - run:
           name: Configure Git identity
           command: |
             git config --global user.name $CIRCLE_USERNAME
             git config --global user.email "engineering@icij.org"
       - run:
-          name: Checkout Datashare Wiki repository
+          name: Checkout ICIJ/datashare-docs repository
           command: |
             ssh-keyscan github.com >> ~/.ssh/known_hosts
-            git clone git@github.com:ICIJ/datashare.wiki.git ~/datashare-wiki
+            git clone git@github.com:ICIJ/datashare-docs.git ~/datashare-docs
       - run:
-          name: Copy generated doc inside the Wiki with a flatten structure
+          name: Copy generated doc inside the Wiki with a flatten structure (no subdirectories)
           command: |
-            rsync --del -r ~/datashare-client/dist/docs/ ~/datashare-wiki/client
+            rsync --del -r ~/datashare-client/dist/docs/ ~/datashare-docs/developers/client
       - run:
           name: Add/Commit changes to the Wiki (if any)
           command: |
-            git -C ~/datashare-wiki add -A
-            git -C ~/datashare-wiki commit -am "Publish client documentation [${CIRCLE_SHA1}]" || true
+            git -C ~/datashare-docs add -A
+            git -C ~/datashare-docs commit -am "doc: update client documentation [${CIRCLE_SHA1}]" || true
       - run:
           name: Push changes to the Wiki (if any)
-          command: git -C ~/datashare-wiki push origin master
+          command: git -C ~/datashare-docs push origin master

--- a/bin/DOCS.COMPONENTS.hbs
+++ b/bin/DOCS.COMPONENTS.hbs
@@ -7,7 +7,7 @@ These widgets are used on the insights page.
 
 {{#each widgets}}
   {{#with this}}
-* [{{title}}]({{wikiPath}}) {{#if description}}<br />— _{{description}}_{{/if}}
+* [{{title}}]({{path}}) {{#if description}}<br />— _{{description}}_{{/if}}
   {{/with}}
 {{/each}}
 
@@ -17,7 +17,7 @@ These filters are used on the search filters panel.
 
 {{#each filters}}
   {{#with this}}
-* [{{title}}]({{wikiPath}}) {{#if description}}<br />— _{{description}}_{{/if}}
+* [{{title}}]({{path}}) {{#if description}}<br />— _{{description}}_{{/if}}
   {{/with}}
 {{/each}}
 
@@ -27,7 +27,7 @@ All pages components.
 
 {{#each pages}}
   {{#with this}}
-* [{{title}}]({{wikiPath}}) {{#if description}}<br />— _{{description}}_{{/if}}
+* [{{title}}]({{path}}) {{#if description}}<br />— _{{description}}_{{/if}}
   {{/with}}
 {{/each}}
 
@@ -35,6 +35,6 @@ All pages components.
 
 {{#each others}}
   {{#with this}}
-* [{{title}}]({{wikiPath}}) {{#if description}}<br />— _{{description}}_{{/if}}
+* [{{title}}]({{path}}) {{#if description}}<br />— _{{description}}_{{/if}}
   {{/with}}
 {{/each}}

--- a/bin/DOCS.HOOKS.hbs
+++ b/bin/DOCS.HOOKS.hbs
@@ -8,6 +8,6 @@ define new Vue Component.
 | --- | --- |
 {{#each hooks}}
   {{#with this}}
-| [{{path}}]({{wikiPath}}) — [source]({{href}}) | `{{hook}}` |
+| [{{component}}]({{path}}) — [source]({{href}}) | `{{hook}}` |
   {{/with}}
 {{/each}}

--- a/bin/collectHooks.js
+++ b/bin/collectHooks.js
@@ -1,7 +1,7 @@
 const Handlebars = require('handlebars')
 const { execSync } = require('child_process')
 const { readFileSync, writeFileSync } = require('fs')
-const { capitalize, compact } = require('lodash')
+const { kebabCase, compact } = require('lodash')
 const { basename, join } = require('path')
 
 const { repository } = require('../package.json')
@@ -11,26 +11,26 @@ const DOC_PATH = join('dist', 'docs')
 const build = Handlebars.compile(readFileSync('bin/DOCS.HOOKS.hbs', 'UTF-8'))
 const joinToDoc = (path) => join(DOC_PATH, path)
 
-function srcToGithubWikiPath(src) {
+function srcToDocumentationPath(src) {
   const name = basename(src, '.vue')
-  const path = src.split('/').slice(1, -1).map(capitalize).join('-›-')
-  return `Client-›-${path}-›-${name}`
+  const path = src.split('/').slice(1, -1).map(kebabCase).join('/')
+  return `${path}/${name}.md`
 }
 
 // Collect hook occurrences with `git grep`
 const occurrences = execSync('git grep --line --no-color --extended-regexp \'<hook name="(.*:\\w*)"\'').toString()
 // Each line is an occurrence, with 3 columns separated by :
 const hooks = compact(occurrences.split('\n')).map((occurrence) => {
-  const path = occurrence.split(':')[0]
+  const component = occurrence.split(':')[0]
   const line = occurrence.split(':')[1]
   const match = occurrence.split(':').slice(2).join(':')
   const hook = (match.match(/\"(.*:\w*)\"/) || [])[1]
-  const wikiPath = srcToGithubWikiPath(path)
-  const href = new URL(`blob/master/${path}#L${line}`, repository.url)
-  return { path, href, line, wikiPath, hook }
+  const path = srcToDocumentationPath(component)
+  const href = new URL(`blob/master/${component}#L${line}`, repository.url)
+  return { component, href, line, path, hook }
 })
 
 // Build templates using components collections
 const content = build({ hooks })
 // Write the table of content for all components!
-writeFileSync(joinToDoc('Client-›-Hooks.md'), content)
+writeFileSync(joinToDoc('hooks.md'), content)

--- a/bin/collectTocForComponentsDoc.js
+++ b/bin/collectTocForComponentsDoc.js
@@ -22,8 +22,7 @@ const components = {
       const nextToTitle = nonEmptyLines[titleIndex + 1] || ''
       const description = nextToTitle.match(RE_DESCRIPTION) ? trimStart(nextToTitle, '> ') : ''
       const path = relative(DOC_PATH, filepath)
-      const wikiPath = basename(filepath, '.md')
-      return { title, description, path, wikiPath }
+      return { title, description, path }
     })
   },
   collectAllTocs() {
@@ -35,19 +34,19 @@ const components = {
     }, {})
   },
   get widgets() {
-    return glob.sync(joinToDoc('Client-›-Components-›-Widget*.md'))
+    return glob.sync(joinToDoc('components/widget/*.md'))
   },
   get filters() {
-    return glob.sync(joinToDoc('Client-›-Components-›-Filter-›-Types-›-Filter*.md'))
+    return glob.sync(joinToDoc('components/filter/types/Filter*.md'))
   },
   get pages() {
-    return glob.sync(joinToDoc('Client-›-Pages-›-*.md'))
+    return glob.sync(joinToDoc('pages/*.md'))
   },
   get others() {
-    const all = glob.sync(joinToDoc('Client-›-Components-›-*.md'))
+    const all = glob.sync(joinToDoc('components/*.md'))
     return filter(all, (f) => {
-      const sw = (target) => startsWith(basename(f).split('-›-').pop(), target)
-      return sw('Filters') || !(sw('Filter') || sw('Widget'))
+      const sw = (target) => startsWith(basename(f).split('/').pop(), target)
+      return sw('filters') || !(sw('filter') || sw('widget'))
     })
   }
 }
@@ -55,4 +54,4 @@ const components = {
 // Compile templates using components collections
 const toc = buildToc(components.collectAllTocs())
 // Write the table of content for all components!
-writeFileSync(joinToDoc('Client-›-Table of Content.md'), toc)
+writeFileSync(joinToDoc('README.md'), toc)

--- a/docgen.config.js
+++ b/docgen.config.js
@@ -1,5 +1,5 @@
 const { join, basename, dirname } = require('path')
-const { capitalize } = require('lodash')
+const { kebabCase } = require('lodash')
 // This looks like it's a hack but in fact it's the documented way
 // to import Webpack configuration:
 // https://cli.vuejs.org/guide/webpack.html#using-resolved-config-as-a-file)
@@ -10,10 +10,10 @@ module.exports = {
   components: '**/[A-Z]*.vue',
   outDir: 'dist/docs/',
   getDestFile: (file, config) => {
-    const outPath = dirname(file).split('/').map(capitalize).join('-›-')
+    const outPath = dirname(file).split('/').map(kebabCase).join('/')
     const outFile = basename(file).replace(/\.vue$/, '.md')
     // Flattn structure to be display correctly by Github Wiki
-    return join(config.outDir, `Client-›-${outPath}-›-${outFile}`)
+    return join(config.outDir, `${outPath}/${outFile}`)
   },
   // inform vue-docgen-api of Webpack aliases
   apiOptions

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "test": "yarn test:unit && yarn test:e2e",
     "doc": "yarn doc:dir && yarn doc:api && yarn doc:hooks && yarn doc:components && yarn doc:components:toc && yarn doc:widgets",
     "doc:dir": "mkdir -p dist/docs",
-    "doc:api": "npm_config_yes=true npx jsdoc-to-markdown --template bin/DOCS.API.hbs src/core/*.js > 'dist/docs/Client-›-API.md'",
+    "doc:api": "npm_config_yes=true npx jsdoc-to-markdown --template bin/DOCS.API.hbs src/core/*.js > 'dist/docs/api.md'",
     "doc:hooks": "node bin/collectHooks.js",
     "doc:components": "npm install -g vue@2 vue-docgen-cli@4 && vue-docgen",
     "doc:components:toc": "node bin/collectTocForComponentsDoc.js",
-    "doc:widgets": "npx jsdoc-to-markdown src/store/widgets/*.js > 'dist/docs/Client-›-Widgets.md'"
+    "doc:widgets": "npx jsdoc-to-markdown src/store/widgets/*.js > 'dist/docs/widgets.md'"
   },
   "dependencies": {
     "@fortawesome/fontawesome": "^1.1.4",


### PR DESCRIPTION
This PR aims at changing the repository where the Client documentation is copied.

The workflow is only running on master on CircleCI ; this PR is mostly for traceability but it cannot be tested upon merge on master.