### PR TITLE
feat: add tab save

### DIFF
--- a/src/components/SearchDocumentNavbar.vue
+++ b/src/components/SearchDocumentNavbar.vue
@@ -105,7 +105,7 @@ export default {
     previousDocument() {
       return this.response.hits[this.documentIndex - 1]
     },
-    nextDocument() {$attrs
+    nextDocument() {
       return this.response.hits[this.documentIndex + 1]
     }
   },
@@ -117,7 +117,7 @@ export default {
   },
   methods: {
     back() {
-      return this.$router.push({ name: 'search', query:this.query })
+      return this.$router.push({ name: 'search', query: this.query })
     },
     saveComponentHeight() {
       const height = `${this.$el.offsetHeight}px`

--- a/src/components/SearchDocumentNavbar.vue
+++ b/src/components/SearchDocumentNavbar.vue
@@ -31,6 +31,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
 import findIndex from 'lodash/findIndex'
 import first from 'lodash/first'
 import last from 'lodash/last'
@@ -58,6 +59,7 @@ export default {
     }
   },
   computed: {
+    ...mapState('search', ['tab']),
     doc() {
       return this.$store.state.document.doc
     },
@@ -122,7 +124,7 @@ export default {
     goToDocument(document) {
       if (document) {
         const params = document.routerParams
-        const query = { q: this.$store.state.search.query }
+        const query = { q: this.$store.state.search.query, tab: this.tab }
         return this.$router.push({ name: 'document', params, query })
       }
     },

--- a/src/components/SearchDocumentNavbar.vue
+++ b/src/components/SearchDocumentNavbar.vue
@@ -105,7 +105,7 @@ export default {
     previousDocument() {
       return this.response.hits[this.documentIndex - 1]
     },
-    nextDocument() {
+    nextDocument() {$attrs
       return this.response.hits[this.documentIndex + 1]
     }
   },
@@ -116,6 +116,9 @@ export default {
     this.saveComponentHeight()
   },
   methods: {
+    back() {
+      return this.$router.push({ name: 'search', query:this.query })
+    },
     saveComponentHeight() {
       const height = `${this.$el.offsetHeight}px`
       // Save component height in a CSS variable after it's been update

--- a/src/components/SearchResultsGrid.vue
+++ b/src/components/SearchResultsGrid.vue
@@ -15,7 +15,7 @@
           />
           <router-link
             class="flex-grow-1 search-results-grid__items__item__thumbnail"
-            :to="{ name: 'document', params: document.routerParams, query: { q: query } }"
+            :to="{ name: 'document', params: document.routerParams, query: { q: query, tab } }"
           >
             <document-thumbnail :document="document" crop size="md" />
           </router-link>
@@ -68,7 +68,7 @@ export default {
     SearchResultsHeader
   },
   computed: {
-    ...mapState('search', ['query', 'response']),
+    ...mapState('search', ['query', 'response', 'tab']),
     hasResults() {
       return this.response.hits.length > 0
     },

--- a/src/components/SearchResultsListLink.vue
+++ b/src/components/SearchResultsListLink.vue
@@ -1,7 +1,7 @@
 <template>
   <router-link
     class="search-results-list-link d-flex align-self-stretch flex-nowrap"
-    :to="{ name: 'document', params, query: { q: query, tab: tab } }"
+    :to="{ name: 'document', params, query: { q: query, tab } }"
   >
     <document-thumbnail :document="document" class="search-results-list-link__thumbnail" crop lazy />
     <div class="search-results-list-link__wrapper">

--- a/src/components/SearchResultsListLink.vue
+++ b/src/components/SearchResultsListLink.vue
@@ -1,7 +1,7 @@
 <template>
   <router-link
     class="search-results-list-link d-flex align-self-stretch flex-nowrap"
-    :to="{ name: 'document', params, query: { q: query } }"
+    :to="{ name: 'document', params, query: { q: query, tab: tab } }"
   >
     <document-thumbnail :document="document" class="search-results-list-link__thumbnail" crop lazy />
     <div class="search-results-list-link__wrapper">
@@ -62,7 +62,7 @@ export default {
     }
   },
   computed: {
-    ...mapState('search', ['indices', 'query']),
+    ...mapState('search', ['indices', 'query', 'tab']),
     folder() {
       const parts = this.document.get('_source.path', '').split('/')
       parts.splice(-1, 1)

--- a/src/components/SearchResultsTable.vue
+++ b/src/components/SearchResultsTable.vue
@@ -63,7 +63,7 @@
         </template>
         <template #cell(path)="{ item }">
           <router-link
-            :to="{ name: 'document', params: item.routerParams, query: { q: query, tab: tab } }"
+            :to="{ name: 'document', params: item.routerParams, query: { q: query, tab } }"
             class="search-results-table__items__row__title"
           >
             <document-sliced-name :document="item" active-text-truncate show-subject />

--- a/src/components/SearchResultsTable.vue
+++ b/src/components/SearchResultsTable.vue
@@ -63,7 +63,7 @@
         </template>
         <template #cell(path)="{ item }">
           <router-link
-            :to="{ name: 'document', params: item.routerParams, query: { q: query } }"
+            :to="{ name: 'document', params: item.routerParams, query: { q: query, tab: tab } }"
             class="search-results-table__items__row__title"
           >
             <document-sliced-name :document="item" active-text-truncate show-subject />
@@ -128,7 +128,7 @@ export default {
     }
   },
   computed: {
-    ...mapState('search', ['indices', 'query', 'response']),
+    ...mapState('search', ['indices', 'query', 'response', 'tab']),
     isAllSelected() {
       return this.response.hits.length === this.selected.length
     },

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -296,6 +296,7 @@
       "MARATHI": "Marathi",
       "MARSHALLESE": "Marshallese",
       "MONGOLIAN": "Mongolian",
+      "MOLDOVAN": "Moldovan",
       "NAURU": "Nauru",
       "NAVAJO": "Navajo",
       "NORTHNDEBELE": "North Ndebele",

--- a/src/pages/DocumentView.vue
+++ b/src/pages/DocumentView.vue
@@ -129,7 +129,7 @@ export default {
   data() {
     return {
       activeTab: TAB_NAME.EXTRACTED_TEXT,
-      tabsThroughtPipeline: []
+      tabsThroughPipeline: []
     }
   },
   computed: {
@@ -138,7 +138,7 @@ export default {
       return this.visibleTabs.map((t) => t.name)
     },
     visibleTabs() {
-      return filter(this.tabsThroughtPipeline, (t) => !t.hidden)
+      return filter(this.tabsThroughPipeline, (t) => !t.hidden)
     },
     tabsPipeline() {
       return this.$store.getters['pipelines/applyPipelineChainByCategory']('document-view-tabs')
@@ -257,9 +257,9 @@ export default {
     async setTabs() {
       if (this.doc) {
         // This apply the document-view-tabs pipeline everytime a document is loaded
-        this.tabsThroughtPipeline = await this.tabsPipeline(this.tabs, this.doc)
+        this.tabsThroughPipeline = await this.tabsPipeline(this.tabs, this.doc)
       } else {
-        this.tabsThroughtPipeline = []
+        this.tabsThroughPipeline = []
       }
     },
     getDownloadStatus() {

--- a/src/pages/DocumentView.vue
+++ b/src/pages/DocumentView.vue
@@ -270,7 +270,7 @@ export default {
     },
     activateTab(name = TAB_NAME.EXTRACTED_TEXT) {
       if (findIndex(this.visibleTabs, { name }) > -1) {
-        this.activeTab = name
+        this.$set(this, 'activeTab', name)
         this.$root.$emit('document::content::changed')
         return name
       }
@@ -283,11 +283,11 @@ export default {
     },
     goToPreviousTab() {
       const indexPreviousActiveTab = this.indexActiveTab === 0 ? this.visibleTabs.length - 1 : this.indexActiveTab - 1
-      this.activeTab = this.visibleTabs[indexPreviousActiveTab].name
+      this.$set(this, 'activeTab', this.visibleTabs[indexPreviousActiveTab].name)
     },
     goToNextTab() {
       const indexNextActiveTab = this.indexActiveTab === this.visibleTabs.length - 1 ? 0 : this.indexActiveTab + 1
-      this.activeTab = this.visibleTabs[indexNextActiveTab].name
+      this.$set(this, 'activeTab', this.visibleTabs[indexNextActiveTab].name)
     },
     getComponentIfActive({ component, name }) {
       if (this.isTabActive(name)) {

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -160,6 +160,7 @@ export const getters = {
       sort: state.sort,
       indices: state.indices.join(','),
       field: state.field,
+      tab: state.tab,
       ...getters.filterValuesAsRouteQuery()
     })
   },

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -32,6 +32,13 @@ import * as filterTypes from '@/store/filters'
 import { isNarrowScreen } from '@/utils/screen'
 import settings from '@/utils/settings'
 
+export const TAB_NAME = {
+  EXTRACTED_TEXT: 'extracted-text',
+  PREVIEW: 'preview',
+  DETAILS: 'details',
+  NAMED_ENTITIES: 'named-entities'
+}
+
 export function initialState() {
   return cloneDeep({
     error: null,
@@ -51,7 +58,8 @@ export function initialState() {
     showFilters: true,
     size: 25,
     sort: settings.defaultSearchSort,
-    values: {}
+    values: {},
+    tab: TAB_NAME.EXTRACTED_TEXT
   })
 }
 
@@ -363,6 +371,9 @@ export const mutations = {
   },
   toggleFilters(state, toggler = !state.showFilters) {
     Vue.set(state, 'showFilters', toggler)
+  },
+  updateTab(state, tab) {
+    state.tab = tab
   }
 }
 
@@ -392,7 +403,7 @@ function actionsBuilder(api) {
       }
     },
     updateFromRouteQuery({ commit, getters }, query) {
-      const excludedKeys = ['index', 'indices', 'showFilters', 'field', 'layout']
+      const excludedKeys = ['index', 'indices', 'showFilters', 'field', 'layout', 'tab']
       const updatedKeys = ['q', 'index', 'indices', 'from', 'size', 'sort', 'field']
       commit('reset', excludedKeys)
       // Add the query to the state with a mutation to avoid triggering a search
@@ -516,6 +527,11 @@ function actionsBuilder(api) {
         query,
         uri
       })
+    },
+    setTab({ state, commit }, tab) {
+      if (state.tab !== tab) {
+        commit('updateTab', tab)
+      }
     }
   }
 }

--- a/tests/unit/specs/components/SearchResultsListLink.spec.js
+++ b/tests/unit/specs/components/SearchResultsListLink.spec.js
@@ -77,7 +77,7 @@ describe('SearchResultsListLink.vue', () => {
 
     store.commit('search/query', 'other')
     await flushPromises()
-    expect(wrapper.find('.search-results-list-link').attributes('href')).toMatch(/foo\/foo\?q=other$/)
+    expect(wrapper.find('.search-results-list-link').attributes('href')).toMatch(/foo\/foo\?q=other&tab=extracted-text/)
   })
 
   it('should display the document sliced name', () => {

--- a/tests/unit/specs/pages/DocumentView.spec.js
+++ b/tests/unit/specs/pages/DocumentView.spec.js
@@ -175,17 +175,17 @@ describe('DocumentView.vue', () => {
     })
 
     it('should add a tab using the `document-view-tabs` pipeline', () => {
-      const lastTab = wrapper.vm.tabsThroughtPipeline[wrapper.vm.tabsThroughtPipeline.length - 1]
+      const lastTab = wrapper.vm.tabsThroughPipeline[wrapper.vm.tabsThroughPipeline.length - 1]
       expect(lastTab.label).toBe('Temporary')
     })
 
     it('should add a tab with a `labelComponent` property', () => {
-      const lastTab = wrapper.vm.tabsThroughtPipeline[wrapper.vm.tabsThroughtPipeline.length - 1]
+      const lastTab = wrapper.vm.tabsThroughPipeline[wrapper.vm.tabsThroughPipeline.length - 1]
       expect(lastTab.labelComponent).toHaveProperty('template')
     })
 
     it('should add a tab with a `labelComponent` within the label in its template', () => {
-      const lastTab = wrapper.vm.tabsThroughtPipeline[wrapper.vm.tabsThroughtPipeline.length - 1]
+      const lastTab = wrapper.vm.tabsThroughPipeline[wrapper.vm.tabsThroughPipeline.length - 1]
       const lastTabWrapper = shallowMount(lastTab.labelComponent, { i18n, localVue })
       expect(lastTabWrapper.text()).toBe('Temporary')
     })

--- a/tests/unit/specs/pages/DocumentView.spec.js
+++ b/tests/unit/specs/pages/DocumentView.spec.js
@@ -175,17 +175,17 @@ describe('DocumentView.vue', () => {
     })
 
     it('should add a tab using the `document-view-tabs` pipeline', () => {
-      const lastTab = wrapper.vm.tabsThoughtPipeline[wrapper.vm.tabsThoughtPipeline.length - 1]
+      const lastTab = wrapper.vm.tabsThroughtPipeline[wrapper.vm.tabsThroughtPipeline.length - 1]
       expect(lastTab.label).toBe('Temporary')
     })
 
     it('should add a tab with a `labelComponent` property', () => {
-      const lastTab = wrapper.vm.tabsThoughtPipeline[wrapper.vm.tabsThoughtPipeline.length - 1]
+      const lastTab = wrapper.vm.tabsThroughtPipeline[wrapper.vm.tabsThroughtPipeline.length - 1]
       expect(lastTab.labelComponent).toHaveProperty('template')
     })
 
     it('should add a tab with a `labelComponent` within the label in its template', () => {
-      const lastTab = wrapper.vm.tabsThoughtPipeline[wrapper.vm.tabsThoughtPipeline.length - 1]
+      const lastTab = wrapper.vm.tabsThroughtPipeline[wrapper.vm.tabsThroughtPipeline.length - 1]
       const lastTabWrapper = shallowMount(lastTab.labelComponent, { i18n, localVue })
       expect(lastTabWrapper.text()).toBe('Temporary')
     })


### PR DESCRIPTION
Related to https://github.com/ICIJ/datashare/issues/1359
Behavior choices:
* The tab is "saved" in vuex module "search". 
* The tab is kept in memory even when clearing the search

Additional fixes:
- add shortcuts back on previous/next tab selection
- add shortcuts back on pressing escape while a document is opened to close it.