### PR TITLE
feat: new facet widgets for "authors", "content types" and "languages"

### DIFF
--- a/src/components/widget/WidgetDocumentsByCreationDate.vue
+++ b/src/components/widget/WidgetDocumentsByCreationDate.vue
@@ -1,11 +1,7 @@
 <template>
   <div class="widget">
-    <div
-      v-if="widget.title"
-      class="widget__header d-md-flex align-items-center"
-      :class="{ 'card-header': widget.card }"
-    >
-      <h4 class="m-0 flex-grow-1" v-html="widget.title"></h4>
+    <div v-if="widget.title" class="widget__header d-md-flex align-items-center" :class="{ 'card-body': widget.card }">
+      <h3 class="m-0 flex-grow-1 h5" v-html="widget.title"></h3>
       <div class="widget__header__selectors d-flex align-items-center">
         <slot name="selector" :selected-path="selectedPath" :set-selected-path="setSelectedPath"></slot>
         <div class="btn-group">

--- a/src/components/widget/WidgetDuplicates.vue
+++ b/src/components/widget/WidgetDuplicates.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="widget widget--duplicates">
-    <div v-if="widget.title" class="widget__header" :class="{ 'card-header': widget.card }">
-      <h4 class="m-0" v-html="widget.title"></h4>
+    <div v-if="widget.title" class="widget__header" :class="{ 'card-body': widget.card }">
+      <h3 class="m-0 h5" v-html="widget.title"></h3>
     </div>
     <div class="p-4">
       <v-wait for="duplicate-counters" transition="fade">

--- a/src/components/widget/WidgetFieldFacets.vue
+++ b/src/components/widget/WidgetFieldFacets.vue
@@ -1,0 +1,245 @@
+<template>
+  <div class="widget widget--field-facets">
+    <div v-if="widget.title" class="widget__header d-flex align-items-center" :class="{ 'card-body': widget.card }">
+      <fa v-if="widget.icon" :icon="widget.icon" fixed-width class="mr-2" />
+      <h3 class="m-0 p-0 h5" v-html="title"></h3>
+    </div>
+    <v-wait :for="loader" transition="fade">
+      <div slot="waiting" class="widget__spinner text-center p-4">
+        <fa icon="circle-notch" spin size="2x"></fa>
+      </div>
+      <div class="list-group widget__list" :class="{ 'list-group-flush': widget.card }">
+        <component
+          :is="item | itemComponent"
+          v-for="(item, i) in items"
+          :key="i"
+          class="list-group-item list-group-item-action widget__list__item"
+          :href="item.href"
+          :class="{ active: item.active }"
+        >
+          <div class="row no-gutters align-items-center">
+            <div class="widget__list__item__label col">
+              {{ item.label }}
+            </div>
+            <b-badge class="widget__list__item__count ml-auto" pill variant="dark">{{ $n(item.count) }}</b-badge>
+          </div>
+          <span class="widget__list__item__bar" :style="{ width: totalPercentage(item.count) }"></span>
+        </component>
+        <infinite-loading v-if="useInfiniteScroll" :identifier="infiniteScrollId" @infinite="loadNextPage">
+          <span slot="spinner"></span>
+          <span slot="no-results"></span>
+        </infinite-loading>
+        <div v-if="reachedTheEnd" class="text-muted p-3 text-center">
+          <span v-if="items.length">•</span>
+          <span v-else>{{ $t('widget.noData') }}</span>
+        </div>
+      </div>
+    </v-wait>
+  </div>
+</template>
+
+<script>
+import bodybuilder from 'bodybuilder'
+import { get, flatten, camelCase, noop, round, uniqueId } from 'lodash'
+import { mapState } from 'vuex'
+import InfiniteLoading from 'vue-infinite-loading'
+
+/**
+ * Widget to display a list of facets on the insights page.
+ */
+export default {
+  name: 'WidgetListGroup',
+  components: {
+    InfiniteLoading
+  },
+  filters: {
+    itemComponent({ href = null } = {}) {
+      return href ? 'a' : 'div'
+    }
+  },
+  props: {
+    /**
+     * The widget definition object.
+     */
+    widget: {
+      type: Object
+    },
+    bucketsSize: {
+      type: Number,
+      default: 50
+    }
+  },
+  data() {
+    return {
+      pages: [],
+      total: 0,
+      infiniteScrollId: uniqueId('infinite-scroll-')
+    }
+  },
+  computed: {
+    ...mapState('insights', ['project']),
+    // The items list is just a concatenation of all pages
+    items() {
+      return flatten(this.pages).map(this.bucketToItem)
+    },
+    field() {
+      return this.widget.field
+    },
+    routeQueryField() {
+      return this.widget.routeQueryField ?? 'q'
+    },
+    title() {
+      if (this.$te(this.titleTranslationKey)) {
+        return this.$t(this.titleTranslationKey)
+      }
+
+      return this.widget.title
+    },
+    titleTranslationKey() {
+      return `widget.${camelCase(this.widget.title)}.title`
+    },
+    loader() {
+      return uniqueId('loading-field-facets-')
+    },
+    offset() {
+      return this.pages.length * this.bucketsSize
+    },
+    nextOffset() {
+      return this.offset + this.bucketsSize
+    },
+    lastPage() {
+      return this.pages[this.pages.length - 1]
+    },
+    reachedTheEnd() {
+      return get(this, 'lastPage.length', 0) < this.bucketsSize
+    },
+    useInfiniteScroll() {
+      return this.offset > 0 && !this.reachedTheEnd
+    }
+  },
+  async mounted() {
+    await this.loadFirstPage()
+  },
+  methods: {
+    clearPages() {
+      this.pages.splice(0, this.pages.length)
+    },
+    async loadFirstPage() {
+      this.clearPages()
+      this.loadPageWithLoader()
+    },
+    async loadPageWithLoader() {
+      this.$wait.start(this.loader)
+      await this.loadPage()
+      this.$wait.end(this.loader)
+    },
+    async loadPage() {
+      const body = this.bodybuilderBase().build()
+      const preference = 'widget-field-facets-' + this.widget.name
+      const res = await this.$core.api.elasticsearch.search({ index: this.project, size: 0, body, preference })
+      const page = get(res, 'aggregations.facets.buckets', [])
+      this.total = get(res, 'hits.total.value', 0)
+      this.pages.push(page)
+    },
+    async loadNextPage($infiniteLoadingState) {
+      await this.loadPage()
+      // Did we reach the end?
+      const method = this.reachedTheEnd ? 'complete' : 'loaded'
+      // Call the right method (with "noop" as safety net in case the method can't be found)
+      return get($infiniteLoadingState, method, noop)()
+    },
+    bodybuilderBase() {
+      const size = this.nextOffset
+      return bodybuilder()
+        .size(0)
+        .rawOption('track_total_hits', true)
+        .query('match', 'type', 'Document')
+        .agg('terms', this.field, { size }, 'facets', (sub) => {
+          const from = this.offset
+          const size = this.bucketsSize
+          return sub.agg('bucket_sort', { size, from }, 'bucket_sort_truncate')
+        })
+    },
+    bucketToItem(bucket) {
+      const label = this.bucketToTranslation(bucket)
+      const query = this.bucketToQuery(bucket)
+      const count = get(bucket, 'doc_count', 0)
+      const { href } = this.$router.resolve({ name: 'search', query })
+      return { label, href, count }
+    },
+    bucketToQueryValue({ key }) {
+      if (this.routeQueryField === 'q') {
+        return `${this.field}:"${key}"`
+      }
+      return key
+    },
+    bucketToQuery(bucket) {
+      const value = this.bucketToQueryValue(bucket)
+      const indices = [this.project]
+      return { [this.routeQueryField]: value, indices }
+    },
+    bucketToTranslation(bucket) {
+      const translationKey = this.widget.bucketTranslation(bucket)
+      return this.$te(translationKey) ? this.$t(translationKey) : translationKey
+    },
+    totalPercentage(value) {
+      if (this.total > 0) {
+        return round((value / this.total) * 100, 2) + '%'
+      }
+      return '0%'
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@keyframes slidingBar {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(0%);
+  }
+}
+
+.widget {
+  &--field-facets {
+    min-height: 100%;
+  }
+
+  &__list {
+    max-height: 400px;
+    overflow: auto;
+
+    &__item {
+      color: $body-color;
+      min-width: 0;
+
+      &[href] {
+        color: $link-color;
+      }
+
+      &__label {
+        color: inherit;
+      }
+
+      &__bar {
+        animation: slidingBar 200ms forwards;
+        height: 3px;
+        background: currentColor;
+        position: absolute;
+        left: 0;
+        bottom: 0;
+        min-width: 1px;
+        transform: translateX(-100%);
+      }
+
+      @for $i from 0 through 100 {
+        &:nth-child(#{$i}) &__bar {
+          animation-delay: $i * 50ms;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/src/components/widget/WidgetFieldFacets.vue
+++ b/src/components/widget/WidgetFieldFacets.vue
@@ -63,7 +63,7 @@ export default {
      */
     widget: {
       type: Object,
-      default:()=>{}
+      default: () => {}
     },
     bucketsSize: {
       type: Number,
@@ -132,7 +132,7 @@ export default {
     },
     async loadFirstPage() {
       this.clearPages()
-     await this.loadPageWithLoader()
+      await this.loadPageWithLoader()
     },
     async loadPageWithLoader() {
       this.$wait.start(this.loader)

--- a/src/components/widget/WidgetFieldFacets.vue
+++ b/src/components/widget/WidgetFieldFacets.vue
@@ -62,7 +62,8 @@ export default {
      * The widget definition object.
      */
     widget: {
-      type: Object
+      type: Object,
+      default:()=>{}
     },
     bucketsSize: {
       type: Number,
@@ -122,8 +123,8 @@ export default {
       return this.offset > 0 && !this.reachedTheEnd
     }
   },
-  async mounted() {
-    await this.loadFirstPage()
+  mounted() {
+    return this.loadFirstPage()
   },
   methods: {
     clearPages() {
@@ -131,7 +132,7 @@ export default {
     },
     async loadFirstPage() {
       this.clearPages()
-      this.loadPageWithLoader()
+     await this.loadPageWithLoader()
     },
     async loadPageWithLoader() {
       this.$wait.start(this.loader)

--- a/src/components/widget/WidgetFieldFacets.vue
+++ b/src/components/widget/WidgetFieldFacets.vue
@@ -17,8 +17,8 @@
           :href="item.href"
           :class="{ active: item.active }"
         >
-          <div class="row no-gutters align-items-center">
-            <div class="widget__list__item__label col">
+          <div class="d-flex align-items-center">
+            <div class="widget__list__item__label">
               {{ item.label }}
             </div>
             <b-badge class="widget__list__item__count ml-auto" pill variant="dark">{{ $n(item.count) }}</b-badge>
@@ -221,6 +221,7 @@ export default {
 
       &__label {
         color: inherit;
+        word-break: break-all;
       }
 
       &__bar {

--- a/src/components/widget/WidgetListGroup.vue
+++ b/src/components/widget/WidgetListGroup.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="widget widget--list-group">
-    <div v-if="widget.title" class="widget__header" :class="{ 'card-header': widget.card }">
-      <h4 class="m-0 h" v-html="widget.title"></h4>
+    <div v-if="widget.title" class="widget__header" :class="{ 'card-body': widget.card }">
+      <h3 class="m-0 h" v-html="widget.title"></h3>
     </div>
     <div class="list-group widget__list" :class="{ 'list-group-flush': widget.card }">
       <component

--- a/src/components/widget/WidgetNames.vue
+++ b/src/components/widget/WidgetNames.vue
@@ -44,7 +44,7 @@ export default {
   },
   computed: {
     total() {
-      return Math.pow(123, 3) + sum(values(this.entities))
+      return sum(values(this.entities))
     },
     humanTotal() {
       return humanNumber(this.total)

--- a/src/components/widget/WidgetText.vue
+++ b/src/components/widget/WidgetText.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="widget widget--text">
-    <div v-if="widget.title" class="widget__header" :class="{ 'card-header': widget.card }">
-      <h4 class="m-0 h" v-html="widget.title"></h4>
+    <div v-if="widget.title" class="widget__header" :class="{ 'card-body': widget.card }">
+      <h3 class="m-0 h5" v-html="widget.title"></h3>
     </div>
     <div class="widget__content lead" :class="{ 'card-body': widget.card }" v-html="content"></div>
   </div>

--- a/src/components/widget/WidgetTreeMap.vue
+++ b/src/components/widget/WidgetTreeMap.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="widget widget--tree-map">
-    <div v-if="widget.title" class="widget__header" :class="{ 'card-header': widget.card }">
+    <div v-if="widget.title" class="widget__header" :class="{ 'card-body': widget.card }">
       <h4 class="m-0 h" v-html="widget.title"></h4>
     </div>
     <div class="widget__content lead" :class="{ 'card-body': widget.card }">

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -913,6 +913,15 @@
     "noData": "No data",
     "noFolders": "No folders",
     "noEntities": "No named entities",
+    "languages": {
+      "title": "Languages"
+    },
+    "contentTypes": {
+      "title": "File types"
+    },
+    "authors": {
+      "title": "Authors"
+    },
     "barometer": {
       "document": "no documents | 1 document | %{total} documents",
       "amongWhich": "among which",

--- a/src/pages/ProjectViewInsights.vue
+++ b/src/pages/ProjectViewInsights.vue
@@ -46,13 +46,24 @@ export default {
 <style lang="scss" scoped>
 .project-view-insights {
   &__container {
-    margin-top: $spacer;
+    margin: $spacer-lg auto;
+
+    .row {
+      margin-right: $spacer-xxs;
+      margin-left: $spacer-xxs;
+
+      & > .col,
+      & > [class*='col-'] {
+        padding-right: $spacer-xxs;
+        padding-left: $spacer-xxs;
+      }
+    }
 
     &__widget {
       display: flex;
       flex-direction: row;
-      margin-bottom: $grid-gutter-width;
-      min-height: calc(100% - #{$grid-gutter-width});
+      margin-bottom: $spacer-xs;
+      min-height: calc(100% - #{$spacer-xs});
       position: relative;
     }
   }

--- a/src/pages/ProjectViewInsights.vue
+++ b/src/pages/ProjectViewInsights.vue
@@ -2,7 +2,7 @@
   <div class="project-view-insights">
     <div class="container project-view-insights__container">
       <b-row class="align-items-stretch">
-        <b-col v-for="(widget, index) in instantiatedWidgets" :key="index" :md="widget.cols">
+        <b-col v-for="(widget, index) in instantiatedWidgets" :key="index" :lg="widget.cols">
           <div class="project-view-insights__container__widget" :class="{ card: widget.card }">
             <component :is="widget.component" :widget="widget" class="flex-grow-1" />
           </div>

--- a/src/store/widgets/WidgetFieldFacets.js
+++ b/src/store/widgets/WidgetFieldFacets.js
@@ -1,0 +1,46 @@
+import { iteratee, isFunction } from 'lodash'
+
+import WidgetListGroup from '@/store/widgets/WidgetListGroup'
+import Component from '@/components/widget/WidgetFieldFacets'
+
+function castFunction(value) {
+  if (isFunction(value)) {
+    return value
+  }
+  return () => value
+}
+
+/**
+ * Widget to display a list of items or links on the insights page
+ */
+class WidgetFieldFacets extends WidgetListGroup {
+  /**
+   * Create a new WidgetFacets
+   * @param title=null {string} - The title of the widget
+   * @param field="type" {string} - Field to build the facet uppon
+   * @param icon=null {mixed}
+   * @param routeQueryField=null {string}
+   * @param bucketTranslation {mixed}
+   * @param options {Object} - See WidgetEmpty for others options
+   */
+  constructor({
+    title = null,
+    field = 'type',
+    icon = null,
+    routeQueryField = null,
+    bucketTranslation = iteratee('key'),
+    ...options
+  }) {
+    super(options)
+    this.title = title ?? options.name ?? field
+    this.field = field
+    this.icon = icon
+    this.routeQueryField = routeQueryField
+    this.bucketTranslation = castFunction(bucketTranslation)
+  }
+  get component() {
+    return Component
+  }
+}
+
+export default WidgetFieldFacets

--- a/src/store/widgets/index.js
+++ b/src/store/widgets/index.js
@@ -1,3 +1,5 @@
+import types from '@/utils/types'
+
 export { default as WidgetDiskUsage } from './WidgetDiskUsage'
 export { default as WidgetDocumentsByCreationDateByPath } from './WidgetDocumentsByCreationDateByPath'
 export { default as WidgetDuplicates } from './WidgetDuplicates'
@@ -10,6 +12,7 @@ export { default as WidgetProject } from './WidgetProject'
 export { default as WidgetSearchBar } from './WidgetSearchBar'
 export { default as WidgetText } from './WidgetText'
 export { default as WidgetTreeMap } from './WidgetTreeMap'
+export { default as WidgetFieldFacets } from './WidgetFieldFacets'
 
 const widgets = [
   {
@@ -54,6 +57,38 @@ const widgets = [
     cols: 12,
     type: 'WidgetDocumentsByCreationDateByPath',
     title: 'Number of documents by creation date'
+  },
+  {
+    name: 'languages',
+    order: 50,
+    icon: 'language',
+    card: true,
+    cols: 4,
+    field: 'language',
+    routeQueryField: 'f[language]',
+    bucketTranslation: ({ key }) => `filter.lang.${key}`,
+    type: 'WidgetFieldFacets'
+  },
+  {
+    name: 'content-types',
+    order: 50,
+    icon: 'file',
+    card: true,
+    cols: 4,
+    field: 'contentType',
+    routeQueryField: 'f[contentType]',
+    bucketTranslation: ({ key }) => types[key]?.label ?? key,
+    type: 'WidgetFieldFacets'
+  },
+  {
+    name: 'authors',
+    order: 50,
+    icon: 'users',
+    card: true,
+    cols: 4,
+    field: 'metadata.tika_metadata_dc_creator.keyword',
+    routeQueryField: null,
+    type: 'WidgetFieldFacets'
   }
 ]
 

--- a/tests/unit/specs/components/widget/WidgetFieldFacets.spec.js
+++ b/tests/unit/specs/components/widget/WidgetFieldFacets.spec.js
@@ -15,7 +15,7 @@ describe('WidgetFieldFacets.vue', () => {
   beforeAll(() => {
     store.commit('insights/project', project)
     // Mock all elasticsearch search calls using a mock
-    elasticsearch.search = jest.fn().mockImplementationOnce(() => {
+    elasticsearch.search = jest.fn().mockImplementation(() => {
       return Promise.resolve({
         aggregations: {
           facets: {
@@ -49,7 +49,6 @@ describe('WidgetFieldFacets.vue', () => {
       }
     })
     // Wait for the loading of the first page
-    await wrapper.vm.loadFirstPage()
     await flushPromises()
   })
 

--- a/tests/unit/specs/components/widget/WidgetFieldFacets.spec.js
+++ b/tests/unit/specs/components/widget/WidgetFieldFacets.spec.js
@@ -14,8 +14,8 @@ describe('WidgetFieldFacets.vue', () => {
 
   beforeAll(() => {
     store.commit('insights/project', project)
-    // Mock the axios API call using jest.mock
-    elasticsearch.search = jest.fn().mockImplementation(() => {
+    // Mock all elasticsearch search calls using a mock
+    elasticsearch.search = jest.fn().mockImplementationOnce(() => {
       return Promise.resolve({
         aggregations: {
           facets: {

--- a/tests/unit/specs/components/widget/WidgetFieldFacets.spec.js
+++ b/tests/unit/specs/components/widget/WidgetFieldFacets.spec.js
@@ -1,0 +1,93 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import { flushPromises } from 'tests/unit/tests_utils'
+import esConnectionHelper from 'tests/unit/specs/utils/esConnectionHelper'
+
+import * as widgets from '@/store/widgets'
+import WidgetFieldFacets from '@/components/widget/WidgetFieldFacets'
+import { Core } from '@/core'
+
+const { index: project, es: elasticsearch } = esConnectionHelper.build()
+const { localVue, router, store, wait, i18n } = Core.init(createLocalVue(), { elasticsearch }).useAll()
+
+describe('WidgetFieldFacets.vue', () => {
+  let wrapper
+
+  beforeAll(() => {
+    store.commit('insights/project', project)
+    // Mock the axios API call using jest.mock
+    elasticsearch.search = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        aggregations: {
+          facets: {
+            buckets: [
+              { key: 'foo', doc_count: 10 },
+              { key: 'bar', doc_count: 20 }
+            ]
+          }
+        },
+        hits: {
+          total: { value: 30 }
+        }
+      })
+    })
+  })
+
+  beforeEach(async () => {
+    wrapper = shallowMount(WidgetFieldFacets, {
+      localVue,
+      router,
+      store,
+      wait,
+      i18n,
+      propsData: {
+        widget: new widgets.WidgetFieldFacets({
+          title: 'Test Widget',
+          card: true,
+          field: 'contentType',
+          routeQueryField: 'contentType'
+        })
+      }
+    })
+    // Wait for the loading of the first page
+    await wrapper.vm.loadFirstPage()
+    await flushPromises()
+  })
+
+  it('renders the component', () => {
+    expect(wrapper.exists()).toBeTruthy()
+  })
+
+  it('has the correct class', () => {
+    expect(wrapper.classes()).toContain('widget--field-facets')
+  })
+
+  it('renders the title with card-header class when card is true', () => {
+    const titleElement = wrapper.find('.widget__header')
+    expect(titleElement.exists()).toBeTruthy()
+    expect(titleElement.classes()).toContain('card-body')
+    expect(titleElement.text()).toBe('Test Widget')
+  })
+
+  it('renders the title without card-header class when card is false', async () => {
+    await wrapper.setProps({
+      widget: new widgets.WidgetFieldFacets({
+        title: 'Test Widget',
+        card: false,
+        field: 'testField',
+        routeQueryField: 'contentType'
+      })
+    })
+
+    const titleElement = wrapper.find('.widget__header')
+    expect(titleElement.exists()).toBeTruthy()
+    expect(titleElement.classes()).not.toContain('card-header')
+    expect(titleElement.text()).toBe('Test Widget')
+  })
+
+  it('loads a page of data', () => {
+    // Assert that the data was loaded correctly
+    expect(wrapper.vm.total).toBe(30)
+    expect(wrapper.vm.items[0]).toEqual({ label: 'foo', count: 10, href: expect.stringContaining('contentType=foo') })
+    expect(wrapper.vm.items[1]).toEqual({ label: 'bar', count: 20, href: expect.stringContaining('contentType=bar') })
+  })
+})

--- a/tests/unit/specs/components/widget/WidgetListGroup.spec.js
+++ b/tests/unit/specs/components/widget/WidgetListGroup.spec.js
@@ -26,20 +26,20 @@ describe('WidgetListGroup.vue', () => {
     expect(wrapper.attributes('class')).toContain('widget--list-group')
   })
 
-  it('should contain a title with a `card-header` class', async () => {
+  it('should contain a title with a `card-body` class', async () => {
     const propsData = { widget: { title: 'Hello world', card: true } }
     const wrapper = shallowMount(WidgetListGroup, { localVue, store, propsData })
     await new Promise((resolve) => setImmediate(resolve))
 
-    expect(wrapper.find('.widget__header').attributes('class')).toContain('card-header')
+    expect(wrapper.find('.widget__header').attributes('class')).toContain('card-body')
   })
 
-  it('should contain a title without `card-header` class', async () => {
+  it('should contain a title without `card-body` class', async () => {
     const propsData = { widget: { title: 'Hello world', card: false } }
     const wrapper = shallowMount(WidgetListGroup, { localVue, store, propsData })
     await new Promise((resolve) => setImmediate(resolve))
 
-    expect(wrapper.find('.widget__header').attributes('class')).not.toContain('card-header')
+    expect(wrapper.find('.widget__header').attributes('class')).not.toContain('card-body')
   })
 
   it('should contain a 3 items', async () => {

--- a/tests/unit/specs/components/widget/WidgetText.spec.js
+++ b/tests/unit/specs/components/widget/WidgetText.spec.js
@@ -37,17 +37,17 @@ describe('WidgetText.vue', () => {
     expect(wrapper.find('.widget__header').text()).toBe('Hello world')
   })
 
-  it('should contain a title with a `card-header` class', () => {
+  it('should contain a title with a `card-body` class', () => {
     const widget = { title: 'Hello world', card: true }
     const propsData = { widget }
     const wrapper = shallowMount(WidgetText, { localVue, store, propsData })
-    expect(wrapper.find('.widget__header').attributes('class')).toContain('card-header')
+    expect(wrapper.find('.widget__header').attributes('class')).toContain('card-body')
   })
 
-  it('should contain a title without `card-header` class', () => {
+  it('should contain a title without `card-body` class', () => {
     const widget = { title: 'Hello world', card: false }
     const propsData = { widget }
     const wrapper = shallowMount(WidgetText, { localVue, store, propsData })
-    expect(wrapper.find('.widget__header').attributes('class')).not.toContain('card-header')
+    expect(wrapper.find('.widget__header').attributes('class')).not.toContain('card-body')
   })
 })


### PR DESCRIPTION
## PR description

This PR adds 3 news widgets to explore value facets for "authors", "content type" and "language". All those widgets use the same `WidgetFieldFacets` class and display an horizontal
bar chart next to the value (see https://github.com/ICIJ/datashare/issues/1226).

## Changes

* feat: new  `WidgetFieldFacets` class and component
* feat: remove `card-header` from all widgets for lighter display
* feat: narrow the spacing between widgets

## Preview

![Screenshot from 2023-10-19 11-40-25](https://github.com/ICIJ/datashare-client/assets/471176/54e219b8-ee41-4f62-b5e1-bc4bbe224ad7)
