### PR TITLE
feat: delete all projects from the sidebar

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -67,8 +67,8 @@ export class Api {
   deleteProject(name) {
     return this.sendActionAsText(`/api/project/${name}`, { method: Method.DELETE })
   }
-  deleteAll(project) {
-    return this.sendActionAsText(`/api/project/${project}`, { method: Method.DELETE })
+  deleteAll() {
+    return this.sendActionAsText(`/api/project/`, { method: Method.DELETE })
   }
   getProject(project) {
     return this.sendAction(`/api/project/${project}`)

--- a/src/components/MountedDataLocation.vue
+++ b/src/components/MountedDataLocation.vue
@@ -60,16 +60,17 @@ export default {
     }
   },
   methods: {
-    async deleteAll() {
+    async deleteAllProjects() {
       try {
         await this.$store.dispatch('indexing/deleteAll')
-        this.$root.$emit('index::delete::all')
         this.$bvToast.toast(this.$t('indexing.deleteSuccess'), { noCloseButton: true, variant: 'success' })
       } catch (error) {
         if (error && error.response && error.response.status !== 404) {
           this.$bvToast.toast(this.$t('indexing.deleteFailure'), { noCloseButton: true, variant: 'danger' })
         }
       }
+    },
+    async deleteAllBatchSearches() {
       try {
         await this.$store.dispatch('batchSearch/deleteBatchSearches')
         this.$bvToast.toast(this.$t('indexing.deleteBatchSearchSuccess'), { noCloseButton: true, variant: 'success' })
@@ -78,6 +79,14 @@ export default {
           this.$bvToast.toast(this.$t('indexing.deleteBatchSearchFailure'), { noCloseButton: true, variant: 'danger' })
         }
       }
+    },
+    async deleteAll() {
+      await this.deleteAllProjects()
+      await this.deleteAllBatchSearches()
+      await this.$core.createDefaultProject()
+      await this.$core.loadUser()
+      this.$store.commit('search/index', this.$config.get('defaultProject'))
+      this.$root.$emit('index::delete::all')
     },
     showTreeView() {
       this.$set(this, 'path', this.dataDir)

--- a/src/components/SearchBarInputDropdownForProjects.vue
+++ b/src/components/SearchBarInputDropdownForProjects.vue
@@ -32,10 +32,7 @@
       </span>
     </template>
     <template #dropdown-item="{ option: project, toggleValue }">
-      <span
-        class="d-inline-flex align-items-center justify-self-center px-3 py-2"
-        @click="toggleValue($event, project)"
-      >
+      <span class="d-flex align-items-center justify-self-center px-3 py-2" @click="toggleValue($event, project)">
         <span class="mr-2 d-inline-flex align-items-center justify-self-center">
           <project-thumbnail :project="project" no-caption width="1.2em" class="rounded" />
         </span>

--- a/src/store/modules/indexing.js
+++ b/src/store/modules/indexing.js
@@ -109,10 +109,8 @@ function actionsBuilder(api) {
         commit('updateTasks', [])
       }
     },
-    async deleteAll({ rootState }) {
-      for (const index of rootState.search.indices) {
-        await api.deleteAll(index)
-      }
+    async deleteAll() {
+      await api.deleteAll()
     },
     getNerPipelines() {
       return api.getNerPipelines()

--- a/tests/unit/specs/store/modules/indexing.spec.js
+++ b/tests/unit/specs/store/modules/indexing.spec.js
@@ -139,7 +139,7 @@ describe('IndexingStore', () => {
     expect(mockAxios.request).toBeCalledTimes(1)
     expect(mockAxios.request).toBeCalledWith(
       expect.objectContaining({
-        url: Api.getFullUrl(`/api/project/${project}`),
+        url: Api.getFullUrl(`/api/project/`),
         method: 'DELETE'
       })
     )


### PR DESCRIPTION
## PR description

This PR uses the new endpoint to delete all projects (https://github.com/ICIJ/datashare/issues/1146).

## To-do before merging

* [x] Merge https://github.com/ICIJ/datashare/pull/1153

## Changes

* feat: use the new `DELETE` `/api/project` endpoint 
* refactor: move projects deletion and batch searches deletion to different methods
* feat: ensure default project is re-created after the delete
* feat ensure user settings (including projects) are reloaded after the delete
* fix: ensure on default project is used in the search store after the delete