### PR TITLE
feat: project links

### DIFF
--- a/src/components/BatchSearchResultsDetails.vue
+++ b/src/components/BatchSearchResultsDetails.vue
@@ -11,21 +11,13 @@
       <dl class="batch-search-results-details__info">
         <div v-if="showProjects">
           <dt>{{ $t('batchSearch.projects') }}</dt>
-          <dd>
-            <span v-for="(project, index) in batchSearch.projects" :key="project.name">
-              <router-link
-                :to="{
-                  name: 'search',
-                  query: {
-                    q: '*',
-                    indices: project.name
-                  }
-                }"
-                class="batch-search-results-details__info__project-link"
-              >
-                <span>{{ project.name }}</span
-                ><span v-if="isNotLastArrayItem(index, batchSearch.projects.length)">, </span>
-              </router-link>
+          <dd class="batch-search-results-details__info__projects">
+            <span
+              v-for="{ name } in batchSearch.projects"
+              :key="name"
+              class="batch-search-results-details__info__projects__link"
+            >
+              <project-link :project="name" class="btn btn-sm btn-light p-1 mr-1" />
             </span>
           </dd>
         </div>
@@ -110,6 +102,7 @@ import BatchSearchActions from '@/components/BatchSearchActions'
 import TaskItemStatus from '@/components/TaskItemStatus'
 import ContentTypeBadge from '@/components/ContentTypeBadge'
 import UserDisplay from '@/components/UserDisplay'
+import ProjectLink from '@/components/ProjectLink'
 import humanSize from '@/filters/humanSize'
 import humanNumber from '@/filters/humanNumber'
 import { humanLongDate } from '@/filters/humanDate'
@@ -122,8 +115,9 @@ export default {
   name: 'BatchSearchResultsDetails',
   components: {
     BatchSearchActions,
-    TaskItemStatus,
     ContentTypeBadge,
+    ProjectLink,
+    TaskItemStatus,
     UserDisplay
   },
   filters: {

--- a/src/components/BatchSearchResultsDetails.vue
+++ b/src/components/BatchSearchResultsDetails.vue
@@ -17,7 +17,7 @@
               :key="name"
               class="batch-search-results-details__info__projects__link"
             >
-              <project-link :project="name" class="btn btn-sm btn-light p-1 mr-1" />
+              <project-link :project="name" class="btn btn-sm btn-light p-1 mr-1 mb-1" />
             </span>
           </dd>
         </div>

--- a/src/components/BatchSearchTable.vue
+++ b/src/components/BatchSearchTable.vue
@@ -102,12 +102,8 @@
       </template>
       <template #cell(projects)="{ item }">
         <span class="batch-search-table__item__projects">
-          <span
-            v-for="{ name } in item.projects"
-            :key="name"
-            class="batch-search-table__item__projects__link d-inline-block mr-1"
-          >
-            <project-link :project="name" class="btn btn-sm btn-light p-1" />
+          <span v-for="{ name } in item.projects" :key="name" class="batch-search-table__item__projects__link">
+            <project-link :project="name" class="btn btn-sm btn-light p-1 mr-1 mb-1" />
           </span>
         </span>
       </template>

--- a/src/components/BatchSearchTable.vue
+++ b/src/components/BatchSearchTable.vue
@@ -101,24 +101,14 @@
         {{ item.isPublished }}
       </template>
       <template #cell(projects)="{ item }">
-        <span
-          v-for="(project, index) in item.projects"
-          :key="project.name"
-          class="batch-search-table__item__projects d-inline-block mr-1"
-        >
-          <router-link
-            :to="{
-              name: 'search',
-              query: {
-                q: '*',
-                indices: project.name
-              }
-            }"
-            class="batch-search-table__item__projects__link"
+        <span class="batch-search-table__item__projects">
+          <span
+            v-for="{ name } in item.projects"
+            :key="name"
+            class="batch-search-table__item__projects__link d-inline-block mr-1"
           >
-            <span>{{ project.label || project.name }}</span>
-          </router-link>
-          <span v-if="isNotLastArrayItem(index, item.projects.length)">, </span>
+            <project-link :project="name" class="btn btn-sm btn-light p-1" />
+          </span>
         </span>
       </template>
     </b-table>
@@ -139,6 +129,7 @@ import { mapState } from 'vuex'
 
 import ColumnFilterDropdown from '@/components/ColumnFilterDropdown'
 import BatchSearchFilterDate from '@/components/BatchSearchFilterDate'
+import ProjectLink from '@/components/ProjectLink'
 import TaskItemStatus from '@/components/TaskItemStatus'
 import UserDisplay from '@/components/UserDisplay'
 import settings from '@/utils/settings'
@@ -169,7 +160,7 @@ const SORT_ORDER = Object.freeze({
 
 export default {
   name: 'BatchSearchTable',
-  components: { UserDisplay, TaskItemStatus, BatchSearchFilterDate, ColumnFilterDropdown },
+  components: { ProjectLink, UserDisplay, TaskItemStatus, BatchSearchFilterDate, ColumnFilterDropdown },
   mixins: [polling, utils],
   data() {
     return {

--- a/src/components/ProjectLink.vue
+++ b/src/components/ProjectLink.vue
@@ -1,0 +1,73 @@
+<template>
+  <component :is="is" :to="projectRoute" class="project-link d-inline-flex">
+    <project-thumbnail
+      v-if="showThumbnail"
+      :project="resolvedProject"
+      class="project-link__thumbnail mr-1 rounded"
+      width="1.6em"
+    />
+    <span class="project-link__display">{{ projectDisplay }}</span>
+  </component>
+</template>
+
+<script>
+import ProjectThumbnail from '@/components/ProjectThumbnail'
+
+/**
+ * Generate a link to a project page
+ */
+export default {
+  name: 'ProjectLink',
+  components: { ProjectThumbnail },
+  props: {
+    /**
+     * The project to use to generate the thumbnail. Can contain `name`, `label` and `logoUrl` which
+     * will be used to generate the thumbnail consistently. If passed as a string, the project will be 
+     * retreived from the config.
+     */
+    project: {
+      type: [Object, String],
+      required: true
+    },
+    /**
+     * Disable the link (make it not clickable)
+     */
+    disabled: {
+      type: Boolean
+    },
+    /**
+     * Hide the project thumbail.
+     */
+    hideThumbnail: {
+      type: Boolean
+    }
+  },
+  computed: {
+    is() {
+      return this.disabled ? 'span' : 'router-link'
+    },
+    projectDisplay() {
+      return this.resolvedProject.label || this.resolvedProject.name
+    },
+    projectRoute() {
+      const { name } = this.resolvedProject
+      return { name: 'project.view', params: { name } }
+    },
+    unknownProject() {
+      return { name: 'unknown', label: 'Unknown' }
+    },
+    resolvedProject() {
+      return this.$core.findProject(this.project.name ?? this.project) ?? this.unknownProject
+    },
+    showThumbnail() {
+      return !this.hideThumbnail
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.project-link {
+  font-weight: bold;
+}
+</style>

--- a/src/components/ProjectLink.vue
+++ b/src/components/ProjectLink.vue
@@ -22,7 +22,7 @@ export default {
   props: {
     /**
      * The project to use to generate the thumbnail. Can contain `name`, `label` and `logoUrl` which
-     * will be used to generate the thumbnail consistently. If passed as a string, the project will be 
+     * will be used to generate the thumbnail consistently. If passed as a string, the project will be
      * retreived from the config.
      */
     project: {

--- a/src/components/SearchResultsListLink.vue
+++ b/src/components/SearchResultsListLink.vue
@@ -11,9 +11,13 @@
       <active-text-truncate class="search-results-list-link__location">
         <span class="d-inline-flex align-items-center">
           <fa icon="folder" class="mr-1" />
-          <b-badge v-if="showIndex" variant="light" class="mr-2">
-            {{ document.index | startCase }}
-          </b-badge>
+          <project-link
+            v-if="showIndex"
+            :project="document.index"
+            class="badge badge-light mr-2"
+            hide-thumbnail
+            disabled
+          />
           {{ location }}
         </span>
       </active-text-truncate>
@@ -32,6 +36,7 @@ import { mapState } from 'vuex'
 
 import DocumentSlicedName from '@/components/DocumentSlicedName'
 import DocumentThumbnail from '@/components/DocumentThumbnail'
+import ProjectLink from '@/components/ProjectLink'
 import ner from '@/mixins/ner'
 
 /**
@@ -41,7 +46,8 @@ export default {
   name: 'SearchResultsLink',
   components: {
     DocumentSlicedName,
-    DocumentThumbnail
+    DocumentThumbnail,
+    ProjectLink
   },
   filters: {
     startCase

--- a/src/components/document/DocumentNavbar.vue
+++ b/src/components/document/DocumentNavbar.vue
@@ -18,6 +18,7 @@
     </slot>
     <div v-if="doc" class="ml-auto d-flex align-items-center">
       <slot name="nav" />
+      <project-link :project="doc.index" class="btn btn-sm btn-light p-0 pr-1 ml-1" />
       <b-btn
         class="mx-2 px-2 py-0 document-navbar__recommended-by"
         size="sm"
@@ -88,6 +89,7 @@
 import { mapState } from 'vuex'
 
 import DocumentActions from '@/components/DocumentActions'
+import ProjectLink from '@/components/ProjectLink'
 import UserDisplay from '@/components/UserDisplay'
 import utils from '@/mixins/utils'
 
@@ -98,6 +100,7 @@ export default {
   name: 'DocumentNavbar',
   components: {
     DocumentActions,
+    ProjectLink,
     UserDisplay
   },
   mixins: [utils],

--- a/src/components/document/DocumentTabDetails.vue
+++ b/src/components/document/DocumentTabDetails.vue
@@ -179,7 +179,7 @@ export default {
           label: this.$t('document.project'),
           class: 'document__content__project',
           value: this.document.index,
-          to: { name: 'search', query: { indices: this.document.index, q: '*' } }
+          to: { name: 'project.view', params: { name: this.document.index } }
         },
         {
           name: 'metadata.tika_metadata_resourcename',

--- a/tests/unit/specs/components/BatchSearchResultsDetails.spec.js
+++ b/tests/unit/specs/components/BatchSearchResultsDetails.spec.js
@@ -102,14 +102,13 @@ describe('BatchSearchResultsDetails.vue', () => {
 
   describe('Projects column', () => {
     it('should contain all the projects in which the batch search is performed', () => {
-      const projectLinks = wrapper.findAll('.batch-search-results-details__info__project-link')
+      const projectLinks = wrapper.findAll('.batch-search-results-details__info__projects__link')
       expect(projectLinks).toHaveLength(2)
     })
 
     it('should display project names as clickable links', () => {
-      const projectLinks = wrapper.findAll('.batch-search-results-details__info__project-link')
-      expect(projectLinks.at(0).element.tagName).toBe('ROUTER-LINK-STUB')
-      expect(projectLinks.at(1).element.tagName).toBe('ROUTER-LINK-STUB')
+      const projects = wrapper.find('.batch-search-results-details__info__projects')
+      expect(projects.findAllComponents({ name: 'ProjectLink' })).toHaveLength(2)
     })
   })
 })

--- a/tests/unit/specs/components/BatchSearchTable.spec.js
+++ b/tests/unit/specs/components/BatchSearchTable.spec.js
@@ -375,12 +375,11 @@ describe('BatchSearchTable.vue', () => {
     it('all projects should be displayed and clickable for a multiproject search', async () => {
       wrapper = mount(BatchSearchTable, { i18n, localVue, router: routerFactory(), store, wait })
       await flushPromises()
-      const projectLinks = wrapper.findAll('.batch-search-table__item__projects__link')
-      expect(projectLinks.at(0).element.tagName).toBe('A')
-      expect(projectLinks.at(0).attributes('href')).toBe(`/?q=%2a&indices=${batchSearchMock.items[0].projects[0].name}`)
-
-      expect(projectLinks.at(1).element.tagName).toBe('A')
-      expect(projectLinks.at(1).attributes('href')).toBe(`/?q=%2a&indices=${batchSearchMock.items[0].projects[1].name}`)
+      const projects = wrapper.find('.batch-search-table__item__projects')
+      const projectsLinks = projects.findAllComponents({ name: 'ProjectLink' })
+      expect(projectsLinks).toHaveLength(2)
+      expect(projectsLinks.at(0).element.tagName).toBe('A')
+      expect(projectsLinks.at(1).element.tagName).toBe('A')
     })
   })
 

--- a/tests/unit/specs/components/ProjectLink.spec.js
+++ b/tests/unit/specs/components/ProjectLink.spec.js
@@ -1,0 +1,61 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+
+import { Core } from '@/core'
+import ProjectLink from '@/components/ProjectLink'
+
+const { localVue, i18n, config } = Core.init(createLocalVue()).useAll()
+
+describe('ProjectLink.vue', () => {
+  beforeAll(() => {
+    config.set('projects', [{ name: 'local-datashare', label: 'Default' }])
+  })
+
+  it('should display the label of the project', () => {
+    const project = 'local-datashare'
+    const propsData = { project }
+    const wrapper = shallowMount(ProjectLink, { localVue, i18n, propsData })
+    expect(wrapper.text().trim()).toBe('Default')
+  })
+
+  it('should have a project thumbnail by default', () => {
+    const project = 'local-datashare'
+    const propsData = { project }
+    const wrapper = shallowMount(ProjectLink, { localVue, i18n, propsData })
+    expect(wrapper.findComponent({ name: 'ProjectThumbnail' }).exists()).toBeTruthy()
+  })
+
+  it('should hide the project thumbnail when `hideThumbnail` is set', () => {
+    const project = 'local-datashare'
+    const propsData = { project, hideThumbnail: true }
+    const wrapper = shallowMount(ProjectLink, { localVue, i18n, propsData })
+    expect(wrapper.findComponent({ name: 'ProjectThumbnail' }).exists()).toBeFalsy()
+  })
+
+  it('should be instanciated with an object instead of a project name', () => {
+    const project = { name: 'local-datashare' }
+    const propsData = { project }
+    const wrapper = shallowMount(ProjectLink, { localVue, i18n, propsData })
+    expect(wrapper.text().trim()).toBe('Default')
+  })
+
+  it('should display an "unknown" project', () => {
+    const project = 'unknown-project-name'
+    const propsData = { project }
+    const wrapper = shallowMount(ProjectLink, { localVue, i18n, propsData })
+    expect(wrapper.text().trim()).toBe('Unknown')
+  })
+
+  it('should be a router link', () => {
+    const project = 'unknown-project-name'
+    const propsData = { project }
+    const wrapper = shallowMount(ProjectLink, { localVue, i18n, propsData })
+    expect(wrapper.findComponent({ name: 'RouterLink' }).exists()).toBeTruthy()
+  })
+
+  it('should not be a router link when `disabled` is set', () => {
+    const project = 'unknown-project-name'
+    const propsData = { project, disabled: true }
+    const wrapper = shallowMount(ProjectLink, { localVue, i18n, propsData })
+    expect(wrapper.findComponent({ name: 'RouterLink ' }).exists()).toBeFalsy()
+  })
+})


### PR DESCRIPTION
## PR description

Standardize the links to the project page in several places. This is done through a new component called `ProjectLink`.

![Screenshot from 2023-07-28 15-43-21](https://github.com/ICIJ/datashare-client/assets/471176/8575db4b-fc82-4100-92de-e3dcab194eec)
![Screenshot from 2023-07-28 15-44-09](https://github.com/ICIJ/datashare-client/assets/471176/d6dcc34f-2fc1-4fff-9dd0-5aa07629fe3a)
![Screenshot from 2023-07-28 15-46-57](https://github.com/ICIJ/datashare-client/assets/471176/91cca971-b025-448d-b089-77c7acc5bec3)

## Changes

* Create the new component `ProjectLink`
* Use the new component in the batch searches list table
* Use the new component in the batch search details
* Use the new component in the document navbar
* Use the new component in the search result item (without thumbnail)