### PR TITLE
feat: create project form

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -57,8 +57,11 @@ export class Api {
   getTasks(filter) {
     return this.sendAction('/api/task/all', { params: { filter } })
   }
-  createProject(project) {
-    return this.sendActionAsText(`/api/index/${project}`, { method: Method.PUT })
+  createIndex(index) {
+    return this.sendActionAsText(`/api/index/${index}`, { method: Method.PUT })
+  }
+  createProject(data) {
+    return this.sendActionAsText(`/api/project/`, { method: Method.POST, data })
   }
   deleteAll(project) {
     return this.sendActionAsText(`/api/project/${project}`, { method: Method.DELETE })

--- a/src/components/ProjectForm.vue
+++ b/src/components/ProjectForm.vue
@@ -29,7 +29,8 @@ export default {
      * Default values of the form
      */
     values: {
-      type: Object
+      type: Object,
+      default: () => ({})
     },
     /**
      * Freeze name and sourcePath in edit mode

--- a/src/components/ProjectForm.vue
+++ b/src/components/ProjectForm.vue
@@ -1,0 +1,200 @@
+<script>
+import { every, cloneDeep, kebabCase } from 'lodash'
+
+import { slugger, isUrl } from '@/utils/strings'
+
+export default {
+  name: 'ProjectForm',
+  props: {
+    card: {
+      type: Boolean
+    },
+    disabled: {
+      type: Boolean
+    }
+  },
+  data() {
+    return {
+      form: {
+        name: null,
+        label: null,
+        description: null,
+        logoUrl: null,
+        sourceUrl: null,
+        publisherName: null,
+        maintainerName: null
+      }
+    }
+  },
+  computed: {
+    bodyComponent() {
+      return this.card ? 'b-card-body' : 'div'
+    },
+    footerComponent() {
+      return this.card ? 'b-card-footer' : 'div'
+    },
+    classList() {
+      return this.card ? ['card'] : []
+    },
+    valid() {
+      return every([
+        !this.disabled,
+        this.isPresent(this.form.name),
+        this.isPresent(this.form.label) && !this.isReservedWord(this.form.label),
+        !this.isPresent(this.form.sourceUrl) || this.isUrl(this.form.sourceUrl),
+        !this.isPresent(this.form.logoUrl) || this.isUrl(this.form.logoUrl)
+      ])
+    }
+  },
+  watch: {
+    'form.label': function (label) {
+      // Transform to kebab case first to insert a "minus" when input is using camel case
+      this.form.name = slugger(kebabCase(label)).toLowerCase()
+    }
+  },
+  methods: {
+    isReservedWord(value) {
+      const reserved = ['new', 'edit', 'delete']
+      return reserved.includes(value.toLowerCase())
+    },
+    isUrl(value) {
+      return isUrl(value)
+    },
+    isPresent(value) {
+      return value !== null && value !== ''
+    },
+    isBlank(value) {
+      return !this.isPresent(value)
+    },
+    submit() {
+      if (this.valid) {
+        this.$emit('submit', cloneDeep(this.form))
+      }
+    },
+    reset() {
+      this.$set(this, 'form', {
+        name: null,
+        label: null,
+        description: null,
+        logoUrl: null,
+        sourceUrl: null,
+        publisherName: null,
+        maintainerName: null
+      })
+    }
+  }
+}
+</script>
+
+<template>
+  <b-form class="project-form" :class="classList" novalidate @submit.stop.prevent="submit">
+    <component :is="bodyComponent">
+      <b-form-row>
+        <b-col>
+          <b-form-group
+            class="project-form__group project-form__group--label"
+            :invalid-feedback="$t('projectForm.form.label.invalidFeedback', { label: form.label })"
+            :label="$t('projectForm.form.label.label')"
+            :description="$t('projectForm.form.label.description')"
+            :disabled="disabled"
+            :validated="isPresent(form.label) && !isReservedWord(form.label)"
+          >
+            <b-form-input
+              v-model="form.label"
+              name="label"
+              type="text"
+              placeholder=""
+              required
+              :state="isBlank(form.label) ? null : !isReservedWord(form.label)"
+            />
+          </b-form-group>
+        </b-col>
+        <b-col>
+          <b-form-group
+            :label="$t('projectForm.form.name.label')"
+            :description="$t('projectForm.form.name.description')"
+            :disabled="disabled"
+          >
+            <b-form-input v-model="form.name" name="name" type="text" placeholder="" required readonly />
+          </b-form-group>
+        </b-col>
+      </b-form-row>
+      <b-form-group
+        class="project-form__group project-form__group--name"
+        :label="$t('projectForm.form.description.label')"
+        :description="$t('projectForm.form.description.description')"
+        :disabled="disabled"
+        :validated="isPresent(form.description)"
+      >
+        <b-form-textarea v-model="form.description" placeholder="" rows="3" max-rows="8" />
+      </b-form-group>
+      <b-form-group
+        class="project-form__group project-form__group--logo-url"
+        :label="$t('projectForm.form.logoUrl.label')"
+        :description="$t('projectForm.form.logoUrl.description')"
+        :disabled="disabled"
+        :validated="isUrl(form.logoUrl)"
+      >
+        <b-form-input
+          v-model="form.logoUrl"
+          :state="isBlank(form.logoUrl) ? null : isUrl(form.logoUrl)"
+          name="logoUrl"
+          type="url"
+          placeholder="https://..."
+        />
+      </b-form-group>
+      <b-form-group
+        class="project-form__group project-form__group--maintainer-name"
+        :label="$t('projectForm.form.maintainerName.label')"
+        :description="$t('projectForm.form.maintainerName.description')"
+        :disabled="disabled"
+        :validated="isPresent(form.maintainerName)"
+      >
+        <b-form-input v-model="form.maintainerName" name="maintainerName" type="text" placeholder="" />
+      </b-form-group>
+      <b-form-row>
+        <b-col>
+          <b-form-group
+            class="project-form__group project-form__group--publisher-name"
+            :label="$t('projectForm.form.publisherName.label')"
+            :description="$t('projectForm.form.publisherName.description')"
+            :disabled="disabled"
+            :validated="isPresent(form.publisherName)"
+          >
+            <b-form-input v-model="form.publisherName" name="publisherName" type="text" placeholder="" />
+          </b-form-group>
+        </b-col>
+        <b-col>
+          <b-form-group
+            class="project-form__group project-form__group--source-url"
+            :label="$t('projectForm.form.sourceUrl.label')"
+            :description="$t('projectForm.form.sourceUrl.description')"
+            :disabled="disabled"
+            :validated="isUrl(form.sourceUrl)"
+          >
+            <b-form-input
+              v-model="form.sourceUrl"
+              name="sourceUrl"
+              type="url"
+              placeholder="https://..."
+              :state="isBlank(form.sourceUrl) ? null : isUrl(form.sourceUrl)"
+            />
+          </b-form-group>
+        </b-col>
+      </b-form-row>
+    </component>
+    <component :is="footerComponent" class="d-flex">
+      <confirm-button
+        type="button"
+        class="btn btn-outline-primary mr-3"
+        :confirmed="reset"
+        :label="$t('projectForm.resetConfirmation')"
+      >
+        <slot name="reset-text">{{ $t('projectForm.reset') }}</slot>
+      </confirm-button>
+      <b-button type="submit" variant="primary" class="ml-auto" :disabled="!valid">
+        <slot name="submit-text">{{ $t('projectForm.submit') }}</slot>
+      </b-button>
+    </component>
+  </b-form>
+</template>

--- a/src/components/ProjectForm.vue
+++ b/src/components/ProjectForm.vue
@@ -93,7 +93,7 @@ export default {
       return isUrl(value)
     },
     isPresent(value) {
-      return value !== null && value !== ''
+      return value?.trim()?.length > 0
     },
     isBlank(value) {
       return !this.isPresent(value)

--- a/src/components/ProjectForm.vue
+++ b/src/components/ProjectForm.vue
@@ -1,10 +1,14 @@
 <script>
 import { every, cloneDeep, kebabCase } from 'lodash'
 
+import InlineDirectoryPicker from '@/components/InlineDirectoryPicker'
 import { slugger, isUrl } from '@/utils/strings'
 
 export default {
   name: 'ProjectForm',
+  components: {
+    InlineDirectoryPicker
+  },
   props: {
     card: {
       type: Boolean
@@ -18,6 +22,7 @@ export default {
       form: {
         name: null,
         label: null,
+        sourcePath: this.$config.get('dataDir'),
         description: null,
         logoUrl: null,
         sourceUrl: null,
@@ -127,6 +132,15 @@ export default {
         :validated="isPresent(form.description)"
       >
         <b-form-textarea v-model="form.description" placeholder="" rows="3" max-rows="8" />
+      </b-form-group>
+      <b-form-group
+        class="project-form__group project-form__group--source-path"
+        :label="$t('projectForm.form.sourcePath.label')"
+        :description="$t('projectForm.form.sourcePath.description')"
+        :disabled="disabled"
+        :validated="isPresent(form.sourcePath)"
+      >
+        <inline-directory-picker v-model="form.sourcePath" />
       </b-form-group>
       <b-form-group
         class="project-form__group project-form__group--logo-url"

--- a/src/components/ProjectForm.vue
+++ b/src/components/ProjectForm.vue
@@ -4,17 +4,32 @@ import { every, cloneDeep, kebabCase } from 'lodash'
 import InlineDirectoryPicker from '@/components/InlineDirectoryPicker'
 import { slugger, isUrl } from '@/utils/strings'
 
+/**
+ * Build project form (to create or edit a project).
+ */
 export default {
   name: 'ProjectForm',
   components: {
     InlineDirectoryPicker
   },
   props: {
+    /**
+     * Display the form in a card
+     */
     card: {
       type: Boolean
     },
+    /**
+     * Disable all inputs
+     */
     disabled: {
       type: Boolean
+    },
+    /**
+     * Default values of the form
+     */
+    values: {
+      type: Object
     }
   },
   data() {
@@ -27,7 +42,10 @@ export default {
         logoUrl: null,
         sourceUrl: null,
         publisherName: null,
-        maintainerName: null
+        maintainerName: null,
+        // Merge with this properties to be able to initialize
+        // the form with an existing project
+        ...this.values
       }
     }
   },
@@ -86,7 +104,10 @@ export default {
         logoUrl: null,
         sourceUrl: null,
         publisherName: null,
-        maintainerName: null
+        maintainerName: null,
+        // Merge with this properties to be able to initialize
+        // the form with an existing project
+        ...this.values
       })
     }
   }

--- a/src/components/ProjectForm.vue
+++ b/src/components/ProjectForm.vue
@@ -80,6 +80,8 @@ export default {
       this.$set(this, 'form', {
         name: null,
         label: null,
+        sourcePath: this.$config.get('dataDir'),
+        allowedMask: '*',
         description: null,
         logoUrl: null,
         sourceUrl: null,

--- a/src/components/ProjectForm.vue
+++ b/src/components/ProjectForm.vue
@@ -43,7 +43,7 @@ export default {
         sourceUrl: null,
         publisherName: null,
         maintainerName: null,
-        // Merge with this properties to be able to initialize
+        // Merge with this property to be able to initialize
         // the form with an existing project
         ...this.values
       }
@@ -105,7 +105,7 @@ export default {
         sourceUrl: null,
         publisherName: null,
         maintainerName: null,
-        // Merge with this properties to be able to initialize
+        // Merge with this propertiy to be able to initialize
         // the form with an existing project
         ...this.values
       })

--- a/src/components/ProjectForm.vue
+++ b/src/components/ProjectForm.vue
@@ -30,6 +30,12 @@ export default {
      */
     values: {
       type: Object
+    },
+    /**
+     * Freeze name and sourcePath in edit mode
+     */
+    edit: {
+      type: Boolean
     }
   },
   data() {
@@ -71,8 +77,11 @@ export default {
   },
   watch: {
     'form.label': function (label) {
-      // Transform to kebab case first to insert a "minus" when input is using camel case
-      this.form.name = slugger(kebabCase(label)).toLowerCase()
+      // The name cannot change when `edit` is set
+      if (!this.edit) {
+        // Transform to kebab case first to insert a "minus" when input is using camel case
+        this.form.name = slugger(kebabCase(label)).toLowerCase()
+      }
     }
   },
   methods: {
@@ -154,9 +163,10 @@ export default {
         :disabled="disabled"
         :validated="isPresent(form.description)"
       >
-        <b-form-textarea v-model="form.description" placeholder="" rows="3" max-rows="8" />
+        <b-form-textarea v-model="form.description" name="description" placeholder="" rows="3" max-rows="8" />
       </b-form-group>
       <b-form-group
+        v-if="!edit"
         class="project-form__group project-form__group--source-path"
         :label="$t('projectForm.form.sourcePath.label')"
         :description="$t('projectForm.form.sourcePath.description')"

--- a/src/core/ProjectsMixin.js
+++ b/src/core/ProjectsMixin.js
@@ -49,7 +49,7 @@ const ProjectsMixin = (superclass) =>
      */
     createDefaultProject() {
       const defaultProject = this.config.get('defaultProject')
-      return this.api.createProject(defaultProject)
+      return this.api.createIndex(defaultProject)
     }
     /**
      * List all projects this user has access to.

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -761,7 +761,7 @@
       },
       "maintainerName": {
         "label": "Maintainer name",
-        "description": "The people or organization that will be in charge of maintaining this project on Datashare."
+        "description": "The people or organization who will be in charge of maintaining this project on Datashare."
       }
     },
     "reset": "Reset",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -24,7 +24,8 @@
   "error": {
     "title": "Something's wrong here",
     "description": "An error has occurred. Please try again later or contact your administrator if the problem persists.",
-    "noProjects": "You have no projects yet. Please contact your administrator."
+    "noProjects": "You have no projects yet. Please contact your administrator.",
+    "notFound": "Page not found."
   },
   "search": {
     "title": "Search",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -757,7 +757,7 @@
       },
       "publisherName": {
         "label": "Publisher name",
-        "description": "The people or organization that published the files in this project."
+        "description": "The people or organization who published the files in this project."
       },
       "maintainerName": {
         "label": "Maintainer name",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -722,7 +722,7 @@
     "description": "",
     "notify": {
       "succeed": "The project was created",
-      "succeedBody": "You can now add documents to this project.",
+      "succeedBody": "Now, you can add documents to this project.",
       "failed": "Unable to create the project",
       "failedBody": "Something happened when trying to create this project."
     },

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -736,6 +736,10 @@
         "label": "Description",
         "description": ""
       },
+      "sourcePath": {
+        "label": "Project folder",
+        "description": "This is the folder where the project's files are located."
+      },
       "logoUrl": {
         "label": "Logo URL",
         "description": ""

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -24,7 +24,7 @@
   "error": {
     "title": "Something's wrong here",
     "description": "An error has occurred. Please try again later or contact your administrator if the problem persists.",
-    "noProjects": "You have no projects yet. Please contact your administrator.",
+    "noProjects": "Your project list is empty. Please contact your administrator.",
     "notFound": "Page not found."
   },
   "search": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -732,7 +732,7 @@
     "form": {
       "name": {
         "label": "ID",
-        "description": "This value is used internally to identify the project."
+        "description": "The internal project identifier."
       },
       "label": {
         "label": "Label",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -719,6 +719,12 @@
   "newProject": {
     "title": "New project",
     "description": "",
+    "notify": {
+      "succeed": "The project was created",
+      "succeedBody": "You can now add documents to this project.",
+      "failed": "Unable to create the project",
+      "failedBody": "Something happened when trying to create this project."
+    },
     "submit": "Create project"
   },
   "projectForm": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -716,6 +716,47 @@
       "heading": "Filter by queries"
     }
   },
+  "newProject": {
+    "title": "New project",
+    "description": "",
+    "submit": "Create project"
+  },
+  "projectForm": {
+    "form": {
+      "name": {
+        "label": "ID",
+        "description": "This value is used internally to identify the project."
+      },
+      "label": {
+        "label": "Label",
+        "description": "",
+        "invalidFeedback": "The label \"{label}\" is a reserved word."
+      },
+      "description": {
+        "label": "Description",
+        "description": ""
+      },
+      "logoUrl": {
+        "label": "Logo URL",
+        "description": ""
+      },
+      "sourceUrl": {
+        "label": "Source URL",
+        "description": ""
+      },
+      "publisherName": {
+        "label": "Publisher name",
+        "description": "The people or organization that published the files in this project."
+      },
+      "maintainerName": {
+        "label": "Maintainer name",
+        "description": "The people or organization that will be in charge of maintaining this project on Datashare."
+      }
+    },
+    "reset": "Reset",
+    "resetConfirmation": "Are you sure you want to reset the form to its initial values?",
+    "submit": "Submit"
+  },
   "shortkeys": {
     "title": "Search shortcuts",
     "goToPreviousDocument": "Go to the previous document",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -745,7 +745,7 @@
       },
       "sourcePath": {
         "label": "Project folder",
-        "description": "This is the folder where the project's files are located."
+        "description": "The folder where the project's files are located."
       },
       "logoUrl": {
         "label": "Logo URL",

--- a/src/pages/Error.vue
+++ b/src/pages/Error.vue
@@ -15,16 +15,20 @@ export default {
   mixins: [utils],
   props: {
     error: {
-      type: [String, Error]
+      type: [String, Error],
+      default: null
     },
     title: {
-      type: String
+      type: String,
+      default: null
     },
     description: {
-      type: String
+      type: String,
+      default: null
     },
     code: {
-      type: Number
+      type: Number,
+      default: null
     }
   },
   data() {

--- a/src/pages/Error.vue
+++ b/src/pages/Error.vue
@@ -6,6 +6,9 @@ import VersionNumber from '@/components/VersionNumber'
 import utils from '@/mixins/utils'
 import settings from '@/utils/settings'
 
+/**
+ * This page display error.
+ */
 export default {
   name: 'Error',
   components: {
@@ -14,18 +17,30 @@ export default {
   },
   mixins: [utils],
   props: {
+    /**
+     * An Error object or the error message directly.
+     */
     error: {
       type: [String, Error],
       default: null
     },
+    /**
+     * Title of the error page.
+     */
     title: {
       type: String,
       default: null
     },
+    /**
+     * Description (bellow the title) of the error page.
+     */
     description: {
       type: String,
       default: null
     },
+    /**
+     * HTTP error code (if appliable).
+     */
     code: {
       type: Number,
       default: null

--- a/src/pages/NewProject.vue
+++ b/src/pages/NewProject.vue
@@ -49,7 +49,7 @@ export default {
     <page-header icon="database" :title="$t('newProject.title')" :description="$t('newProject.description')" />
     <div class="container">
       <b-overlay rounded="sm" opacity="0.6" :show="$wait.is('creating')">
-        <project-form class="my-4" card :disbaled="$wait.is('creating')" @submit="submit">
+        <project-form class="my-4" card :disabled="$wait.is('creating')" @submit="submit">
           <template #submit-text>
             {{ $t('newProject.submit') }}
           </template>

--- a/src/pages/NewProject.vue
+++ b/src/pages/NewProject.vue
@@ -4,6 +4,9 @@ import { get } from 'lodash'
 import PageHeader from '@/components/PageHeader'
 import ProjectForm from '@/components/ProjectForm'
 
+/**
+ * This page display a form to create a new project.
+ */
 export default {
   name: 'NewProject',
   components: {

--- a/src/pages/NewProject.vue
+++ b/src/pages/NewProject.vue
@@ -1,0 +1,60 @@
+<script>
+import { get } from 'lodash'
+
+import PageHeader from '@/components/PageHeader'
+import ProjectForm from '@/components/ProjectForm'
+
+export default {
+  name: 'NewProject',
+  components: {
+    PageHeader,
+    ProjectForm
+  },
+  data() {
+    return {
+      project: {}
+    }
+  },
+  methods: {
+    async submit(project) {
+      try {
+        this.$wait.start('creating')
+        await this.$core.api.createProject(project)
+        this.notifyCreationSucceed()
+        this.$router.push({ name: 'landing' })
+      } catch (error) {
+        this.notifyCreationFailed(error)
+      } finally {
+        this.$wait.end('creating')
+      }
+    },
+    notifyCreationSucceed() {
+      const title = this.$t('newProject.notify.succeed')
+      const variant = 'success'
+      const body = this.$t('newProject.notify.succeedBody')
+      this.$root.$bvToast.toast(body, { variant, title })
+    },
+    notifyCreationFailed(error) {
+      const title = this.$t('newProject.notify.failed')
+      const variant = 'danger'
+      const body = get(error, 'response.data.error') ?? this.$t('newProject.notify.failedBody')
+      this.$root.$bvToast.toast(body, { variant, title })
+    }
+  }
+}
+</script>
+
+<template>
+  <div class="new-project">
+    <page-header icon="database" :title="$t('newProject.title')" :description="$t('newProject.description')" />
+    <div class="container">
+      <b-overlay rounded="sm" opacity="0.6" :show="$wait.is('creating')">
+        <project-form class="my-4" card :disbaled="$wait.is('creating')" @submit="submit">
+          <template #submit-text>
+            {{ $t('newProject.submit') }}
+          </template>
+        </project-form>
+      </b-overlay>
+    </div>
+  </div>
+</template>

--- a/src/pages/NewProject.vue
+++ b/src/pages/NewProject.vue
@@ -10,11 +10,6 @@ export default {
     PageHeader,
     ProjectForm
   },
-  data() {
-    return {
-      project: {}
-    }
-  },
   methods: {
     async submit(project) {
       try {

--- a/src/pages/Project.vue
+++ b/src/pages/Project.vue
@@ -1,0 +1,11 @@
+<script>
+export default {
+  name: 'Project'
+}
+</script>
+
+<template>
+  <div class="project">
+    <router-view></router-view>
+  </div>
+</template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -200,6 +200,9 @@ export const router = {
               path: 'new',
               components: {
                 default: () => import('@/pages/NewProject')
+              },
+              meta: {
+                allowedModes: ['LOCAL', 'EMBEDDED']
               }
             }
           ]

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -183,6 +183,28 @@ export const router = {
           ]
         },
         {
+          path: 'p',
+          components: {
+            default: () => import('@/pages/Project')
+          },
+          children: [
+            {
+              path: '',
+              name: 'project',
+              redirect: {
+                name: 'project.new'
+              }
+            },
+            {
+              name: 'project.new',
+              path: 'new',
+              components: {
+                default: () => import('@/pages/NewProject')
+              }
+            }
+          ]
+        },
+        {
           name: 'user-history',
           path: 'user-history',
           component: () => import('@/pages/UserHistory'),

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -1,5 +1,11 @@
 import { escapeRegExp, some, trimEnd } from 'lodash'
 
+/**
+ * Slugify a string value.
+ *
+ * @param {string} [value=''] - The string to be slugified.
+ * @return {string} - The slugified string.
+ */
 export function slugger(value = '') {
   return value
     .toLowerCase()
@@ -8,6 +14,13 @@ export function slugger(value = '') {
     .replace(/\s/g, '-')
 }
 
+/**
+ * Check if a value is a valid URL.
+ *
+ * @param {string} value - The value to check.
+ * @param {string[]} [protocols=['https', 'http']] - The protocols to validate against.
+ * @return {boolean} - True if the value is a valid URL, false otherwise.
+ */
 export function isUrl(value, protocols = ['https', 'http']) {
   let url
 
@@ -20,6 +33,16 @@ export function isUrl(value, protocols = ['https', 'http']) {
   return some(protocols, (protocol) => protocol === trimEnd(url.protocol, ':'))
 }
 
+/**
+ * Add a mark class to a string based on search term offsets.
+ *
+ * @param {Object} [params={}] - The parameters for marking.
+ * @param {string} [params.content=''] - The string content to search in.
+ * @param {string} [params.term=''] - The search term.
+ * @param {number[]} [params.offsets=[]] - The offsets of the search term in the content.
+ * @param {number} [params.delta=0] - Optional offset correction.
+ * @return {string} - The content string with marked search terms.
+ */
 export function addLocalSearchMarksClassByOffsets({ content = '', term = '', offsets = [], delta = 0 } = {}) {
   // Create one chunk for each letter
   const chunks = content.split('')
@@ -37,6 +60,15 @@ export function addLocalSearchMarksClassByOffsets({ content = '', term = '', off
   return chunks.join('')
 }
 
+/**
+ * Highlight search term occurrences in the given content.
+ *
+ * @param {string} [content='<div></div>'] - The HTML content to search in.
+ * @param {Object} [localSearchTerm={ label: '' }] - The search term object.
+ * @param {string} [localSearchTerm.label=''] - The label of the search term.
+ * @param {boolean} [localSearchTerm.regex=false] - Indicates if the term is a regular expression.
+ * @return {Object} - An object with updated content, local search index and local search occurrences count.
+ */
 export function addLocalSearchMarksClass(content = '<div></div>', localSearchTerm = { label: '' }) {
   const escapedLocalSearchTerm = localSearchTerm.regex ? localSearchTerm.label : escapeRegExp(localSearchTerm.label)
   // In case the searched term is split on 2 lines in the content

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -1,4 +1,4 @@
-import { escapeRegExp } from 'lodash'
+import { escapeRegExp, some, trimEnd } from 'lodash'
 
 export function slugger(value = '') {
   return value
@@ -6,6 +6,18 @@ export function slugger(value = '') {
     .trim()
     .replace(/[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,./:;<=>?@[\]^`{|}~]/g, '')
     .replace(/\s/g, '-')
+}
+
+export function isUrl(value, protocols = ['https', 'http']) {
+  let url
+
+  try {
+    url = new URL(value)
+  } catch (_) {
+    return false
+  }
+
+  return some(protocols, (protocol) => protocol === trimEnd(url.protocol, ':'))
 }
 
 export function addLocalSearchMarksClassByOffsets({ content = '', term = '', offsets = [], delta = 0 } = {}) {
@@ -49,17 +61,4 @@ export function addLocalSearchMarksClass(content = '<div></div>', localSearchTer
   } catch (error) {
     return { content, localSearchIndex, localSearchOccurrences }
   }
-}
-
-export function isUrl(url = '') {
-  const pattern = new RegExp(
-    '^(https?:\\/\\/)?' + // protocol
-      '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
-      '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
-      '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-      '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-      '(\\#[-a-z\\d_]*)?$',
-    'i'
-  ) // fragment locator
-  return !!pattern.test(url)
 }

--- a/tests/unit/specs/api/index.spec.js
+++ b/tests/unit/specs/api/index.spec.js
@@ -75,8 +75,8 @@ describe('Datashare backend client', () => {
     expect(json).toEqual({})
   })
 
-  it('should return backend response to createProject', async () => {
-    json = await api.createProject()
+  it('should return backend response to createIndex', async () => {
+    json = await api.createIndex()
     expect(json).toEqual({})
   })
 
@@ -344,7 +344,7 @@ describe('Datashare backend client', () => {
     EventBus.$on('http::error', mockCallback)
 
     try {
-      await api.createProject()
+      await api.createIndex()
     } catch (err) {
       expect(err).toEqual(error)
     }

--- a/tests/unit/specs/components/ProjectForm.spec.js
+++ b/tests/unit/specs/components/ProjectForm.spec.js
@@ -3,13 +3,13 @@ import { createLocalVue, mount } from '@vue/test-utils'
 import ProjectForm from '@/components/ProjectForm'
 import { Core } from '@/core'
 
-const { localVue, i18n } = Core.init(createLocalVue()).useAll()
+const { localVue, i18n, wait, store, config } = Core.init(createLocalVue()).useAll()
 
 describe('ProjectForm.vue', () => {
   let wrapper
 
   beforeEach(() => {
-    wrapper = mount(ProjectForm, { localVue, i18n })
+    wrapper = mount(ProjectForm, { localVue, i18n, wait, store, config })
   })
 
   it('should not use b-card-* components by default', () => {

--- a/tests/unit/specs/components/ProjectForm.spec.js
+++ b/tests/unit/specs/components/ProjectForm.spec.js
@@ -8,133 +8,156 @@ const { localVue, i18n, wait, store, config } = Core.init(createLocalVue()).useA
 describe('ProjectForm.vue', () => {
   let wrapper
 
-  beforeEach(() => {
-    wrapper = mount(ProjectForm, { localVue, i18n, wait, store, config })
+  describe('without an existing project', () => {
+    beforeEach(() => {
+      wrapper = mount(ProjectForm, { localVue, i18n, wait, store, config })
+    })
+
+    it('should not use b-card-* components by default', () => {
+      expect(wrapper.findComponent({ name: 'b-card-body' }).exists()).toBeFalsy()
+      expect(wrapper.findComponent({ name: 'b-card-footer' }).exists()).toBeFalsy()
+    })
+
+    it('should not have the .card class by default', async () => {
+      expect(wrapper.classes('card')).toBeFalsy()
+    })
+
+    it('should use b-card-* components when `card` prop is set', async () => {
+      await wrapper.setProps({ card: true })
+      expect(wrapper.findComponent({ name: 'b-card-body' }).exists()).toBeTruthy()
+      expect(wrapper.findComponent({ name: 'b-card-footer' }).exists()).toBeTruthy()
+    })
+
+    it('should have the .card class when `card` prop is set', async () => {
+      await wrapper.setProps({ card: true })
+      expect(wrapper.classes('card')).toBeTruthy()
+    })
+
+    it('should generate a slugified name when setting the label', async () => {
+      await wrapper.find('input[name=label]').setValue('Pandora Papers')
+      expect(wrapper.find('input[name=name]').element.value).toBe('pandora-papers')
+    })
+
+    it('should generate a slugified name when setting the label, respecting case', async () => {
+      await wrapper.find('input[name=label]').setValue('PandoraPapers')
+      expect(wrapper.find('input[name=name]').element.value).toBe('pandora-papers')
+    })
+
+    it('should not validate the form group if a reserved name is used as label', async () => {
+      await wrapper.find('input[name=label]').setValue('new')
+      expect(wrapper.find('.project-form__group--label').classes('was-validated')).toBeFalsy()
+      expect(wrapper.find('.project-form__group--label .invalid-feedback').exists()).toBeTruthy()
+    })
+
+    it('should not validate the form group if an invalid URL for sourceUrl', async () => {
+      await wrapper.find('input[name=sourceUrl]').setValue('sftp://foo.bar')
+      expect(wrapper.find('.project-form__group--source-url').classes('was-validated')).toBeFalsy()
+    })
+
+    it('should validate the form group if a valid URL for sourceUrl', async () => {
+      await wrapper.find('input[name=sourceUrl]').setValue('https://foo.bar')
+      expect(wrapper.find('.project-form__group--source-url').classes('was-validated')).toBeTruthy()
+    })
+
+    it('should not validate the form group if an invalid URL for logoUrl', async () => {
+      await wrapper.find('input[name=logoUrl]').setValue('sftp://foo.bar')
+      expect(wrapper.find('.project-form__group--logo-url').classes('was-validated')).toBeFalsy()
+    })
+
+    it('should validate the form group if a valid URL for logoUrl', async () => {
+      await wrapper.find('input[name=logoUrl]').setValue('https://foo.bar')
+      expect(wrapper.find('.project-form__group--logo-url').classes('was-validated')).toBeTruthy()
+    })
+
+    it('should not submit an invalid form without name', async () => {
+      await wrapper.trigger('submit')
+      expect(wrapper.emitted().submit).toBeFalsy()
+    })
+
+    it('should not submit an invalid form with a name but an invalid logoUrl', async () => {
+      await wrapper.find('input[name=label]').setValue('foo')
+      await wrapper.find('input[name=logoUrl]').setValue('sftp://foo.bar')
+      await wrapper.trigger('submit')
+      expect(wrapper.emitted().submit).toBeFalsy()
+    })
+
+    it('should not submit an invalid form with a name but an invalid sourceUrl', async () => {
+      await wrapper.find('input[name=label]').setValue('foo')
+      await wrapper.find('input[name=sourceUrl]').setValue('sftp://foo.bar')
+      await wrapper.trigger('submit')
+      expect(wrapper.emitted().submit).toBeFalsy()
+    })
+
+    it('should submit a valid form with a label', async () => {
+      await wrapper.find('input[name=label]').setValue('foo')
+      await wrapper.trigger('submit')
+      expect(wrapper.emitted().submit).toBeTruthy()
+    })
+
+    it('should submit a valid form with a label and a sourceUrl', async () => {
+      await wrapper.find('input[name=label]').setValue('foo')
+      await wrapper.find('input[name=sourceUrl]').setValue('https://foo.bar')
+      await wrapper.trigger('submit')
+      expect(wrapper.emitted().submit).toBeTruthy()
+    })
+
+    it('should submit a valid form with a label and a logoUrl', async () => {
+      await wrapper.find('input[name=label]').setValue('foo')
+      await wrapper.find('input[name=logoUrl]').setValue('https://foo.bar')
+      await wrapper.trigger('submit')
+      expect(wrapper.emitted().submit).toBeTruthy()
+    })
+
+    it('should not submit the form with a reserved word as label', async () => {
+      await wrapper.find('input[name=label]').setValue('new')
+      await wrapper.trigger('submit')
+      expect(wrapper.emitted().submit).toBeFalsy()
+    })
+
+    it('should not disabled any form group by default', () => {
+      expect(wrapper.find('fieldset[disabled]').exists()).toBeFalsy()
+      expect(wrapper.find('fieldset:not([disabled])').exists()).toBeTruthy()
+    })
+
+    it('should disabled all form groups when `disabled` is set', async () => {
+      await wrapper.setProps({ disabled: true })
+      expect(wrapper.find('fieldset[disabled]').exists()).toBeTruthy()
+      expect(wrapper.find('fieldset:not([disabled])').exists()).toBeFalsy()
+    })
+
+    it('should not be able to submit the form when `disabled` is set', async () => {
+      await wrapper.setProps({ disabled: true })
+      await wrapper.find('input[name=label]').setValue('foo')
+      await wrapper.trigger('submit')
+      expect(wrapper.emitted().submit).toBeFalsy()
+    })
+
+    it('should not hide the sourcePath input', async () => {
+      await wrapper.find('input[name=label]').setValue('bar')
+      expect(wrapper.find('.project-form__group--source-path').exists()).toBeTruthy()
+    })
   })
 
-  it('should not use b-card-* components by default', () => {
-    expect(wrapper.findComponent({ name: 'b-card-body' }).exists()).toBeFalsy()
-    expect(wrapper.findComponent({ name: 'b-card-footer' }).exists()).toBeFalsy()
-  })
+  describe('with an existing project', () => {
+    beforeEach(() => {
+      const values = { name: 'foo', description: 'A description' }
+      const propsData = { values, edit: true }
+      wrapper = mount(ProjectForm, { localVue, i18n, wait, store, config, propsData })
+    })
 
-  it('should not have the .card class by default', async () => {
-    expect(wrapper.classes('card')).toBeFalsy()
-  })
+    it('should initialize the form with default project values', () => {
+      expect(wrapper.find('input[name=name]').element.value).toBe('foo')
+      expect(wrapper.find('textarea[name=description]').element.value).toBe('A description')
+    })
 
-  it('should use b-card-* components when `card` prop is set', async () => {
-    await wrapper.setProps({ card: true })
-    expect(wrapper.findComponent({ name: 'b-card-body' }).exists()).toBeTruthy()
-    expect(wrapper.findComponent({ name: 'b-card-footer' }).exists()).toBeTruthy()
-  })
+    it('should not update name when label changes', async () => {
+      await wrapper.find('input[name=label]').setValue('bar')
+      expect(wrapper.find('input[name=name]').element.value).toBe('foo')
+    })
 
-  it('should have the .card class when `card` prop is set', async () => {
-    await wrapper.setProps({ card: true })
-    expect(wrapper.classes('card')).toBeTruthy()
-  })
-
-  it('should generate a slugified name when setting the label', async () => {
-    await wrapper.find('input[name=label]').setValue('Pandora Papers')
-    expect(wrapper.find('input[name=name]').element.value).toBe('pandora-papers')
-  })
-
-  it('should generate a slugified name when setting the label, respecting case', async () => {
-    await wrapper.find('input[name=label]').setValue('PandoraPapers')
-    expect(wrapper.find('input[name=name]').element.value).toBe('pandora-papers')
-  })
-
-  it('should not validate the form group if a reserved name is used as label', async () => {
-    await wrapper.find('input[name=label]').setValue('new')
-    expect(wrapper.find('.project-form__group--label').classes('was-validated')).toBeFalsy()
-    expect(wrapper.find('.project-form__group--label .invalid-feedback').exists()).toBeTruthy()
-  })
-
-  it('should not validate the form group if an invalid URL for sourceUrl', async () => {
-    await wrapper.find('input[name=sourceUrl]').setValue('sftp://foo.bar')
-    expect(wrapper.find('.project-form__group--source-url').classes('was-validated')).toBeFalsy()
-  })
-
-  it('should validate the form group if a valid URL for sourceUrl', async () => {
-    await wrapper.find('input[name=sourceUrl]').setValue('https://foo.bar')
-    expect(wrapper.find('.project-form__group--source-url').classes('was-validated')).toBeTruthy()
-  })
-
-  it('should not validate the form group if an invalid URL for logoUrl', async () => {
-    await wrapper.find('input[name=logoUrl]').setValue('sftp://foo.bar')
-    expect(wrapper.find('.project-form__group--logo-url').classes('was-validated')).toBeFalsy()
-  })
-
-  it('should validate the form group if a valid URL for logoUrl', async () => {
-    await wrapper.find('input[name=logoUrl]').setValue('https://foo.bar')
-    expect(wrapper.find('.project-form__group--logo-url').classes('was-validated')).toBeTruthy()
-  })
-
-  it('should not submit an invalid form without name', async () => {
-    await wrapper.trigger('submit')
-    expect(wrapper.emitted().submit).toBeFalsy()
-  })
-
-  it('should not submit an invalid form with a name but an invalid logoUrl', async () => {
-    await wrapper.find('input[name=label]').setValue('foo')
-    await wrapper.find('input[name=logoUrl]').setValue('sftp://foo.bar')
-    await wrapper.trigger('submit')
-    expect(wrapper.emitted().submit).toBeFalsy()
-  })
-
-  it('should not submit an invalid form with a name but an invalid sourceUrl', async () => {
-    await wrapper.find('input[name=label]').setValue('foo')
-    await wrapper.find('input[name=sourceUrl]').setValue('sftp://foo.bar')
-    await wrapper.trigger('submit')
-    expect(wrapper.emitted().submit).toBeFalsy()
-  })
-
-  it('should submit a valid form with a label', async () => {
-    await wrapper.find('input[name=label]').setValue('foo')
-    await wrapper.trigger('submit')
-    expect(wrapper.emitted().submit).toBeTruthy()
-  })
-
-  it('should submit a valid form with a label and a sourceUrl', async () => {
-    await wrapper.find('input[name=label]').setValue('foo')
-    await wrapper.find('input[name=sourceUrl]').setValue('https://foo.bar')
-    await wrapper.trigger('submit')
-    expect(wrapper.emitted().submit).toBeTruthy()
-  })
-
-  it('should submit a valid form with a label and a logoUrl', async () => {
-    await wrapper.find('input[name=label]').setValue('foo')
-    await wrapper.find('input[name=logoUrl]').setValue('https://foo.bar')
-    await wrapper.trigger('submit')
-    expect(wrapper.emitted().submit).toBeTruthy()
-  })
-
-  it('should not submit the form with a reserved word as label', async () => {
-    await wrapper.find('input[name=label]').setValue('new')
-    await wrapper.trigger('submit')
-    expect(wrapper.emitted().submit).toBeFalsy()
-  })
-
-  it('should not disabled any form group by default', () => {
-    expect(wrapper.find('fieldset[disabled]').exists()).toBeFalsy()
-    expect(wrapper.find('fieldset:not([disabled])').exists()).toBeTruthy()
-  })
-
-  it('should disabled all form groups when `disabled` is set', async () => {
-    await wrapper.setProps({ disabled: true })
-    expect(wrapper.find('fieldset[disabled]').exists()).toBeTruthy()
-    expect(wrapper.find('fieldset:not([disabled])').exists()).toBeFalsy()
-  })
-
-  it('should not be able to submit the form when `disabled` is set', async () => {
-    await wrapper.setProps({ disabled: true })
-    await wrapper.find('input[name=label]').setValue('foo')
-    await wrapper.trigger('submit')
-    expect(wrapper.emitted().submit).toBeFalsy()
-  })
-
-  it('should initialize the form with default project values', () => {
-    const values = { name: 'foo' }
-    const propsData = { values }
-    wrapper = mount(ProjectForm, { localVue, i18n, wait, store, config, propsData })
-    expect(wrapper.find('input[name=name]').element.value).toBe('foo')
+    it('should hide the sourcePath input', async () => {
+      await wrapper.find('input[name=label]').setValue('bar')
+      expect(wrapper.find('.project-form__group--source-path').exists()).toBeFalsy()
+    })
   })
 })

--- a/tests/unit/specs/components/ProjectForm.spec.js
+++ b/tests/unit/specs/components/ProjectForm.spec.js
@@ -1,0 +1,133 @@
+import { createLocalVue, mount } from '@vue/test-utils'
+
+import ProjectForm from '@/components/ProjectForm'
+import { Core } from '@/core'
+
+const { localVue, i18n } = Core.init(createLocalVue()).useAll()
+
+describe('ProjectForm.vue', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(ProjectForm, { localVue, i18n })
+  })
+
+  it('should not use b-card-* components by default', () => {
+    expect(wrapper.findComponent({ name: 'b-card-body' }).exists()).toBeFalsy()
+    expect(wrapper.findComponent({ name: 'b-card-footer' }).exists()).toBeFalsy()
+  })
+
+  it('should not have the .card class by default', async () => {
+    expect(wrapper.classes('card')).toBeFalsy()
+  })
+
+  it('should use b-card-* components when `card` prop is set', async () => {
+    await wrapper.setProps({ card: true })
+    expect(wrapper.findComponent({ name: 'b-card-body' }).exists()).toBeTruthy()
+    expect(wrapper.findComponent({ name: 'b-card-footer' }).exists()).toBeTruthy()
+  })
+
+  it('should have the .card class when `card` prop is set', async () => {
+    await wrapper.setProps({ card: true })
+    expect(wrapper.classes('card')).toBeTruthy()
+  })
+
+  it('should generate a slugified name when setting the label', async () => {
+    await wrapper.find('input[name=label]').setValue('Pandora Papers')
+    expect(wrapper.find('input[name=name]').element.value).toBe('pandora-papers')
+  })
+
+  it('should generate a slugified name when setting the label, respecting case', async () => {
+    await wrapper.find('input[name=label]').setValue('PandoraPapers')
+    expect(wrapper.find('input[name=name]').element.value).toBe('pandora-papers')
+  })
+
+  it('should not validate the form group if a reserved name is used as label', async () => {
+    await wrapper.find('input[name=label]').setValue('new')
+    expect(wrapper.find('.project-form__group--label').classes('was-validated')).toBeFalsy()
+    expect(wrapper.find('.project-form__group--label .invalid-feedback').exists()).toBeTruthy()
+  })
+
+  it('should not validate the form group if an invalid URL for sourceUrl', async () => {
+    await wrapper.find('input[name=sourceUrl]').setValue('sftp://foo.bar')
+    expect(wrapper.find('.project-form__group--source-url').classes('was-validated')).toBeFalsy()
+  })
+
+  it('should validate the form group if a valid URL for sourceUrl', async () => {
+    await wrapper.find('input[name=sourceUrl]').setValue('https://foo.bar')
+    expect(wrapper.find('.project-form__group--source-url').classes('was-validated')).toBeTruthy()
+  })
+
+  it('should not validate the form group if an invalid URL for logoUrl', async () => {
+    await wrapper.find('input[name=logoUrl]').setValue('sftp://foo.bar')
+    expect(wrapper.find('.project-form__group--logo-url').classes('was-validated')).toBeFalsy()
+  })
+
+  it('should validate the form group if a valid URL for logoUrl', async () => {
+    await wrapper.find('input[name=logoUrl]').setValue('https://foo.bar')
+    expect(wrapper.find('.project-form__group--logo-url').classes('was-validated')).toBeTruthy()
+  })
+
+  it('should not submit an invalid form without name', async () => {
+    await wrapper.trigger('submit')
+    expect(wrapper.emitted().submit).toBeFalsy()
+  })
+
+  it('should not submit an invalid form with a name but an invalid logoUrl', async () => {
+    await wrapper.find('input[name=label]').setValue('foo')
+    await wrapper.find('input[name=logoUrl]').setValue('sftp://foo.bar')
+    await wrapper.trigger('submit')
+    expect(wrapper.emitted().submit).toBeFalsy()
+  })
+
+  it('should not submit an invalid form with a name but an invalid sourceUrl', async () => {
+    await wrapper.find('input[name=label]').setValue('foo')
+    await wrapper.find('input[name=sourceUrl]').setValue('sftp://foo.bar')
+    await wrapper.trigger('submit')
+    expect(wrapper.emitted().submit).toBeFalsy()
+  })
+
+  it('should submit a valid form with a label', async () => {
+    await wrapper.find('input[name=label]').setValue('foo')
+    await wrapper.trigger('submit')
+    expect(wrapper.emitted().submit).toBeTruthy()
+  })
+
+  it('should submit a valid form with a label and a sourceUrl', async () => {
+    await wrapper.find('input[name=label]').setValue('foo')
+    await wrapper.find('input[name=sourceUrl]').setValue('https://foo.bar')
+    await wrapper.trigger('submit')
+    expect(wrapper.emitted().submit).toBeTruthy()
+  })
+
+  it('should submit a valid form with a label and a logoUrl', async () => {
+    await wrapper.find('input[name=label]').setValue('foo')
+    await wrapper.find('input[name=logoUrl]').setValue('https://foo.bar')
+    await wrapper.trigger('submit')
+    expect(wrapper.emitted().submit).toBeTruthy()
+  })
+
+  it('should not submit the form with a reserved word as label', async () => {
+    await wrapper.find('input[name=label]').setValue('new')
+    await wrapper.trigger('submit')
+    expect(wrapper.emitted().submit).toBeFalsy()
+  })
+
+  it('should not disabled any form group by default', () => {
+    expect(wrapper.find('fieldset[disabled]').exists()).toBeFalsy()
+    expect(wrapper.find('fieldset:not([disabled])').exists()).toBeTruthy()
+  })
+
+  it('should disabled all form groups when `disabled` is set', async () => {
+    await wrapper.setProps({ disabled: true })
+    expect(wrapper.find('fieldset[disabled]').exists()).toBeTruthy()
+    expect(wrapper.find('fieldset:not([disabled])').exists()).toBeFalsy()
+  })
+
+  it('should not be able to submit the form when `disabled` is set', async () => {
+    await wrapper.setProps({ disabled: true })
+    await wrapper.find('input[name=label]').setValue('foo')
+    await wrapper.trigger('submit')
+    expect(wrapper.emitted().submit).toBeFalsy()
+  })
+})

--- a/tests/unit/specs/components/ProjectForm.spec.js
+++ b/tests/unit/specs/components/ProjectForm.spec.js
@@ -130,4 +130,11 @@ describe('ProjectForm.vue', () => {
     await wrapper.trigger('submit')
     expect(wrapper.emitted().submit).toBeFalsy()
   })
+
+  it('should initialize the form with default project values', () => {
+    const values = { name: 'foo' }
+    const propsData = { values }
+    wrapper = mount(ProjectForm, { localVue, i18n, wait, store, config, propsData })
+    expect(wrapper.find('input[name=name]').element.value).toBe('foo')
+  })
 })

--- a/tests/unit/specs/router/guards.spec.js
+++ b/tests/unit/specs/router/guards.spec.js
@@ -44,7 +44,6 @@ describe('guards', () => {
     })
   })
 
-
   describe('checkMode', () => {
     let wrapper
 

--- a/tests/unit/specs/utils/strings.spec.js
+++ b/tests/unit/specs/utils/strings.spec.js
@@ -156,5 +156,15 @@ describe('strings', () => {
       const url = 'http://www.google.fr'
       expect(isUrl(url)).toBeTruthy()
     })
+
+    it('should return false if it is an sftp url', () => {
+      const url = 'sftp://www.google.fr'
+      expect(isUrl(url)).toBeFalsy()
+    })
+
+    it('should return true if it is an sftp url as requested', () => {
+      const url = 'sftp://www.google.fr'
+      expect(isUrl(url, ['sftp'])).toBeTruthy()
+    })
   })
 })


### PR DESCRIPTION
## PR description

This PR adds a new page to create a project, as described in https://github.com/ICIJ/datashare/issues/1112. This page relies on a new component called `ProjectForm` which is intended to be used for issue https://github.com/ICIJ/datashare/issues/1111 as well.

![Screenshot 2023-07-18 at 18-27-09 Datashare](https://github.com/ICIJ/datashare-client/assets/471176/b546cd61-6e39-48c1-94ac-9ed6f7c5f9ac)

## Changes

* Create a new `ProjectForm` component that emits an updated project on submit ;
* Create a new `NewProject` page that receives the submitted project and send it to the API ;
* Create a new `Project` page that will hold all project pages ;
* Create a new guard called `checkMode` that can read a route's meta to limit it to specific mode ;
* Refactor `utils/strings.js` to add JSDoc and a simpler implementation of `isUrl`.

## Limitations

* The `ProjectForm` could benefit from a "preview" using the project thumbnail https://github.com/ICIJ/datashare/issues/1115 ;
* The `ProjectForm` doesn't check if the name is already taken although saving a duplicate will be rejected ;
* The `ProjectForm` is validated without a third-party library (like [VeeValidate](https://vee-validate.logaretm.com/v4/)) which tends to make the code more complex. This choice was made to avoid charging the dependencies graph ;
* The `InlineFolderPicker` seems to have rendering issues on light background. This might be improved in another branch ;
* Currently the `NewProject` page can only be reached by entering the `#/p/new` URL manually. This is a transient state until other project-related features are implemented ;
* When a new project is created, the user has to reload the page to see it. This is a transient state until other project-related features are implemented ;


