### PR TITLE
feat: add rename saved search

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -215,12 +215,19 @@ export class Api {
     const data = { projectIds, type, name, uri }
     return this.sendActionAsText('/api/users/me/history', { method: Method.PUT, data })
   }
+  renameSavedSearch(eventId, newName) {
+    return this.sendAction('/api/users/me/history', {
+      method: Method.PUT,
+      data: { eventId, name: newName, type: 'SEARCH' }
+    })
+  }
   deleteUserHistory(type) {
     return this.sendAction('/api/users/me/history', { method: Method.DELETE, params: { type } })
   }
   deleteUserHistoryEvent(id) {
     return this.sendAction('/api/users/me/history/event', { method: Method.DELETE, params: { id } })
   }
+
   setMarkAsRecommended(project, data) {
     return this.sendActionAsText(`/api/${project}/documents/batchUpdate/recommend`, { method: Method.POST, data })
   }

--- a/src/components/UserHistorySaveSearchForm.vue
+++ b/src/components/UserHistorySaveSearchForm.vue
@@ -10,7 +10,7 @@
       <div class="card-footer">
         <div class="d-flex justify-content-end align-items-center">
           <b-btn type="submit" variant="primary">
-            {{ $t('global.submit') }}
+            {{ $t('userHistorySaveSearchForm.save') }}
           </b-btn>
         </div>
       </div>
@@ -29,12 +29,20 @@ export default {
      * The indices of the current item.
      */
     indices: {
-      type: [String, Array]
+      type: [String, Array],
+      default: ''
+    },
+    /**
+     * The indices of the current item.
+     */
+    event: {
+      type: Object,
+      default: null
     }
   },
   data() {
     return {
-      name: ''
+      name: this.event?.name || ''
     }
   },
   computed: {
@@ -56,7 +64,12 @@ export default {
   methods: {
     async saveSearch() {
       try {
-        await this.$core.api.addUserHistoryEvent(this.indices, 'SEARCH', this.name, this.uriFromStore)
+        if (this.event) {
+          await this.$core.api.renameSavedSearch(this.event.id, this.name)
+          this.$emit('submit:rename', { event: { ...this.event, name: this.name } })
+        } else {
+          await this.$core.api.addUserHistoryEvent(this.indices, 'SEARCH', this.name, this.uriFromStore)
+        }
         const { href } = this.$router.resolve({ name: 'user-history.saved-search.list' })
         const toastParams = { href, noCloseButton: true, variant: 'success' }
         this.$root.$bvToast.toast(this.$t('userHistory.submitSuccess'), toastParams)

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -626,10 +626,12 @@
     "delete": "Delete",
     "deleted": "The saved search have been deleted.",
     "confirmDelete": "Are you sure you want to delete this saved search?",
-    "deleteError": "Something went wrong, unable to delete the record."
+    "deleteError": "Something went wrong, unable to delete the record.",
+    "renameSavedSearch": "Rename saved search"
   },
   "userHistorySaveSearchForm": {
-    "description": "You can retrieve all your saved searches in <a href=\"{searchHistoryPath}\">History › Searches</a>."
+    "description": "You can retrieve all your saved searches in <a href=\"{searchHistoryPath}\">History › Searches</a>.",
+    "save": "Save"
   },
   "tasks": {
     "title": "Tasks",

--- a/src/pages/UserHistorySavedSearchList.vue
+++ b/src/pages/UserHistorySavedSearchList.vue
@@ -11,9 +11,9 @@
             <span class="user-history-saved-search-list__list__item__name font-weight-bold mb-1">
               {{ event.name }}
               <b-btn
-                v-b-tooltip.hover.bottomleft
+                v-b-tooltip.hover.topright
                 :title="$t('userHistory.renameSavedSearch')"
-                class="user-history-saved-search-list__list__item__name--rename text-dark py-0"
+                class="user-history-saved-search-list__list__item__name--rename text-dark px-1 py-0 ml-1"
                 size="md"
                 variant="transparent"
                 @click.prevent="showEvent({ ...event, idx: eventIdx })"

--- a/src/pages/UserHistorySavedSearchList.vue
+++ b/src/pages/UserHistorySavedSearchList.vue
@@ -3,13 +3,23 @@
     <div class="mt-4">
       <ul v-if="events.length" class="list-unstyled user-history-saved-search-list__list card mb-4">
         <li
-          v-for="event in searches"
+          v-for="(event, eventIdx) in searches"
           :key="event.id"
           class="user-history-saved-search-list__list__item d-inline-flex justify-content-between"
         >
           <router-link :to="{ path: event.uri }" class="p-3 d-block">
             <span class="user-history-saved-search-list__list__item__name font-weight-bold mb-1">
               {{ event.name }}
+              <b-btn
+                v-b-tooltip.hover.bottomleft
+                :title="$t('userHistory.renameSavedSearch')"
+                class="user-history-saved-search-list__list__item__name--rename text-dark py-0"
+                size="md"
+                variant="transparent"
+                @click.prevent="showEvent({ ...event, idx: eventIdx })"
+              >
+                <fa icon="pen" fixed-width size="1x" />
+              </b-btn>
             </span>
             <div class="user-history-saved-search-list__list__item__query">
               <applied-search-filters-item
@@ -47,18 +57,33 @@
         {{ $t('userHistory.empty') }}
       </div>
     </div>
+    <keep-alive>
+      <b-modal
+        ref="user-history-save-search-form"
+        :visible="show"
+        body-class="p-0"
+        hide-footer
+        size="md"
+        :title="$t('userHistory.renameSavedSearch')"
+        @hide="show = false"
+      >
+        <user-history-save-search-form :event="currentEvent" @submit:rename="updateEvent" @submit="show = false" />
+      </b-modal>
+    </keep-alive>
   </div>
 </template>
 
 <script>
 import AppliedSearchFiltersItem from '@/components/AppliedSearchFiltersItem'
+import UserHistorySaveSearchForm from '@/components/UserHistorySaveSearchForm'
 import { humanTime } from '@/filters/humanTime'
 import { humanDate } from '@/filters/humanDate'
 
 export default {
   name: 'UserHistorySavedSearchList',
   components: {
-    AppliedSearchFiltersItem
+    AppliedSearchFiltersItem,
+    UserHistorySaveSearchForm
   },
   filters: {
     humanDate,
@@ -71,7 +96,9 @@ export default {
   },
   data() {
     return {
-      searches: this.events
+      show: false,
+      searches: this.events,
+      currentEvent: null
     }
   },
   methods: {
@@ -119,6 +146,13 @@ export default {
         const searches = this.searches.filter((e) => !(e === event))
         this.$set(this, 'searches', searches)
       }
+    },
+    showEvent(event) {
+      this.currentEvent = event
+      this.show = true
+    },
+    updateEvent({ event }) {
+      this.searches[this.currentEvent.idx] = { ...this.currentEvent, name: event.name }
     }
   }
 }
@@ -128,6 +162,9 @@ export default {
 .user-history-saved-search-list {
   &__list {
     &__item {
+      &__name--rename {
+        vertical-align: bottom;
+      }
       a:hover {
         text-decoration: none;
         color: $table-hover-color;


### PR DESCRIPTION
Allow rename of saved searches in the save searches list
related to [#1203](https://github.com/ICIJ/datashare/issues/1203)
The list of saved searches:
![Screenshot from 2023-10-13 18-27-18](https://github.com/ICIJ/datashare-client/assets/4643139/dd60ff34-f917-416e-8d23-1136582b7ea6)
Before saving :
![Screenshot from 2023-10-13 18-28-02](https://github.com/ICIJ/datashare-client/assets/4643139/99ace6c3-2334-40f8-9fd0-80a70432574a)
After saving, the title of the search is updated in background, and modal is closed:
![Screenshot from 2023-10-13 18-27-43](https://github.com/ICIJ/datashare-client/assets/4643139/f3cdb805-cc43-4433-8b23-456bb09573e4)
