### PR TITLE
feat: histogram picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",
     "@fortawesome/vue-fontawesome": "^2.0.8",
-    "@icij/murmur": "3.7.5",
+    "@icij/murmur": "3.9.2",
     "axios": "^0.27.2",
     "bodybuilder": "^2.5.0",
     "bootstrap": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",
     "@fortawesome/vue-fontawesome": "^2.0.8",
-    "@icij/murmur": "3.7.1",
+    "@icij/murmur": "3.7.2",
     "axios": "^0.27.2",
     "bodybuilder": "^2.5.0",
     "bootstrap": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",
     "@fortawesome/vue-fontawesome": "^2.0.8",
-    "@icij/murmur": "3.7.2",
+    "@icij/murmur": "3.7.5",
     "axios": "^0.27.2",
     "bodybuilder": "^2.5.0",
     "bootstrap": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",
     "@fortawesome/vue-fontawesome": "^2.0.8",
-    "@icij/murmur": "3.9.2",
+    "@icij/murmur": "3.9.3",
     "axios": "^0.27.2",
     "bodybuilder": "^2.5.0",
     "bootstrap": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",
     "@fortawesome/vue-fontawesome": "^2.0.8",
-    "@icij/murmur": "3.6.2",
+    "@icij/murmur": "3.7.1",
     "axios": "^0.27.2",
     "bodybuilder": "^2.5.0",
     "bootstrap": "4.6.2",

--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -197,7 +197,7 @@ export function datasharePlugin(Client) {
     return this._search({ index, body })
   }
 
-  Client.prototype.countByProject = function (index, query = {}, size = 1000) {
+  Client.prototype.countByProject = function (index, query = undefined, size = 1000) {
     const aggs = { index: { terms: { field: '_index', size } } }
     const body = { size: 0, query, aggs }
     const preference = 'count-by-project'

--- a/src/components/ColumnChartPicker.vue
+++ b/src/components/ColumnChartPicker.vue
@@ -1,0 +1,154 @@
+<script>
+import { clamp, compact, throttle } from 'lodash'
+import * as d3 from 'd3'
+
+/**
+ * Widget to display the number of file by creation date on the insights page.
+ */
+export default {
+  name: 'ColumnChartPicker',
+  model: {
+    prop: 'value',
+    event: 'update'
+  },
+  props: {
+    /**
+     * Initial values of the range bounds. Should contain two timestamps.
+     * indicating the start and end of the range.
+     */
+    value: {
+      type: Object,
+      default: null
+    },
+    /**
+     * The data to visualize (from an ElasticSearch aggregation)
+     */
+    data: {
+      type: Array
+    },
+    /**
+     * Active interval unit
+     */
+    interval: {
+      type: String,
+      default: 'year'
+    }
+  },
+  data() {
+    return {
+      intervals: {
+        year: {
+          time: d3.utcYear,
+          bins: d3.utcYears
+        },
+        month: {
+          time: d3.utcMonth,
+          bins: d3.utcMonths
+        }
+      }
+    }
+  },
+  computed: {
+    range: {
+      get() {
+        return compact([this.rangeStart, this.rangeEnd])
+      },
+      set: throttle(function ([rangeStart, rangeEnd]) {
+        const scale = d3.scaleLinear([0, 1], this.timesExtent)
+        const start = scale(rangeStart)
+        const end = scale(rangeEnd)
+        this.$emit('update', { start, end })
+      }, 1000)
+    },
+    rangeScale() {
+      return d3.scaleLinear(this.timesExtent, [0, 1])
+    },
+    rangeStart() {
+      return this.value?.start ? this.rangeScale(this.value.start) : null
+    },
+    rangeEnd() {
+      return this.value?.end ? this.rangeScale(this.value.end) : null
+    },
+    chartWidth() {
+      return this.$el?.querySelector('.column-chart-picker__chart')?.offsetWidth ?? 0
+    },
+    intervalTime() {
+      return this.intervals[this.interval].time
+    },
+    intervalBins() {
+      const minTime = this.intervalTime.offset(this.datesExtent[0], -1)
+      const maxTime = this.intervalTime.offset(this.datesExtent[1], 1)
+      const { bins } = this.intervals[this.interval]
+      return bins(minTime, maxTime)
+    },
+    timesExtent() {
+      return d3.extent(this.cleanData, (d) => d.key)
+    },
+    datesExtent() {
+      return d3.extent(this.cleanData, (d) => d.date)
+    },
+    datesScale() {
+      return d3.scaleUtc().domain(this.datesExtent).rangeRound([0, this.chartWidth])
+    },
+    datesThresholds() {
+      return this.datesScale.ticks(this.intervalBins.length)
+    },
+    datesHistogram() {
+      const histogram = d3
+        .histogram()
+        .value((d) => d.key)
+        .domain(this.datesScale.domain())
+        .thresholds(this.datesThresholds)
+      return histogram(this.data)
+    },
+    ticks() {
+      return clamp(1, this.endTick - this.startTick, this.maxTicks)
+    },
+    startTick() {
+      return Math.round(this.range[0] * this.datesHistogram.length)
+    },
+    endTick() {
+      return Math.round(this.range[1] * this.datesHistogram.length)
+    },
+    isDatesRangeSliced() {
+      return this.datesHistogram.length > this.ticks
+    },
+    cleanData() {
+      return this.data.reduce((buckets, bucket) => {
+        if (this.isBucketKeyInRange(bucket.key)) {
+          bucket.date = new Date(bucket.key)
+          buckets.push(bucket)
+        }
+        return buckets
+      }, [])
+    },
+    aggregatedData() {
+      return this.datesHistogram.map((bin) => {
+        return { date: bin.x0, value: d3.sum(bin, (d) => d.doc_count) }
+      })
+    }
+  },
+  methods: {
+    isBucketKeyInRange(key) {
+      return key > 0 && key < new Date().getTime()
+    }
+  }
+}
+</script>
+
+<template>
+  <range-picker v-model="range" class="column-chart-picker py-1 my-1 overflow-hidden" rounded variant="light">
+    <column-chart
+      :key="interval"
+      :data="aggregatedData"
+      :fixed-height="100"
+      :bar-padding="0"
+      :bar-margin="1"
+      class="column-chart-picker__chart"
+      column-color="currentColor"
+      no-tooltips
+      no-x-axis
+      no-y-axis
+    />
+  </range-picker>
+</template>

--- a/src/components/ColumnChartPicker.vue
+++ b/src/components/ColumnChartPicker.vue
@@ -1,5 +1,5 @@
 <script>
-import { clamp, compact, throttle } from 'lodash'
+import { cloneDeep, defaultTo, iteratee, isNumber, last, throttle } from 'lodash'
 import * as d3 from 'd3'
 
 /**
@@ -32,18 +32,59 @@ export default {
     interval: {
       type: String,
       default: 'year'
+    },
+    /**
+     * Throttle to trigger the update
+     */
+    throttle: {
+      type: Number,
+      default: 1000
+    },
+    /**
+     * Should or should not "snap" range picker
+     */
+    columnSnap: {
+      type: Boolean
+    },
+    /**
+     * Add a margin to each column
+     */
+    columnMargin: {
+      type: Number,
+      default: 0
+    },
+    /**
+     * Change the ratio of the columns' height
+     */
+    columnHeightRatio: {
+      type: Number,
+      default: 0.3
+    },
+    /**
+     * Apply a different variant color to the range picker
+     */
+    variant: {
+      type: String,
+      default: 'warning'
     }
   },
   data() {
     return {
       intervals: {
         year: {
+          format: d3.utcFormat('%Y'),
           time: d3.utcYear,
           bins: d3.utcYears
         },
         month: {
+          format: d3.utcFormat('%b. %Y'),
           time: d3.utcMonth,
           bins: d3.utcMonths
+        },
+        day: {
+          format: d3.utcFormat('%B %d, %Y'),
+          time: d3.utcDay,
+          bins: d3.utcDays
         }
       }
     }
@@ -51,17 +92,29 @@ export default {
   computed: {
     range: {
       get() {
-        return compact([this.rangeStart, this.rangeEnd])
+        return [this.rangeStart, this.rangeEnd].filter(isNumber)
       },
-      set: throttle(function ([rangeStart, rangeEnd]) {
-        const scale = d3.scaleLinear([0, 1], this.timesExtent)
-        const start = scale(rangeStart)
-        const end = scale(rangeEnd)
+      set(range) {
+        return this.setRangeWithThrottle(range)
+      }
+    },
+    setRangeWithThrottle() {
+      return throttle(function ([rangeStart, rangeEnd]) {
+        // The range is expressed in timestamps but
+        // the scale might returns floating values so
+        // we needc to round it first.
+        const start = new Date(Math.round(this.rangeScale.invert(rangeStart)))
+        const end = new Date(Math.round(this.rangeScale.invert(rangeEnd)))
+        /**
+         * Fired when the range is update
+         * @event update
+         * @param Object New range value
+         */
         this.$emit('update', { start, end })
-      }, 1000)
+      }, this.throttle)
     },
     rangeScale() {
-      return d3.scaleLinear(this.timesExtent, [0, 1])
+      return d3.scaleLinear(this.intervalTimesExtent, [0, 1])
     },
     rangeStart() {
       return this.value?.start ? this.rangeScale(this.value.start) : null
@@ -72,8 +125,8 @@ export default {
     chartWidth() {
       return this.$el?.querySelector('.column-chart-picker__chart')?.offsetWidth ?? 0
     },
-    intervalTime() {
-      return this.intervals[this.interval].time
+    intervalFormat() {
+      return this.intervals[this.interval].format
     },
     intervalBins() {
       const minTime = this.intervalTime.offset(this.datesExtent[0], -1)
@@ -81,14 +134,36 @@ export default {
       const { bins } = this.intervals[this.interval]
       return bins(minTime, maxTime)
     },
-    timesExtent() {
-      return d3.extent(this.cleanData, (d) => d.key)
+    intervalTime() {
+      return this.intervals[this.interval].time
+    },
+    start() {
+      return this.intervalDatesExtent[0]
+    },
+    end() {
+      return this.intervalDatesExtent[1]
+    },
+    startYear() {
+      return this.start.getFullYear()
+    },
+    endYear() {
+      return this.end.getFullYear()
+    },
+    intervalTimesExtent() {
+      const start = this.toIntervalStart(this.datesExtent[0]).getTime()
+      const end = this.toIntervalEnd(this.datesExtent[1]).getTime()
+      return [start, end]
     },
     datesExtent() {
-      return d3.extent(this.cleanData, (d) => d.date)
+      return d3.extent(this.cleanData, iteratee('date'))
+    },
+    intervalDatesExtent() {
+      const start = this.toIntervalStart(this.datesExtent[0])
+      const end = this.toIntervalEnd(this.datesExtent[1])
+      return [start, end]
     },
     datesScale() {
-      return d3.scaleUtc().domain(this.datesExtent).rangeRound([0, this.chartWidth])
+      return d3.scaleUtc().domain(this.intervalDatesExtent).rangeRound([0, this.chartWidth])
     },
     datesThresholds() {
       return this.datesScale.ticks(this.intervalBins.length)
@@ -96,59 +171,109 @@ export default {
     datesHistogram() {
       const histogram = d3
         .histogram()
-        .value((d) => d.key)
+        .value(iteratee('key'))
         .domain(this.datesScale.domain())
         .thresholds(this.datesThresholds)
-      return histogram(this.data)
-    },
-    ticks() {
-      return clamp(1, this.endTick - this.startTick, this.maxTicks)
-    },
-    startTick() {
-      return Math.round(this.range[0] * this.datesHistogram.length)
-    },
-    endTick() {
-      return Math.round(this.range[1] * this.datesHistogram.length)
-    },
-    isDatesRangeSliced() {
-      return this.datesHistogram.length > this.ticks
+      return histogram(this.cleanData)
     },
     cleanData() {
-      return this.data.reduce((buckets, bucket) => {
-        if (this.isBucketKeyInRange(bucket.key)) {
-          bucket.date = new Date(bucket.key)
-          buckets.push(bucket)
-        }
-        return buckets
-      }, [])
+      return this.data
+        .filter(this.isBucketValid)
+        .map(cloneDeep)
+        .map((datum) => {
+          datum.date = new Date(datum.key)
+          return datum
+        })
     },
     aggregatedData() {
       return this.datesHistogram.map((bin) => {
-        return { date: bin.x0, value: d3.sum(bin, (d) => d.doc_count) }
+        return { date: bin.x0, value: d3.sum(bin, iteratee('doc_count')) }
       })
+    },
+    minRangeDistance() {
+      return 1 / (this.endYear - this.startYear)
+    },
+    snap() {
+      if (this.columnSnap) {
+        return 1 / this.aggregatedData.length
+      }
+      return 0.000001
     }
   },
   methods: {
-    isBucketKeyInRange(key) {
+    isBucketValid({ key }) {
       return key > 0 && key < new Date().getTime()
+    },
+    select({ date }) {
+      const bin = this.datesHistogram.find(({ x0, x1 }) => date >= x0 && date < x1)
+      // We found the histogram bin or we use the last
+      const { x0: start, x1: end } = defaultTo(bin, last(this.datesHistogram))
+      /**
+       * Fired when the range is update
+       * @event update
+       * @param Object New range value
+       */
+      this.$emit('update', { start, end })
+    },
+    toIntervalStart(date) {
+      const startMonth = this.interval === 'year' ? 0 : date.getMonth()
+      return new Date(Date.UTC(date.getFullYear(), startMonth, 1))
+    },
+    toIntervalEnd(date) {
+      const endMonth = this.interval === 'year' ? 11 : date.getMonth()
+      return new Date(Date.UTC(date.getFullYear(), endMonth + 1, 0, 23, 59, 59))
     }
   }
 }
 </script>
 
 <template>
-  <range-picker v-model="range" class="column-chart-picker py-1 my-1 overflow-hidden" rounded variant="light">
-    <column-chart
-      :key="interval"
-      :data="aggregatedData"
-      :fixed-height="100"
-      :bar-padding="0"
-      :bar-margin="1"
-      class="column-chart-picker__chart"
-      column-color="currentColor"
-      no-tooltips
-      no-x-axis
-      no-y-axis
-    />
-  </range-picker>
+  <div class="column-chart-picker overflow-visible">
+    <range-picker
+      v-model="range"
+      class="column-chart-picker__range my-1"
+      rounded
+      :variant="variant"
+      :min-distance="minRangeDistance"
+      :snap="snap"
+    >
+      <column-chart
+        :key="interval"
+        :data="aggregatedData"
+        :chart-height-ratio="columnHeightRatio"
+        :bar-padding="0"
+        :bar-margin="columnMargin"
+        class="column-chart-picker__range__chart"
+        column-color="currentColor"
+        no-tooltips
+        no-y-axis
+        no-x-axis
+        hover
+        @select="select"
+      />
+    </range-picker>
+    <div class="column-chart-picker__scale d-flex">
+      <div>{{ intervalFormat(start) }}</div>
+      <div class="ml-auto">{{ intervalFormat(end) }}</div>
+    </div>
+  </div>
 </template>
+
+<style scoped lang="scss">
+.column-chart-picker {
+  &__range {
+    &__chart {
+      color: currentColor;
+
+      &:deep(.column-chart__columns__item) {
+        cursor: pointer;
+      }
+    }
+  }
+
+  &__scale {
+    font-weight: bold;
+    opacity: 0.6;
+  }
+}
+</style>

--- a/src/components/ColumnChartPicker.vue
+++ b/src/components/ColumnChartPicker.vue
@@ -263,7 +263,7 @@ export default {
 .column-chart-picker {
   &__range {
     &__chart {
-      color: currentColor;
+      fill: currentColor;
 
       &:deep(.column-chart__columns__item) {
         cursor: pointer;

--- a/src/components/filter/FilterBoilerplate.vue
+++ b/src/components/filter/FilterBoilerplate.vue
@@ -206,18 +206,18 @@ export default {
       default: true
     },
     /**
-     * Either or not results should be loaded on scroll
-     */
-    infiniteScroll: {
-      type: Boolean,
-      default: true
-    },
-    /**
      * Display the filter on dark background
      */
     dark: {
       type: Boolean,
       default: true
+    },
+    /**
+     * Either or not results should be loaded on scroll
+     */
+    noInfiniteScroll: {
+      type: Boolean,
+      default: false
     },
     /**
      * Disable the attempt to translate an item value
@@ -310,7 +310,7 @@ export default {
       return this.isReady && this.items.length === 0
     },
     useInfiniteScroll() {
-      return this.infiniteScroll && this.offset > 0 && this.items.length >= this.size
+      return !this.noInfiniteScroll && this.offset > 0 && this.items.length >= this.size
     },
     fromElasticSearch() {
       return get(this, 'filter.fromElasticSearch', false)

--- a/src/components/filter/types/FilterAbstract.vue
+++ b/src/components/filter/types/FilterAbstract.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-import { camelCase, flatten, get, noop, reduce } from 'lodash'
+import { camelCase, flatten, get, reduce } from 'lodash'
 
 import FilterBoilerplate from '@/components/filter/FilterBoilerplate'
 import filters from '@/mixins/filters'
@@ -48,13 +48,6 @@ export default {
         },
         {}
       )
-    },
-    async bindOnRoot(...args) {
-      if (!this.mounted) {
-        await this.$nextTick()
-      }
-      // Bind the function with safety net in case no "root" is mounted yet
-      return get(this, 'root.$on', noop).call(this, ...args)
     }
   }
 }

--- a/src/components/filter/types/FilterDateRange.vue
+++ b/src/components/filter/types/FilterDateRange.vue
@@ -50,7 +50,7 @@
           </template>
         </date-picker>
         <column-chart-picker
-          v-if="items.length"
+          v-if="items.length > 1"
           v-model="selectedDate"
           class="mx-1"
           :data="items"

--- a/src/components/filter/types/FilterDateRange.vue
+++ b/src/components/filter/types/FilterDateRange.vue
@@ -7,13 +7,13 @@
     hide-contextualize
     hide-sort
   >
-    <template #items>
+    <template #items="{ items }">
       <div class="m-2">
         <date-picker
           ref="calendar"
           :key="locale"
           v-model="selectedDate"
-          class="date-picker d-flex flex-grow-1"
+          class="date-picker d-flex flex-grow-1 mb-3"
           :popover="{ visibility: 'focus' }"
           is-range
           is-dark
@@ -32,7 +32,7 @@
                 :alt="$t('filter.dateRange.startingDate')"
                 :placeholder="placeholderMask"
                 :value="inputValue.start"
-                class="filter--date-range__inputs__start"
+                class="filter--date-range__inputs__start form-control form-control-sm"
                 v-on="inputEvents.start"
               />
               <fa icon="arrow-right" fixed-width />
@@ -42,12 +42,13 @@
                 :alt="$t('filter.dateRange.endingDate')"
                 :placeholder="placeholderMask"
                 :value="inputValue.end"
-                class="filter--date-range__inputs__end"
+                class="filter--date-range__inputs__end form-control form-control-sm"
                 v-on="inputEvents.end"
               />
             </div>
           </template>
         </date-picker>
+        <column-chart-picker v-model="selectedDate" :data="items" :interval="filter.interval" />
       </div>
     </template>
   </filter-boilerplate>
@@ -58,6 +59,7 @@ import DatePicker from 'v-calendar/lib/components/date-picker.umd'
 import max from 'lodash/max'
 import min from 'lodash/min'
 
+import ColumnChartPicker from '@/components/ColumnChartPicker'
 import FilterAbstract from '@/components/filter/types/FilterAbstract'
 import FilterBoilerplate from '@/components/filter/FilterBoilerplate'
 
@@ -68,6 +70,7 @@ export default {
   name: 'FilterDateRange',
   components: {
     DatePicker,
+    ColumnChartPicker,
     FilterBoilerplate
   },
   extends: FilterAbstract,
@@ -133,7 +136,7 @@ export default {
         this.placeholderMask = this.$refs.calendar.$locale?.masks?.L
       }
     },
-    async updateFocus(e) {
+    async updateFocus() {
       await this.$nextTick()
       const start = this.$refs.dateStart
       const end = this.$refs.dateEnd

--- a/src/components/filter/types/FilterDateRange.vue
+++ b/src/components/filter/types/FilterDateRange.vue
@@ -6,6 +6,7 @@
     hide-show-more
     hide-contextualize
     hide-sort
+    no-infinite-scroll
   >
     <template #items="{ items }">
       <div class="m-2">
@@ -48,7 +49,13 @@
             </div>
           </template>
         </date-picker>
-        <column-chart-picker v-model="selectedDate" :data="items" :interval="filter.interval" />
+        <column-chart-picker
+          v-if="items.length"
+          v-model="selectedDate"
+          class="mx-1"
+          :data="items"
+          :interval="filter.interval"
+        />
       </div>
     </template>
   </filter-boilerplate>
@@ -84,14 +91,14 @@ export default {
       return [
         {
           key: 'today',
+          dates: new Date(),
           highlight: {
             style: {
               backgroundColor: 'var(--yellow-900)',
               opacity: '0.3',
               borderRadius: 'var(--rounded-full)'
             }
-          },
-          dates: new Date()
+          }
         }
       ]
     },

--- a/src/components/filter/types/FilterRecommendedBy.vue
+++ b/src/components/filter/types/FilterRecommendedBy.vue
@@ -6,7 +6,7 @@
     hide-exclude
     hide-sort
     hide-contextualize
-    :infinite-scroll="false"
+    no-infinite-scroll
     @reset-filter-values="resetFilterValues"
   >
     <template #all>

--- a/src/components/filter/types/FilterStarred.vue
+++ b/src/components/filter/types/FilterStarred.vue
@@ -6,7 +6,7 @@
     hide-exclude
     hide-contextualize
     hide-sort
-    :infinite-scroll="false"
+    no-infinite-scroll
     @reset-filter-values="resetFilterValues"
   >
     <template #items-group>

--- a/src/components/widget/WidgetDocumentsByCreationDate.vue
+++ b/src/components/widget/WidgetDocumentsByCreationDate.vue
@@ -223,6 +223,19 @@ export default {
     project() {
       this.selectedPath = this.dataDir
       this.init()
+    },
+    sliceRange({ start, end }, { start: prevStart, end: prevEnd }) {
+      // The new range size is bigger than the allowed ticks number
+      if (this.endTick - this.startTick > this.maxSliceTicks) {
+        // We are moving the range from the start
+        if (start < prevStart) {
+          this.sliceRange.end = this.ticksScale.invert(this.startTick + this.maxSliceTicks)
+        }
+        // We are moving the range from the end
+        if (end > prevEnd) {
+          this.sliceRange.start = this.ticksScale.invert(this.endTick - this.maxSliceTicks)
+        }
+      }
     }
   },
   async mounted() {

--- a/src/components/widget/WidgetDocumentsByCreationDate.vue
+++ b/src/components/widget/WidgetDocumentsByCreationDate.vue
@@ -40,6 +40,7 @@
             :snap="1 / aggregatedData.length"
             class="widget__content__chart__range"
             rounded
+            hover
             variant="secondary"
           >
             <column-chart
@@ -268,9 +269,7 @@ export default {
           'date_histogram',
           field,
           'agg_by_creation_date',
-          (sub) => {
-            return sub.agg('bucket_sort', { size, from }, 'bucket_sort_truncate')
-          },
+          (sub) => sub.agg('bucket_sort', { size, from }, 'bucket_sort_truncate'),
           this.aggDateHistogramOptions
         )
     },
@@ -326,12 +325,6 @@ export default {
       text-align: center;
       background: $card-bg;
       padding: $spacer;
-    }
-
-    &__chart {
-      &__range:hover {
-        background: $light;
-      }
     }
   }
 }

--- a/src/components/widget/WidgetDocumentsByCreationDate.vue
+++ b/src/components/widget/WidgetDocumentsByCreationDate.vue
@@ -12,8 +12,8 @@
           <span
             v-for="(value, interval) in intervals"
             :key="interval"
-            class="btn btn-link border py-1 px-2"
             :class="{ active: selectedInterval === interval }"
+            class="btn btn-link border py-1 px-2"
           >
             <span class="widget__header__selectors__selector" @click="setSelectedInterval(interval)">
               {{ $t('widget.creationDate.intervals.' + interval) }}
@@ -73,12 +73,9 @@
 
 <script>
 import bodybuilder from 'bodybuilder'
-import get from 'lodash/get'
-import clamp from 'lodash/clamp'
-import isFunction from 'lodash/isFunction'
-import uniqueId from 'lodash/uniqueId'
-import * as d3 from 'd3'
+import { clamp, get, uniqueId } from 'lodash'
 import { mapState } from 'vuex'
+import * as d3 from 'd3'
 
 import FilterDate from '@/store/filters/FilterDate'
 
@@ -107,8 +104,8 @@ export default {
       data: [],
       intervals: {
         year: {
-          xAxisFormat: '%Y',
-          tooltipFormat: '%Y',
+          xAxisFormat: d3.utcFormat('%Y'),
+          tooltipFormat: d3.utcFormat('%Y'),
           time: d3.utcYear,
           bins: d3.utcYears
         },
@@ -118,7 +115,7 @@ export default {
               return d3.utcFormat('%Y')(date)
             }
           },
-          tooltipFormat: '%B, %Y',
+          tooltipFormat: d3.utcFormat('%B, %Y'),
           time: d3.utcMonth,
           bins: d3.utcMonths
         }
@@ -144,12 +141,6 @@ export default {
     },
     dataDir() {
       return this.$config.get('mountedDataDir') || this.$config.get('dataDir')
-    },
-    selectedIntervalFormat() {
-      return this.intervals[this.selectedInterval].xAxisFormat
-    },
-    selectedTooltipFormat() {
-      return this.intervals[this.selectedInterval].tooltipFormat
     },
     selectedIntervalTime() {
       return this.intervals[this.selectedInterval].time
@@ -313,16 +304,10 @@ export default {
       this.init()
     },
     tooltipFormat(date) {
-      if (isFunction(this.selectedTooltipFormat)) {
-        return this.selectedTooltipFormat(date)
-      }
-      return d3.utcFormat(this.selectedTooltipFormat)(date)
+      return this.intervals[this.selectedInterval].tooltipFormat(date)
     },
     xAxisTickFormat(date) {
-      if (isFunction(this.selectedIntervalFormat)) {
-        return this.selectedIntervalFormat(date)
-      }
-      return d3.utcFormat(this.selectedIntervalFormat)(date)
+      return this.intervals[this.selectedInterval].xAxisFormat(date)
     }
   }
 }

--- a/src/components/widget/WidgetDocumentsByCreationDate.vue
+++ b/src/components/widget/WidgetDocumentsByCreationDate.vue
@@ -149,13 +149,6 @@ export default {
     selectedIntervalBins() {
       return this.intervals[this.selectedInterval].bins
     },
-    binByDate() {
-      return this.datesHistogram.reduce((res, bin) => {
-        const key = bin.x0.getTime()
-        res[key] = bin
-        return res
-      }, {})
-    },
     datesExtent() {
       return d3.extent(this.data, (d) => d.date)
     },
@@ -201,9 +194,6 @@ export default {
     },
     sliceRangeEnd() {
       return this.endTick / this.datesHistogram.length
-    },
-    maxstartingTick() {
-      return Math.max(0, this.datesHistogram.length - this.ticks)
     },
     isDatesRangeSliced() {
       return this.datesHistogram.length > this.ticks

--- a/src/components/widget/WidgetDocumentsByCreationDate.vue
+++ b/src/components/widget/WidgetDocumentsByCreationDate.vue
@@ -317,13 +317,9 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 .widget {
   min-height: 100%;
-
-  &__header__selectors__selector {
-    cursor: pointer;
-  }
 
   &__content {
     &__spinner {
@@ -331,6 +327,10 @@ export default {
       background: $card-bg;
       padding: $spacer;
     }
+  }
+
+  &:deep(.column-chart-picker .column-chart__columns__item) {
+    fill: $primary;
   }
 }
 </style>

--- a/src/components/widget/WidgetDocumentsByCreationDate.vue
+++ b/src/components/widget/WidgetDocumentsByCreationDate.vue
@@ -34,7 +34,7 @@
             </template>
           </column-chart>
           <column-chart-picker
-            v-if="sliceRange"
+            v-if="hasRangePicker"
             v-model="sliceRange"
             column-snap
             :throttle="0"
@@ -214,6 +214,9 @@ export default {
     },
     missings() {
       return this.missingData.reduce((sum, { doc_count: count }) => sum + count, 0)
+    },
+    hasRangePicker() {
+      return this.sliceRange && this.datesHistogram.length > Math.round(this.chartWidth / this.minColumnWidth) 
     }
   },
   watch: {

--- a/src/components/widget/WidgetDocumentsByCreationDate.vue
+++ b/src/components/widget/WidgetDocumentsByCreationDate.vue
@@ -46,7 +46,7 @@
         </div>
         <div v-if="missings" class="widget__content__missing small d-flex align-items-center mt-2">
           <p class="my-0 text-muted" :title="$t('widget.creationDate.missingTooltip')">
-            {{ $tc('widget.creationDate.missing', missing, { total: $n(missing) }) }}
+            {{ $tc('widget.creationDate.missing', missings, { total: $n(missings) }) }}
           </p>
         </div>
         <div v-else class="text-muted text-center">
@@ -216,7 +216,7 @@ export default {
       return this.missingData.reduce((sum, { doc_count: count }) => sum + count, 0)
     },
     hasRangePicker() {
-      return this.sliceRange && this.datesHistogram.length > Math.round(this.chartWidth / this.minColumnWidth) 
+      return this.sliceRange && this.datesHistogram.length > Math.round(this.chartWidth / this.minColumnWidth)
     }
   },
   watch: {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -278,7 +278,7 @@ export const router = {
                   name: 'project.view.add-documents',
                   path: 'add-documents',
                   components: {
-                    default: () => import('@/pages/ProjectViewAddDocuments.vue')
+                    default: () => import('@/pages/ProjectViewAddDocuments')
                   },
                   meta: {
                     allowedModes: ['LOCAL', 'EMBEDDED']
@@ -288,7 +288,7 @@ export const router = {
                   name: 'project.view.find-named-entities',
                   path: 'find-named-entities',
                   components: {
-                    default: () => import('@/pages/ProjectViewFindNamedEntities.vue')
+                    default: () => import('@/pages/ProjectViewFindNamedEntities')
                   },
                   meta: {
                     allowedModes: ['LOCAL', 'EMBEDDED']

--- a/src/store/filters/FilterDate.js
+++ b/src/store/filters/FilterDate.js
@@ -29,14 +29,14 @@ export default class FilterDate extends FilterDocument {
   body(body, { size = 0, interval = 'month' } = {}) {
     return body
       .query('match', 'type', 'Document')
-      .agg('date_histogram', this.key, FilterDate.getHistogramAggregation(interval), this.key, (a) => {
+      .agg('date_histogram', this.key, FilterDate.getIntervalAgg(interval), this.key, (a) => {
         return a.agg('bucket_sort', { size }, 'bucket_sort_truncate')
       })
   }
 
-  static getHistogramAggregation(interval = 'month') {
+  static getIntervalAgg(interval = 'month') {
     return {
-      ...FilterDate.getIntervalOptions(interval),
+      ...FilterDate.getIntervalOption(interval),
       min_doc_count: 1,
       order: {
         _key: 'desc'
@@ -44,16 +44,14 @@ export default class FilterDate extends FilterDocument {
     }
   }
 
-  static getIntervalOptions(interval = 'month') {
+  static getIntervalOption(interval = 'month') {
     switch (interval) {
       case 'day':
         return { interval: '1d', format: 'yyyy-MM-dd', missing: '1970-01-01' }
       case 'month':
         return { interval: '1M', format: 'yyyy-MM', missing: '1970-01' }
-      case 'year':
-        return { interval: '1y', format: 'yyyy', missing: '1970' }
       default:
-        return { interval: '1M', format: 'yyyy-MM', missing: '1970-01' }
+        return { interval: '1y', format: 'yyyy', missing: '1970' }
     }
   }
 }

--- a/src/store/filters/FilterDate.js
+++ b/src/store/filters/FilterDate.js
@@ -13,7 +13,7 @@ export default class FilterDate extends FilterDocument {
   queryBuilder(body, param, func) {
     return body.query('bool', (sub) => {
       param.values.forEach((date) => {
-        if (parseInt(date) === -62167219200000) {
+        if (parseInt(date) === 0) {
           sub.notQuery('exists', this.key)
         } else {
           const gte = new Date(parseInt(date))

--- a/src/store/filters/FilterDateRange.js
+++ b/src/store/filters/FilterDateRange.js
@@ -4,10 +4,10 @@ import moment from 'moment'
 import FilterDate from './FilterDate'
 
 export default class FilterDateRange extends FilterDate {
-  constructor(options) {
+  constructor({ interval = 'year', ...options }) {
     super(options)
     this.component = 'FilterDateRange'
-    this.interval = 'year'
+    this.interval = interval
   }
 
   itemLabel(item) {

--- a/src/store/filters/FilterNamedEntity.js
+++ b/src/store/filters/FilterNamedEntity.js
@@ -84,4 +84,8 @@ export default class FilterNamedEntity extends FilterType {
         return sub.agg('bucket_sort', { size, from }, 'bucket_truncate')
       })
   }
+
+  get isNamedEntityFilter() {
+    return true
+  }
 }

--- a/src/store/filters/FilterNamedEntity.js
+++ b/src/store/filters/FilterNamedEntity.js
@@ -84,8 +84,4 @@ export default class FilterNamedEntity extends FilterType {
         return sub.agg('bucket_sort', { size, from }, 'bucket_truncate')
       })
   }
-
-  get isNamedEntityFilter() {
-    return true
-  }
 }

--- a/src/store/filters/FilterText.js
+++ b/src/store/filters/FilterText.js
@@ -77,7 +77,8 @@ export default class FilterText {
       const filterType = this.isNamedEntityAggregation(body) ? 'Parent' : 'Child'
       const filterName = this.reverse ? 'Exclude' : 'Include'
       const options = { name: this.name, values: this.values, reverse: this.reverse }
-      return get(this, `add${filterType}${filterName}Filter`, noop)(body, options)
+      const method = `add${filterType}${filterName}Filter`
+      return this[method] ? this[method](body, options) : null
     }
   }
 

--- a/src/store/filters/FilterText.js
+++ b/src/store/filters/FilterText.js
@@ -1,6 +1,4 @@
 import get from 'lodash/get'
-import includes from 'lodash/includes'
-import some from 'lodash/some'
 
 // Private properties keys
 const _VALUES = typeof Symbol === 'function' ? Symbol('_values') : '_values'
@@ -73,30 +71,15 @@ export default class FilterText {
 
   addFilter(body) {
     if (this.hasValues()) {
-      if (this.reverse) {
-        if (this.isNamedEntityAggregation(body)) {
-          return this.addParentExcludeFilter(body, { name: this.name, values: this.values, reverse: this.reverse })
-        } else {
-          return this.addChildExcludeFilter(body, { name: this.name, values: this.values, reverse: this.reverse })
-        }
-      } else {
-        if (this.isNamedEntityAggregation(body)) {
-          return this.addParentIncludeFilter(body, { name: this.name, values: this.values, reverse: this.reverse })
-        } else {
-          return this.addChildIncludeFilter(body, { name: this.name, values: this.values, reverse: this.reverse })
-        }
-      }
+      const filterType = this.isNamedEntityFilter ? 'Parent' : 'Child'
+      const filterName = this.reverse ? 'Exclude' : 'Include'
+      const options = { name: this.name, values: this.values, reverse: this.reverse }
+      return this[`add${filterType}${filterName}Filter`](body, options)
     }
   }
 
   hasValues() {
     return this.values.length > 0
-  }
-
-  isNamedEntityAggregation(body) {
-    return some(['"must":{"term":{"type":"NamedEntity"}}', '"must":[{"term":{"type":"NamedEntity"}}'], (str) =>
-      includes(JSON.stringify(body.build()), str)
-    )
   }
 
   applyTo(body) {
@@ -105,6 +88,10 @@ export default class FilterText {
 
   bindRootState(rootState) {
     this[_ROOT_STATE] = this[_ROOT_STATE] || rootState
+  }
+
+  get isNamedEntityFilter() {
+    return false
   }
 
   get rootState() {

--- a/src/store/filters/FilterText.js
+++ b/src/store/filters/FilterText.js
@@ -1,5 +1,6 @@
 import get from 'lodash/get'
 import includes from 'lodash/includes'
+import noop from 'lodash/noop'
 import some from 'lodash/some'
 
 // Private properties keys
@@ -76,7 +77,7 @@ export default class FilterText {
       const filterType = this.isNamedEntityAggregation(body) ? 'Parent' : 'Child'
       const filterName = this.reverse ? 'Exclude' : 'Include'
       const options = { name: this.name, values: this.values, reverse: this.reverse }
-      return this[`add${filterType}${filterName}Filter`](body, options)
+      return get(this, `add${filterType}${filterName}Filter`, noop)(body, options)
     }
   }
 

--- a/src/store/filters/FilterText.js
+++ b/src/store/filters/FilterText.js
@@ -1,6 +1,5 @@
 import get from 'lodash/get'
 import includes from 'lodash/includes'
-import noop from 'lodash/noop'
 import some from 'lodash/some'
 
 // Private properties keys

--- a/src/store/filters/FilterText.js
+++ b/src/store/filters/FilterText.js
@@ -1,4 +1,6 @@
 import get from 'lodash/get'
+import includes from 'lodash/includes'
+import some from 'lodash/some'
 
 // Private properties keys
 const _VALUES = typeof Symbol === 'function' ? Symbol('_values') : '_values'
@@ -71,7 +73,7 @@ export default class FilterText {
 
   addFilter(body) {
     if (this.hasValues()) {
-      const filterType = this.isNamedEntityFilter ? 'Parent' : 'Child'
+      const filterType = this.isNamedEntityAggregation(body) ? 'Parent' : 'Child'
       const filterName = this.reverse ? 'Exclude' : 'Include'
       const options = { name: this.name, values: this.values, reverse: this.reverse }
       return this[`add${filterType}${filterName}Filter`](body, options)
@@ -82,16 +84,18 @@ export default class FilterText {
     return this.values.length > 0
   }
 
+  isNamedEntityAggregation(body) {
+    return some(['"must":{"term":{"type":"NamedEntity"}}', '"must":[{"term":{"type":"NamedEntity"}}'], (str) =>
+      includes(JSON.stringify(body.build()), str)
+    )
+  }
+
   applyTo(body) {
     this.addFilter(body)
   }
 
   bindRootState(rootState) {
     this[_ROOT_STATE] = this[_ROOT_STATE] || rootState
-  }
-
-  get isNamedEntityFilter() {
-    return false
   }
 
   get rootState() {

--- a/src/store/filters/index.js
+++ b/src/store/filters/index.js
@@ -60,8 +60,7 @@ export default [
       name: 'creationDate',
       key: 'metadata.tika_metadata_dcterms_created',
       icon: 'calendar-alt',
-      order: 50,
-      fromElasticSearch: false
+      order: 50
     }
   },
   {

--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -14,6 +14,9 @@ global.console = Object.assign(global.console, {
   info: jest.fn()
 })
 
+document.fonts = {}
+document.fonts.ready = Promise.resolve()
+
 window.matchMedia = jest.fn().mockImplementation((query) => {
   return {
     matches: false,

--- a/tests/unit/specs/components/ColumnChartPicker.spec.js
+++ b/tests/unit/specs/components/ColumnChartPicker.spec.js
@@ -1,0 +1,56 @@
+import { createLocalVue, mount } from '@vue/test-utils'
+
+import ColumnChartPicker from '@/components/ColumnChartPicker'
+import { Core } from '@/core'
+
+describe('ColumnChartPicker.vue', () => {
+  const { i18n, localVue } = Core.init(createLocalVue()).useAll()
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(ColumnChartPicker, {
+      i18n,
+      localVue,
+      propsData: {
+        data: [
+          {
+            key: 1672531200000,
+            doc_count: 2
+          },
+          {
+            key: 1640995200000,
+            doc_count: 1
+          },
+          {
+            key: 1577836800000,
+            doc_count: 1
+          },
+          {
+            key: 1199145600000,
+            doc_count: 1
+          },
+          {
+            key: 0,
+            doc_count: 7
+          }
+        ],
+        interval: 'year',
+        value: {
+          start: 0,
+          end: 1
+        }
+      }
+    })
+  })
+
+  it('renders correctly', () => {
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('emits the "update" event when the range is changed', async () => {
+    await wrapper.setData({ range: [0.2, 0.8] })
+
+    expect(wrapper.emitted().update).toBeTruthy()
+    expect(wrapper.emitted().update[0]).toEqual([{ start: expect.any(Number), end: expect.any(Number) }])
+  })
+})

--- a/tests/unit/specs/components/ColumnChartPicker.spec.js
+++ b/tests/unit/specs/components/ColumnChartPicker.spec.js
@@ -1,5 +1,4 @@
 import { createLocalVue, mount } from '@vue/test-utils'
-
 import ColumnChartPicker from '@/components/ColumnChartPicker'
 import { Core } from '@/core'
 
@@ -52,5 +51,38 @@ describe('ColumnChartPicker.vue', () => {
 
     expect(wrapper.emitted().update).toBeTruthy()
     expect(wrapper.emitted().update[0]).toEqual([{ start: expect.any(Number), end: expect.any(Number) }])
+  })
+
+  it('computes the "aggregatedData" correctly', () => {
+    const aggregatedData = wrapper.vm.aggregatedData
+    expect(aggregatedData).toHaveLength(16)
+    expect(aggregatedData[0]).toEqual({ date: expect.any(Date), value: expect.any(Number) })
+  })
+
+  it('computes the "startYear" correctly', () => {
+    expect(wrapper.vm.startYear).toBe(2008)
+  })
+
+  it('computes the "endYear" correctly', () => {
+    expect(wrapper.vm.endYear).toBe(2023)
+  })
+
+  it('computes the "intervalTimesExtent" correctly', () => {
+    expect(wrapper.vm.intervalTimesExtent).toEqual([
+      new Date(Date.UTC(2008, 0, 1)).getTime(),
+      new Date(Date.UTC(2023, 11, 31, 23, 59, 59)).getTime()
+    ])
+  })
+
+  it('computes the "intervalDatesExtent" correctly', () => {
+    expect(wrapper.vm.intervalDatesExtent).toEqual([
+      new Date(Date.UTC(2008, 0, 1)),
+      new Date(Date.UTC(2023, 11, 31, 23, 59, 59))
+    ])
+  })
+
+  it('executes "isBucketValid" method correctly', () => {
+    expect(wrapper.vm.isBucketValid({ key: 1234567890 })).toBe(true)
+    expect(wrapper.vm.isBucketValid({ key: 0 })).toBe(false)
   })
 })

--- a/tests/unit/specs/components/ColumnChartPicker.spec.js
+++ b/tests/unit/specs/components/ColumnChartPicker.spec.js
@@ -1,4 +1,5 @@
 import { createLocalVue, mount } from '@vue/test-utils'
+
 import ColumnChartPicker from '@/components/ColumnChartPicker'
 import { Core } from '@/core'
 
@@ -50,7 +51,7 @@ describe('ColumnChartPicker.vue', () => {
     await wrapper.setData({ range: [0.2, 0.8] })
 
     expect(wrapper.emitted().update).toBeTruthy()
-    expect(wrapper.emitted().update[0]).toEqual([{ start: expect.any(Number), end: expect.any(Number) }])
+    expect(wrapper.emitted().update[0]).toEqual([{ start: expect.any(Date), end: expect.any(Date) }])
   })
 
   it('computes the "aggregatedData" correctly', () => {

--- a/tests/unit/specs/components/widget/WidgetDocumentsByCreationDate.spec.js
+++ b/tests/unit/specs/components/widget/WidgetDocumentsByCreationDate.spec.js
@@ -1,57 +1,67 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils'
 import { flushPromises } from 'tests/unit/tests_utils'
-import { IndexedDocument, letData } from 'tests/unit/es_utils'
 import esConnectionHelper from 'tests/unit/specs/utils/esConnectionHelper'
 
 import { Core } from '@/core'
 import WidgetDocumentsByCreationDate from '@/components/widget/WidgetDocumentsByCreationDate'
 
 describe('WidgetDocumentsByCreationDate.vue', () => {
-  const { index: project, es } = esConnectionHelper.build()
+  const { index: project, es: elasticsearch } = esConnectionHelper.build()
   const { index: anotherProject } = esConnectionHelper.build()
-
-  const api = { elasticsearch: es }
-  const { i18n, localVue, store, wait } = Core.init(createLocalVue(), api).useAll()
+  const { i18n, localVue, store, wait } = Core.init(createLocalVue(), { elasticsearch }).useAll()
   const propsData = { widget: { title: 'Hello world' } }
   let wrapper = null
 
-  beforeAll(() => store.commit('insights/project', project))
+  describe('with one valid creation date', () => {
+    beforeEach(() => {
+      store.commit('insights/project', project)
+      wrapper = shallowMount(WidgetDocumentsByCreationDate, { i18n, localVue, propsData, store, wait })
+    })
 
-  beforeEach(() => {
-    wrapper = shallowMount(WidgetDocumentsByCreationDate, { i18n, localVue, propsData, store, wait })
+    it('should be a Vue instance', () => {
+      expect(wrapper).toBeTruthy()
+    })
+
+    it('should rerun init on project change', async () => {
+      const init = jest.spyOn(wrapper.vm, 'init').mockImplementationOnce(jest.fn())
+      store.commit('insights/project', anotherProject)
+      await flushPromises()
+      expect(init).toBeCalledTimes(1)
+      store.commit('insights/project', project)
+      await flushPromises()
+      expect(init).toBeCalledTimes(2)
+    })
+
+    it('should display no message if no data are missing', async () => {
+      await wrapper.setData({
+        data: [
+          { date: new Date(2012, 1), key: 1328050800000, doc_count: 2 },
+          { date: new Date(2012, 2), key: 1330556400000, doc_count: 4 }
+        ]
+      })
+
+      expect(wrapper.find('.widget__content__missing').exists()).toBeFalsy()
+    })
+
+    it('should display a message if data are missing', async () => {
+      await wrapper.setData({
+        data: [
+          { date: new Date(2012, 1), key: 1328050800000, doc_count: 2 },
+          { date: new Date(2012, 2), key: 1330556400000, doc_count: 4 },
+          { date: new Date(1968, 0, 1), key: -63158400000, doc_count: 4 }
+        ]
+      })
+
+      expect(wrapper.find('.widget__content__missing').exists()).toBeTruthy()
+    })
   })
 
-  it('should be a Vue instance', () => {
-    expect(wrapper).toBeTruthy()
-  })
+  describe('with 3 valid creation date', () => {
+    beforeEach(() => {
+      store.commit('insights/project', anotherProject)
+      wrapper = shallowMount(WidgetDocumentsByCreationDate, { i18n, localVue, propsData, store, wait })
+    })
 
-  it('should filter data where creation date < 1970', async () => {
-    await letData(es)
-      .have(new IndexedDocument('document_01', project).withCreationDate('2019-08-19T00:00:00.000Z'))
-      .commit()
-    await letData(es)
-      .have(new IndexedDocument('document_02', project).withCreationDate('0000-01-01T00:00:00.000Z'))
-      .commit()
-    await letData(es)
-      .have(new IndexedDocument('document_03', project).withCreationDate('1968-01-01T00:00:00.000Z'))
-      .commit()
-
-    await wrapper.vm.loadData()
-
-    expect(wrapper.vm.data).toHaveLength(1)
-  })
-
-  it('should rerun init on project change', async () => {
-    const init = jest.spyOn(wrapper.vm, 'init')
-    store.commit('insights/project', anotherProject)
-    await flushPromises()
-    expect(init).toBeCalledTimes(1)
-    store.commit('insights/project', project)
-    await flushPromises()
-    expect(init).toBeCalledTimes(2)
-  })
-
-  describe('selectedInterval value and selectors', () => {
     it('should display 2 selectors', () => {
       expect(wrapper.findAll('.widget__header__selectors__selector')).toHaveLength(2)
     })
@@ -61,63 +71,9 @@ describe('WidgetDocumentsByCreationDate.vue', () => {
     })
 
     it('should change the value of the selectedInterval and reload data', async () => {
-      await letData(es)
-        .have(new IndexedDocument('document_01', project).withCreationDate('2019-08-01T00:00:00.000Z'))
-        .commit()
-      await letData(es)
-        .have(new IndexedDocument('document_02', project).withCreationDate('2019-07-01T00:00:00.000Z'))
-        .commit()
-      await letData(es)
-        .have(new IndexedDocument('document_03', project).withCreationDate('2019-06-01T00:00:00.000Z'))
-        .commit()
-
       await wrapper.vm.setSelectedInterval('year')
-
       expect(wrapper.vm.selectedInterval).toBe('year')
       expect(wrapper.vm.data).toHaveLength(0)
-    })
-  })
-
-  describe('missing data', () => {
-    it('should display no message if no data are missing', async () => {
-      await wrapper.setData({
-        data: [
-          { date: new Date('2012-02'), doc_count: 2 },
-          { date: new Date('2012-03'), doc_count: 4 }
-        ],
-        missing: 0
-      })
-
-      expect(wrapper.find('.widget__content__missing').exists()).toBeFalsy()
-    })
-
-    it('should display a message if data are missing', async () => {
-      await wrapper.setData({
-        data: [
-          { date: new Date('2012-02'), doc_count: 2 },
-          { date: new Date('2012-03'), doc_count: 4 }
-        ],
-        missing: 2
-      })
-
-      expect(wrapper.find('.widget__content__missing').exists()).toBeTruthy()
-    })
-
-    it('should count missing creation dates while loading data', async () => {
-      await letData(es)
-        .have(new IndexedDocument('document_01', project).withCreationDate('2019-08-19T00:00:00.000Z'))
-        .commit()
-      await letData(es)
-        .have(new IndexedDocument('document_02', project).withCreationDate('0000-01-01T00:00:00.000Z'))
-        .commit()
-      await letData(es)
-        .have(new IndexedDocument('document_03', project).withCreationDate('1968-01-01T00:00:00.000Z'))
-        .commit()
-
-      await wrapper.vm.loadData()
-      await flushPromises()
-
-      expect(wrapper.vm.missing).toBe(2)
     })
   })
 })

--- a/tests/unit/specs/store/modules/searchfilters.spec.js
+++ b/tests/unit/specs/store/modules/searchfilters.spec.js
@@ -256,7 +256,7 @@ describe('SearchFilters', () => {
       expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets[0].doc_count).toBe(1)
       expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets[1].key).toBe(1522540800000)
       expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets[1].doc_count).toBe(1)
-      expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets[2].key).toBe(-62135596800000)
+      expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets[2].key).toBe(0)
       expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets[2].doc_count).toBe(2)
     })
 

--- a/tests/unit/specs/store/modules/searchfilters.spec.js
+++ b/tests/unit/specs/store/modules/searchfilters.spec.js
@@ -251,13 +251,11 @@ describe('SearchFilters', () => {
 
       const response = await store.dispatch('search/queryFilter', { name, options: { size: 8 } })
 
-      expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets).toHaveLength(3)
-      expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets[0].key).toBe(1525132800000)
-      expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets[0].doc_count).toBe(1)
-      expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets[1].key).toBe(1522540800000)
-      expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets[1].doc_count).toBe(1)
-      expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets[2].key).toBe(0)
-      expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets[2].doc_count).toBe(2)
+      expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets).toHaveLength(2)
+      expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets[0].key).toBe(0)
+      expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets[0].doc_count).toBe(2)
+      expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets[1].key).toBe(1514764800000)
+      expect(response.aggregations['metadata.tika_metadata_dcterms_created'].buckets[1].doc_count).toBe(2)
     })
 
     it('should count only Document types and not the NamedEntities', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1156,10 +1156,10 @@
     eslint-plugin-vue "^9.9.0"
     prettier "^2.8.4"
 
-"@icij/murmur@3.7.1":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@icij/murmur/-/murmur-3.7.1.tgz#50f2d7c2be61b4b19c4563a429d52fa8db76599a"
-  integrity sha512-O1IwKm4N9YKEEnWa8QDC9hdBlFgy2qtrHd5ygl3i7yXcWQrLBxUQruRlw5N67yKVieYatrV8NyLoOFgdQN+oxw==
+"@icij/murmur@3.7.2":
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/@icij/murmur/-/murmur-3.7.2.tgz#241ed3b66fd9f5d88e825de9586c2663f56fcc67"
+  integrity sha512-N5150HVz1gJMuxNoCcZVTDWi9NrS2eQ1uKzbC9AEt/5rpNwmoAjvrejPqH+fg7dvqwTO+h5G9mQQlVqTU7p9EA==
   dependencies:
     "@fortawesome/fontawesome" "^1.1.4"
     "@fortawesome/fontawesome-svg-core" "^6.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1156,10 +1156,10 @@
     eslint-plugin-vue "^9.9.0"
     prettier "^2.8.4"
 
-"@icij/murmur@3.7.2":
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/@icij/murmur/-/murmur-3.7.2.tgz#241ed3b66fd9f5d88e825de9586c2663f56fcc67"
-  integrity sha512-N5150HVz1gJMuxNoCcZVTDWi9NrS2eQ1uKzbC9AEt/5rpNwmoAjvrejPqH+fg7dvqwTO+h5G9mQQlVqTU7p9EA==
+"@icij/murmur@3.7.5":
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/@icij/murmur/-/murmur-3.7.5.tgz#ea8335cf328584d061e303ee84bd92eeb7e58f4b"
+  integrity sha512-H+mna+4En/2ygveM9i3NQeTWXFK5sE80D2dEQEpEWx5mJ+InfQp8uJtzdIcL/mCsHW5+2XRw1SkJhCDVBeTOWw==
   dependencies:
     "@fortawesome/fontawesome" "^1.1.4"
     "@fortawesome/fontawesome-svg-core" "^6.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1156,10 +1156,10 @@
     eslint-plugin-vue "^9.9.0"
     prettier "^2.8.4"
 
-"@icij/murmur@3.9.2":
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/@icij/murmur/-/murmur-3.9.2.tgz#28b6673e3b3616aacb44bb4ce0ea608b4d1a564a"
-  integrity sha512-yc4/KlHsutXM+jWMFm+y8OCAGWtdd3wPq2P5GBzumP8raS95cDqvdAIdeS5+Bd8k8h7kRGDsuCCnDh8AI2Yr2A==
+"@icij/murmur@3.9.3":
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/@icij/murmur/-/murmur-3.9.3.tgz#b3ef0b3519e425d771a77683d220beda4bf9080c"
+  integrity sha512-F9UqYBgsN98Hoer+/HxdGTrHn2U1CmMHibl3DrvMjCjpPjPzjAJv4E6GKmx46Z+23nEMTxTvYZBQqDDBHAFuKg==
   dependencies:
     "@fortawesome/fontawesome" "^1.1.4"
     "@fortawesome/fontawesome-svg-core" "^6.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1156,10 +1156,10 @@
     eslint-plugin-vue "^9.9.0"
     prettier "^2.8.4"
 
-"@icij/murmur@3.6.2":
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/@icij/murmur/-/murmur-3.6.2.tgz#f74d06f6be43af53d85bf53119cc1d7921c3fe78"
-  integrity sha512-J+cd3MOO0Op17AfhRhkMcVz2cj1LzeXbprsu6jfQQz11q4Gyf3BF4akx9PuLcyGSQrP1yHZ/xC1BmENHsA7UTw==
+"@icij/murmur@3.7.1":
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/@icij/murmur/-/murmur-3.7.1.tgz#50f2d7c2be61b4b19c4563a429d52fa8db76599a"
+  integrity sha512-O1IwKm4N9YKEEnWa8QDC9hdBlFgy2qtrHd5ygl3i7yXcWQrLBxUQruRlw5N67yKVieYatrV8NyLoOFgdQN+oxw==
   dependencies:
     "@fortawesome/fontawesome" "^1.1.4"
     "@fortawesome/fontawesome-svg-core" "^6.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1156,10 +1156,10 @@
     eslint-plugin-vue "^9.9.0"
     prettier "^2.8.4"
 
-"@icij/murmur@3.7.5":
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/@icij/murmur/-/murmur-3.7.5.tgz#ea8335cf328584d061e303ee84bd92eeb7e58f4b"
-  integrity sha512-H+mna+4En/2ygveM9i3NQeTWXFK5sE80D2dEQEpEWx5mJ+InfQp8uJtzdIcL/mCsHW5+2XRw1SkJhCDVBeTOWw==
+"@icij/murmur@3.9.2":
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/@icij/murmur/-/murmur-3.9.2.tgz#28b6673e3b3616aacb44bb4ce0ea608b4d1a564a"
+  integrity sha512-yc4/KlHsutXM+jWMFm+y8OCAGWtdd3wPq2P5GBzumP8raS95cDqvdAIdeS5+Bd8k8h7kRGDsuCCnDh8AI2Yr2A==
   dependencies:
     "@fortawesome/fontawesome" "^1.1.4"
     "@fortawesome/fontawesome-svg-core" "^6.4.2"


### PR DESCRIPTION
## PR description

Add an histogram range picker on the creation date filter and creation date widget (see [#1041](https://github.com/ICIJ/datashare/issues/1041)).

## Changes

* chore: upgrade to Murmur 3.9.3 with the new `RangePicker` componet
* feat: add new `ColumnRangePicker` component
* feat: use the `ColumnRangePicker` component in `FilterDateRange`
* feat: use the `ColumnRangePicker` component in `WidgetDocumentByCreationDate`

## Preview

[Screencast from 18-10-2023 16:03:54.webm](https://github.com/ICIJ/datashare-client/assets/471176/b3269016-d2b4-4efe-8d75-e94e06ed60d3)

[Screencast from 18-10-2023 16:04:44.webm](https://github.com/ICIJ/datashare-client/assets/471176/4b8b4e69-2cd2-47a3-89de-a434b8908e1d)


