### PR TITLE
fix: display batch search error message

### DIFF
--- a/src/components/TaskItemStatus.vue
+++ b/src/components/TaskItemStatus.vue
@@ -68,7 +68,7 @@ export default {
       return this.statusName === 'failure' || this.statusName === 'error'
     },
     errorMessage() {
-      return this.taskItem?.errorMessage?.message ?? ''
+      return this.taskItem?.errorMessage?.message ?? this.taskItem?.errorMessage ?? ''
     },
     errorMessageAsJson() {
       const re = /{"error":.+}/gm


### PR DESCRIPTION
Add error message back in the black box when a task fails
![image](https://github.com/ICIJ/datashare-client/assets/4643139/89d4b39c-b223-4cb8-ad8d-5b8b6545221b)
