### PR TITLE
fix: use all user's projects

### DIFF
--- a/src/components/MountedDataLocation.vue
+++ b/src/components/MountedDataLocation.vue
@@ -28,7 +28,7 @@
       </div>
     </b-popover>
     <b-modal id="mounting-data-location-tree-view" lazy scrollable hide-header hide-footer body-class="p-0" size="lg">
-      <tree-view v-model="path" size count></tree-view>
+      <tree-view v-model="path" :projects="projects" size count></tree-view>
     </b-modal>
   </div>
 </template>
@@ -57,6 +57,9 @@ export default {
     },
     dataDir() {
       return this.$config.get('mountedDataDir') || this.$config.get('dataDir')
+    },
+    projects() {
+      return this.$core.projectIds
     }
   },
   methods: {


### PR DESCRIPTION
# PR description

Ensure the "tree view" available from the "mounted data point" (in the sidebar) is show statistics for all projects, not only `local-datashare` (https://github.com/ICIJ/datashare/issues/1156).