### PR TITLE
refactor: remove openAnyway shortcut

### DIFF
--- a/src/lang/ach.json
+++ b/src/lang/ach.json
@@ -725,7 +725,7 @@
     "findPreviousOccurrence": "crwdns1078:0crwdne1078:0",
     "findPreviousOccurrenceAlt": "crwdns1080:0crwdne1080:0",
     "findNextOccurrence": "crwdns1082:0crwdne1082:0",
-    "findNextOccurrenceAlt": "crwdns1084:0crwdne1084:0",
+    "findNextOccurrenceAlt": "crwdns1084:0crwdne1084:0"
   },
   "server": {
     "title": "crwdns2108:0crwdne2108:0",

--- a/src/lang/ach.json
+++ b/src/lang/ach.json
@@ -726,7 +726,6 @@
     "findPreviousOccurrenceAlt": "crwdns1080:0crwdne1080:0",
     "findNextOccurrence": "crwdns1082:0crwdne1082:0",
     "findNextOccurrenceAlt": "crwdns1084:0crwdne1084:0",
-    "openAnyway": "crwdns2392:0crwdne2392:0"
   },
   "server": {
     "title": "crwdns2108:0crwdne2108:0",

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -726,7 +726,6 @@
     "findPreviousOccurrenceAlt": "Das vorherige Vorkommen im Dokument finden",
     "findNextOccurrence": "Das nächsten Vorkommen im Dokument finden",
     "findNextOccurrenceAlt": "Das nächsten Vorkommen im Dokument finden",
-    "openAnyway": "Trotzdem öffnen"
   },
   "server": {
     "title": "Einstellungen",

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -725,7 +725,7 @@
     "findPreviousOccurrence": "Das vorherige Vorkommen im Dokument finden",
     "findPreviousOccurrenceAlt": "Das vorherige Vorkommen im Dokument finden",
     "findNextOccurrence": "Das nächsten Vorkommen im Dokument finden",
-    "findNextOccurrenceAlt": "Das nächsten Vorkommen im Dokument finden",
+    "findNextOccurrenceAlt": "Das nächsten Vorkommen im Dokument finden"
   },
   "server": {
     "title": "Einstellungen",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -726,8 +726,7 @@
     "findPreviousOccurrence": "Find the previous occurrence in the document",
     "findPreviousOccurrenceAlt": "Find the previous occurrence in the document",
     "findNextOccurrence": "Find the next occurrence in the document",
-    "findNextOccurrenceAlt": "Find the next occurrence in the document",
-    "openAnyway": "Open anyway"
+    "findNextOccurrenceAlt": "Find the next occurrence in the document"
   },
   "server": {
     "title": "Settings",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -725,7 +725,7 @@
     "findPreviousOccurrence": "Encontrar la ocurrencia previa en el documento",
     "findPreviousOccurrenceAlt": "Encontrar la ocurrencia previa en el documento",
     "findNextOccurrence": "Encontrar la próxima ocurrencia en el documento",
-    "findNextOccurrenceAlt": "Encontrar la siguiente ocurrencia en el documento",
+    "findNextOccurrenceAlt": "Encontrar la siguiente ocurrencia en el documento"
   },
   "server": {
     "title": "Configuración",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -726,7 +726,6 @@
     "findPreviousOccurrenceAlt": "Encontrar la ocurrencia previa en el documento",
     "findNextOccurrence": "Encontrar la próxima ocurrencia en el documento",
     "findNextOccurrenceAlt": "Encontrar la siguiente ocurrencia en el documento",
-    "openAnyway": "Abrir de todos modos"
   },
   "server": {
     "title": "Configuración",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -726,7 +726,6 @@
     "findPreviousOccurrenceAlt": "Aller à l'occurrence précédente dans le document",
     "findNextOccurrence": "Aller à l'occurrence suivante dans le document",
     "findNextOccurrenceAlt": "Aller à l'occurrence suivante dans le document",
-    "openAnyway": "Ouvrir quand même"
   },
   "server": {
     "title": "Paramètres",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -725,7 +725,7 @@
     "findPreviousOccurrence": "Aller à l'occurrence précédente dans le document",
     "findPreviousOccurrenceAlt": "Aller à l'occurrence précédente dans le document",
     "findNextOccurrence": "Aller à l'occurrence suivante dans le document",
-    "findNextOccurrenceAlt": "Aller à l'occurrence suivante dans le document",
+    "findNextOccurrenceAlt": "Aller à l'occurrence suivante dans le document"
   },
   "server": {
     "title": "Paramètres",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -726,7 +726,6 @@
     "findPreviousOccurrenceAlt": "検索結果のうち直前の語に移動",
     "findNextOccurrence": "検索結果のうち次の語に移動",
     "findNextOccurrenceAlt": "検索結果のうち次の語に移動",
-    "openAnyway": "Open anyway"
   },
   "server": {
     "title": "Settings",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -725,7 +725,7 @@
     "findPreviousOccurrence": "検索結果のうち直前の語に移動",
     "findPreviousOccurrenceAlt": "検索結果のうち直前の語に移動",
     "findNextOccurrence": "検索結果のうち次の語に移動",
-    "findNextOccurrenceAlt": "検索結果のうち次の語に移動",
+    "findNextOccurrenceAlt": "検索結果のうち次の語に移動"
   },
   "server": {
     "title": "Settings",

--- a/src/utils/shortkeys.json
+++ b/src/utils/shortkeys.json
@@ -79,15 +79,6 @@
       },
       "link": "https://icij.gitbook.io/datashare/all/use-keyboard-shortcuts#navigate-a-documents-tabs",
       "page": "search"
-    },
-    "openAnyway": {
-      "keys": {
-        "mac": ["o"],
-        "default": ["o"]
-      },
-      "action": "openAnyway",
-      "label": "shortkeys.openAnyway",
-      "page": "search"
     }
   },
   "DocumentLocalSearchInput": {


### PR DESCRIPTION
The openAnyway shortcut was still displayed after removing document extracted text limit. This PR removes it from the list.
