### PR TITLE
feat: multiple projects in local mode

### DIFF
--- a/src/components/BatchSearchFilterDate.vue
+++ b/src/components/BatchSearchFilterDate.vue
@@ -6,6 +6,7 @@
         v-model="selectedDateRange"
         is-range
         color="gray"
+        class="border-0"
         :max-date="new Date()"
         :model-config="modelConfig"
         :locale="locale"

--- a/src/components/BatchSearchTable.vue
+++ b/src/components/BatchSearchTable.vue
@@ -101,25 +101,23 @@
       </template>
       <template #cell(projects)="{ item }">
         <span
-          v-for="(projectName, index) in item.projectsNames"
-          :key="projectName"
-          v-b-tooltip.hover
-          class="batch-search-table__item__projects text-truncate"
-          :title="projectName"
+          v-for="(project, index) in item.projects"
+          :key="project.name"
+          class="batch-search-table__item__projects d-inline-block mr-1"
         >
           <router-link
             :to="{
               name: 'search',
               query: {
                 q: '*',
-                indices: projectName
+                indices: project.name
               }
             }"
             class="batch-search-table__item__projects__link"
           >
-            <span>{{ projectName }}</span>
+            <span>{{ project.label || project.name }}</span>
           </router-link>
-          <span v-if="isNotLastArrayItem(index, item.projectsNames.length)">, </span>
+          <span v-if="isNotLastArrayItem(index, item.projects.length)">, </span>
         </span>
       </template>
     </b-table>
@@ -249,7 +247,7 @@ export default {
           sortable: true,
           name: 'published'
         }),
-        this.serverField({
+        this.withProjectsField({
           key: 'projects',
           label: this.$t('batchSearch.projects'),
           sortable: false,
@@ -291,7 +289,7 @@ export default {
       return Math.ceil(this.total / this.perPage)
     },
     projects() {
-      return this.$core.projects
+      return this.$core.projectIds
     },
     selectedDateRange: {
       get() {
@@ -490,6 +488,9 @@ export default {
     },
     serverField(field) {
       return this.isServer ? field : null
+    },
+    withProjectsField(field) {
+      return this.isServer || this.projects.length > 1 ? field : null
     },
     async sortChanged(ctx) {
       this.selectedSort = {

--- a/src/components/ProjectCards.vue
+++ b/src/components/ProjectCards.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="project-cards container-fluid p-0">
     <div class="row">
-      <div v-for="project in projects" :key="project" class="col-4 mb-4">
+      <div v-for="project in projects" :key="project.name" class="col-4 mb-4">
         <router-link
-          :to="{ name: 'search', query: { indices: project, q: '*' } }"
+          :to="{ name: 'search', query: { indices: project.name, q: '*' } }"
           class="project-cards__item d-flex justify-content-start text-nowrap"
           :class="{ 'project-cards__item--active': isActive(project) }"
         >
@@ -11,7 +11,7 @@
             <fa icon="book"></fa>
           </div>
           <div class="project-cards__item__body py-2 px-3 font-weight-bold">
-            {{ startCase(project) }}
+            {{ project.label || startCase(project.name) }}
           </div>
         </router-link>
       </div>
@@ -33,7 +33,7 @@ export default {
   },
   methods: {
     isActive(project) {
-      return this.$store.state.search.indices.includes(project)
+      return this.$store.state.search.indices.includes(project.name)
     },
     startCase
   }

--- a/src/components/ProjectSelector.vue
+++ b/src/components/ProjectSelector.vue
@@ -48,8 +48,9 @@ export default {
       return this.$core.projects
     },
     projectOptions() {
-      return this.projects.map((value) => {
-        const text = startCase(value)
+      return this.projects.map((project) => {
+        const text = project.label || startCase(project.name)
+        const value = project.name
         const disabled = this.multiple && isEqual(this.selectedProject, [value])
         return { disabled, text, value }
       })

--- a/src/components/filter/types/FilterProject.vue
+++ b/src/components/filter/types/FilterProject.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="filter card" v-if="showProjects">
+  <div v-if="showProjects" class="filter card">
     <div class="card-header px-2">
       <h6 class="pt-0" @click="toggleItems">
         <span class="filter__items__item__icon pl-0 pr-1">

--- a/src/components/filter/types/FilterProject.vue
+++ b/src/components/filter/types/FilterProject.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="showSelector" class="filter card">
+  <div class="filter card" v-if="showProjects">
     <div class="card-header px-2">
       <h6 class="pt-0" @click="toggleItems">
         <span class="filter__items__item__icon pl-0 pr-1">
@@ -16,8 +16,6 @@
 </template>
 
 <script>
-import { compact, uniq } from 'lodash'
-
 import ProjectSelector from '@/components/ProjectSelector'
 import utils from '@/mixins/utils'
 
@@ -36,10 +34,8 @@ export default {
     }
   },
   computed: {
-    projects() {
-      const defaultProject = this.$config.get('defaultProject')
-      const projects = this.$config.get('groups_by_applications.datashare', [])
-      return compact(uniq([...projects, defaultProject]).sort())
+    showProjects() {
+      return this.isServer || this.$core.projects.length > 1
     },
     selectedProject: {
       get: function () {
@@ -53,9 +49,6 @@ export default {
     },
     headerIcon() {
       return this.collapseItems ? 'plus' : 'minus'
-    },
-    showSelector() {
-      return this.isServer || this.projects.length > 1
     }
   },
   async created() {

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -13,6 +13,7 @@ import VueScrollTo from 'vue-scrollto'
 import VueShortkey from 'vue-shortkey'
 import VueWait from 'vue-wait'
 import VueEllipseProgress from 'vue-ellipse-progress'
+import { iteratee } from 'lodash'
 
 import FiltersMixin from './FiltersMixin'
 import HooksMixin from './HooksMixin'
@@ -207,8 +208,10 @@ class Core extends Behaviors {
   }
 
   getDefaultProject() {
-    const userProjects = this.config.get('groups_by_applications.datashare', [])
-    if (userProjects.length === 0) return ''
+    const userProjects = this.config.get('projects', []).map(iteratee('name'))
+    if (userProjects.length === 0) {
+      return ''
+    }
     const defaultProject = this.config.get('defaultProject', '')
     return userProjects.indexOf(defaultProject) === -1 ? userProjects[0] : defaultProject
   }

--- a/src/core/ProjectsMixin.js
+++ b/src/core/ProjectsMixin.js
@@ -1,4 +1,4 @@
-import { castArray, compact, get, noop, uniq } from 'lodash'
+import { castArray, iteratee, sortBy, get, noop } from 'lodash'
 
 /**
   Mixin class extending the core to add helpers for projects.
@@ -56,14 +56,14 @@ const ProjectsMixin = (superclass) =>
      * @returns {Array:String}
      */
     get projects() {
-      const projects = this.config.get('groups_by_applications.datashare', [])
-      // In local mode, we ensure the "defaultProject" is included. In server mode,
-      // the list of projects defines what the user can see.
-      if (this.config.get('mode') === 'LOCAL') {
-        const defaultProject = this.config.get('defaultProject')
-        return compact(uniq([...projects, defaultProject]).sort())
-      }
-      return [...projects].sort()
+      return sortBy(this.config.get('projects', []), iteratee('name'))
+    }
+    /**
+     * List all projects this user has access to.
+     * @returns {Array:String}
+     */
+    get projectIds() {
+      return this.projects.map(iteratee('name'))
     }
   }
 

--- a/src/pages/BatchSearchResults.vue
+++ b/src/pages/BatchSearchResults.vue
@@ -19,7 +19,7 @@
             {{ batchSearch.description }}
           </p>
           <dl class="batch-search-results__info">
-            <div v-if="isServer">
+            <div v-if="showProjects">
               <dt>
                 {{ $t('batchSearch.projects') }}
               </dt>
@@ -35,9 +35,9 @@
                     }"
                     class="batch-search-results__info__project-link"
                   >
-                    <span>{{ project.name }}</span
-                    ><span v-if="isNotLastArrayItem(index, batchSearch.projects.length)">, </span>
+                    <span>{{ project.name }}</span>
                   </router-link>
+                  <span v-if="isNotLastArrayItem(index, batchSearch.projects.length)">, </span>
                 </span>
               </dd>
             </div>
@@ -346,6 +346,9 @@ export default {
   },
   computed: {
     ...mapState('batchSearch', ['batchSearch', 'results']),
+    showProjects() {
+      return this.isServer || this.$core.projects.length > 1
+    },
     isLoaded() {
       return !!Object.keys(this.batchSearch).length
     },

--- a/src/pages/Landing.vue
+++ b/src/pages/Landing.vue
@@ -9,7 +9,7 @@
       <hook name="landing.form.heading:after"></hook>
       <search-bar class="landing__form__search-bar py-3" size="md"></search-bar>
       <hook name="landing.form.project:before"></hook>
-      <div v-if="isServer" class="mt-5 text-white">
+      <div v-if="showProjects" class="mt-5 text-white">
         <div class="landing__form__projects">
           <h2 class="text-uppercase h5">
             {{ $t('filter.projects') }}
@@ -36,7 +36,12 @@ export default {
     ProjectCards,
     SearchBar
   },
-  mixins: [utils]
+  mixins: [utils],
+  computed: {
+    showProjects() {
+      return this.isServer || this.$core.projects.length > 1
+    }
+  }
 }
 </script>
 

--- a/src/router/guards.js
+++ b/src/router/guards.js
@@ -25,8 +25,8 @@ export default ({ router, auth, store, config, i18n, setPageTitle }) => {
     }
   }
 
-  function checkUserProjects(to, _from, next) {
-    const projects = config.get('groups_by_applications.datashare', [])
+  function checkUserProjects(to, from, next) {
+    const projects = config.get('projects', [])
     // No project given for this user
     if (!projects.length && ['error', 'login'].indexOf(to.name) === -1) {
       const title = i18n.t('error.noProjects')

--- a/tests/unit/specs/components/BatchSearchForm.spec.js
+++ b/tests/unit/specs/components/BatchSearchForm.spec.js
@@ -24,7 +24,10 @@ describe('BatchSearchForm.vue', () => {
   })
   let wrapper = null
 
-  beforeAll(() => Murmur.config.merge({ groups_by_applications: { datashare: [project] }, dataDir: '/root/project' }))
+  beforeAll(() => {
+    Murmur.config.set('projects', [{ name: project }])
+    Murmur.config.set('dataDir', '/root/project')
+  })
 
   beforeEach(() => {
     Murmur.config.merge({ mode: 'LOCAL' })
@@ -116,17 +119,17 @@ describe('BatchSearchForm.vue', () => {
   })
 
   it('should reset the form', () => {
-    wrapper.vm.$set(wrapper.vm, 'csvFile', new File(['File content'], 'test_file.csv', { type: 'text/csv' }))
-    wrapper.vm.$set(wrapper.vm, 'description', 'This is a description')
-    wrapper.vm.$set(wrapper.vm, 'fileType', 'PDF')
-    wrapper.vm.$set(wrapper.vm, 'fileTypes', [{ label: 'PDF' }])
-    wrapper.vm.$set(wrapper.vm, 'fuzziness', 2)
-    wrapper.vm.$set(wrapper.vm, 'name', 'Example')
-    wrapper.vm.$set(wrapper.vm, 'paths', ['This', 'is', 'a', 'multiple', 'paths'])
-    wrapper.vm.$set(wrapper.vm, 'phraseMatch', false)
-    wrapper.vm.$set(wrapper.vm, 'projects', ['project-example'])
-    wrapper.vm.$set(wrapper.vm, 'published', false)
-    wrapper.vm.$set(wrapper.vm, 'showAdvancedFilters', true)
+    wrapper.setData({ csvFile: new File(['File content'], 'test_file.csv', { type: 'text/csv' }) })
+    wrapper.setData({ description: 'This is a description' })
+    wrapper.setData({ fileType: 'PDF' })
+    wrapper.setData({ fileTypes: [{ label: 'PDF' }] })
+    wrapper.setData({ fuzziness: 2 })
+    wrapper.setData({ name: 'Example' })
+    wrapper.setData({ paths: ['This', 'is', 'a', 'multiple', 'paths'] })
+    wrapper.setData({ phraseMatch: false })
+    wrapper.setData({ projects: ['project-example'] })
+    wrapper.setData({ published: false })
+    wrapper.setData({ showAdvancedFilters: true })
 
     wrapper.vm.resetForm()
 
@@ -156,7 +159,7 @@ describe('BatchSearchForm.vue', () => {
     })
 
     it('should hide suggestions', () => {
-      wrapper.vm.$set(wrapper.vm, 'suggestionFileTypes', ['suggestion_01', 'suggestion_02', 'suggestion_03'])
+      wrapper.setData({ suggestionFileTypes: ['suggestion_01', 'suggestion_02', 'suggestion_03'] })
 
       wrapper.vm.hideSuggestionsFileTypes()
 
@@ -164,12 +167,14 @@ describe('BatchSearchForm.vue', () => {
     })
 
     it('should filter fileTypes according to the fileTypes input on mime file', () => {
-      wrapper.vm.$set(wrapper.vm, 'allFileTypes', [
-        { label: 'Visio document', mime: 'visio' },
-        { label: 'StarWriter 5 document', mime: 'vision' },
-        { label: 'Something else', mime: 'else' }
-      ])
-      wrapper.vm.$set(wrapper.vm, 'fileType', 'visi')
+      wrapper.setData({
+        fileType: 'visi',
+        allFileTypes: [
+          { label: 'Visio document', mime: 'visio' },
+          { label: 'StarWriter 5 document', mime: 'vision' },
+          { label: 'Something else', mime: 'else' }
+        ]
+      })
 
       wrapper.vm.searchFileTypes()
 
@@ -179,11 +184,13 @@ describe('BatchSearchForm.vue', () => {
     })
 
     it('should filter according to the fileTypes input on label file', () => {
-      wrapper.vm.$set(wrapper.vm, 'allFileTypes', [
-        { label: 'Label PDF', mime: 'PDF' },
-        { label: 'another type', mime: 'other' }
-      ])
-      wrapper.vm.$set(wrapper.vm, 'fileType', 'PDF')
+      wrapper.setData({
+        fileType: 'PDF',
+        allFileTypes: [
+          { label: 'Label PDF', mime: 'PDF' },
+          { label: 'another type', mime: 'other' }
+        ]
+      })
 
       wrapper.vm.searchFileTypes()
 
@@ -192,8 +199,8 @@ describe('BatchSearchForm.vue', () => {
     })
 
     it('should hide already selected file type from suggestions', () => {
-      wrapper.vm.$set(wrapper.vm, 'fileTypes', [{ mime: 'application/pdf', label: 'Portable Document Format (PDF)' }])
-      wrapper.vm.$set(wrapper.vm, 'fileType', 'PDF')
+      wrapper.setData({ fileTypes: [{ mime: 'application/pdf', label: 'Portable Document Format (PDF)' }] })
+      wrapper.setData({ fileType: 'PDF' })
 
       wrapper.vm.searchFileTypes()
 
@@ -202,8 +209,8 @@ describe('BatchSearchForm.vue', () => {
 
     it('should set the clicked item in fileTypes', () => {
       wrapper = mount(BatchSearchForm, { i18n, localVue, store, wait })
-      wrapper.vm.$set(wrapper.vm, 'fileTypes', [{ label: 'Excel 2003 XML spreadsheet visio' }])
-      wrapper.vm.$set(wrapper.vm, 'selectedFileType', { label: 'StarWriter 5 document' })
+      wrapper.setData({ fileTypes: [{ label: 'Excel 2003 XML spreadsheet visio' }] })
+      wrapper.setData({ selectedFileType: { label: 'StarWriter 5 document' } })
       wrapper.vm.searchFileType()
 
       expect(wrapper.vm.fileTypes).toEqual([
@@ -301,8 +308,8 @@ describe('BatchSearchForm.vue', () => {
 
   describe('setPaths', () => {
     it('should set paths from selected ones', () => {
-      wrapper.vm.$set(wrapper.vm, 'paths', ['path_01', 'path_02'])
-      wrapper.vm.$set(wrapper.vm, 'selectedPaths', ['path_02', 'path_03'])
+      wrapper.setData({ paths: ['path_01', 'path_02'] })
+      wrapper.setData({ selectedPaths: ['path_02', 'path_03'] })
 
       wrapper.vm.setPaths()
 
@@ -311,7 +318,7 @@ describe('BatchSearchForm.vue', () => {
     })
 
     it('should reset the path', () => {
-      wrapper.vm.$set(wrapper.vm, 'path', 'path_00')
+      wrapper.setData({ path: 'path_00' })
 
       wrapper.vm.setPaths()
 

--- a/tests/unit/specs/components/ProjectCards.spec.js
+++ b/tests/unit/specs/components/ProjectCards.spec.js
@@ -10,28 +10,28 @@ describe('ProjectCards.vue', () => {
   let wrapper
 
   it('should display one card for first-index', () => {
-    Murmur.config.merge({ groups_by_applications: { datashare: ['first-index'] } })
+    Murmur.config.set('projects', [{ name: 'foo' }])
     wrapper = shallowMount(ProjectCards, { localVue, store })
 
     expect(wrapper.findAll('.project-cards__item')).toHaveLength(1)
   })
 
   it('should display one card for with the index name in titlecase', () => {
-    Murmur.config.merge({ groups_by_applications: { datashare: ['first-index'] } })
+    Murmur.config.set('projects', [{ name: 'first-index' }])
     wrapper = shallowMount(ProjectCards, { localVue, store })
 
     expect(wrapper.find('.project-cards__item__body').text()).toBe('First Index')
   })
 
   it('should display two cards', () => {
-    Murmur.config.merge({ groups_by_applications: { datashare: ['first-index', 'second-index'] } })
+    Murmur.config.set('projects', [{ name: 'first-index' }, { name: 'second-index' }])
     wrapper = shallowMount(ProjectCards, { localVue, store })
 
     expect(wrapper.findAll('.project-cards__item')).toHaveLength(2)
   })
 
   it('should display one active card among the two cards', () => {
-    Murmur.config.merge({ groups_by_applications: { datashare: ['first-index', 'second-index'] } })
+    Murmur.config.set('projects', [{ name: 'first-index' }, { name: 'second-index' }])
     store.commit('search/index', 'second-index')
     wrapper = shallowMount(ProjectCards, { localVue, store })
 

--- a/tests/unit/specs/components/ProjectSelector.spec.js
+++ b/tests/unit/specs/components/ProjectSelector.spec.js
@@ -13,7 +13,7 @@ describe('ProjectSelector.vue', () => {
     beforeEach(() => {
       Murmur.config.merge({
         defaultProject: 'first-index',
-        groups_by_applications: { datashare: ['second-index', 'third-index'] }
+        projects: [{ name: 'second-index' }, { name: 'third-index' }]
       })
       wrapper = shallowMount(ProjectSelector, { localVue, store, propsData: { value: 'first-index' } })
     })
@@ -38,7 +38,9 @@ describe('ProjectSelector.vue', () => {
     let wrapper
 
     beforeEach(() => {
-      Murmur.config.merge({ groups_by_applications: { datashare: ['first-index', 'second-index', 'third-index'] } })
+      Murmur.config.merge({
+        projects: [{ name: 'first-index' }, { name: 'second-index' }, { name: 'third-index' }]
+      })
       wrapper = shallowMount(ProjectSelector, {
         localVue,
         store,

--- a/tests/unit/specs/components/filter/types/FilterProject.spec.js
+++ b/tests/unit/specs/components/filter/types/FilterProject.spec.js
@@ -27,7 +27,7 @@ describe('FilterProject.vue', () => {
     localVue.config.optionMergeStrategies.created = (parent, _) => mergeCreatedStrategy(parent)
     localVue.mixin({ created() {} })
 
-    Murmur.config.merge({ groups_by_applications: { datashare: JSON.stringify([project, anotherProject]) } })
+    Murmur.config.set('projects', [{ name: project }, { name: anotherProject }])
     store.commit('search/index', project)
   })
 

--- a/tests/unit/specs/core/Core.spec.js
+++ b/tests/unit/specs/core/Core.spec.js
@@ -123,14 +123,14 @@ describe('Core', () => {
 
   it('should getDefaultProject when user has it', () => {
     const core = Core.init(localVue).useAll()
-    core.config.set('groups_by_applications.datashare', ['my_project'])
+    core.config.set('projects', [{ name: 'my_project' }])
     core.config.set('defaultProject', 'my_project')
     expect(core.getDefaultProject()).toEqual('my_project')
   })
 
   it("should return first user project when user doesn't have the default project", () => {
     const core = Core.init(localVue).useAll()
-    core.config.set('groups_by_applications.datashare', ['user_project'])
+    core.config.set('projects', [{ name: 'user_project' }])
     core.config.set('defaultProject', 'default_project')
     expect(core.getDefaultProject()).toEqual('user_project')
   })

--- a/tests/unit/specs/pages/Landing.spec.js
+++ b/tests/unit/specs/pages/Landing.spec.js
@@ -9,8 +9,7 @@ describe('Landing.vue', () => {
   let wrapper = null
 
   beforeEach(() => {
-    Murmur.config.merge({ mode: 'SERVER' })
-    Murmur.config.merge({ groups_by_applications: { datashare: ['project'] } })
+    Murmur.config.merge({ mode: 'SERVER', projects: [{ name: 'project' }] })
     wrapper = shallowMount(Landing, { i18n, localVue, store })
   })
 

--- a/tests/unit/specs/router/guards.spec.js
+++ b/tests/unit/specs/router/guards.spec.js
@@ -10,7 +10,7 @@ describe('guards', () => {
     let wrapper = null
 
     beforeAll(() => {
-      config.set('groups_by_applications.datashare', ['local-datashare'])
+      config.set('projects', ['local-datashare'])
       wrapper = shallowMount({ template: '<router-view />' }, { localVue, router })
     })
 
@@ -48,6 +48,7 @@ describe('guards', () => {
     let wrapper
 
     beforeAll(() => {
+      config.set('projects', ['local-datashare'])
       wrapper = shallowMount({ template: '<router-view />' }, { localVue, router })
     })
 


### PR DESCRIPTION
## PR description

This PR allow LOCAL mode to handle several project. For backward compatibility, SERVER mode will continue to display projects as before. In LOCAL mode, they are shown only if the user has several projects.

## Changes

* Update `ProjectsMixin` with a new accessors to get `projects` and `projectNames`
* Use the new mixin accessors in `BatchSearchForm`, `BatchSearchTable`, `ProjectCard` and `ProjectSelector`

## Limitations

If most project display use the new "label" metadata when available, the filter on the batch searchers list will continue to display the "name". This will be solved when we'll have a proper component to display project in various places.