### PR TITLE
refactor: cache get batch search list on polling

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,4 +1,4 @@
-import { isNull, join, map, omitBy, replace, trim, toLower } from 'lodash'
+import { isNull, join, map, omitBy, replace, toLower, trim } from 'lodash'
 
 const Method = Object.freeze({
   POST: 'POST',
@@ -162,9 +162,28 @@ export class Api {
     batchDate = null,
     publishState = null
   ) {
-    const data = { from, size, sort, order, query, field, project, state, batchDate, publishState }
-    return this.sendActionAsText('/api/batch/search', { method: Method.POST, data })
+    const searchParams = new URLSearchParams()
+
+    const queryData = {
+      from,
+      size,
+      sort,
+      order,
+      query,
+      field,
+      project: project.length ?? null,
+      state: state.length ?? null,
+      batchDate,
+      publishState
+    }
+    for (const q in queryData) {
+      if (queryData[q]) {
+        searchParams.append(q, queryData[q])
+      }
+    }
+    return this.sendActionAsText('/api/batch/search?' + searchParams, { method: Method.GET })
   }
+
   getBatchSearchResults(
     batchId,
     from = 0,

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -286,6 +286,11 @@ export class Api {
   textLanguages() {
     return this.sendAction('/api/settings/text/languages')
   }
+
+  getMappings(projectIds, fields) {
+    return this.sendActionAsText(`/api/index/search/${projectIds}/_mapping/field/${fields}`, { method: Method.GET })
+  }
+
   async sendAction(url, config = {}) {
     try {
       const r = await this.axios?.request({ url: Api.getFullUrl(url), ...config })

--- a/src/components/SearchResultsHeader.vue
+++ b/src/components/SearchResultsHeader.vue
@@ -165,6 +165,9 @@ export default {
   },
   computed: {
     ...mapState('search', ['from', 'response', 'size', 'sort']),
+    fields() {
+      return this.keywordSorts.map(this.getSortField).join(',')
+    },
     firstDocument() {
       return this.lastDocument === 0 ? 0 : this.from + 1
     },
@@ -221,10 +224,9 @@ export default {
       return this.sorts.filter(this.isSortVisible)
     }
   },
-  async mounted() {
-    const fields = this.keywordSorts.map(this.getSortField).join(',')
+  async created() {
     // We need to load all mappings to filter out non-sortable fields
-    this.mappings = await this.$core.api.sendAction(`/api/index/search/${this.projectIds}/_mapping/field/${fields}`)
+    this.mappings = await this.$core.api.getMappings(this.projectIds, this.fields)
     // Force page to scroll top at each load
     // Specially for pagination
     document.body.scrollTop = document.documentElement.scrollTop = 0

--- a/tests/unit/specs/api/index.spec.js
+++ b/tests/unit/specs/api/index.spec.js
@@ -375,6 +375,19 @@ describe('Datashare backend client', () => {
     })
   })
 
+  it('should return a backend response to mappings', async () => {
+    const projectIds = ['prj1', 'prj2']
+    const fields = ['title', 'title2']
+    json = await api.getMappings(projectIds, fields)
+    expect(json).toEqual({})
+    expect(mockAxios.request).toBeCalledWith({
+      url: Api.getFullUrl(`/api/index/search/prj1,prj2/_mapping/field/title,title2`),
+      method: 'GET',
+      responseType: 'text',
+      headers: { 'Content-Type': 'text/plain;charset=UTF-8' }
+    })
+  })
+
   it('should emit an error if the backend response has a bad status', async () => {
     const error = new Error('Forbidden')
     mockAxios.request.mockReturnValue(Promise.reject(error))

--- a/tests/unit/specs/components/SearchResultsHeader.spec.js
+++ b/tests/unit/specs/components/SearchResultsHeader.spec.js
@@ -11,7 +11,11 @@ describe('SearchResultsHeader.vue', () => {
   let wrapper, i18n, localVue, router, store, api
 
   beforeAll(() => {
-    api = { runBatchDownload: jest.fn(), elasticsearch: es, sendAction: jest.fn() }
+    api = {
+      runBatchDownload: jest.fn(),
+      elasticsearch: es,
+      getMappings: jest.fn()
+    }
     const core = Core.init(createLocalVue(), api).useAll()
     i18n = core.i18n
     localVue = core.localVue


### PR DESCRIPTION
Before merge: 
- [ ] merge ICIJ/datashare#1242

# Changes
:rocket: Update getBatchSearches query to use GET verb and query params API endpoint

 :sandwich: Side refactor : Create getMappings API method
