### PR TITLE
feat: ensure tree view returns directory paths

### DIFF
--- a/src/components/TreeView.vue
+++ b/src/components/TreeView.vue
@@ -346,7 +346,7 @@ export default {
         return this.toDirectories(this.selectedPaths)
       },
       set(paths) {
-        // Ensute the given apths are directorues paths
+        // Ensute the given paths are directories paths
         paths = this.toDirectories(paths)
         const diff = difference(paths, this.selectedPaths)
         // True if the current path just has been selected.

--- a/tests/unit/specs/components/TreeView.spec.js
+++ b/tests/unit/specs/components/TreeView.spec.js
@@ -107,7 +107,7 @@ describe('TreeView.vue', () => {
     })
 
     it('should init selected on component creation', () => {
-      expect(wrapper.vm.selected).toEqual(['path_01', 'path_02'])
+      expect(wrapper.vm.selected).toEqual(['path_01/', 'path_02/'])
     })
 
     it('should display checkboxes if component is selectable', async () => {


### PR DESCRIPTION
This overrides the selected paths in the tree view to make sure they all ends with a path separator (`/`). This should fix [#1190](https://github.com/ICIJ/datashare/issues/1190).
