### PR TITLE
feat: delete project

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -64,6 +64,9 @@ export class Api {
     const { name } = data
     return this.sendActionAsText(`/api/project/${name}`, { method: Method.PUT, data })
   }
+  deleteProject(name) {
+    return this.sendActionAsText(`/api/project/${name}`, { method: Method.DELETE })
+  }
   deleteAll(project) {
     return this.sendActionAsText(`/api/project/${project}`, { method: Method.DELETE })
   }

--- a/src/components/InlineDirectoryPicker.vue
+++ b/src/components/InlineDirectoryPicker.vue
@@ -103,8 +103,11 @@ export default {
       if (this.browse) {
         this.$wait.start(this.waitIdentifier)
         this.browsingPath = this.path || this.cannonicalDataDir
-        this.browsingTree = await this.$core.api.tree(this.browsingPath)
-        this.$wait.end(this.waitIdentifier)
+        try {
+          this.browsingTree = await this.$core.api.tree(this.browsingPath)
+        } finally {
+          this.$wait.end(this.waitIdentifier)
+        }
       }
     }
   }

--- a/src/components/ProjectForm.vue
+++ b/src/components/ProjectForm.vue
@@ -118,7 +118,7 @@ export default {
       this.$set(this, 'form', this.initialFormValues())
     },
     emitDelete() {
-      this.$emit('delete', this.name)
+      this.$emit('delete', this.values.name)
     }
   }
 }

--- a/src/components/ProjectForm.vue
+++ b/src/components/ProjectForm.vue
@@ -37,6 +37,12 @@ export default {
      */
     edit: {
       type: Boolean
+    },
+    /**
+     * Show delete project button
+     */
+    showDeleteButton: {
+      type: Boolean
     }
   },
   data() {
@@ -110,6 +116,9 @@ export default {
     },
     reset() {
       this.$set(this, 'form', this.initialFormValues())
+    },
+    emitDelete() {
+      this.$emit('delete', this.name)
     }
   }
 }
@@ -224,14 +233,23 @@ export default {
     </component>
     <component :is="footerComponent" class="d-flex">
       <confirm-button
+        v-if="showDeleteButton"
         type="button"
-        class="btn btn-outline-primary mr-3"
+        class="project-form__action--delete btn btn-danger mr-3"
+        :confirmed="emitDelete"
+        :label="$t('projectForm.deleteConfirmation')"
+      >
+        <slot name="delete-text">{{ $t('projectForm.delete') }}</slot>
+      </confirm-button>
+      <confirm-button
+        type="button"
+        class="project-form__action--reset btn btn-outline-primary ml-auto"
         :confirmed="reset"
         :label="$t('projectForm.resetConfirmation')"
       >
         <slot name="reset-text">{{ $t('projectForm.reset') }}</slot>
       </confirm-button>
-      <b-button type="submit" variant="primary" class="ml-auto" :disabled="!valid">
+      <b-button type="submit" variant="primary" class="ml-2" :disabled="!valid">
         <slot name="submit-text">{{ $t('projectForm.submit') }}</slot>
       </b-button>
     </component>

--- a/src/core/ProjectsMixin.js
+++ b/src/core/ProjectsMixin.js
@@ -57,7 +57,7 @@ const ProjectsMixin = (superclass) =>
       return this.setProject(project)
     }
     /**
-     * Return true if the default project exist
+     * Return true if the default project exists
      * @returns {Promise:Boolean}
      */
     async defaultProjectExists() {
@@ -69,15 +69,32 @@ const ProjectsMixin = (superclass) =>
       }
     }
     /**
-     * Retreive a project by its name
-     * @param {String} name Name of the project to retreive
+     * Retrieve a project by its name
+     * @param {String} name Name of the project to retrieve
      * @returns {Object} The project matching with this name
      */
     findProject(name) {
       return find(this.projects, { name })
     }
     /**
-     * Update a project in the list or add it if doesn't exists yet.
+     * Delete a project by it name identifier.
+     * @param {String} name Name of the project to retrieve
+     * @returns {Integer} Index of the project deleted or -1 if project does not exist
+     */
+    deleteProject(name) {
+      // Create a new projects list so we avoid mutating object
+      const projects = [...this.projects]
+      const index = findIndex(projects, { name })
+
+      if (index > -1) {
+        projects.splice(index, 1)
+        this.config.set('projects', projects)
+      }
+
+      return index
+    }
+    /**
+     * Update a project in the list or add it if it doesn't exist yet.
      * @param {Object} project
      * @returns {Object} The project
      */
@@ -101,7 +118,7 @@ const ProjectsMixin = (superclass) =>
       return sortBy(this.config.get('projects', []), iteratee('name'))
     }
     /**
-     * List all projects this user has access to.
+     * List all projects name ids this user has access to.
      * @returns {Array:String}
      */
     get projectIds() {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -742,10 +742,18 @@
   "projectViewEdit":{
     "title": "Edit project",
     "notify": {
-      "succeed": "The project was saved",
-      "succeedBody": "Project saved.",
-      "failed": "Unable to edit the project",
-      "failedBody": "Something happened when trying to edit this project."
+      "delete": {
+        "succeed": "The project was deleted",
+        "succeedBody": "The project deleted.",
+        "failed": "Unable to delete the project",
+        "failedBody": "Something happened when trying to delete this project."
+      },
+      "update":{
+        "succeed": "The project was saved",
+        "succeedBody": "Project saved.",
+        "failed": "Unable to edit the project",
+        "failedBody": "Something happened when trying to edit this project."
+      }
     },
     "submit": "Edit project"
   },

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -744,7 +744,7 @@
     "notify": {
       "delete": {
         "succeed": "The project was deleted",
-        "succeedBody": "The project deleted.",
+        "succeedBody": "The documents in this project have been removed from Datashare.",
         "failed": "Unable to delete the project",
         "failedBody": "Something happened when trying to delete this project."
       },

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -787,7 +787,9 @@
     },
     "reset": "Reset",
     "resetConfirmation": "Are you sure you want to reset the form to its initial values?",
-    "submit": "Submit"
+    "submit": "Submit",
+    "deleteConfirmation": "Are you sure you want to delete the project?",
+    "delete": "Delete"
   },
   "shortkeys": {
     "title": "Search shortcuts",

--- a/src/pages/ProjectViewEdit.vue
+++ b/src/pages/ProjectViewEdit.vue
@@ -7,6 +7,7 @@
           edit
           card
           :disabled="$wait.is(loaderId)"
+          show-delete-button
           :values="project"
           @submit="submit"
           @delete="deleteProject"

--- a/src/pages/ProjectViewEdit.vue
+++ b/src/pages/ProjectViewEdit.vue
@@ -89,9 +89,11 @@ export default {
       try {
         this.$wait.start(this.loaderId)
         await this.$core.api.deleteProject(name)
-        this.$core.deleteProject(name)
         this.$wait.end(this.loaderId)
-        return this.redirectToProjectList().then(() => this.notifySucceed(OPERATION.DELETE))
+        return this.redirectToProjectList().then(() => {
+          this.$core.deleteProject(name)
+          this.notifySucceed(OPERATION.DELETE)
+        })
       } catch (error) {
         this.$wait.end(this.loaderId)
         this.notifyFailed(error, OPERATION.DELETE)

--- a/src/pages/ProjectViewEdit.vue
+++ b/src/pages/ProjectViewEdit.vue
@@ -81,17 +81,19 @@ export default {
       const params = { name }
       return this.$router.push({ name: 'project.view', params })
     },
-    async deleteProject({ name }) {
+    redirectToProjectList() {
+      return this.$router.push({ name: 'project.list' })
+    },
+    async deleteProject(name) {
       try {
         this.$wait.start(this.loaderId)
         await this.$core.api.deleteProject(name)
         this.$core.deleteProject(name)
-        this.notifySucceed(OPERATION.DELETE)
         this.$wait.end(this.loaderId)
-        return this.redirectToProject({ name })
+        return this.redirectToProjectList().then(() => this.notifySucceed(OPERATION.DELETE))
       } catch (error) {
-        this.notifyFailed(error, OPERATION.DELETE)
         this.$wait.end(this.loaderId)
+        this.notifyFailed(error, OPERATION.DELETE)
       }
     }
   }

--- a/tests/unit/specs/api/index.spec.js
+++ b/tests/unit/specs/api/index.spec.js
@@ -363,6 +363,18 @@ describe('Datashare backend client', () => {
     })
   })
 
+  it('should return a backend response to deleteProject', async () => {
+    const name = 'hello'
+    json = await api.deleteProject(name)
+    expect(json).toEqual({})
+    expect(mockAxios.request).toBeCalledWith({
+      url: Api.getFullUrl('/api/project/hello'),
+      method: 'DELETE',
+      responseType: 'text',
+      headers: { 'Content-Type': 'text/plain;charset=UTF-8' }
+    })
+  })
+
   it('should emit an error if the backend response has a bad status', async () => {
     const error = new Error('Forbidden')
     mockAxios.request.mockReturnValue(Promise.reject(error))

--- a/tests/unit/specs/components/ProjectForm.spec.js
+++ b/tests/unit/specs/components/ProjectForm.spec.js
@@ -159,5 +159,11 @@ describe('ProjectForm.vue', () => {
       await wrapper.find('input[name=label]').setValue('bar')
       expect(wrapper.find('.project-form__group--source-path').exists()).toBeFalsy()
     })
+
+    it('should show the delete button', async () => {
+      expect(wrapper.find('.project-form__action--delete').exists()).toBe(false)
+      await wrapper.setProps({ showDeleteButton: true })
+      expect(wrapper.find('.project-form__action--delete').exists()).toBe(true)
+    })
   })
 })

--- a/tests/unit/specs/pages/ProjectViewEdit.spec.js
+++ b/tests/unit/specs/pages/ProjectViewEdit.spec.js
@@ -18,10 +18,11 @@ describe('ProjectViewEdit.vue', () => {
     localVue = core.localVue
     store = core.store
     wait = core.wait
+  })
+  beforeEach(() => {
     // Ensure the local-datashare project can be found
     config.set('projects', [{ name: 'local-datashare', label: 'Default', sourcePath: '/' }])
   })
-
   afterAll(() => {
     jest.clearAllMocks()
   })
@@ -69,13 +70,12 @@ describe('ProjectViewEdit.vue', () => {
     const propsData = { name: 'local-datashare' }
 
     const wrapper = mount(ProjectViewEdit, { localVue, store, wait, i18n, propsData, config })
-    expect(wrapper.vm.$core.projects).toHaveLength(1)
+    expect(wrapper.vm.$core.projects.length).toBe(1)
 
     const projectForm = wrapper.findComponent({ name: 'ProjectForm' })
-    projectForm.vm.$emit('delete', { name: 'local-datashare' })
+    projectForm.vm.$emit('delete', 'local-datashare')
     await flushPromises()
-
-    expect(wrapper.vm.$core.projects).toHaveLength(0)
+    expect(wrapper.vm.$core.projects.length).toBe(0)
     expect(api.deleteProject).toBeCalledWith('local-datashare')
   })
 })

--- a/tests/unit/specs/pages/ProjectViewEdit.spec.js
+++ b/tests/unit/specs/pages/ProjectViewEdit.spec.js
@@ -1,5 +1,6 @@
 import { createLocalVue, shallowMount, mount } from '@vue/test-utils'
 import { flushPromises } from 'tests/unit/tests_utils'
+import VueRouter from 'vue-router'
 
 import { Api } from '@/api'
 import { Core } from '@/core'
@@ -68,8 +69,15 @@ describe('ProjectViewEdit.vue', () => {
 
   it('deletes the project when the form emits a deleted event', async () => {
     const propsData = { name: 'local-datashare' }
-
-    const wrapper = mount(ProjectViewEdit, { localVue, store, wait, i18n, propsData, config })
+    const router = new VueRouter({
+      routes: [
+        {
+          name: 'project.list',
+          path: 'project'
+        }
+      ]
+    })
+    const wrapper = mount(ProjectViewEdit, { localVue, store, wait, i18n, propsData, config, router })
     expect(wrapper.vm.$core.projects).toHaveLength(1)
 
     const projectForm = wrapper.findComponent({ name: 'ProjectForm' })

--- a/tests/unit/specs/pages/ProjectViewEdit.spec.js
+++ b/tests/unit/specs/pages/ProjectViewEdit.spec.js
@@ -70,12 +70,12 @@ describe('ProjectViewEdit.vue', () => {
     const propsData = { name: 'local-datashare' }
 
     const wrapper = mount(ProjectViewEdit, { localVue, store, wait, i18n, propsData, config })
-    expect(wrapper.vm.$core.projects.length).toBe(1)
+    expect(wrapper.vm.$core.projects).toHaveLength(1)
 
     const projectForm = wrapper.findComponent({ name: 'ProjectForm' })
     projectForm.vm.$emit('delete', 'local-datashare')
     await flushPromises()
-    expect(wrapper.vm.$core.projects.length).toBe(0)
+    expect(wrapper.vm.$core.projects).toHaveLength(0)
     expect(api.deleteProject).toBeCalledWith('local-datashare')
   })
 })


### PR DESCRIPTION
Allows users in the edit form (only available in local and embedded mode) to delete a project via a button in the bottom of the form. Deleting a project is validated by a popup confirmation. 

![image](https://github.com/ICIJ/datashare-client/assets/4643139/79902160-5f68-455b-a6bd-4c962b5a3c3c)


The project form has been modified to have a delete button props on project page to show delete button. Clicking on the delete button emits a delete event with the name of the project in parameter.


Side effects that remains to handle: 
What happen when deleting last project?
