### PR TITLE
fix: displays resourcename instead of basename in doc tab details

### DIFF
--- a/src/components/document/DocumentTabDetails.vue
+++ b/src/components/document/DocumentTabDetails.vue
@@ -178,7 +178,7 @@ export default {
           name: 'metadata.tika_metadata_resourcename',
           label: this.$t('document.name'),
           trClass: 'document__content__basename',
-          value: this.document.basename
+          value: this.document.meta('resourcename')
         },
         {
           name: 'path',

--- a/tests/unit/es_utils.js
+++ b/tests/unit/es_utils.js
@@ -75,6 +75,7 @@ class IndexedDocument {
     this.type = 'Document'
     this.language = 'ENGLISH'
     this.metadata = {
+      tika_metadata_resourcename: 'document',
       tika_metadata_another_metadata: null,
       tika_metadata_content_type: null,
       tika_metadata_dcterms_created: null,
@@ -111,6 +112,10 @@ class IndexedDocument {
   }
   withIndexingDate(indexingDate) {
     this.extractionDate = indexingDate
+    return this
+  }
+  withResourceName(resourceName) {
+    this.metadata.tika_metadata_resourcename = resourceName
     return this
   }
   withAuthor(author) {

--- a/tests/unit/specs/components/document/DocumentTabDetails.spec.js
+++ b/tests/unit/specs/components/document/DocumentTabDetails.spec.js
@@ -60,7 +60,7 @@ describe('DocumentTabDetails.vue', () => {
 
   it('should display a child document', async () => {
     const parentDocument = 'parentDocument'
-    await letData(es).have(new IndexedDocument(parentDocument, index)).commit()
+    await letData(es).have(new IndexedDocument(parentDocument, index).withResourceName('parentDocument')).commit()
     await letData(es).have(new IndexedDocument(id, index).withParent(parentDocument)).commit()
     await store
       .dispatch('document/get', { index, id, routing: parentDocument })


### PR DESCRIPTION
**Goal**
Currently in the document details, the basename of the document is displayed as document name instead of the tika resourcename. Consequently, the document and its embedded docs share the same document name. The PR fix this by displaying the resource name.