### PR TITLE
feat: project indexing

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "vue-virtual-scroller": "^1.0.0-rc.2",
     "vue-wait": "^1.4.8",
     "vuex": "^3.6.0",
-    "vuex-map-fields": "^1.4.1",
     "vuex-persistedstate": "^4.0.0-beta.1",
     "xlsx": "^0.18.5",
     "xss": "^1.0.13"

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -34,8 +34,10 @@ export class Api {
   runBatchDownload(options) {
     return this.sendAction('/api/task/batchDownload', { method: Method.POST, data: { options } })
   }
-  findNames(pipeline, options) {
-    return this.sendActionAsText(`/api/task/findNames/${pipeline}`, { method: Method.POST, data: { options } })
+  findNames(pipeline, { syncModels = true, defaultProject = null } = {}) {
+    const options = omitBy({ syncModels, defaultProject }, isNull)
+    const data = { options }
+    return this.sendActionAsText(`/api/task/findNames/${pipeline}`, { method: Method.POST, data })
   }
   stopPendingTasks() {
     return this.sendAction('/api/task/stopAll', { method: Method.PUT })

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,4 +1,4 @@
-import { join, map, replace, trim, toLower } from 'lodash'
+import { isNull, join, map, omitBy, replace, trim, toLower } from 'lodash'
 
 const Method = Object.freeze({
   POST: 'POST',
@@ -16,20 +16,15 @@ export class Api {
   tree(path) {
     return this.sendAction('/api/tree/' + trim(path, '/'), { method: Method.GET })
   }
-  index({ ocr = false, filter = true, language = null } = {}) {
-    const ocrLanguage = language
-    const options = Object.fromEntries(
-      Object.entries({ ocr, filter, language, ocrLanguage }).filter(([_, v]) => v !== null)
-    )
-    const data = { options }
-    return this.sendActionAsText('/api/task/batchUpdate/index/file', { method: Method.POST, data })
+  index(options = {}) {
+    return this.indexPath('file', options)
   }
-  indexPath(path, { ocr = false, filter = true, language = null } = {}) {
+  indexPath(path, { ocr = false, filter = true, language = null, defaultProject = null } = {}) {
     const ocrLanguage = language
-    const options = Object.fromEntries(
-      Object.entries({ ocr, filter, language, ocrLanguage }).filter(([_, v]) => v !== null)
-    )
-    const data = Object.fromEntries(Object.entries({ options }).filter(([_, v]) => v != null))
+    const queueName = defaultProject ? `extract:queue:${defaultProject}` : null
+    const reportName = defaultProject ? `extract:report:${defaultProject}` : null
+    const options = omitBy({ ocr, filter, language, ocrLanguage, defaultProject, queueName, reportName }, isNull)
+    const data = { options }
     const trimedPath = trim(path, '/')
     return this.sendActionAsText(`/api/task/batchUpdate/index/${trimedPath}`, { method: Method.POST, data })
   }

--- a/src/store/modules/indexing.js
+++ b/src/store/modules/indexing.js
@@ -1,5 +1,4 @@
 import { remove } from 'lodash'
-import { getField, updateField } from 'vuex-map-fields'
 import Vue from 'vue'
 
 export function initialState() {
@@ -10,6 +9,7 @@ export function initialState() {
       ocr: false,
       offline: false,
       path: null,
+      defaultProject: null,
       pipeline: 'CORENLP'
     },
     tasks: []
@@ -18,15 +18,7 @@ export function initialState() {
 
 export const state = initialState()
 
-// indexing/getField is used with vuex-map-field in:
-// - FindNamedEntitiesForm.vue
-// - ExtractingForm.vue
-export const getters = {
-  getField
-}
-
 export const mutations = {
-  updateField,
   reset(state) {
     // acquire initial state
     const s = initialState()
@@ -52,6 +44,27 @@ export const mutations = {
   resetFindNamedEntitiesForm(state) {
     state.form.pipeline = initialState().form.pipeline
     state.form.offline = initialState().form.offline
+  },
+  formOcr(state, value) {
+    state.form.ocr = value
+  },
+  formFilter(state, value) {
+    state.form.filter = value
+  },
+  formPath(state, value) {
+    state.form.path = value
+  },
+  formLanguage(state, value) {
+    state.form.language = value
+  },
+  formDefaultProject(state, value) {
+    state.form.defaultProject = value
+  },
+  formPipeline(state, value) {
+    state.form.pipeline = value
+  },
+  formOffline(state, value) {
+    state.form.offline = value
   }
 }
 
@@ -67,7 +80,9 @@ function actionsBuilder(api) {
       return api.runBatchSearch()
     },
     submitFindNamedEntities({ state }) {
-      return api.findNames(state.form.pipeline, { syncModels: !state.form.offline })
+      const defaultProject = state.form.defaultProject ?? null
+      const options = { syncModels: !state.form.offline, defaultProject }
+      return api.findNames(state.form.pipeline, options)
     },
     async stopPendingTasks({ commit }) {
       try {
@@ -110,7 +125,6 @@ export function indexingStoreBuilder(api) {
   return {
     namespaced: true,
     state,
-    getters,
     mutations,
     actions: actionsBuilder(api)
   }

--- a/src/store/modules/indexing.js
+++ b/src/store/modules/indexing.js
@@ -20,11 +20,7 @@ export const state = initialState()
 
 export const mutations = {
   reset(state) {
-    // acquire initial state
-    const s = initialState()
-    Object.keys(s).forEach((key) => {
-      state[key] = s[key]
-    })
+    Object.assign(state, initialState())
   },
   stopPendingTasks(state) {
     remove(state.tasks, (item) => item.state === 'RUNNING')
@@ -40,6 +36,9 @@ export const mutations = {
   },
   resetExtractForm(state) {
     state.form.ocr = initialState().form.ocr
+    state.form.language = initialState().form.language
+    state.form.filter = initialState().form.filter
+    state.form.path = initialState().form.path
   },
   resetFindNamedEntitiesForm(state) {
     state.form.pipeline = initialState().form.pipeline

--- a/tests/unit/specs/store/modules/indexing.spec.js
+++ b/tests/unit/specs/store/modules/indexing.spec.js
@@ -114,7 +114,7 @@ describe('IndexingStore', () => {
   })
 
   it('should reset the extracting form', () => {
-    store.commit('indexing/updateField', { path: 'form.ocr', value: true })
+    store.commit('indexing/formOcr', true)
     expect(store.state.indexing.form.ocr).toBeTruthy()
 
     store.commit('indexing/resetExtractForm')
@@ -122,8 +122,8 @@ describe('IndexingStore', () => {
   })
 
   it('should reset the Find Named Entities form', () => {
-    store.commit('indexing/updateField', { path: 'form.pipeline', value: 'OPENNLP' })
-    store.commit('indexing/updateField', { path: 'form.offline', value: true })
+    store.commit('indexing/formPipeline', 'OPENNLP')
+    store.commit('indexing/formOffline', true)
     expect(store.state.indexing.form.pipeline).toBe('OPENNLP')
     expect(store.state.indexing.form.offline).toBeTruthy()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14009,11 +14009,6 @@ vue@2.7.10:
     "@vue/compiler-sfc" "2.7.10"
     csstype "^3.1.0"
 
-vuex-map-fields@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/vuex-map-fields/-/vuex-map-fields-1.4.1.tgz#3f22f0c3d39e25968d3a74fc2b43738c23c4ae4d"
-  integrity sha512-jvIcpvoIPqwvJCOfRkPU9Rj0EbjWuk7GlNC5LXU9mCXVGZph6bWGHZssnoUzpLMxJtXQEHoVyZkKf7YQV+/bnQ==
-
 vuex-persistedstate@^4.0.0-beta.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/vuex-persistedstate/-/vuex-persistedstate-4.1.0.tgz#127165f85f5b4534fb3170a5d3a8be9811bd2a53"


### PR DESCRIPTION
## PR description

Add project selector to indexing form, and named entities finder form.

![Screenshot 2023-07-21 at 20-02-22 Analyze your documents - Datashare](https://github.com/ICIJ/datashare-client/assets/471176/9c057995-ec19-43ea-aeb0-2d9fd0b5fa04)
![Screenshot 2023-07-21 at 20-02-29 Analyze your documents - Datashare](https://github.com/ICIJ/datashare-client/assets/471176/a5624c03-ab73-4d4e-81b1-e3f6198ee1f7)

## To-do before merging

Currently the backend only take into account the `defaultProject` parameter while indexing. This allow to index files in a project but requires the task to be done (and the queue emptied) before being able to start indexing on another project.

* [x] merge https://github.com/ICIJ/datashare/pull/1137

## Changes

* Boyscouting: I used this opportunity to remove the library `vuex-map-fields` which was only used in those two components. I don't think they add enough value to justify adding a dependency to the project.
* Add `defaultProject`, `reportName`, `queueName` to the requests to create the tasks
* Add project selector component to pick a project (when necessary). 
