### PR TITLE
feat: allow widgets settings to use a factory function or a class

### DIFF
--- a/src/store/modules/insights.js
+++ b/src/store/modules/insights.js
@@ -1,6 +1,8 @@
 import cloneDeep from 'lodash/cloneDeep'
 import find from 'lodash/find'
 import findIndex from 'lodash/findIndex'
+import isString from 'lodash/isString'
+import isFunction from 'lodash/isFunction'
 import sortBy from 'lodash/sortBy'
 import Vue from 'vue'
 
@@ -39,12 +41,33 @@ const mutations = {
 }
 
 export const getters = {
+  getWidgetClass() {
+    return (type) => {
+      // Check if the provided 'type' is a string and exists in the 'widgetTypes' object
+      if (isString(type) && type in widgetTypes) {
+        // Return the corresponding widget class from 'widgetTypes'
+        return widgetTypes[type]
+      }
+      // Check if the 'type' is an object and an instance of the 'WidgetEmpty' class
+      if (type?.prototype instanceof widgetTypes.WidgetEmpty) {
+        // Return the 'type' itself as it is a valid widget class
+        return type
+      }
+      // Check if the 'type' is a function
+      if (isFunction(type)) {
+        // Call the 'type' function with 'WidgetEmpty' as an argument and return the result
+        return type(widgetTypes.WidgetEmpty)
+      }
+      // If none of the above conditions are met, throw an error as the provided 'type' is not valid
+      throw new Error(`Cannot find widget type '${type}'`)
+    }
+  },
   getWidget(state, getters) {
     return (predicate) => find(state.widgets, predicate)
   },
-  instantiateWidget(state) {
+  instantiateWidget(state, getters) {
     return ({ type = 'WidgetEmpty', ...options } = {}) => {
-      const Type = widgetTypes[type]
+      const Type = getters.getWidgetClass(type)
       const widget = new Type(options)
       // Bind current state to be able to retrieve its values
       widget.bindState(state)

--- a/tests/unit/specs/core/WidgetsMixin.spec.js
+++ b/tests/unit/specs/core/WidgetsMixin.spec.js
@@ -1,5 +1,6 @@
 import { createLocalVue } from '@vue/test-utils'
 
+import WidgetEmpty from '@/store/widgets/WidgetEmpty'
 import { Core } from '@/core'
 
 describe('WidgetsMixin', () => {
@@ -108,6 +109,43 @@ describe('WidgetsMixin', () => {
     expect(widgets[0].name).toBe('foo')
     core.replaceWidget('foo', { order: 10, name: 'bar' })
     widgets = core.store.getters['insights/instantiatedWidgets']
+    expect(widgets).toHaveLength(1)
+    expect(widgets[0].name).toBe('foo')
+  })
+
+  it('should register a widget with a custom type with a function', () => {
+    core.clearWidgets()
+    core.registerWidget({
+      name: 'foo',
+      type(WidgetEmpty) {
+        return class WidgetTest extends WidgetEmpty {
+          get component() {
+            return {
+              name: 'WidgetTest',
+              template: '<div>WidgetTest</div>'
+            }
+          }
+        }
+      }
+    })
+    const widgets = core.store.getters['insights/instantiatedWidgets']
+    expect(widgets).toHaveLength(1)
+    expect(widgets[0].name).toBe('foo')
+  })
+
+  it('should register a widget with a custom type with a class', () => {
+    class WidgetTest extends WidgetEmpty {
+      get component() {
+        return {
+          name: 'WidgetTest',
+          template: '<div>WidgetTest</div>'
+        }
+      }
+    }
+
+    core.clearWidgets()
+    core.registerWidget({ name: 'foo', type: WidgetTest })
+    const widgets = core.store.getters['insights/instantiatedWidgets']
     expect(widgets).toHaveLength(1)
     expect(widgets[0].name).toBe('foo')
   })


### PR DESCRIPTION
## PR description

This PR aims at letting plugin define their own widgets (https://github.com/ICIJ/datashare/issues/1148).

## API

The new API can be used as follow (using the same `registerWidget` method):

```js
core.registerWidget({
  name: 'test',
  type(WidgetEmpty) {
    return class WidgetTest extends WidgetEmpty {
      get component() {
        return {
          name: 'WidgetTest',
          template: '<div>WidgetTest</div>'
        }
      }
    }
  }
})
```