### PR TITLE
feat: project dropdown in search bar

### DIFF
--- a/src/components/BatchSearchFilterQuery.vue
+++ b/src/components/BatchSearchFilterQuery.vue
@@ -7,11 +7,11 @@
       hide-tips
       :disable-submit="emptySearch"
     >
-      <template #fields>
+      <template #addons>
         <search-bar-input-dropdown
           v-model="field"
-          :field-options="fieldOptions"
-          :field-options-path="fieldOptionsPath"
+          :options="fieldOptions"
+          :options-path="fieldOptionsPath"
           class="batch-search-filter-query__field"
         />
       </template>

--- a/src/components/ProjectThumbnail.vue
+++ b/src/components/ProjectThumbnail.vue
@@ -1,5 +1,7 @@
 <template>
-  <span class="project-thumbnail" :style="style" :class="classList" :data-caption="caption"></span>
+  <span class="project-thumbnail" :style="style" :class="classList" :data-caption="caption">
+    <span class="project-thumbnail__caption">{{ caption }}</span>
+  </span>
 </template>
 
 <script>
@@ -121,8 +123,7 @@ export default {
       @include gradient-directional(rgba(#000, 0.25), rgba(#fff, 0.25));
     }
 
-    &:after {
-      content: attr(data-caption);
+    .project-thumbnail__caption {
       font-family: $font-family-monospace;
       position: absolute;
       top: 50%;
@@ -148,8 +149,7 @@ export default {
       background: #000;
     }
 
-    &:after {
-      content: '✔';
+    .project-thumbnail__caption {
       position: absolute;
       top: 0;
       left: 0;

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -15,14 +15,8 @@
         @input="onInput"
         @focus="onFocus"
       >
-        <template #fields>
-          <search-bar-input-dropdown
-            v-if="!hideFieldDropdown"
-            v-model="field"
-            class="search-bar__field-options"
-            :field-options="fieldOptions"
-            :field-options-path="fieldOptionsPath"
-          />
+        <template #addons>
+          <search-bar-input-dropdown-for-field v-if="!hideFieldDropdown" v-model="field" />
           <search-bar-input-dropdown-for-projects v-model="selectedProjects" :disabled="indices" :no-caret="indices" />
         </template>
         <template #suggestions>
@@ -85,7 +79,7 @@ import lucene from 'lucene'
 import elasticsearch from '@/api/elasticsearch'
 import ShortkeysModal from '@/components/ShortkeysModal'
 import SearchBarInput from '@/components/SearchBarInput'
-import SearchBarInputDropdown from '@/components/SearchBarInputDropdown'
+import SearchBarInputDropdownForField from '@/components/SearchBarInputDropdownForField'
 import SearchBarInputDropdownForProjects from '@/components/SearchBarInputDropdownForProjects'
 import UserHistorySaveSearchForm from '@/components/UserHistorySaveSearchForm'
 import settings from '@/utils/settings'
@@ -104,7 +98,7 @@ export default {
     SearchBarInput,
     ShortkeysModal,
     UserHistorySaveSearchForm,
-    SearchBarInputDropdown,
+    SearchBarInputDropdownForField,
     SearchBarInputDropdownForProjects
   },
   props: {
@@ -134,22 +128,6 @@ export default {
      */
     hideFieldDropdown: {
       type: Boolean
-    },
-    /**
-     * Search field configuration dictionary.
-     */
-    fieldOptions: {
-      type: Array,
-      default() {
-        return settings.searchFields.map((field) => field.key)
-      }
-    },
-    /**
-     * Field option translation path
-     */
-    fieldOptionsPath: {
-      type: Array,
-      default: () => ['search', 'field']
     },
     /**
      * Search input size

--- a/src/components/SearchBarInput.vue
+++ b/src/components/SearchBarInput.vue
@@ -20,7 +20,7 @@
       >
         <fa icon="question-circle" fixed-width />
       </a>
-      <slot name="fields"> </slot>
+      <slot name="addons"> </slot>
       <button type="submit" class="btn btn-dark search-bar-input__submit" :disabled="disableSubmit">
         {{ $t('search.buttonLabel') }}
       </button>

--- a/src/components/SearchBarInputDropdown.vue
+++ b/src/components/SearchBarInputDropdown.vue
@@ -13,9 +13,9 @@
     variant="outline-light"
   >
     <template #button-content>
-      <slot name="button-content" v-bind="{ value }">
-        <span v-for="(value, v) in values" :key="v">
-          {{ $t(optionsPathValue + value) }}
+      <slot name="button-content">
+        <span v-for="v in values" :key="v">
+          {{ $t(optionsPathValue + v) }}
         </span>
       </slot>
     </template>

--- a/src/components/SearchBarInputDropdown.vue
+++ b/src/components/SearchBarInputDropdown.vue
@@ -77,9 +77,15 @@ export default {
     multiple: {
       type: Boolean
     },
+    /**
+     * The dropdown toggler must be disabled.
+     */
     disabled: {
       type: Boolean
     },
+    /**
+     * The caret in the dropdown toggler must be hidden.
+     */
     noCaret: {
       type: Boolean
     }

--- a/src/components/SearchBarInputDropdown.vue
+++ b/src/components/SearchBarInputDropdown.vue
@@ -15,19 +15,19 @@
     <template #button-content>
       <slot name="button-content" v-bind="{ value }">
         <span v-for="(value, v) in values" :key="v">
-          {{ $t(fieldOptionsPathValue + value) }}
+          {{ $t(optionsPathValue + value) }}
         </span>
       </slot>
     </template>
     <b-dropdown-item
-      v-for="(option, o) in fieldOptions"
+      v-for="(option, o) in options"
       :key="o"
       :active="hasValue(option)"
       class="search-bar-input-dropdown__option"
       @click="toggleValue(option)"
     >
       <slot name="dropdown-item" v-bind="{ option }">
-        {{ $t(fieldOptionsPathValue + option) }}
+        {{ $t(optionsPathValue + option) }}
       </slot>
     </b-dropdown-item>
   </b-dropdown>
@@ -35,8 +35,6 @@
 
 <script>
 import { castArray, includes, without } from 'lodash'
-
-import settings from '@/utils/settings'
 
 /**
  * The general search input dropdown.
@@ -49,20 +47,18 @@ export default {
   },
   props: {
     /**
-     * Search field configuration dictionary.
+     * Options list.
      */
-    fieldOptions: {
+    options: {
       type: Array,
-      default() {
-        return settings.searchFields.map((field) => field.key)
-      }
+      default: () => []
     },
     /**
-     * Field option translation path
+     * Translation path for each option value.
      */
-    fieldOptionsPath: {
+    optionsPath: {
       type: Array,
-      default: () => ['search', 'field']
+      default: () => []
     },
     /**
      * Selected value
@@ -91,8 +87,8 @@ export default {
     }
   },
   computed: {
-    fieldOptionsPathValue() {
-      return `${this.fieldOptionsPath.join('.')}.`
+    optionsPathValue() {
+      return `${this.optionsPath.join('.')}.`
     },
     values() {
       return castArray(this.value)

--- a/src/components/SearchBarInputDropdownForField.vue
+++ b/src/components/SearchBarInputDropdownForField.vue
@@ -1,0 +1,69 @@
+<template>
+  <search-bar-input-dropdown
+    v-model="selectedField"
+    class="search-bar-input-dropdown-for-field"
+    :disabled="disabled"
+    :no-caret="noCaret"
+    :options="options"
+    :options-path="optionsPath"
+  />
+</template>
+
+<script>
+import SearchBarInputDropdown from '@/components/SearchBarInputDropdown'
+import settings from '@/utils/settings'
+
+export default {
+  name: 'SearchBarInputDropdownForField',
+  components: {
+    SearchBarInputDropdown
+  },
+  props: {
+    /**
+     * Selected field
+     */
+    value: {
+      type: String,
+      required: true
+    },
+    /**
+     * The dropdown toggler must be disabled.
+     */
+    disabled: {
+      type: Boolean
+    },
+    /**
+     * The caret in the dropdown toggler must be hidden.
+     */
+    noCaret: {
+      type: Boolean
+    },
+    /**
+     * Search field configuration dictionary.
+     */
+    options: {
+      type: Array,
+      default() {
+        return settings.searchFields.map((field) => field.key)
+      }
+    },
+    /**
+     * Field option translation path
+     */
+    optionsPath: {
+      type: Array,
+      default: () => ['search', 'field']
+    }
+  },
+  computed: {
+    selectedField: {
+      get() {
+        return this.value
+      },
+      set(value) {
+        this.$emit('input', value)
+      }
+    }
+  }
+}
+</script>

--- a/src/components/SearchBarInputDropdownForProjects.vue
+++ b/src/components/SearchBarInputDropdownForProjects.vue
@@ -1,0 +1,158 @@
+<template>
+  <search-bar-input-dropdown
+    v-model="selectedProjects"
+    class="search-bar-input-dropdown-for-projects"
+    multiple
+    :class="{
+      'search-bar-input-dropdown-for-projects--multiple': hasMultipleProjects,
+      'search-bar-input-dropdown-for-projects--sliced': hasSlicedProjects
+    }"
+    :disabled="disabled"
+    :no-caret="noCaret"
+    :field-options="projectsOptions"
+  >
+    <template #button-content>
+      <span
+        v-for="(project, p) in slicedProjects"
+        :key="p"
+        class="search-bar-input-dropdown-for-projects__button-content__project"
+      >
+        <project-thumbnail
+          :project="project"
+          no-caption
+          width="1.2em"
+          class="search-bar-input-dropdown-for-projects__button-content__project__thumbnail rounded"
+        />
+        <template v-if="hasOneProject">
+          {{ project.label || project.name }}
+        </template>
+        <template v-else-if="isLastProjectSlice(p)">
+          {{ $tc('searchBarInputDropdownForProjects.projectsCount', selectedProjects.length) }}
+        </template>
+      </span>
+    </template>
+    <template #dropdown-item="{ option: project }">
+      <span class="d-inline-flex align-items-center justify-self-center">
+        <span class="mr-2 d-inline-flex align-items-center justify-self-center">
+          <project-thumbnail :project="project" no-caption width="1.2em" class="rounded" />
+        </span>
+        {{ project.label || project.name }}
+      </span>
+    </template>
+  </search-bar-input-dropdown>
+</template>
+
+<script>
+import { iteratee } from 'lodash'
+
+import ProjectThumbnail from './ProjectThumbnail.vue'
+import SearchBarInputDropdown from './SearchBarInputDropdown.vue'
+
+export default {
+  name: 'SearchBarInputDropdownForProjects',
+  components: {
+    ProjectThumbnail,
+    SearchBarInputDropdown
+  },
+  props: {
+    /**
+     * List of selected projects
+     */
+    value: {
+      type: Array,
+      default: () => []
+    },
+    /**
+     * Limit the number of visible project thumbnails
+     */
+    sliceSize: {
+      type: Number,
+      default: 3
+    },
+    /**
+     * The dropdown toggler must be disabled.
+     */
+    disabled: {
+      type: Boolean
+    },
+    /**
+     * The caret in the dropdown toggler must be hidden.
+     */
+    noCaret: {
+      type: Boolean
+    }
+  },
+  computed: {
+    valueNames() {
+      return this.value.map(iteratee('name'))
+    },
+    selectedProjects: {
+      get() {
+        return this.value.map(({ name }) => {
+          return this.$core.findProject(name)
+        })
+      },
+      set(value) {
+        this.$emit('input', value)
+      }
+    },
+    slicedProjects() {
+      return this.selectedProjects.slice(0, this.sliceSize + 1)
+    },
+    projectsOptions() {
+      return this.$core.projects
+    },
+    hasOneProject() {
+      return this.selectedProjects.length === 1
+    },
+    hasMultipleProjects() {
+      return this.selectedProjects.length > 1
+    },
+    hasSlicedProjects() {
+      return this.selectedProjects.length > this.sliceSize
+    }
+  },
+  methods: {
+    isLastProjectSlice(p) {
+      return p === this.slicedProjects.length - 1
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+.search-bar-input-dropdown-for-projects {
+  &__button-content__project {
+    display: inline-flex;
+    align-items: center;
+    font-weight: bold;
+
+    .search-bar-input-dropdown-for-projects--multiple &:not(:first-of-type) &__thumbnail {
+      box-shadow: -1px 0 0 0 #fff;
+      margin-left: -0.5em;
+      margin-right: 0;
+    }
+
+    &:last-of-type &__thumbnail {
+      margin-right: $spacer-xs !important;
+    }
+
+    .search-bar-input-dropdown-for-projects--sliced &:last-of-type &__thumbnail {
+      background: $text-muted !important;
+
+      &:after {
+        content: '+';
+        color: #fff;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/SearchBarInputDropdownForProjects.vue
+++ b/src/components/SearchBarInputDropdownForProjects.vue
@@ -9,7 +9,7 @@
     }"
     :disabled="disabled"
     :no-caret="noCaret"
-    :field-options="projectsOptions"
+    :options="options"
   >
     <template #button-content>
       <span
@@ -99,7 +99,7 @@ export default {
     slicedProjects() {
       return this.selectedProjects.slice(0, this.sliceSize + 1)
     },
-    projectsOptions() {
+    options() {
       return this.$core.projects
     },
     hasOneProject() {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1005,5 +1005,8 @@
     "documentsCount": "No documents | 1 document | %{count} documents",
     "about": "About",
     "search": "Search"
+  },
+  "searchBarInputDropdownForProjects": {
+    "projectsCount": "%{count} projects"
   }
 }

--- a/src/pages/Landing.vue
+++ b/src/pages/Landing.vue
@@ -7,7 +7,7 @@
         <img src="~images/logo-color.svg" alt="Datashare" />
       </h1>
       <hook name="landing.form.heading:after"></hook>
-      <search-bar class="landing__form__search-bar py-3 container" size="md"></search-bar>
+      <search-bar class="landing__form__search-bar py-3 container" hide-field-dropdown size="md"></search-bar>
     </div>
     <hook name="landing.form:after"></hook>
     <div v-if="showProjects" class="mt-5 text-white container">

--- a/tests/unit/specs/components/BatchSearchFilterQuery.spec.js
+++ b/tests/unit/specs/components/BatchSearchFilterQuery.spec.js
@@ -97,9 +97,9 @@ describe('BatchSearchFilterQuery.vue', () => {
       Murmur.config.merge({ mode: 'SERVER' })
       const wrapper = mount(BatchSearchFilterQuery, { i18n, localVue })
 
-      const fields = wrapper.findAll('.search-bar-input-fields__option')
+      const fields = wrapper.findAll('.search-bar-input-dropdown__option')
       expect(fields).toHaveLength(4)
-      const field = wrapper.find('.search-bar-input-fields__option:nth-child(4)')
+      const field = wrapper.find('.search-bar-input-dropdown__option:nth-child(4)')
       expect(field.text()).toContain('Author')
     })
 
@@ -107,9 +107,9 @@ describe('BatchSearchFilterQuery.vue', () => {
       Murmur.config.merge({ mode: 'LOCAL' })
       const wrapper = mount(BatchSearchFilterQuery, { i18n, localVue })
 
-      const fieldsLOCAL = wrapper.findAll('.search-bar-input-fields__option')
+      const fieldsLOCAL = wrapper.findAll('.search-bar-input-dropdown__option')
       expect(fieldsLOCAL).toHaveLength(3)
-      const noAuthorField = wrapper.find('.search-bar-input-fields__option:nth-child(4)')
+      const noAuthorField = wrapper.find('.search-bar-input-dropdown__option:nth-child(4)')
       expect(noAuthorField.exists()).toBeFalsy()
     })
   })

--- a/tests/unit/specs/components/SearchBar.spec.js
+++ b/tests/unit/specs/components/SearchBar.spec.js
@@ -47,8 +47,8 @@ describe('SearchBar.vue', function () {
 
   it('should display a search bar input with dropdown field options', () => {
     wrapper = mountFactory()
-    expect(wrapper.find('.search-bar__input').element).toBeTruthy()
-    expect(wrapper.find('.search-bar__field-options').element).toBeTruthy()
+    expect(wrapper.findComponent({ name: 'SearchBarInput' }).exists()).toBeTruthy()
+    expect(wrapper.findComponent({ name: 'SearchBarInputDropdownForField' }).exists()).toBeTruthy()
   })
 
   it('should display a suggestion dropdown when there are suggestions', async () => {

--- a/tests/unit/specs/components/SearchBar.spec.js
+++ b/tests/unit/specs/components/SearchBar.spec.js
@@ -8,7 +8,7 @@ import { Core } from '@/core'
 import SearchBar from '@/components/SearchBar'
 
 describe('SearchBar.vue', function () {
-  const { i18n, localVue, store } = Core.init(createLocalVue()).useAll()
+  const { i18n, localVue, store, config } = Core.init(createLocalVue()).useAll()
   const router = new VueRouter()
   const { index, es } = esConnectionHelper.build('search-bar')
   const { index: indexFoo } = esConnectionHelper.build('search-bar-foo')
@@ -22,6 +22,13 @@ describe('SearchBar.vue', function () {
   const mountFactory = (propsData = {}, data = () => ({ suggestions: [] })) => {
     return mount(SearchBar, { i18n, localVue, router, store, propsData, data })
   }
+
+  beforeAll(() => {
+    config.set('projects', [
+      { name: index, label: 'default' },
+      { name: indexFoo, label: 'foo' }
+    ])
+  })
 
   beforeEach(() => {
     store.commit('search/index', index)

--- a/tests/unit/specs/components/SearchBarInputDropdown.spec.js
+++ b/tests/unit/specs/components/SearchBarInputDropdown.spec.js
@@ -5,13 +5,20 @@ import SearchBarInputDropdown from '@/components/SearchBarInputDropdown'
 import { Core } from '@/core'
 
 describe('SearchBarInputDropdown.vue', function () {
-  const { i18n, localVue, store } = Core.init(createLocalVue()).useAll()
+  const { i18n, localVue, store, config } = Core.init(createLocalVue()).useAll()
   const router = new VueRouter()
 
-  it('should display a dropdown with 8 options fields with All fields selected by default', () => {
+  beforeAll(() => {
+    config.set('projects', [{ name: 'local-datashare', label: 'default' }])
+  })
+
+  it('should display a dropdown with 8 options fields', () => {
     const wrapper = shallowMount(SearchBarInputDropdown, { i18n, localVue, router, store })
-    expect(wrapper.find('.search-bar-input-fields').element).toBeTruthy()
-    expect(wrapper.find('.search-bar-input-fields').element.getAttribute('text')).toBe('All fields')
     expect(wrapper.findAll('b-dropdown-item-stub')).toHaveLength(8)
+  })
+
+  it('should display a dropdown with "All fields" selected by default', () => {
+    const wrapper = shallowMount(SearchBarInputDropdown, { i18n, localVue, router, store })
+    expect(wrapper.find('b-dropdown-item-stub[active=true]').text().trim()).toBe('All fields')
   })
 })

--- a/tests/unit/specs/components/SearchBarInputDropdown.spec.js
+++ b/tests/unit/specs/components/SearchBarInputDropdown.spec.js
@@ -7,18 +7,21 @@ import { Core } from '@/core'
 describe('SearchBarInputDropdown.vue', function () {
   const { i18n, localVue, store, config } = Core.init(createLocalVue()).useAll()
   const router = new VueRouter()
+  let wrapper
 
   beforeAll(() => {
     config.set('projects', [{ name: 'local-datashare', label: 'default' }])
+    const options = ['all', 'relevance', 'creationDateNewest']
+    const optionsPath = ['search', 'field']
+    const propsData = { options, optionsPath, value: 'all' }
+    wrapper = shallowMount(SearchBarInputDropdown, { propsData, i18n, localVue, router, store })
   })
 
-  it('should display a dropdown with 8 options fields', () => {
-    const wrapper = shallowMount(SearchBarInputDropdown, { i18n, localVue, router, store })
-    expect(wrapper.findAll('b-dropdown-item-stub')).toHaveLength(8)
+  it('should display a dropdown with 2 options fields', () => {
+    expect(wrapper.findAll('b-dropdown-item-stub')).toHaveLength(3)
   })
 
   it('should display a dropdown with "All fields" selected by default', () => {
-    const wrapper = shallowMount(SearchBarInputDropdown, { i18n, localVue, router, store })
     expect(wrapper.find('b-dropdown-item-stub[active=true]').text().trim()).toBe('All fields')
   })
 })

--- a/tests/unit/specs/components/SearchBarInputDropdownForProjects.spec.js
+++ b/tests/unit/specs/components/SearchBarInputDropdownForProjects.spec.js
@@ -1,0 +1,49 @@
+import { createLocalVue, mount } from '@vue/test-utils'
+import VueRouter from 'vue-router'
+
+import SearchBarInputDropdownForProjects from '@/components/SearchBarInputDropdownForProjects'
+import { Core } from '@/core'
+
+describe('SearchBarInputDropdownForProjects.vue', function () {
+  const { i18n, localVue, store, config } = Core.init(createLocalVue()).useAll()
+  const router = new VueRouter()
+
+  beforeAll(() => {
+    config.set('projects', [
+      { name: 'local-datashare', label: 'Default' },
+      { name: 'foo', label: 'Foo' },
+      { name: 'bar', label: 'Bar' }
+    ])
+  })
+
+  it('should display a dropdown with 3 options fields', () => {
+    const propsData = { value: [{ name: 'local-datashare' }] }
+    const wrapper = mount(SearchBarInputDropdownForProjects, { propsData, i18n, localVue, router, store })
+    expect(wrapper.findAll('.dropdown-item')).toHaveLength(3)
+  })
+
+  it('should display a dropdown with "Default" selected', () => {
+    const propsData = { value: [{ name: 'local-datashare' }] }
+    const wrapper = mount(SearchBarInputDropdownForProjects, { propsData, i18n, localVue, router, store })
+    expect(wrapper.find('.dropdown-item.active').text().trim()).toBe('Default')
+  })
+
+  it('should display a dropdown with "Default" as button content', () => {
+    const propsData = { value: [{ name: 'local-datashare' }] }
+    const wrapper = mount(SearchBarInputDropdownForProjects, { propsData, i18n, localVue, router, store })
+    expect(wrapper.find('.dropdown-toggle').text().trim()).toBe('Default')
+  })
+
+  it('should display a dropdown with "Default" and "Foo selected', () => {
+    const propsData = { value: [{ name: 'local-datashare' }, { name: 'foo' }] }
+    const wrapper = mount(SearchBarInputDropdownForProjects, { propsData, i18n, localVue, router, store })
+    expect(wrapper.findAll('.dropdown-item.active').at(0).text().trim()).toBe('Foo')
+    expect(wrapper.findAll('.dropdown-item.active').at(1).text().trim()).toBe('Default')
+  })
+
+  it('should display a dropdown with "Default" as button content', () => {
+    const propsData = { value: [{ name: 'local-datashare' }, { name: 'foo' }] }
+    const wrapper = mount(SearchBarInputDropdownForProjects, { propsData, i18n, localVue, router, store })
+    expect(wrapper.find('.dropdown-toggle').text().trim()).toBe('2 projects')
+  })
+})

--- a/tests/unit/specs/components/SearchBarInputDropdownForProjects.spec.js
+++ b/tests/unit/specs/components/SearchBarInputDropdownForProjects.spec.js
@@ -16,7 +16,7 @@ describe('SearchBarInputDropdownForProjects.vue', function () {
     ])
   })
 
-  it('should display a dropdown with 3 options fields', () => {
+  it('should display a dropdown with 3 options for each project', () => {
     const propsData = { value: [{ name: 'local-datashare' }] }
     const wrapper = mount(SearchBarInputDropdownForProjects, { propsData, i18n, localVue, router, store })
     expect(wrapper.findAll('.dropdown-item')).toHaveLength(3)


### PR DESCRIPTION
## PR Description

This PR aims at making more obvious which project is currently selected in the search bar. This should also solve https://github.com/ICIJ/datashare/issues/1116 at the same time.


![Screenshot from 2023-08-02 19-16-07](https://github.com/ICIJ/datashare-client/assets/471176/87c1ff18-ff3d-451f-8410-17841a5709ce)
![Screenshot from 2023-08-02 19-16-22](https://github.com/ICIJ/datashare-client/assets/471176/e2b1f3c7-9161-4bf9-ac73-845152ca67fe)
![Screenshot from 2023-08-02 19-16-32](https://github.com/ICIJ/datashare-client/assets/471176/364ce59a-cca0-40b7-853f-18ad4f755533)

## Changes

* refactor: make the `SearchBarInputDropdown` more generic ;
* feat: create a new `SearchBarInputDropdownForProjects` to hold the new dropdown ;
* feat: create a new `SearchBarInputDropdownForFields` to hold the existing field dropdown ;
