### PR TITLE
feat: new project page

### DIFF
--- a/src/components/ExtractingForm.vue
+++ b/src/components/ExtractingForm.vue
@@ -61,13 +61,15 @@
       </b-form-checkbox>
     </div>
     <div class="extracting-form__footer mt-4 row no-gutters">
-      <div class="col text-right">
-        <b-overlay :show="isWaitingForSubmitExtract" opacity="0.6" rounded spinner-small class="d-inline-flex">
-          <b-btn variant="primary" class="font-weight-bold" type="submit" :disabled="isWaitingForSubmitExtract">
-            {{ $t('indexing.go') }}
-          </b-btn>
-        </b-overlay>
-      </div>
+      <slot name="footer" :disabled="isWaitingForSubmitExtract">
+        <div class="col text-right">
+          <b-overlay :show="isWaitingForSubmitExtract" opacity="0.6" rounded spinner-small class="d-inline-flex">
+            <b-btn variant="primary" class="ml-2" type="submit" :disabled="isWaitingForSubmitExtract">
+              {{ $t('indexing.go') }}
+            </b-btn>
+          </b-overlay>
+        </div>
+      </slot>
     </div>
   </form>
 </template>

--- a/src/components/ExtractingForm.vue
+++ b/src/components/ExtractingForm.vue
@@ -208,8 +208,8 @@ export default {
       try {
         await this.dispatchExtract()
         this.$emit('submit', { error: false })
-      } catch (e) {
-        this.$emit('submit', { error: e })
+      } catch (error) {
+        this.$emit('submit', { error })
       } finally {
         this.$store.commit('indexing/resetExtractForm')
       }

--- a/src/components/ExtractingForm.vue
+++ b/src/components/ExtractingForm.vue
@@ -175,9 +175,8 @@ export default {
     },
     showProjectSelector() {
       return (
-        !this.hideProjectSelector ||
-        this.$core.projects.length > 1 ||
-        this.defaultProject !== this.$config.get('defaultProject')
+        !this.hideProjectSelector &&
+        (this.$core.projects.length > 1 || this.defaultProject !== this.$config.get('defaultProject'))
       )
     }
   },

--- a/src/components/ExtractingForm.vue
+++ b/src/components/ExtractingForm.vue
@@ -7,15 +7,15 @@
     <div v-if="showProjectSelector" class="extracting-form__group mb-4">
       <fa icon="database" class="position-absolute mt-1 ml-1" size="lg" />
       <div class="ml-4 pl-3">
-        <p class="font-weight-bold">In which project index documents?</p>
-        <project-selector v-model="defaultProject" />
+        <p class="font-weight-bold">{{ $t('indexing.projectIndexationSelection') }}</p>
+        <project-selector v-model="defaultProject" :disabled="disableProjectSelection" />
       </div>
     </div>
     <div class="extracting-form__group mb-4">
       <fa icon="folder-open" class="position-absolute mt-1 ml-1" size="lg" />
       <div class="ml-4 pl-3">
-        <p class="font-weight-bold mb-0">In which folder do you want to index?</p>
-        <p class="small mb-2">The entire Datashare folder will be indexed by default.</p>
+        <p class="font-weight-bold mb-0">{{ $t('indexing.folderSelection') }}</p>
+        <p class="small mb-2">{{ $t('indexing.folderSelectionDescription') }}</p>
         <inline-directory-picker v-model="path" :source-path="sourcePath" hide-folder-icon dark />
       </div>
     </div>
@@ -171,6 +171,9 @@ export default {
     }
   },
   async mounted() {
+    if (this.$core.findProject(this.projectName)) {
+      this.defaultProject = this.projectName
+    }
     await this.loadLanguages()
     // This trick ensure the default project is not null
     // when submiting the form

--- a/src/components/ExtractingForm.vue
+++ b/src/components/ExtractingForm.vue
@@ -1,5 +1,9 @@
 <template>
-  <form class="extracting-form position-relative" @submit.prevent="submitExtract">
+  <form
+    class="extracting-form position-relative"
+    :class="{ 'extracting-form--dark': dark }"
+    @submit.prevent="submitExtract"
+  >
     <div v-if="showProjectSelector" class="extracting-form__group mb-4">
       <fa icon="database" class="position-absolute mt-1 ml-1" size="lg" />
       <div class="ml-4 pl-3">
@@ -69,7 +73,7 @@
 </template>
 
 <script>
-import { noop, uniqueId, castArray } from 'lodash'
+import { uniqueId, castArray } from 'lodash'
 import { waitFor } from 'vue-wait'
 
 import ExtractingLanguageFormControl from '@/components/ExtractingLanguageFormControl'
@@ -90,11 +94,10 @@ export default {
   },
   props: {
     /**
-     * Callback function to call when the form have been submitted (this should be replaced by an event in future versions).
+     * Dark mode option
      */
-    finally: {
-      type: Function,
-      default: noop
+    dark: {
+      type: Boolean
     }
   },
   data() {
@@ -201,7 +204,7 @@ export default {
         await this.dispatchExtract()
       } finally {
         this.$store.commit('indexing/resetExtractForm')
-        this.finally()
+        this.$emit('submit')
       }
     }
   }
@@ -209,7 +212,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.extracting-form {
+.extracting-form--dark {
   background: darken($primary, 20);
   color: white;
 }

--- a/src/components/ExtractingForm.vue
+++ b/src/components/ExtractingForm.vue
@@ -8,7 +8,7 @@
       <fa icon="database" class="position-absolute mt-1 ml-1" size="lg" />
       <div class="ml-4 pl-3">
         <p class="font-weight-bold">{{ $t('indexing.projectIndexationSelection') }}</p>
-        <project-selector v-model="defaultProject" :disabled="disableProjectSelection" />
+        <project-selector v-model="defaultProject" />
       </div>
     </div>
     <div class="extracting-form__group mb-4">
@@ -100,6 +100,13 @@ export default {
      */
     dark: {
       type: Boolean
+    },
+    /**
+     * Force hiding the project selector input
+     */
+    hideProjectSelector: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -167,7 +174,11 @@ export default {
       return !this.hasTesseract || !!this.ocr
     },
     showProjectSelector() {
-      return this.$core.projects.length > 1 || this.defaultProject !== this.$config.get('defaultProject')
+      return (
+        !this.hideProjectSelector ||
+        this.$core.projects.length > 1 ||
+        this.defaultProject !== this.$config.get('defaultProject')
+      )
     }
   },
   async mounted() {

--- a/src/components/ExtractingForm.vue
+++ b/src/components/ExtractingForm.vue
@@ -207,9 +207,11 @@ export default {
     async submitExtract() {
       try {
         await this.dispatchExtract()
+        this.$emit('submit', { error: false })
+      } catch (e) {
+        this.$emit('submit', { error: e })
       } finally {
         this.$store.commit('indexing/resetExtractForm')
-        this.$emit('submit')
       }
     }
   }

--- a/src/components/FindNamedEntitiesForm.vue
+++ b/src/components/FindNamedEntitiesForm.vue
@@ -159,8 +159,8 @@ export default {
         this.$wait.start('launch ner task')
         await this.$store.dispatch('indexing/submitFindNamedEntities')
         this.$emit('submit', { error: false })
-      } catch (e) {
-        this.$emit('submit', { error: e })
+      } catch (error) {
+        this.$emit('submit', { error })
       } finally {
         this.$wait.end('launch ner task')
         this.$store.commit('indexing/resetFindNamedEntitiesForm')

--- a/src/components/FindNamedEntitiesForm.vue
+++ b/src/components/FindNamedEntitiesForm.vue
@@ -135,6 +135,7 @@ export default {
         await this.$store.dispatch('indexing/submitFindNamedEntities')
       } finally {
         this.$store.commit('indexing/resetFindNamedEntitiesForm')
+        this.disabled = false
         this.$emit('submit')
       }
     },

--- a/src/components/FindNamedEntitiesForm.vue
+++ b/src/components/FindNamedEntitiesForm.vue
@@ -31,9 +31,9 @@
                 :key="pip"
                 class="list-group-item bg-transparent border-light"
               >
-                <b-form-radio v-model="pipeline" name="pipeline" :value="pip">
+                <b-form-radio v-model="pipeline" name="pipeline" :value="pip.toUpperCase()">
                   {{ $t(`${translationReference}`) }}
-                  <div v-if="pip.toLowerCase() === 'corenlp'" class="font-italic small">
+                  <div v-if="pip.toUpperCase() === 'CORENLP'" class="font-italic small">
                     {{ $t('indexing.default') }}
                   </div>
                 </b-form-radio>
@@ -129,7 +129,7 @@ export default {
         this.$store.commit('indexing/formPipeline', value)
       },
       get() {
-        return this.$store.state.indexing.form.pipeline.toLowerCase()
+        return this.$store.state.indexing.form.pipeline.toUpperCase()
       }
     },
     defaultProject: {

--- a/src/components/FindNamedEntitiesForm.vue
+++ b/src/components/FindNamedEntitiesForm.vue
@@ -157,9 +157,11 @@ export default {
     async submitFindNamedEntities() {
       try {
         await this.$store.dispatch('indexing/submitFindNamedEntities')
+        this.$emit('submit', { error: false })
+      } catch (e) {
+        this.$emit('submit', { error: e })
       } finally {
         this.$store.commit('indexing/resetFindNamedEntitiesForm')
-        this.$emit('submit')
       }
     },
     handlePipelinesTranslation(pipelines) {

--- a/src/components/FindNamedEntitiesForm.vue
+++ b/src/components/FindNamedEntitiesForm.vue
@@ -12,7 +12,7 @@
           <p class="font-weight-bold">
             {{ $t('indexing.findNamedEntitiesProjectSelection') }}
           </p>
-          <project-selector v-model="defaultProject" :disabled="disableProjectSelection" />
+          <project-selector v-model="defaultProject" />
         </div>
       </div>
       <div class="find-named-entities-form__group mb-4">
@@ -100,9 +100,9 @@ export default {
       default: null
     },
     /**
-     * Disable project selection select input
+     * Force hiding the project selector input
      */
-    disableProjectSelection: {
+    hideProjectSelector: {
       type: Boolean,
       default: false
     }
@@ -141,7 +141,11 @@ export default {
       }
     },
     showProjectSelector() {
-      return this.$core.projects.length > 1 || this.defaultProject !== this.$config.get('defaultProject')
+      return (
+        !this.hideProjectSelector ||
+        this.$core.projects.length > 1 ||
+        this.defaultProject !== this.$config.get('defaultProject')
+      )
     }
   },
   async mounted() {

--- a/src/components/FindNamedEntitiesForm.vue
+++ b/src/components/FindNamedEntitiesForm.vue
@@ -1,7 +1,11 @@
 <template>
   <v-wait for="load ner pipelines">
     <fa slot="waiting" icon="circle-notch" spin size="2x" class="d-flex mx-auto my-5 text-light" />
-    <form class="find-named-entities-form position-relative" @submit.prevent="submitFindNamedEntities">
+    <form
+      class="find-named-entities-form position-relative"
+      :class="{ 'find-named-entities-form--dark': dark }"
+      @submit.prevent="submitFindNamedEntities"
+    >
       <div v-if="showProjectSelector" class="find-named-entities-form__group mb-4">
         <fa icon="database" class="position-absolute mt-1 ml-1" size="lg" />
         <div class="ml-4 pl-3">
@@ -47,18 +51,20 @@
         </b-form-checkbox>
       </div>
       <div class="find-named-entities-form__footer mt-4 row no-gutters">
-        <div class="col text-right">
-          <b-btn variant="primary" class="font-weight-bold" type="submit" :disabled="disabled">
-            {{ $t('indexing.go') }}
-          </b-btn>
-        </div>
+        <slot name="footer" :disabled="disabled">
+          <div class="col text-right">
+            <b-btn variant="primary" class="font-weight-bold" type="submit" :disabled="disabled">
+              {{ $t('indexing.go') }}
+            </b-btn>
+          </div>
+        </slot>
       </div>
     </form>
   </v-wait>
 </template>
 
 <script>
-import { lowerCase, noop, startCase, values } from 'lodash'
+import { lowerCase, startCase, values } from 'lodash'
 
 import ProjectSelector from '@/components/ProjectSelector'
 import utils from '@/mixins/utils'
@@ -76,6 +82,11 @@ export default {
     startCase
   },
   mixins: [utils],
+  props: {
+    dark: {
+      type: Boolean
+    }
+  },
   data() {
     return {
       pipelines: [],
@@ -140,8 +151,10 @@ export default {
 
 <style lang="scss" scoped>
 .find-named-entities-form {
-  background: darken($primary, 20);
-  color: white;
+  &--dark {
+    background: darken($primary, 20);
+    color: white;
+  }
 
   &__header h4 {
     font-size: 1.2em;

--- a/src/components/FindNamedEntitiesForm.vue
+++ b/src/components/FindNamedEntitiesForm.vue
@@ -76,15 +76,6 @@ export default {
     startCase
   },
   mixins: [utils],
-  props: {
-    /**
-     * Callback function to call when the form have been submitted (this should be replaced by an event in future versions).
-     */
-    finally: {
-      type: Function,
-      default: noop
-    }
-  },
   data() {
     return {
       pipelines: [],
@@ -133,7 +124,7 @@ export default {
         await this.$store.dispatch('indexing/submitFindNamedEntities')
       } finally {
         this.$store.commit('indexing/resetFindNamedEntitiesForm')
-        this.finally()
+        this.$emit('submit')
       }
     },
     handlePipelinesTranslation(pipelines) {

--- a/src/components/FindNamedEntitiesForm.vue
+++ b/src/components/FindNamedEntitiesForm.vue
@@ -108,13 +108,12 @@ export default {
   },
   data() {
     return {
-      pipelines: [],
-      waiting: false
+      pipelines: []
     }
   },
   computed: {
     disabled() {
-      return this.pipeline && this.waiting
+      return this.pipeline && !this.$wait.waiting('load ner pipelines')
     },
     offline: {
       set(value) {

--- a/src/components/FindNamedEntitiesForm.vue
+++ b/src/components/FindNamedEntitiesForm.vue
@@ -142,9 +142,8 @@ export default {
     },
     showProjectSelector() {
       return (
-        !this.hideProjectSelector ||
-        this.$core.projects.length > 1 ||
-        this.defaultProject !== this.$config.get('defaultProject')
+        !this.hideProjectSelector &&
+        (this.$core.projects.length > 1 || this.defaultProject !== this.$config.get('defaultProject'))
       )
     }
   },

--- a/src/components/FindNamedEntitiesForm.vue
+++ b/src/components/FindNamedEntitiesForm.vue
@@ -148,7 +148,7 @@ export default {
     if (this.$core.findProject(this.projectName)) {
       this.defaultProject = this.projectName
     }
-    this.$wait.start('load ner pipelinesccccc')
+    this.$wait.start('load ner pipelines')
     const pipelines = await this.$store.dispatch('indexing/getNerPipelines')
     this.$set(this, 'pipelines', this.handlePipelinesTranslation(values(pipelines).map(lowerCase)))
     this.$wait.end('load ner pipelines')

--- a/src/components/ProjectForm.vue
+++ b/src/components/ProjectForm.vue
@@ -109,7 +109,7 @@ export default {
         sourceUrl: null,
         publisherName: null,
         maintainerName: null,
-        // Merge with this propertiy to be able to initialize
+        // Merge with this property to be able to initialize
         // the form with an existing project
         ...this.values
       }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -757,6 +757,7 @@
     "submit": "Save"
   },
   "projectForm": {
+    "newProject": "New project",
     "form": {
       "name": {
         "label": "ID",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -722,6 +722,8 @@
     }
   },
   "projectList": {
+    "title": "Projects",
+    "newProject": "New project",
     "fields": {
       "label": "Label",
       "updateDate": "Updated"
@@ -757,7 +759,6 @@
     "submit": "Save"
   },
   "projectForm": {
-    "newProject": "New project",
     "form": {
       "name": {
         "label": "ID",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -529,7 +529,6 @@
     "title": "Analyze your documents",
     "description": "Please <a href=\"%{howToLink}\" target=\"_blank\">read the documentation</a> about adding documents.",
     "go": "Launch",
-    "goAndSee": "Launch and see tasks",
     "tasks": "Tasks",
     "empty": "You have not yet started any tasks. <a href=\"%{howToLink}\" target=\"_blank\">Read more.</a>",
     "extractText": "Add documents",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -762,6 +762,26 @@
     },
     "submit": "Save"
   },
+  "projectViewAddDocuments": {
+    "title": "Add documents to project",
+    "notify": {
+      "succeed": "Add document task launched",
+      "succeedBody": "Indexing task to add documents has been launched.",
+      "seeTasks": "See tasks",
+      "failed": "Add document task failed",
+      "failedBody": "An error occurred when launching indexing task to add documents."
+    }
+  },
+  "projectViewFindNamedEntities": {
+    "title": "Find named entities",
+    "notify": {
+      "succeed": "Find named entities task launched",
+      "succeedBody": "Finding named entities has been launched.",
+      "seeTasks": "See tasks",
+      "failed": "Find named entities task failed",
+      "failedBody": "An error occurred when launching indexing task to add documents."
+    }
+  },
   "projectForm": {
     "form": {
       "name": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -528,7 +528,8 @@
   "indexing": {
     "title": "Analyze your documents",
     "description": "Please <a href=\"%{howToLink}\" target=\"_blank\">read the documentation</a> about adding documents.",
-    "go": "Go",
+    "go": "Launch",
+    "goAndSee": "Launch and see tasks",
     "tasks": "Tasks",
     "empty": "You have not yet started any tasks. <a href=\"%{howToLink}\" target=\"_blank\">Read more.</a>",
     "extractText": "Add documents",
@@ -538,6 +539,7 @@
     "extractOnlyNewHelp": "If yes, Datashare will only extract text from files that are not yet searchable in Datashare.",
     "extractLanguage": "In which language are your documents?",
     "findNamedEntities": "Find people, organizations, locations and emails",
+    "findNamedEntitiesProjectSelection": "In which project do you want to find named entities?",
     "findNamedEntitiesHeader": "What would you like to do?",
     "findNamedEntitiesSubheader": "Datashare uses Natural Language Processing models.",
     "findNamedEntitiesTooltip": "Texts must be extracted before finding named entities",
@@ -549,8 +551,10 @@
       "mitie": "Find people, organizations and locations with MITIE",
       "ixapipe": "Find people, organizations and locations with IXA Pipe",
       "gatenlp": "Find people, organizations and locations with GateNLP"
-
     },
+    "projectIndexationSelection": "In which project do you want to add documents?",
+    "folderSelection": "Which folder do you want to index?",
+    "folderSelectionDescription": "By default, the entire project folder is selected.",
     "default": "By default - Offers the highest probability of working in most documents",
     "syncModelsLabel": "Do you want to work offline?",
     "syncModels": "Check this box if you are working without internet connection.",

--- a/src/pages/ProjectList.vue
+++ b/src/pages/ProjectList.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="project-list">
-    <page-header title="Projects" icon="database">
+    <page-header :title="$t('projectList.title')" icon="database">
       <b-btn v-if="!isServer" class="ml-auto my-1 text-nowrap" variant="primary" :to="{ name: 'project.new' }">
         <fa class="mr-1" icon="plus" />
-        {{ $t('projectForm.newProject') }}
+        {{ $t('projectList.newProject') }}
       </b-btn>
     </page-header>
     <div class="container py-4">

--- a/src/pages/ProjectList.vue
+++ b/src/pages/ProjectList.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="project-list">
-    <page-header title="Projects" icon="database" />
+    <page-header title="Projects" icon="database">
+      <b-btn v-if="!isServer" class="ml-auto my-1 text-nowrap" variant="primary" :to="{ name: 'project.new' }">
+        <fa class="mr-1" icon="plus" />
+        {{ $t('projectForm.newProject') }}
+      </b-btn>
+    </page-header>
     <div class="container py-4">
       <b-table striped :items="projects" :fields="fields" outlined class="bg-white">
         <template #table-colgroup>
@@ -28,6 +33,7 @@
 import { humanShortDate } from '@/filters/humanDate'
 import PageHeader from '@/components/PageHeader'
 import ProjectThumbnail from '@/components/ProjectThumbnail'
+import utils from '@/mixins/utils'
 
 export default {
   name: 'ProjectList',
@@ -35,6 +41,7 @@ export default {
     PageHeader,
     ProjectThumbnail
   },
+  mixins: [utils],
   data() {
     return {
       fields: [

--- a/src/pages/ProjectNew.vue
+++ b/src/pages/ProjectNew.vue
@@ -13,6 +13,11 @@ export default {
     PageHeader,
     ProjectForm
   },
+  computed: {
+    projectRoute() {
+      return { name: 'project.list' }
+    }
+  },
   methods: {
     async submit(project) {
       try {
@@ -51,8 +56,14 @@ export default {
   <div class="project-new">
     <page-header icon="database" :title="$t('projectNew.title')" :description="$t('projectNew.description')" />
     <div class="container">
+      <div class="mx-1 mb-2 mt-3">
+        <router-link :to="projectRoute">
+          <fa icon="angle-left" class="mr-1" fixed-width />
+          {{ $t('projectList.title') }}
+        </router-link>
+      </div>
       <b-overlay rounded="sm" opacity="0.6" :show="$wait.is('creating')">
-        <project-form class="my-4" card :disabled="$wait.is('creating')" @submit="submit">
+        <project-form class="mb-4" card :disabled="$wait.is('creating')" @submit="submit">
           <template #submit-text>
             {{ $t('projectNew.submit') }}
           </template>

--- a/src/pages/ProjectView.vue
+++ b/src/pages/ProjectView.vue
@@ -42,7 +42,12 @@ export default {
       }
     },
     tabRoutes() {
-      return ['project.view.insights', 'project.view.document-extract', 'project.view.edit']
+      return [
+        'project.view.insights',
+        'project.view.add-documents',
+        'project.view.find-named-entities',
+        'project.view.edit'
+      ]
     }
   },
   beforeMount() {
@@ -76,6 +81,12 @@ export default {
           <template #title>
             <fa icon="file" fixed-width class="mr-1" />
             Add documents
+          </template>
+        </b-tab>
+        <b-tab title-item-class=" project-view__tab project-view__tab--insights">
+          <template #title>
+            <fa icon="user-tag" fixed-width class="mr-1" />
+            Find named entities
           </template>
         </b-tab>
         <b-tab v-if="!isServer" title-item-class="ml-auto project-view__tab project-view__tab--edit">

--- a/src/pages/ProjectView.vue
+++ b/src/pages/ProjectView.vue
@@ -42,7 +42,7 @@ export default {
       }
     },
     tabRoutes() {
-      return ['project.view.insights', 'project.view.edit']
+      return ['project.view.insights', 'project.view.document-extract', 'project.view.edit']
     }
   },
   beforeMount() {
@@ -70,6 +70,12 @@ export default {
           <template #title>
             <fa icon="chart-bar" fixed-width class="mr-1" />
             Insights
+          </template>
+        </b-tab>
+        <b-tab title-item-class=" project-view__tab project-view__tab--insights">
+          <template #title>
+            <fa icon="file" fixed-width class="mr-1" />
+            Add documents
           </template>
         </b-tab>
         <b-tab v-if="!isServer" title-item-class="ml-auto project-view__tab project-view__tab--edit">

--- a/src/pages/ProjectViewAddDocuments.vue
+++ b/src/pages/ProjectViewAddDocuments.vue
@@ -57,7 +57,7 @@ export default {
           id="extracting-form"
           class="card-body"
           :project-name="projectName"
-          disable-project-selection
+          hide-project-selector
           @submit="submit"
         >
           <template #footer="{ disabled }">

--- a/src/pages/ProjectViewAddDocuments.vue
+++ b/src/pages/ProjectViewAddDocuments.vue
@@ -1,0 +1,71 @@
+<script>
+import { get } from 'lodash'
+
+import ExtractingForm from '@/components/ExtractingForm'
+
+/**
+ * This page display a form to create a new project.
+ */
+export default {
+  name: 'ProjectViewAddDocuments',
+  components: {
+    ExtractingForm
+  },
+  computed: {
+    projectRoute() {
+      return { name: 'project.document-extract' }
+    }
+  },
+  methods: {
+    async submit(project) {
+      try {
+        this.$wait.start('creating')
+        await this.$core.api.createProject(project)
+        await this.$core.setProject(project)
+        this.notifyCreationSucceed()
+        this.redirectToProject(project)
+      } catch (error) {
+        this.notifyCreationFailed(error)
+      } finally {
+        this.$wait.end('creating')
+      }
+    },
+    notifyCreationSucceed() {
+      const title = this.$t('projectNew.notify.succeed')
+      const variant = 'success'
+      const body = this.$t('projectNew.notify.succeedBody')
+      this.$root.$bvToast.toast(body, { variant, title })
+    },
+    notifyCreationFailed(error) {
+      const title = this.$t('projectNew.notify.failed')
+      const variant = 'danger'
+      const body = get(error, 'response.data.error') ?? this.$t('projectNew.notify.failedBody')
+      this.$root.$bvToast.toast(body, { variant, title })
+    },
+    redirectToProject({ name }) {
+      const params = { name }
+      return this.$router.push({ name: 'project.view', params })
+    }
+  }
+}
+</script>
+
+<template>
+  <div class="project-new">
+    <div class="container p-4">
+      <div class="card">
+        <h4 class="card-header">Add documents</h4>
+        <extracting-form id="extracting-form" class="card-body">
+          <template #footer="{ disabled }">
+            <div class="col text-right">
+              <b-btn variant="outline-primary" type="reset" :disabled="disabled"> Reset </b-btn>
+              <b-btn variant="primary" class="ml-2" type="submit" :disabled="disabled">
+                {{ $t('indexing.go') }}
+              </b-btn>
+            </div>
+          </template>
+        </extracting-form>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/pages/ProjectViewAddDocuments.vue
+++ b/src/pages/ProjectViewAddDocuments.vue
@@ -14,37 +14,35 @@ export default {
   computed: {
     projectRoute() {
       return { name: 'project.document-extract' }
+    },
+    projectName() {
+      return this.$route.params?.name
     }
   },
   methods: {
-    async submit(project) {
-      try {
-        this.$wait.start('creating')
-        await this.$core.api.createProject(project)
-        await this.$core.setProject(project)
-        this.notifyCreationSucceed()
-        this.redirectToProject(project)
-      } catch (error) {
-        this.notifyCreationFailed(error)
-      } finally {
-        this.$wait.end('creating')
-      }
-    },
     notifyCreationSucceed() {
-      const title = this.$t('projectNew.notify.succeed')
+      const title = this.$t('projectViewAddDocuments.notify.succeed')
       const variant = 'success'
-      const body = this.$t('projectNew.notify.succeedBody')
+      const message = this.$t('projectViewAddDocuments.notify.succeedBody')
+      const linkText = this.$t('projectViewAddDocuments.notify.seeTasks')
+      const body = this.$createElement('div', {}, [
+        this.$createElement('p', {}, message),
+        this.$createElement('router-link', { props: { to: { name: 'task.analysis.list' } } }, linkText)
+      ])
       this.$root.$bvToast.toast(body, { variant, title })
     },
     notifyCreationFailed(error) {
-      const title = this.$t('projectNew.notify.failed')
+      const title = this.$t('projectViewAddDocuments.notify.failed')
       const variant = 'danger'
-      const body = get(error, 'response.data.error') ?? this.$t('projectNew.notify.failedBody')
+      const body = get(error, 'response.data.error') ?? this.$t('projectViewAddDocuments.notify.failedBody')
       this.$root.$bvToast.toast(body, { variant, title })
     },
-    redirectToProject({ name }) {
-      const params = { name }
-      return this.$router.push({ name: 'project.view', params })
+    submit({ error }) {
+      if (error) {
+        this.notifyCreationFailed(error)
+      } else {
+        this.notifyCreationSucceed()
+      }
     }
   }
 }
@@ -55,10 +53,15 @@ export default {
     <div class="container p-4">
       <div class="card">
         <h4 class="card-header">Add documents</h4>
-        <extracting-form id="extracting-form" class="card-body">
+        <extracting-form
+          id="extracting-form"
+          class="card-body"
+          :project-name="projectName"
+          disable-project-selection
+          @submit="submit"
+        >
           <template #footer="{ disabled }">
             <div class="col text-right">
-              <b-btn variant="outline-primary" type="reset" :disabled="disabled"> Reset </b-btn>
               <b-btn variant="primary" class="ml-2" type="submit" :disabled="disabled">
                 {{ $t('indexing.go') }}
               </b-btn>

--- a/src/pages/ProjectViewDocumentExtract.vue
+++ b/src/pages/ProjectViewDocumentExtract.vue
@@ -1,0 +1,59 @@
+<script>
+import { get } from 'lodash'
+
+import ExtractingForm from '@/components/ExtractingForm'
+
+/**
+ * This page display a form to create a new project.
+ */
+export default {
+  name: 'ProjectDocumentExtract',
+  components: {
+    ExtractingForm
+  },
+  computed: {
+    projectRoute() {
+      return { name: 'project.document-extract' }
+    }
+  },
+  methods: {
+    async submit(project) {
+      try {
+        this.$wait.start('creating')
+        await this.$core.api.createProject(project)
+        await this.$core.setProject(project)
+        this.notifyCreationSucceed()
+        this.redirectToProject(project)
+      } catch (error) {
+        this.notifyCreationFailed(error)
+      } finally {
+        this.$wait.end('creating')
+      }
+    },
+    notifyCreationSucceed() {
+      const title = this.$t('projectNew.notify.succeed')
+      const variant = 'success'
+      const body = this.$t('projectNew.notify.succeedBody')
+      this.$root.$bvToast.toast(body, { variant, title })
+    },
+    notifyCreationFailed(error) {
+      const title = this.$t('projectNew.notify.failed')
+      const variant = 'danger'
+      const body = get(error, 'response.data.error') ?? this.$t('projectNew.notify.failedBody')
+      this.$root.$bvToast.toast(body, { variant, title })
+    },
+    redirectToProject({ name }) {
+      const params = { name }
+      return this.$router.push({ name: 'project.view', params })
+    }
+  }
+}
+</script>
+
+<template>
+  <div class="project-new">
+    <div class="container">
+      <extracting-form id="extracting-form" class="my-4 px-3" />
+    </div>
+  </div>
+</template>

--- a/src/pages/ProjectViewFindNamedEntities.vue
+++ b/src/pages/ProjectViewFindNamedEntities.vue
@@ -4,7 +4,7 @@ import { get } from 'lodash'
 import FindNamedEntitiesForm from '@/components/FindNamedEntitiesForm'
 
 /**
- * This page display a form to create a new project.
+ * This page displays a form to create a new project.
  */
 export default {
   name: 'ProjectViewFindNamedEntities',
@@ -14,37 +14,35 @@ export default {
   computed: {
     projectRoute() {
       return { name: 'project.document-extract' }
+    },
+    projectName() {
+      return this.$route.params?.name
     }
   },
   methods: {
-    async submit(project) {
-      try {
-        this.$wait.start('creating')
-        await this.$core.api.createProject(project)
-        await this.$core.setProject(project)
-        this.notifyCreationSucceed()
-        this.redirectToProject(project)
-      } catch (error) {
+    async submit({ error }) {
+      if (error) {
         this.notifyCreationFailed(error)
-      } finally {
-        this.$wait.end('creating')
+      } else {
+        this.notifyCreationSucceed()
       }
     },
     notifyCreationSucceed() {
-      const title = this.$t('projectNew.notify.succeed')
+      const title = this.$t('projectViewFindNamedEntities.notify.succeed')
       const variant = 'success'
-      const body = this.$t('projectNew.notify.succeedBody')
+      const message = this.$t('projectViewFindNamedEntities.notify.succeedBody')
+      const linkText = this.$t('projectViewFindNamedEntities.notify.seeTasks')
+      const body = this.$createElement('div', {}, [
+        this.$createElement('p', {}, message),
+        this.$createElement('router-link', { props: { to: { name: 'task.analysis.list' } } }, linkText)
+      ])
       this.$root.$bvToast.toast(body, { variant, title })
     },
     notifyCreationFailed(error) {
-      const title = this.$t('projectNew.notify.failed')
+      const title = this.$t('projectViewFindNamedEntities.notify.failed')
       const variant = 'danger'
-      const body = get(error, 'response.data.error') ?? this.$t('projectNew.notify.failedBody')
+      const body = get(error, 'response.data.error') ?? this.$t('projectViewFindNamedEntities.notify.failedBody')
       this.$root.$bvToast.toast(body, { variant, title })
-    },
-    redirectToProject({ name }) {
-      const params = { name }
-      return this.$router.push({ name: 'project.view', params })
     }
   }
 }
@@ -55,10 +53,15 @@ export default {
     <div class="container p-4">
       <div class="card">
         <h4 class="card-header">Find named entities (people, locations, organisations)</h4>
-        <find-named-entities-form id="find-named-entities-form p-4" class="card-body" @submit="() => {}">
+        <find-named-entities-form
+          id="find-named-entities-form p-4"
+          class="card-body"
+          :project-name="projectName"
+          disable-project-selection
+          @submit="submit"
+        >
           <template #footer="{ disabled }">
             <div class="col text-right">
-              <b-btn variant="outline-primary" type="reset" :disabled="disabled"> Reset </b-btn>
               <b-btn variant="primary" class="ml-2" type="submit" :disabled="disabled">
                 {{ $t('indexing.go') }}
               </b-btn>

--- a/src/pages/ProjectViewFindNamedEntities.vue
+++ b/src/pages/ProjectViewFindNamedEntities.vue
@@ -57,7 +57,7 @@ export default {
           id="find-named-entities-form p-4"
           class="card-body"
           :project-name="projectName"
-          disable-project-selection
+          hide-project-selector
           @submit="submit"
         >
           <template #footer="{ disabled }">

--- a/src/pages/ProjectViewFindNamedEntities.vue
+++ b/src/pages/ProjectViewFindNamedEntities.vue
@@ -1,15 +1,15 @@
 <script>
 import { get } from 'lodash'
 
-import ExtractingForm from '@/components/ExtractingForm'
+import FindNamedEntitiesForm from '@/components/FindNamedEntitiesForm'
 
 /**
  * This page display a form to create a new project.
  */
 export default {
-  name: 'ProjectDocumentExtract',
+  name: 'ProjectViewFindNamedEntities',
   components: {
-    ExtractingForm
+    FindNamedEntitiesForm
   },
   computed: {
     projectRoute() {
@@ -52,8 +52,20 @@ export default {
 
 <template>
   <div class="project-new">
-    <div class="container">
-      <extracting-form id="extracting-form" class="my-4 px-3" />
+    <div class="container p-4">
+      <div class="card">
+        <h4 class="card-header">Find named entities (people, locations, organisations)</h4>
+        <find-named-entities-form id="find-named-entities-form p-4" class="card-body" @submit="() => {}">
+          <template #footer="{ disabled }">
+            <div class="col text-right">
+              <b-btn variant="outline-primary" type="reset" :disabled="disabled"> Reset </b-btn>
+              <b-btn variant="primary" class="ml-2" type="submit" :disabled="disabled">
+                {{ $t('indexing.go') }}
+              </b-btn>
+            </div>
+          </template>
+        </find-named-entities-form>
+      </div>
     </div>
   </div>
 </template>

--- a/src/pages/TaskAnalysisList.vue
+++ b/src/pages/TaskAnalysisList.vue
@@ -64,7 +64,7 @@
               <fa icon="user-tag" class="mr-1" />
               {{ $t('indexing.findNamedEntities') }}
             </template>
-            <find-named-entities-form id="find-named-entities-form" @submit="closeFindNamedEntitiesForm" />
+            <find-named-entities-form id="find-named-entities-form" dark @submit="closeFindNamedEntitiesForm" />
           </b-modal>
         </div>
       </div>

--- a/src/pages/TaskAnalysisList.vue
+++ b/src/pages/TaskAnalysisList.vue
@@ -51,7 +51,7 @@
               <fa icon="search-plus" class="mr-1" />
               {{ $t('indexing.extractText') }}
             </template>
-            <extracting-form id="extracting-form" :finally="closeExtractingForm" />
+            <extracting-form id="extracting-form" dark @submit="closeExtractingForm" />
           </b-modal>
           <b-modal
             :id="findNamedEntitiesFormId"
@@ -64,7 +64,7 @@
               <fa icon="user-tag" class="mr-1" />
               {{ $t('indexing.findNamedEntities') }}
             </template>
-            <find-named-entities-form id="find-named-entities-form" :finally="closeFindNamedEntitiesForm" />
+            <find-named-entities-form id="find-named-entities-form" @submit="closeFindNamedEntitiesForm" />
           </b-modal>
         </div>
       </div>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -273,6 +273,16 @@ export const router = {
                   meta: {
                     allowedModes: ['LOCAL', 'EMBEDDED']
                   }
+                },
+                {
+                  name: 'project.view.document-extract',
+                  path: 'document-extract',
+                  components: {
+                    default: () => import('@/pages/ProjectViewDocumentExtract.vue')
+                  },
+                  meta: {
+                    allowedModes: ['LOCAL', 'EMBEDDED']
+                  }
                 }
               ]
             }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -275,10 +275,20 @@ export const router = {
                   }
                 },
                 {
-                  name: 'project.view.document-extract',
-                  path: 'document-extract',
+                  name: 'project.view.add-documents',
+                  path: 'add-documents',
                   components: {
-                    default: () => import('@/pages/ProjectViewDocumentExtract.vue')
+                    default: () => import('@/pages/ProjectViewAddDocuments.vue')
+                  },
+                  meta: {
+                    allowedModes: ['LOCAL', 'EMBEDDED']
+                  }
+                },
+                {
+                  name: 'project.view.find-named-entities',
+                  path: 'find-named-entities',
+                  components: {
+                    default: () => import('@/pages/ProjectViewFindNamedEntities.vue')
                   },
                   meta: {
                     allowedModes: ['LOCAL', 'EMBEDDED']


### PR DESCRIPTION
This PR resolves: ICIJ/datashare#1160 and resolves  ICIJ/datashare#1159
It adds in local mode:
- a button on the project page to create a new project 
- a tab to launch index task AKA "add documents" per project
- a tab to launch named entities extraction AKA "find named entities" per project

This involves the refactoring of the tasks forms to made display them as pages instead of modal with props change:
- dark background option
- project name option to directly select the concerned project
- add of a submit event to handle toast notifications when the task is launched

Fix: 
In `FindNamedEntitiesForm.vue` the radio button was previously not selected due to lowercase/uppercase mismatch of the string CORENLP.


Screenshots:
![Screenshot from 2023-08-30 15-26-45](https://github.com/ICIJ/datashare-client/assets/4643139/6984db63-45f6-4de5-8aff-401149817dca)

![Screenshot from 2023-08-30 15-26-59](https://github.com/ICIJ/datashare-client/assets/4643139/cf19e5fb-c773-4a0d-9ad3-9d1d63fbe333)

![Screenshot from 2023-08-30 15-27-49](https://github.com/ICIJ/datashare-client/assets/4643139/ad07c419-8a3d-427c-bf8a-9f326fff4759)

![Screenshot from 2023-08-30 15-27-56](https://github.com/ICIJ/datashare-client/assets/4643139/122b5624-ea16-4af5-a03f-c53412a2c2c9)

