### PR TITLE
fix: restore missing prop

### DIFF
--- a/src/components/ExtractingForm.vue
+++ b/src/components/ExtractingForm.vue
@@ -107,6 +107,13 @@ export default {
     hideProjectSelector: {
       type: Boolean,
       default: false
+    },
+    /**
+     * Project name to select in the input instead of default project
+     */
+    projectName: {
+      type: String,
+      default: null
     }
   },
   data() {


### PR DESCRIPTION
The `projectName` prop was missing from the ExtractingForm component which led to the unability to preselect a project (causing [#1196](https://github.com/ICIJ/datashare/issues/1196)).