### PR TITLE
feat: ensure active projects are pre-selected in BS form

### DIFF
--- a/src/components/BatchSearchForm.vue
+++ b/src/components/BatchSearchForm.vue
@@ -185,12 +185,10 @@
 
 <script>
 import {
-  castArray,
   compact,
   concat,
   each,
   find,
-  first,
   filter,
   flatten,
   get,
@@ -280,7 +278,11 @@ export default {
       return this.$core.projects
     },
     defaultSelectedProjects() {
-      return compact(castArray(first(this.projectOptions)))
+      return filter(this.projectOptions, ({ name }) => {
+        // In case the store is not initalized yet,
+        // all project are selected by default
+        return get(this, '$store.state.search.indices', [name]).includes(name)
+      })
     },
     projects: {
       get() {


### PR DESCRIPTION
## PR description

This PR ensures that the default selected projects in a new batch search are the same as the selected one in the general search (@see https://github.com/ICIJ/datashare/issues/1208).