### PR TITLE
feat: search from the widgets in project page

### DIFF
--- a/src/components/MountedDataLocation.vue
+++ b/src/components/MountedDataLocation.vue
@@ -28,7 +28,7 @@
       </div>
     </b-popover>
     <b-modal id="mounting-data-location-tree-view" lazy scrollable hide-header hide-footer body-class="p-0" size="lg">
-      <tree-view v-model="path" :projects="projects" size count></tree-view>
+      <tree-view v-model="path" :projects="projects" size count searchable></tree-view>
     </b-modal>
   </div>
 </template>

--- a/src/components/TreeView.vue
+++ b/src/components/TreeView.vue
@@ -14,7 +14,7 @@
             <router-link
               v-if="searchable"
               :to="searchInPathRoute(path)"
-              class="tree-view__header__search ml-2 btn-outline-primary btn btn-sm rounded-pill"
+              class="tree-view__header__search ml-2 btn-primary btn btn-sm rounded-pill"
             >
               <fa icon="search"></fa>
               {{ $t('treeView.searchPath') }}

--- a/src/components/TreeView.vue
+++ b/src/components/TreeView.vue
@@ -625,7 +625,6 @@ export default {
 
       &:hover &__search.btn {
         display: inline-block;
-
       }
 
       &__bar {

--- a/src/components/widget/WidgetDiskUsage.vue
+++ b/src/components/widget/WidgetDiskUsage.vue
@@ -13,7 +13,7 @@
       </p>
     </v-wait>
     <b-modal id="modal-disk-usage-details" lazy scrollable hide-header hide-footer body-class="p-0" size="lg">
-      <tree-view v-model="path" :projects="[project]" count size>
+      <tree-view v-model="path" :projects="[project]" count size searchable>
         <template #above>
           <b-collapse :visible="path === dataDir">
             <div class="my-2 mx-3 alert alert-warning p-2">

--- a/src/components/widget/WidgetDocumentsByCreationDate.vue
+++ b/src/components/widget/WidgetDocumentsByCreationDate.vue
@@ -28,6 +28,7 @@
             :data="aggregatedDataSlice"
             :max-value="maxValue"
             :x-axis-tick-format="xAxisTickFormat"
+            @select="searchInterval"
           >
             <template #tooltip="{ datum: { date, value: total } }">
               <h5 class="m-0">{{ tooltipFormat(date) }}</h5>
@@ -313,6 +314,23 @@ export default {
       const endMonth = (this.selectedInterval === 'year' ? 11 : date.getMonth()) + monthOffset
       const endDay = this.selectedInterval !== 'day' ? 0 : date.getDate()
       return new Date(Date.UTC(date.getFullYear(), endMonth, endDay, 23, 59, 59))
+    },
+    searchInterval({ date }) {
+      const bin = this.dateToBin(date)
+      const query = this.binToQuery(bin)
+      this.$router.push({ name: 'search', query })
+    },
+    dateToBin(date) {
+      return this.datesHistogram.find(({ x0, x1 }) => date >= x0 && date < x1)
+    },
+    binToQueryValues({ x0, x1 }) {
+      return [x0.getTime(), x1.getTime()]
+    },
+    binToQuery(bin) {
+      const indices = [this.project]
+      const routeQueryField = 'f[creationDate]'
+      const values = this.binToQueryValues(bin)
+      return { [routeQueryField]: values, indices }
     }
   }
 }
@@ -330,8 +348,9 @@ export default {
     }
   }
 
-  &:deep(.column-chart-picker .column-chart__columns__item) {
+  &:deep(.column-chart__columns__item) {
     fill: $primary;
+    cursor: pointer;
   }
 }
 </style>

--- a/src/components/widget/WidgetDocumentsByCreationDate.vue
+++ b/src/components/widget/WidgetDocumentsByCreationDate.vue
@@ -226,7 +226,10 @@ export default {
       this.selectedPath = this.dataDir
       this.init()
     },
-    sliceRange({ start, end }, { start: prevStart, end: prevEnd }) {
+    sliceRange(value, previousValue) {
+      // Safe access to the slice range values
+      const { start, end } = value ?? { start: 0, end: 1 }
+      const { start: prevStart = 0, end: prevEnd = 1 } = previousValue ?? { start: 0, end: 1 }
       // The new range size is bigger than the allowed ticks number
       if (this.endTick - this.startTick > this.maxSliceTicks) {
         // We are moving the range from the start

--- a/src/components/widget/WidgetDocumentsByCreationDate.vue
+++ b/src/components/widget/WidgetDocumentsByCreationDate.vue
@@ -24,6 +24,7 @@
         </div>
         <div v-if="data.length > 0" class="widget__content__chart align-items-center">
           <column-chart
+            hover
             :chart-height-ratio="0.4"
             :data="aggregatedDataSlice"
             :max-value="maxValue"

--- a/src/components/widget/WidgetFileBarometer.vue
+++ b/src/components/widget/WidgetFileBarometer.vue
@@ -9,8 +9,10 @@
         </strong>
         <template v-if="onDisk != total">
           {{ $t('widget.barometer.amongWhich') }}
-          <span :title="onDisk">{{ onDisk | humanNumber($t('human.number')) }}</span>
-          {{ $t('widget.barometer.onDisk') }}
+          <router-link :to="searchOnDiskRoute">
+            {{ onDisk | humanNumber($t('human.number')) }}
+            {{ $t('widget.barometer.onDisk') }}
+          </router-link>
         </template>
       </p>
     </v-wait>
@@ -40,6 +42,13 @@ export default {
     return {
       onDisk: null,
       total: null
+    }
+  },
+  computed: {
+    searchOnDiskRoute() {
+      const indices = [this.$store.state.insights.project]
+      const query = { 'f[extractionLevel]': 0, indices }
+      return { name: 'search', query }
     }
   },
   async created() {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1026,6 +1026,7 @@
     "docs": "doc | docs",
     "datadir": "Home",
     "all": "All",
+    "searchPath": "Search in this directory",
     "includingIndividualDocuments": "including individual documents"
   },
   "quickItemNav": {

--- a/tests/unit/specs/components/TreeView.spec.js
+++ b/tests/unit/specs/components/TreeView.spec.js
@@ -164,7 +164,39 @@ describe('TreeView.vue', () => {
 
       expect(spyLoadTree).toBeCalledTimes(1)
     })
+
+    it('should show a search button in the header', async () => {
+      await wrapper.setProps({ searchable: true })
+      await wrapper.vm.loadData({ clearPages: true })
+      expect(wrapper.find('.tree-view__header__search').exists()).toBeTruthy()
+    })
+
+    it('should not show a search button in the header', async () => {
+      await wrapper.setProps({ searchable: false })
+      await wrapper.vm.loadData({ clearPages: true })
+      expect(wrapper.find('.tree-view__header__search').exists()).toBeFalsy()
+    })
+
+    it('should show a search button in each items', async () => {
+      await wrapper.setProps({ searchable: true })
+      await wrapper.setData({
+        pages: [
+          {
+            aggregations: {
+              byDirname: {
+                buckets: [
+                  { key: 'bar', contentLength: { value: 1024 } },
+                  { key: 'baz', contentLength: { value: 1024 } }
+                ]
+              }
+            }
+          }
+        ]
+      })
+      expect(wrapper.findAll('.tree-view__directories__item__search').length).toBe(2)
+    })
   })
+
   describe('Windows', () => {
     let wrapper = null
     const { index, es } = esConnectionHelper.build('spec', true)

--- a/tests/unit/specs/components/widget/WidgetDocumentsByCreationDate.spec.js
+++ b/tests/unit/specs/components/widget/WidgetDocumentsByCreationDate.spec.js
@@ -75,5 +75,19 @@ describe('WidgetDocumentsByCreationDate.vue', () => {
       expect(wrapper.vm.selectedInterval).toBe('year')
       expect(wrapper.vm.data).toHaveLength(0)
     })
+
+    it('should give the correct search query params for a date', async () => {
+      await wrapper.setData({
+        data: [
+          { date: new Date(2012, 0), key: 1325372400000, doc_count: 2 },
+          { date: new Date(2013, 0), key: 1356994800000, doc_count: 4 },
+          { date: new Date(2014, 0), key: 1388534400000, doc_count: 4 }
+        ]
+      })
+
+      const bin = wrapper.vm.dateToBin(new Date(2013, 0))
+      const query = wrapper.vm.binToQuery(bin)
+      expect(query).toStrictEqual({ 'f[creationDate]': [1356998400000, 1388534400000], indices: [anotherProject] })
+    })
   })
 })


### PR DESCRIPTION
## PR description

This PR aims at making all widgets on the search page linking to the search (see https://github.com/ICIJ/datashare/issues/1229).

## Changes

* feat: add link to files on disk filter from `WidgetFileBarometer`
* feat: add link to path filter from `TreeView` in `WidgetDiskUsage`
* feat: add link to creation date filter from `WidgetDocumentsByCreationDate`