### PR TITLE
fix: batch search query route

### DIFF
--- a/src/components/BatchSearchResultsFilters.vue
+++ b/src/components/BatchSearchResultsFilters.vue
@@ -51,7 +51,7 @@
                 </span>
                 <span
                   class="batch-search-results-filters__queries__dropdown__item__search"
-                  @click.stop.prevent="executeSearch(item.label)"
+                  @click.stop.prevent="searchQuery(item.label)"
                 >
                   <fa icon="search" class="text-tertiary"></fa>
                 </span>
@@ -105,7 +105,7 @@ export default {
      * The batch search indices
      */
     indices: {
-      type: [String, Array]
+      type: String
     },
     selectedQueries: {
       type: Array,
@@ -168,11 +168,12 @@ export default {
         return this.$router.push({ name: 'task.batch-search.view.results', query }).catch(() => {})
       }
     },
-    executeSearch(q) {
+    searchQuery(q) {
       this.$store.commit('search/reset')
-      this.$router
-        .push({ name: 'search', query: { queries: this.selectedQueries, q, indices: this.indices.join(',') } })
-        .catch(() => {})
+      const queries = this.selectedQueries
+      const indices = this.indices
+      const query = { queries, q, indices }
+      return this.$router.push({ name: 'search', query })
     },
     excludeSelectedQueries() {
       const query = { ...this.routeQuery, queriesExcluded: !this.queriesExcluded }

--- a/src/components/BatchSearchResultsTable.vue
+++ b/src/components/BatchSearchResultsTable.vue
@@ -144,7 +144,7 @@ export default {
      * The indices of the current batch search
      */
     indices: {
-      type: [String, Array]
+      type: String
     }
   },
   data() {

--- a/src/pages/TaskBatchSearchViewResults.vue
+++ b/src/pages/TaskBatchSearchViewResults.vue
@@ -37,8 +37,7 @@
           :local-search-params="params"
         />
       </b-row>
-      <batch-search-results-table :indices="indices" :uuid="uuid" @show-document-modal="openDocumentModal">
-      </batch-search-results-table>
+      <batch-search-results-table :indices="indices" :uuid="uuid" @show-document-modal="openDocumentModal" />
       <document-in-modal v-model="documentInModalPageIndex" :page="page" @update:page="updatePage" />
     </div>
   </div>
@@ -57,6 +56,7 @@ import humanNumber from '@/filters/humanNumber'
 import utils from '@/mixins/utils'
 import settings from '@/utils/settings'
 import AppliedSearchFiltersItem from '@/components/AppliedSearchFiltersItem'
+
 const SEARCH_PARAMS_LOCAL = Object.freeze({
   queries: true,
   indices: false,
@@ -64,6 +64,7 @@ const SEARCH_PARAMS_LOCAL = Object.freeze({
   order: true,
   sort: true
 })
+
 /**
  * This page will list all the results of a batch search.
  */
@@ -93,7 +94,7 @@ export default {
      * The indices of the current batch search
      */
     indices: {
-      type: [String, Array]
+      type: String
     }
   },
   data() {
@@ -184,7 +185,7 @@ export default {
   },
   async created() {
     await this.fetch()
-    return this.setIsMyBatchSearch()
+    await this.setIsMyBatchSearch()
   },
   methods: {
     async fetch() {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -209,7 +209,7 @@ export const router = {
                 },
                 {
                   name: 'task.batch-search.view',
-                  path: ':index/:uuid',
+                  path: ':indices/:uuid',
                   components: {
                     default: () => import('@/pages/TaskBatchSearchView')
                   },

--- a/tests/unit/specs/components/BatchSearchResultsFilters.spec.js
+++ b/tests/unit/specs/components/BatchSearchResultsFilters.spec.js
@@ -17,7 +17,7 @@ describe('BatchSearchResultsFilters.vue', () => {
       { label: 'query_02', count: 3 },
       { label: 'query_03', count: 2 }
     ],
-    indices: [project, anotherProject]
+    indices: [project, anotherProject].join(',')
   }
   const propsDataSingleQuery = { queryKeys: [{ label: 'query_04', count: 12 }], indices: project }
 
@@ -153,7 +153,7 @@ describe('BatchSearchResultsFilters.vue', () => {
         propsData: propsDataMultipleQueries
       })
       await wrapper.vm.$nextTick()
-      const spy = jest.spyOn(wrapper.vm.$router, 'push')
+      const spy = jest.spyOn(wrapper.vm.$router, 'push').mockResolvedValue(null)
       wrapper.find('.batch-search-results-filters__queries__dropdown__item__search').trigger('click')
 
       expect(wrapper.vm.$router.push).toBeCalled()
@@ -223,7 +223,7 @@ describe('BatchSearchResultsFilters.vue', () => {
         },
         propsData: propsDataMultipleQueries
       })
-      const spy = jest.spyOn(wrapper.vm.$router, 'push')
+      const spy = jest.spyOn(wrapper.vm.$router, 'push').mockResolvedValue(null)
       spy.mockClear()
 
       await wrapper.vm.sort('default')
@@ -243,7 +243,7 @@ describe('BatchSearchResultsFilters.vue', () => {
         store,
         propsData: propsDataMultipleQueries
       })
-      const spy = jest.spyOn(wrapper.vm.$router, 'push')
+      const spy = jest.spyOn(wrapper.vm.$router, 'push').mockResolvedValue(null)
       spy.mockClear()
       const excludeFilter = wrapper.find('.filter__footer__action input')
       expect(excludeFilter.exists()).toBe(true)


### PR DESCRIPTION
## PR description

This ensure we can click on a query from a batch search to be redirected to the general search page.

## Changes

* fix: use the correct name in the route property ("indices" instead of "index")
* refactor: use the "indices" property so it's always a string