### PR TITLE
feat: use b-table to list metadata

### DIFF
--- a/src/api/resources/Document.js
+++ b/src/api/resources/Document.js
@@ -40,8 +40,8 @@ export default class Document extends EsDoc {
     return `${name}:"${value}"`
   }
   metaAsQueryParam(name, defaultValue) {
-    const tikaMetadataName = `metadata.tika_metadata_${this.shortMetaName(name)}`
-    return this.valueAsQueryParam(tikaMetadataName, this.meta(name, defaultValue))
+    const rawName = name in this.raw ? name : `metadata.tika_metadata_${this.shortMetaName(name)}`
+    return this.valueAsQueryParam(rawName, this.meta(name, defaultValue))
   }
   shortMetaName(name) {
     return name.replace('tika_metadata_', '')

--- a/src/components/ProjectLink.vue
+++ b/src/components/ProjectLink.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="is" :to="projectRoute" class="project-link d-inline-flex">
+  <component :is="is" :to="projectRoute" class="project-link d-inline-flex align-items-center">
     <project-thumbnail
       v-if="showThumbnail"
       :project="resolvedProject"

--- a/src/components/ProjectThumbnail.vue
+++ b/src/components/ProjectThumbnail.vue
@@ -133,6 +133,7 @@ export default {
       font-weight: bolder;
       font-size: 40cqw;
       line-height: 1;
+      white-space: nowrap;
     }
   }
 

--- a/src/components/document/DocumentTabDetails.vue
+++ b/src/components/document/DocumentTabDetails.vue
@@ -77,6 +77,7 @@ import { filter, get, map, startCase, uniq } from 'lodash'
 import { mapState } from 'vuex'
 
 import DocumentTagsForm from '@/components/DocumentTagsForm'
+import ProjectLink from '@/components/ProjectLink'
 import { getDocumentTypeLabel, getExtractionLevelTranslationKey } from '@/utils/utils'
 
 /**
@@ -85,7 +86,8 @@ import { getDocumentTypeLabel, getExtractionLevelTranslationKey } from '@/utils/
 export default {
   name: 'DocumentTabDetails',
   components: {
-    DocumentTagsForm
+    DocumentTagsForm,
+    ProjectLink
   },
   filters: {
     startCase
@@ -134,7 +136,8 @@ export default {
           tdClass: 'align-middle document__content__details__item__label'
         },
         {
-          key: 'value'
+          key: 'value',
+          tdClass: 'align-middle document__content__details__item__value'
         }
       ]
     },
@@ -166,7 +169,10 @@ export default {
           label: this.$t('document.project'),
           trClass: 'document__content__project',
           value: this.document.index,
-          to: { name: 'project.view', params: { name: this.document.index } }
+          component: ProjectLink,
+          componentBinding: {
+            project: this.document.index
+          }
         },
         {
           name: 'metadata.tika_metadata_resourcename',

--- a/src/components/document/DocumentTabDetails.vue
+++ b/src/components/document/DocumentTabDetails.vue
@@ -37,7 +37,7 @@
       <p class="text-muted">
         {{ $t('document.detailsInfo') }}
       </p>
-      <b-table :items="items" :fields="fields" :tbody-tr-class="itemRowClass" responsive striped borderless >
+      <b-table :items="items" :fields="fields" :tbody-tr-class="itemRowClass" responsive striped borderless>
         <template #cell(label)="{ item: { name, label, value } }">
           <div class="font-weight-bold d-flex justify-content-between">
             <div class="text-truncate mr-1 w-100" :title="name">

--- a/src/lang/ach.json
+++ b/src/lang/ach.json
@@ -458,8 +458,6 @@
     "tagsNew": "crwdns1968:0crwdne1968:0",
     "details": "crwdns890:0crwdne890:0",
     "detailsInfo": "crwdns1970:0crwdne1970:0",
-    "showMoreDetails": "crwdns894:0crwdne894:0",
-    "showLessDetails": "crwdns896:0crwdne896:0",
     "author": "crwdns898:0crwdne898:0",
     "extractionDate": "crwdns1972:0crwdne1972:0",
     "parent": "crwdns902:0crwdne902:0",

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -458,8 +458,6 @@
     "tagsNew": "Einen Tag hinzufügen",
     "details": "Details",
     "detailsInfo": "Diese Informationen werden aus den Metadaten des Dokuments extrahiert.",
-    "showMoreDetails": "Mehr Details anzeigen",
-    "showLessDetails": "Weniger Details anzeigen",
     "author": "Autor",
     "extractionDate": "Indizierungsdatum",
     "parent": "Container-Datei",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -459,8 +459,6 @@
     "tagsNew": "Add a new tag",
     "details": "Details",
     "detailsInfo": "These information are extracted from the document's metadata.",
-    "showMoreDetails": "Show more details",
-    "showLessDetails": "Show less details",
     "author": "Author",
     "extractionDate": "Indexing date",
     "parent": "Parent",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -458,8 +458,6 @@
     "tagsNew": "Añadir una nueva etiqueta",
     "details": "Etiqueta & Detalles",
     "detailsInfo": "Esta información se extrae de los metadatos del documento.",
-    "showMoreDetails": "Más detalles",
-    "showLessDetails": "Menos detalles",
     "author": "Autor",
     "extractionDate": "Fecha de índice",
     "parent": "Archivo de base",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -458,8 +458,6 @@
     "tagsNew": "Ajouter un nouveau tag",
     "details": "Détails",
     "detailsInfo": "Ces informations sont tirées des méta-données du document.",
-    "showMoreDetails": "Afficher plus de détails",
-    "showLessDetails": "Afficher moins de détails",
     "author": "Auteur·e",
     "extractionDate": "Date d'indexation",
     "parent": "Parent",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -458,8 +458,6 @@
     "tagsNew": "新規タグを追加",
     "details": "詳細",
     "detailsInfo": "これらの情報は文書のメタデータから抽出されました",
-    "showMoreDetails": "詳細をもっと表示",
-    "showLessDetails": "詳細を少なく表示",
     "author": "筆者",
     "extractionDate": "インデックスの日付",
     "parent": "親",

--- a/tests/unit/specs/components/document/DocumentTabDetails.spec.js
+++ b/tests/unit/specs/components/document/DocumentTabDetails.spec.js
@@ -1,4 +1,4 @@
-import { createLocalVue, shallowMount } from '@vue/test-utils'
+import { createLocalVue, mount } from '@vue/test-utils'
 import Murmur from '@icij/murmur'
 import esConnectionHelper from 'tests/unit/specs/utils/esConnectionHelper'
 import { IndexedDocument, letData } from 'tests/unit/es_utils'
@@ -10,13 +10,14 @@ import { Api } from '@/api'
 describe('DocumentTabDetails.vue', () => {
   const { index, es } = esConnectionHelper.build()
   const id = 'document'
-  let wrapper, i18n, localVue, store, api, mockAxios
+  let wrapper, i18n, localVue, store, router, api, mockAxios
   beforeAll(() => {
     mockAxios = { request: jest.fn() }
     api = new Api(mockAxios, null)
     const core = Core.init(createLocalVue(), api).useAll()
     i18n = core.i18n
     localVue = core.localVue
+    router = core.router
     store = core.store
   })
 
@@ -30,27 +31,29 @@ describe('DocumentTabDetails.vue', () => {
     const id = '/home/datashare/data/foo.txt'
     await letData(es).have(new IndexedDocument(id, index)).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, {
+    wrapper = mount(DocumentTabDetails, {
       i18n,
       localVue,
       store,
+      router,
       propsData: { document: store.state.document.doc }
     })
 
-    expect(wrapper.find('.document__content__path').text()).toBe('C:/Users/ds/docs/foo.txt')
+    expect(wrapper.find('.document__content__path input[type=text]').vm.value).toBe('C:/Users/ds/docs/foo.txt')
   })
 
   it('should display the document type', async () => {
     await letData(es).have(new IndexedDocument(id, index).withContentType('application/pdf')).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, {
+    wrapper = mount(DocumentTabDetails, {
       i18n,
       localVue,
       store,
+      router,
       propsData: { document: store.state.document.doc }
     })
 
-    expect(wrapper.find('.document__content__content-type').text()).toBe('Portable Document Format (PDF)')
+    expect(wrapper.find('.document__content__content-type input[type=text]').vm.value).toBe('Portable Document Format (PDF)')
   })
 
   it('should display a child document', async () => {
@@ -60,25 +63,27 @@ describe('DocumentTabDetails.vue', () => {
     await store
       .dispatch('document/get', { index, id, routing: parentDocument })
       .then(() => store.dispatch('document/getParent'))
-    wrapper = shallowMount(DocumentTabDetails, {
+    wrapper = mount(DocumentTabDetails, {
       i18n,
       localVue,
       store,
+      router,
       propsData: { document: store.state.document.doc, parentDocument: store.state.document.parentDocument }
     })
 
-    expect(wrapper.find('.document__content__basename').text()).toBe(id)
-    expect(wrapper.find('.document__content__tree-level').text()).toBe('1st')
-    expect(wrapper.find('.document__content__parent').text()).toBe(parentDocument)
+    expect(wrapper.find('.document__content__basename input[type=text]').vm.value).toBe(id)
+    expect(wrapper.find('.document__content__tree-level input[type=text]').vm.value).toBe('1st')
+    expect(wrapper.find('.document__content__parent input[type=text]').vm.value).toBe(parentDocument)
   })
 
   it('should not display the creation date if it is missing', async () => {
     await letData(es).have(new IndexedDocument(id, index)).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, {
+    wrapper = mount(DocumentTabDetails, {
       i18n,
       localVue,
       store,
+      router,
       propsData: { document: store.state.document.doc }
     })
 
@@ -88,10 +93,11 @@ describe('DocumentTabDetails.vue', () => {
   it('should display the creation date if it is defined', async () => {
     await letData(es).have(new IndexedDocument(id, index).withCreationDate('2020-12-04T00:00:01Z')).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, {
+    wrapper = mount(DocumentTabDetails, {
       i18n,
       localVue,
       store,
+      router,
       propsData: { document: store.state.document.doc }
     })
 
@@ -101,10 +107,11 @@ describe('DocumentTabDetails.vue', () => {
   it('should not display the author if it is missing', async () => {
     await letData(es).have(new IndexedDocument(id, index)).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, {
+    wrapper = mount(DocumentTabDetails, {
       i18n,
       localVue,
       store,
+      router,
       propsData: { document: store.state.document.doc }
     })
 
@@ -114,10 +121,11 @@ describe('DocumentTabDetails.vue', () => {
   it('should display the author date if it is defined', async () => {
     await letData(es).have(new IndexedDocument(id, index).withAuthor('local')).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, {
+    wrapper = mount(DocumentTabDetails, {
       i18n,
       localVue,
       store,
+      router,
       propsData: { document: store.state.document.doc }
     })
 
@@ -127,10 +135,11 @@ describe('DocumentTabDetails.vue', () => {
   it('should display a link to the list of children documents', async () => {
     await letData(es).have(new IndexedDocument(id, index)).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, {
+    wrapper = mount(DocumentTabDetails, {
       i18n,
       localVue,
       store,
+      router,
       propsData: { document: store.state.document.doc }
     })
 
@@ -140,10 +149,11 @@ describe('DocumentTabDetails.vue', () => {
   it('should display a link to the search in the folder of the document', async () => {
     await letData(es).have(new IndexedDocument(id, index)).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, {
+    wrapper = mount(DocumentTabDetails, {
       i18n,
       localVue,
       store,
+      router,
       propsData: { document: store.state.document.doc }
     })
 
@@ -153,28 +163,30 @@ describe('DocumentTabDetails.vue', () => {
   it('should display an "Unknown" file size', async () => {
     await letData(es).have(new IndexedDocument(id, index)).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, {
+    wrapper = mount(DocumentTabDetails, {
       i18n,
       localVue,
       store,
+      router,
       propsData: { document: store.state.document.doc }
     })
 
     expect(wrapper.find('.document__content__content-length').exists()).toBeTruthy()
-    expect(wrapper.find('.document__content__content-length').text()).toBe('Unknown')
+    expect(wrapper.find('.document__content__content-length td:last-of-type').text().trim()).toBe('Unknown')
   })
 
   it('should display an file size', async () => {
     await letData(es).have(new IndexedDocument(id, index).withContentLength('123456')).commit()
     await store.dispatch('document/get', { id, index })
-    wrapper = shallowMount(DocumentTabDetails, {
+    wrapper = mount(DocumentTabDetails, {
       i18n,
       localVue,
       store,
+      router,
       propsData: { document: store.state.document.doc }
     })
 
     expect(wrapper.find('.document__content__content-length').exists()).toBeTruthy()
-    expect(wrapper.find('.document__content__content-length').text()).toBe('120.56 KB (123456 B)')
+    expect(wrapper.find('.document__content__content-length input[type=text]').vm.value).toBe('120.56 KB (123456 B)')
   })
 })

--- a/tests/unit/specs/components/document/DocumentTabDetails.spec.js
+++ b/tests/unit/specs/components/document/DocumentTabDetails.spec.js
@@ -53,7 +53,9 @@ describe('DocumentTabDetails.vue', () => {
       propsData: { document: store.state.document.doc }
     })
 
-    expect(wrapper.find('.document__content__content-type input[type=text]').vm.value).toBe('Portable Document Format (PDF)')
+    expect(wrapper.find('.document__content__content-type input[type=text]').vm.value).toBe(
+      'Portable Document Format (PDF)'
+    )
   })
 
   it('should display a child document', async () => {


### PR DESCRIPTION
## PR description

To resolve [#1144](https://github.com/ICIJ/datashare/issues/1144), this PR uses a `b-table` to list a document's metadata. This allow build-in sort features and simplify the implementation. This new table also includes input with copy button for usability. Finally, the PR removes the "show more" button which wasn't adding any value to the user experience.

![Screenshot 2023-07-28 at 18-38-24 Document - Datashare](https://github.com/ICIJ/datashare-client/assets/471176/d31ded55-5ccb-4991-95e8-2144c608845b)
