### PR TITLE
feat: batch search form page

### DIFF
--- a/src/components/BatchSearchActions.vue
+++ b/src/components/BatchSearchActions.vue
@@ -133,7 +133,7 @@ export default {
       try {
         await this.$store.dispatch('batchSearch/deleteBatchSearch', { batchId })
         this.$root.$bvToast.toast(this.$t('batchSearch.deleted'), { noCloseButton: true, variant: 'success' })
-        return this.$router.push({ name: 'batch-search' })
+        return this.$router.push({ name: 'batch-search-list' })
       } catch (e) {
         this.$root.$bvToast.toast(this.$t('batchSearch.deleteError'), { noCloseButton: true, variant: 'danger' })
       }

--- a/src/components/BatchSearchCopyForm.vue
+++ b/src/components/BatchSearchCopyForm.vue
@@ -68,7 +68,7 @@ export default {
         if (this.deleteAfterRelaunch) {
           await this.$store.dispatch('batchSearch/deleteBatchSearch', { batchId })
         }
-        this.$router.push({ name: 'batch-search' })
+        this.$router.push({ name: 'batch-search-list' })
       } catch (_) {
         this.$root.$bvToast.toast(this.$t('batchSearch.submitError'), { noCloseButton: true, variant: 'danger' })
       }

--- a/src/components/BatchSearchFilterQuery.vue
+++ b/src/components/BatchSearchFilterQuery.vue
@@ -64,7 +64,7 @@ export default {
       const params = this.$route?.query ?? {}
       return this.$router
         .push({
-          name: 'batch-search',
+          name: 'batch-search-list',
           query: { ...params, page: 1, query: this.search, field: this.field }
         })
         .catch((_) => {

--- a/src/components/BatchSearchForm.vue
+++ b/src/components/BatchSearchForm.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="batch-search-form">
     <b-form @submit.prevent="onSubmit">
-      <h5 v-if="!hideTitle" class="py-2 h6 text-uppercase text-muted">
-        {{ $t('batchSearch.heading') }}
-      </h5>
       <div :class="{ 'border-0': hideBorder }" class="card w-100">
+        <h5 v-if="!hideTitle" class="card-header">
+          {{ $t('batchSearch.heading') }}
+        </h5>
         <div class="card-body pb-1">
           <b-form-group :label="`${$t('batchSearch.name')} *`" class="batch-search-form__name" label-size="sm">
             <b-form-input v-model="name" required type="text" trim></b-form-input>

--- a/src/components/BatchSearchTable.vue
+++ b/src/components/BatchSearchTable.vue
@@ -401,7 +401,7 @@ export default {
       this.removeEmptySearchParams(queryParams)
 
       return {
-        name: 'batch-search',
+        name: 'batch-search-list',
         query: queryParams
       }
     },

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -693,8 +693,11 @@
       "description": "Description"
     }
   },
+  "newBatchSearch": {
+    "title": "Start a new batch search"
+  },
   "batchSearchResults": {
-    "title": "Batch Search Results",
+    "title": "Batch search results",
     "rank": "Rank",
     "query": "Query",
     "documentPath": "Document Path",

--- a/src/pages/BatchSearch.vue
+++ b/src/pages/BatchSearch.vue
@@ -1,75 +1,9 @@
 <template>
-  <div class="batch-search container h-100 pt-4">
-    <v-wait class="batch-search__wait" for="load haveBatchSearch">
-      <fa slot="waiting" class="d-flex mx-auto mt-5" icon="circle-notch" size="2x" spin />
-      <template v-if="hasBatchSearch">
-        <div class="d-flex flex-wrap align-items-center">
-          <batch-search-filter-query class="batch-search__search-bar my-1" />
-          <batch-search-clear-filters
-            class="batch-search__clear-filter-btn m-1"
-            route-name="batch-search"
-            :local-search-params="LOCAL_SEARCH_PARAMS"
-          />
-        </div>
-        <batch-search-table />
-      </template>
-      <template v-else>
-        <div class="batch-search__none text-center">
-          <div class="batch-search__none__message b-table-empty-row" v-html="noBatchSearch" />
-        </div>
-      </template>
-    </v-wait>
-  </div>
+  <router-view></router-view>
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
-
-import utils from '@/mixins/utils'
-import BatchSearchTable from '@/components/BatchSearchTable'
-import BatchSearchClearFilters from '@/components/BatchSearchClearFilters'
-import BatchSearchFilterQuery from '@/components/BatchSearchFilterQuery'
-const LOCAL_SEARCH_PARAMS = Object.freeze({
-  query: true,
-  publishState: false,
-  project: false,
-  dateStart: true,
-  dateEnd: true,
-  state: true,
-  order: true,
-  sort: true
-})
 export default {
-  name: 'BatchSearches',
-  components: {
-    BatchSearchFilterQuery,
-    BatchSearchClearFilters,
-    BatchSearchTable
-  },
-  mixins: [utils],
-  data() {
-    return { LOCAL_SEARCH_PARAMS }
-  },
-  computed: {
-    ...mapGetters('batchSearch', ['hasBatchSearch']),
-    howToLink() {
-      return '#/docs/all-batch-search-documents'
-    },
-    noBatchSearch() {
-      return this.$t('batchSearch.empty', { howToLink: this.howToLink })
-    }
-  },
-  mounted() {
-    if (!this.hasBatchSearch) {
-      return this.getBatchSearches()
-    }
-  },
-  methods: {
-    async getBatchSearches() {
-      this.$wait.start('load haveBatchSearch')
-      await this.$store.dispatch('batchSearch/getBatchSearches', { init: true })
-      this.$wait.end('load haveBatchSearch')
-    }
-  }
+  name: 'BatchSearch'
 }
 </script>

--- a/src/pages/BatchSearchList.vue
+++ b/src/pages/BatchSearchList.vue
@@ -5,7 +5,11 @@
       <template v-if="hasBatchSearch">
         <div class="d-flex flex-wrap align-items-center">
           <batch-search-filter-query class="batch-search-list__search-bar my-1" />
-          <batch-search-clear-filters class="batch-search-list__clear-filter-btn m-1" />
+          <batch-search-clear-filters
+            class="batch-search-list__clear-filter-btn m-1"
+            route-name="batch-search"
+            :local-search-params="LOCAL_SEARCH_PARAMS"
+          />
         </div>
         <batch-search-table />
       </template>
@@ -26,6 +30,17 @@ import BatchSearchTable from '@/components/BatchSearchTable'
 import BatchSearchClearFilters from '@/components/BatchSearchClearFilters'
 import BatchSearchFilterQuery from '@/components/BatchSearchFilterQuery'
 
+const LOCAL_SEARCH_PARAMS = Object.freeze({
+  query: true,
+  publishState: false,
+  project: false,
+  dateStart: true,
+  dateEnd: true,
+  state: true,
+  order: true,
+  sort: true
+})
+
 export default {
   name: 'BatchSearchList',
   components: {
@@ -34,6 +49,9 @@ export default {
     BatchSearchTable
   },
   mixins: [utils],
+  data() {
+    return { LOCAL_SEARCH_PARAMS }
+  },
   computed: {
     ...mapGetters('batchSearch', ['hasBatchSearch']),
     howToLink() {
@@ -57,6 +75,7 @@ export default {
   }
 }
 </script>
+
 <style lang="scss" scoped>
 .batch-search-list__none__message {
   padding: 0.75em;

--- a/src/pages/BatchSearchList.vue
+++ b/src/pages/BatchSearchList.vue
@@ -1,21 +1,17 @@
 <template>
-  <div class="batch-search container h-100 pt-4">
-    <v-wait class="batch-search__wait" for="load haveBatchSearch">
+  <div class="batch-search-list container h-100 pt-4">
+    <v-wait class="batch-search-list__wait" for="load haveBatchSearch">
       <fa slot="waiting" class="d-flex mx-auto mt-5" icon="circle-notch" size="2x" spin />
       <template v-if="hasBatchSearch">
         <div class="d-flex flex-wrap align-items-center">
-          <batch-search-filter-query class="batch-search__search-bar my-1" />
-          <batch-search-clear-filters
-            class="batch-search__clear-filter-btn m-1"
-            route-name="batch-search"
-            :local-search-params="LOCAL_SEARCH_PARAMS"
-          />
+          <batch-search-filter-query class="batch-search-list__search-bar my-1" />
+          <batch-search-clear-filters class="batch-search-list__clear-filter-btn m-1" />
         </div>
         <batch-search-table />
       </template>
       <template v-else>
-        <div class="batch-search__none text-center">
-          <div class="batch-search__none__message b-table-empty-row" v-html="noBatchSearch" />
+        <div class="batch-search-list__none text-center">
+          <div class="batch-search-list__none__message b-table-empty-row" v-html="noBatchSearch" />
         </div>
       </template>
     </v-wait>
@@ -29,27 +25,15 @@ import utils from '@/mixins/utils'
 import BatchSearchTable from '@/components/BatchSearchTable'
 import BatchSearchClearFilters from '@/components/BatchSearchClearFilters'
 import BatchSearchFilterQuery from '@/components/BatchSearchFilterQuery'
-const LOCAL_SEARCH_PARAMS = Object.freeze({
-  query: true,
-  publishState: false,
-  project: false,
-  dateStart: true,
-  dateEnd: true,
-  state: true,
-  order: true,
-  sort: true
-})
+
 export default {
-  name: 'BatchSearches',
+  name: 'BatchSearchList',
   components: {
     BatchSearchFilterQuery,
     BatchSearchClearFilters,
     BatchSearchTable
   },
   mixins: [utils],
-  data() {
-    return { LOCAL_SEARCH_PARAMS }
-  },
   computed: {
     ...mapGetters('batchSearch', ['hasBatchSearch']),
     howToLink() {
@@ -73,3 +57,10 @@ export default {
   }
 }
 </script>
+<style lang="scss" scoped>
+.batch-search-list__none__message {
+  padding: 0.75em;
+  border: 1px solid #dee2e6;
+  background-color: white;
+}
+</style>

--- a/src/pages/BatchSearchResults.vue
+++ b/src/pages/BatchSearchResults.vue
@@ -1,11 +1,14 @@
 <template>
   <div v-if="isLoaded" class="batch-search-results">
     <div class="my-4 container">
-      <div class="mx-1 mb-2">
+      <div class="mx-1 mb-2 d-flex">
         <router-link :to="generateTo">
           <fa icon="angle-left" class="mr-1" fixed-width />
           {{ $t('batchSearch.title') }}
         </router-link>
+        <span class="border-left border-dark pl-3 ml-3 font-weight-bold">
+          {{ $t('batchSearchResults.title') }}
+        </span>
       </div>
       <batch-search-results-details :batch-search="batchSearch" @update:published="changePublished" />
     </div>
@@ -123,7 +126,7 @@ export default {
         : null
     },
     generateTo() {
-      const baseTo = { name: 'batch-search' }
+      const baseTo = { name: 'batch-search-list' }
       return {
         ...baseTo,
         ...(this.$route.query?.query && { query: { query: this.$route.query.query } })

--- a/src/pages/NewBatchSearch.vue
+++ b/src/pages/NewBatchSearch.vue
@@ -26,10 +26,7 @@ export default {
         <fa icon="angle-left" class="mr-1" fixed-width />
         {{ $t('batchSearch.title') }}
       </router-link>
-      <span class="border-left border-dark pl-3 ml-3 font-weight-bold">
-        {{ $t('newBatchSearch.title') }}
-      </span>
     </div>
-    <batch-search-form hide-title @submit="submit"></batch-search-form>
+    <batch-search-form @submit="submit"></batch-search-form>
   </div>
 </template>

--- a/src/pages/NewBatchSearch.vue
+++ b/src/pages/NewBatchSearch.vue
@@ -1,0 +1,35 @@
+<script>
+import BatchSearchForm from '@/components/BatchSearchForm'
+
+export default {
+  name: 'NewBatchSearch',
+  components: {
+    BatchSearchForm
+  },
+  computed: {
+    batchSearchRoute() {
+      return { name: 'batch-search-list' }
+    }
+  },
+  methods: {
+    submit() {
+      this.$router.push(this.batchSearchRoute)
+    }
+  }
+}
+</script>
+
+<template>
+  <div class="container py-4">
+    <div class="mx-1 mb-2 d-flex">
+      <router-link :to="batchSearchRoute">
+        <fa icon="angle-left" class="mr-1" fixed-width />
+        {{ $t('batchSearch.title') }}
+      </router-link>
+      <span class="border-left border-dark pl-3 ml-3 font-weight-bold">
+        {{ $t('newBatchSearch.title') }}
+      </span>
+    </div>
+    <batch-search-form hide-title @submit="submit"></batch-search-form>
+  </div>
+</template>

--- a/src/pages/Tasks.vue
+++ b/src/pages/Tasks.vue
@@ -21,14 +21,11 @@
           </template>
         </b-tab>
       </template>
-      <div v-if="$route.name === 'batch-search'">
-        <b-btn class="ml-auto my-1 text-nowrap" variant="primary" @click="$refs['batch-search-form'].show()">
+      <div v-if="$route.name === 'batch-search-list'">
+        <b-btn class="ml-auto my-1 text-nowrap" variant="primary" :to="{ name: 'new-batch-search' }">
           <fa class="mr-1" icon="plus" />
           {{ $t('batchSearch.heading') }}
         </b-btn>
-        <b-modal ref="batch-search-form" :title="$t('batchSearch.heading')" body-class="p-0" hide-footer size="md">
-          <batch-search-form hide-border hide-title @submit="$refs['batch-search-form'].hide()"></batch-search-form>
-        </b-modal>
       </div>
     </page-header>
     <router-view />
@@ -39,13 +36,11 @@
 import { findIndex } from 'lodash'
 
 import utils from '@/mixins/utils'
-import BatchSearchForm from '@/components/BatchSearchForm'
 import PageHeader from '@/components/PageHeader'
 
 export default {
   name: 'Tasks',
   components: {
-    BatchSearchForm,
     PageHeader
   },
   mixins: [utils],
@@ -55,7 +50,7 @@ export default {
       if (defaultTab > -1) {
         vm.defaultTab = defaultTab
       } else if (!vm.$route.name.includes('batch-search')) {
-        vm.$router.push({ name: 'batch-search' })
+        vm.$router.push({ name: 'batch-search-list' })
       }
     })
   },
@@ -75,14 +70,17 @@ export default {
       },
       set(value) {
         const name = this.tabRoutes[value]
+        const resolvedPath = this.$router.resolve({ name })?.route?.path
+        // Must be the current route or one of its children
+        const isMatchedRoute = this.$route.matched.some((m) => m.path.startsWith(resolvedPath))
         // Change tab only if the route changed
-        if (name !== this.$route.name) {
+        if (!isMatchedRoute) {
           this.$router.push({ name })
         }
       }
     },
     tabRoutes() {
-      return ['batch-search', 'batch-download', 'indexing']
+      return ['batch-search-list', 'batch-download', 'indexing']
     }
   }
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -86,7 +86,7 @@ export const router = {
         {
           path: 'batch-search',
           redirect: {
-            name: 'batch-search'
+            name: 'batch-search-list'
           }
         },
         {
@@ -106,7 +106,7 @@ export const router = {
           path: 'tasks',
           component: () => import('@/pages/Tasks'),
           redirect: {
-            name: 'batch-search'
+            name: 'batch-search-list'
           },
           meta: {
             title: ({ i18n }) => i18n.t('tasks.title')
@@ -151,34 +151,59 @@ export const router = {
               }
             },
             {
-              name: 'batch-search',
+              name: 'batch-search-list',
               path: 'batch-search',
               components: {
                 default: () => import('@/pages/BatchSearch')
               },
-              meta: {
-                title: ({ i18n }) => i18n.t('batchSearch.title'),
-                docs: [
-                  {
-                    title: 'How to use batch searches',
-                    path: 'all/batch-search-documents'
+              children: [
+                {
+                  path: '',
+                  name: 'batch-search-list',
+                  components: {
+                    default: () => import('@/pages/BatchSearchList')
+                  },
+                  meta: {
+                    title: ({ i18n }) => i18n.t('batchSearch.title'),
+                    docs: [
+                      {
+                        title: 'How to use batch searches',
+                        path: 'all/batch-search-documents'
+                      }
+                    ]
                   }
-                ]
-              }
-            },
-            {
-              name: 'batch-search.results',
-              path: 'batch-search/:index/:uuid',
-              components: {
-                default: () => import('@/pages/BatchSearchResults')
-              },
-              props: {
-                default: true,
-                sidebar: true
-              },
-              meta: {
-                title: ({ i18n }) => i18n.t('batchSearchResults.title')
-              }
+                },
+                {
+                  name: 'new-batch-search',
+                  path: 'new',
+                  components: {
+                    default: () => import('@/pages/NewBatchSearch')
+                  },
+                  meta: {
+                    title: ({ i18n }) => i18n.t('newBatchSearch.title'),
+                    docs: [
+                      {
+                        title: 'How to use batch searches',
+                        path: 'all/batch-search-documents'
+                      }
+                    ]
+                  }
+                },
+                {
+                  name: 'batch-search.results',
+                  path: ':index/:uuid',
+                  components: {
+                    default: () => import('@/pages/BatchSearchResults')
+                  },
+                  props: {
+                    default: true,
+                    sidebar: true
+                  },
+                  meta: {
+                    title: ({ i18n }) => i18n.t('batchSearchResults.title')
+                  }
+                }
+              ]
             }
           ]
         },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -151,7 +151,7 @@ export const router = {
               }
             },
             {
-              name: 'batch-search-list',
+              name: 'batch-search',
               path: 'batch-search',
               components: {
                 default: () => import('@/pages/BatchSearch')

--- a/tests/unit/specs/components/BatchSearchActions.spec.js
+++ b/tests/unit/specs/components/BatchSearchActions.spec.js
@@ -146,6 +146,6 @@ describe('BatchSearchActions.vue', () => {
     wrapper = shallowMount(BatchSearchActions, { i18n, localVue, propsData, router, store, wait })
     await wrapper.vm.deleteBatchSearch()
     expect(router.push).toBeCalled()
-    expect(router.push).toBeCalledWith({ name: 'batch-search' })
+    expect(router.push).toBeCalledWith({ name: 'batch-search-list' })
   })
 })

--- a/tests/unit/specs/components/BatchSearchClearFiltersButton.spec.js
+++ b/tests/unit/specs/components/BatchSearchClearFiltersButton.spec.js
@@ -13,7 +13,7 @@ describe('BatchSearchClearFilters.vue', () => {
     router = new VueRouter({
       routes: [
         {
-          name: 'batch-search',
+          name: 'batch-search-list',
           path: 'batch-search'
         }
       ]
@@ -32,7 +32,7 @@ describe('BatchSearchClearFilters.vue', () => {
     const button = wrapper.find('.batch-search-clear-filters')
     expect(button.attributes().disabled).toBeTruthy()
     await router.push({
-      name: 'batch-search',
+      name: 'batch-search-list',
       query: { page: 1, query: 'hello' }
     })
     const buttonEnabled = wrapper.find('.batch-search-clear-filters')
@@ -41,7 +41,7 @@ describe('BatchSearchClearFilters.vue', () => {
 
   it('trigger clear filters button', async () => {
     await router.push({
-      name: 'batch-search',
+      name: 'batch-search-list',
       query: { page: 1, query: 'hello' }
     })
     wrapper = shallowMount(BatchSearchClearFilters, { i18n, localVue, router, propsData })
@@ -52,14 +52,14 @@ describe('BatchSearchClearFilters.vue', () => {
 
   it('is active only on batch search filters', async () => {
     await router.push({
-      name: 'batch-search',
+      name: 'batch-search-list',
       query: { test: 'test' }
     })
     wrapper = shallowMount(BatchSearchClearFilters, { i18n, localVue, router, propsData })
     expect(wrapper.vm.$route.query).toEqual({ test: 'test' })
     expect(wrapper.vm.hasActiveFilter).toBe(false)
     await router.push({
-      name: 'batch-search',
+      name: 'batch-search-list',
       query: { query: 'hello' }
     })
     expect(wrapper.vm.$route.query).toEqual({ query: 'hello' })
@@ -67,7 +67,7 @@ describe('BatchSearchClearFilters.vue', () => {
   })
   it('is not active when not listed in local search params', async () => {
     await router.push({
-      name: 'batch-search',
+      name: 'batch-search-list',
       query: { publishState: 'publishState' }
     })
     const propsData = { routeName: 'batch-search', localSearchParams: { publishState: false } }
@@ -75,7 +75,7 @@ describe('BatchSearchClearFilters.vue', () => {
     wrapper = shallowMount(BatchSearchClearFilters, { i18n, localVue, router, propsData })
     expect(wrapper.vm.$route.query).toEqual({ publishState: 'publishState' })
     await router.push({
-      name: 'batch-search',
+      name: 'batch-search-list',
       query: { project: 'project' }
     })
     expect(wrapper.vm.$route.query).toEqual({ project: 'project' })
@@ -84,7 +84,7 @@ describe('BatchSearchClearFilters.vue', () => {
   it('is active with server batch search filters', async () => {
     const computed = { isServer: () => true }
     await router.push({
-      name: 'batch-search',
+      name: 'batch-search-list',
       query: { publishState: 'publishState' }
     })
     wrapper = shallowMount(BatchSearchClearFilters, { i18n, localVue, router, computed, propsData })
@@ -92,7 +92,7 @@ describe('BatchSearchClearFilters.vue', () => {
     expect(wrapper.vm.hasActiveFilter).toBe(true)
 
     await router.push({
-      name: 'batch-search',
+      name: 'batch-search-list',
       query: { project: 'project' }
     })
     expect(wrapper.vm.$route.query).toEqual({ project: 'project' })

--- a/tests/unit/specs/components/BatchSearchCopyForm.spec.js
+++ b/tests/unit/specs/components/BatchSearchCopyForm.spec.js
@@ -10,7 +10,7 @@ describe('BatchSearchCopyForm.vue', () => {
   let i18n, localVue, store, wait
   const routes = [
     {
-      name: 'batch-search',
+      name: 'batch-search-list',
       path: '/batch-search'
     },
     {

--- a/tests/unit/specs/components/BatchSearchFilterQuery.spec.js
+++ b/tests/unit/specs/components/BatchSearchFilterQuery.spec.js
@@ -30,7 +30,7 @@ describe('BatchSearchFilterQuery.vue', () => {
       router = new VueRouter({
         routes: [
           {
-            name: 'batch-search',
+            name: 'batch-search-list',
             path: 'batch-search'
           }
         ],
@@ -67,7 +67,7 @@ describe('BatchSearchFilterQuery.vue', () => {
     })
     it('gets query from search params', async () => {
       await router.push({
-        name: 'batch-search',
+        name: 'batch-search-list',
         query: { query: 'search_from_url' }
       })
       const wrapper = shallowMount(BatchSearchFilterQuery, { i18n, localVue, router })
@@ -80,7 +80,7 @@ describe('BatchSearchFilterQuery.vue', () => {
 
     it('should execute "filterByQuery" on submit one time', async () => {
       await router.push({
-        name: 'batch-search',
+        name: 'batch-search-list',
         query: { query: 'search_from_url' }
       })
       const wrapper = mount(BatchSearchFilterQuery, { i18n, localVue, router })

--- a/tests/unit/specs/components/BatchSearchTable.spec.js
+++ b/tests/unit/specs/components/BatchSearchTable.spec.js
@@ -38,7 +38,7 @@ const routerFactory = () => {
   return new VueRouter({
     routes: [
       {
-        name: 'batch-search',
+        name: 'batch-search-list',
         path: 'batch-search'
       },
       {
@@ -52,7 +52,7 @@ const routerFactory = () => {
 
 const routeFactory = function (args) {
   return {
-    name: 'batch-search',
+    name: 'batch-search-list',
     query: { page: 1, sort: 'batch_date', order: 'desc', field: 'all', ...args }
   }
 }
@@ -246,7 +246,7 @@ describe('BatchSearchTable.vue', () => {
       })
       it('get params with accepted values', async () => {
         await router.push({
-          name: 'batch-search',
+          name: 'batch-search-list',
           query: {
             query: 'test',
             page: 2,
@@ -275,7 +275,7 @@ describe('BatchSearchTable.vue', () => {
 
       it('get params with invalid values', async () => {
         await router.push({
-          name: 'batch-search',
+          name: 'batch-search-list',
           query: {
             page: -1,
             sort: 'not_existing_sort',
@@ -302,7 +302,7 @@ describe('BatchSearchTable.vue', () => {
       it('clear all filters in table', async () => {
         // GIVEN
         await router.push({
-          name: 'batch-search',
+          name: 'batch-search-list',
           query: {
             query: 'test',
             page: 2,
@@ -320,7 +320,7 @@ describe('BatchSearchTable.vue', () => {
 
         // THEN
         await router.push({
-          name: 'batch-search',
+          name: 'batch-search-list',
           query: {}
         })
         expect(wrapper.vm.search).toBe('')
@@ -339,7 +339,7 @@ describe('BatchSearchTable.vue', () => {
         const fetchSpy = jest.spyOn(wrapper.vm, 'fetch')
         expect(fetchSpy).not.toBeCalled()
         await router.push({
-          name: 'batch-search',
+          name: 'batch-search-list',
           query: {
             query: 'new search'
           }

--- a/tests/unit/specs/pages/BatchSearchList.spec.js
+++ b/tests/unit/specs/pages/BatchSearchList.spec.js
@@ -6,10 +6,10 @@ import { flushPromises } from 'tests/unit/tests_utils'
 import Vuex from 'vuex'
 
 import { Core } from '@/core'
-import BatchSearch from '@/pages/BatchSearch'
+import BatchSearchList from '@/pages/BatchSearchList'
 import { Api } from '@/api'
 
-describe('BatchSearch.vue', () => {
+describe('BatchSearchList.vue', () => {
   let i18n, localVue, store, wait, api
   let wrapper = null
   const router = new VueRouter()
@@ -51,7 +51,7 @@ describe('BatchSearch.vue', () => {
     await flushPromises()
   })
   beforeEach(async () => {
-    wrapper = mount(BatchSearch, { i18n, localVue, router, store, wait })
+    wrapper = mount(BatchSearchList, { i18n, localVue, router, store, wait })
     await flushPromises()
   })
 
@@ -60,7 +60,7 @@ describe('BatchSearch.vue', () => {
   })
 
   it('should display a search bar', () => {
-    expect(wrapper.find('.batch-search__search-bar').exists()).toBeTruthy()
+    expect(wrapper.find('.batch-search-list__search-bar').exists()).toBeTruthy()
   })
 
   it('should display a batch search table', () => {
@@ -79,9 +79,9 @@ describe('BatchSearch.vue', () => {
     const actions = { getBatchSearches: jest.fn() }
     const store = new Vuex.Store({ modules: { batchSearch: { namespaced: true, state, getters, actions } } })
 
-    wrapper = mount(BatchSearch, { i18n, localVue, router, store, wait })
+    wrapper = mount(BatchSearchList, { i18n, localVue, router, store, wait })
     await flushPromises()
 
-    expect(wrapper.find('.batch-search__none').exists()).toBeTruthy()
+    expect(wrapper.find('.batch-search-list__none').exists()).toBeTruthy()
   })
 })

--- a/tests/unit/specs/pages/Tasks.spec.js
+++ b/tests/unit/specs/pages/Tasks.spec.js
@@ -16,7 +16,7 @@ describe('Tasks.vue', () => {
         children: [
           { name: 'indexing', path: 'indexing' },
           { name: 'batch-download', path: 'batch-download' },
-          { name: 'batch-search', path: 'batch-search' }
+          { name: 'batch-search-list', path: 'batch-search' }
         ]
       }
     ]
@@ -32,13 +32,6 @@ describe('Tasks.vue', () => {
     replaceRouteby({ name: 'tasks' })
     wrapper = shallowMount(Tasks, { i18n, localVue, store, router })
     expect(wrapper.vm.tab).toBe(null)
-  })
-
-  it('should add the new "batch-search" form in a modal', async () => {
-    replaceRouteby({ name: 'batch-search' })
-    wrapper = shallowMount(Tasks, { i18n, localVue, store, router })
-    await wrapper.vm.$nextTick()
-    expect(wrapper.vm.$refs['batch-search-form']).not.toBeUndefined()
   })
 
   it('should select the "batch-download" tab when the route is active', () => {


### PR DESCRIPTION
## PR description

In order to anticipate on future enhancements, this PR aims at moving the Batch Search Form to a separated page (instead of a modal).

![Screenshot 2023-07-17 at 19-08-22 Start a new batch search - Datashare](https://github.com/ICIJ/datashare-client/assets/471176/7cd6152d-2e52-45e6-bc07-a72f36832a95)

## Changes

* Create a new page `NewBatchSearch` to hold the form
* Create a new page `BatchSearch` to hold all batch search related views 
* Rename `BatchSearch` to `BatchSearchList`
* Make `NewBatchSearch`, `BatchSearchList` and `BatchSearchResult` children of the same route
* Remove `BatchSearchForm` from the modal

## Limitations

* The `batch-search` route should never be navigated directly (it's empty), hence why I edited all links to use `batch-search-list` ;
* `NewBatchSearch` page name might be confusing although its syntax is more correct than `BatchSearchNew`.