### PR TITLE
Fixed broken links to documentation

### DIFF
--- a/src/components/BatchSearchForm.vue
+++ b/src/components/BatchSearchForm.vue
@@ -30,7 +30,7 @@
           <p class="help small">
             <a
               class="text-muted"
-              href="https://icij.gitbook.io/datashare/all/batch-search-documents#write-your-queries-in-a-spreadsheet"
+              href="https://icij.gitbook.io/datashare/usage/batch-search-documents#write-your-queries-in-a-spreadsheet"
               target="_blank"
             >
               {{ $t('batchSearch.learnMore') }}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -36,19 +36,19 @@ export const router = {
             docs: [
               {
                 title: 'Search documents',
-                path: 'all/search-documents'
+                path: 'usage/search-documents'
               },
               {
                 title: 'Filter a documents',
-                path: 'all/filter-documents'
+                path: 'usage/filter-documents'
               },
               {
                 title: 'Search with operators',
-                path: 'all/search-with-operators'
+                path: 'usage/search-with-operators'
               },
               {
                 title: 'Star a document',
-                path: 'all/star-documents'
+                path: 'usage/star-documents'
               }
             ]
           },
@@ -68,15 +68,15 @@ export const router = {
                 docs: [
                   {
                     title: 'Star a document',
-                    path: 'all/star-documents'
+                    path: 'usage/star-documents'
                   },
                   {
                     title: 'Tag a document',
-                    path: 'all/tag-documents'
+                    path: 'usage/tag-documents'
                   },
                   {
                     title: 'Use keyboard shortcuts',
-                    path: 'all/use-keyboard-shortcuts'
+                    path: 'usage/use-keyboard-shortcuts'
                   }
                 ]
               }

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -35,13 +35,13 @@ export default {
   documentationUrl: 'https://icij.gitbook.io/datashare',
   documentationLinks: {
     indexing: {
-      mac: 'https://icij.gitbook.io/datashare/mac/how-to-add-documents-to-datashare',
-      windows: 'https://icij.gitbook.io/datashare/windows/how-to-add-documents-to-datashare',
-      linux: 'https://icij.gitbook.io/datashare/linux/how-to-add-documents-to-datashare',
-      default: 'https://icij.gitbook.io/datashare/mac/how-to-add-documents-to-datashare'
+      mac: 'https://icij.gitbook.io/datashare/local-mode/install-datashare-on-mac/add-documents-to-datashare-on-mac',
+      windows: 'https://icij.gitbook.io/datashare/local-mode/install-datashare-on-windows/add-documents-to-datashare-on-windows',
+      linux: 'https://icij.gitbook.io/datashare/local-mode/install-datashare-on-linux/add-documents-to-datashare-on-linux',
+      default: 'https://icij.gitbook.io/datashare/local-mode/install-datashare-on-mac/add-documents-to-datashare-on-mac'
     },
     operators: {
-      default: 'https://icij.gitbook.io/datashare/all/search-with-operators'
+      default: 'https://icij.gitbook.io/datashare/usage/search-with-operators'
     }
   },
   hotKeyPrevented: ['.search-bar__input'],

--- a/src/utils/shortkeys.json
+++ b/src/utils/shortkeys.json
@@ -30,7 +30,7 @@
       "action": "goToPreviousDocument",
       "icon": "caret-left",
       "label": "shortkeys.goToPreviousDocument",
-      "link": "https://icij.gitbook.io/datashare/all/use-keyboard-shortcuts#go-to-the-next-previous-document",
+      "link": "https://icij.gitbook.io/datashare/usage/use-keyboard-shortcuts#go-to-the-next-previous-document",
       "page": "search"
     },
     "goToNextDocument": {
@@ -41,7 +41,7 @@
       "action": "goToNextDocument",
       "icon": "caret-right",
       "label": "shortkeys.goToNextDocument",
-      "link": "https://icij.gitbook.io/datashare/all/use-keyboard-shortcuts#go-to-the-next-previous-document",
+      "link": "https://icij.gitbook.io/datashare/usage/use-keyboard-shortcuts#go-to-the-next-previous-document",
       "page": "search"
     },
     "backToSearchResults": {
@@ -52,7 +52,7 @@
       "action": "back",
       "icon": "chevron-circle-left",
       "label": "shortkeys.backToSearchResults",
-      "link": "https://icij.gitbook.io/datashare/all/use-keyboard-shortcuts#go-back-to-search-results",
+      "link": "https://icij.gitbook.io/datashare/usage/use-keyboard-shortcuts#go-back-to-search-results",
       "page": "search"
     }
   },
@@ -77,7 +77,7 @@
         "goToPreviousTab": "shortkeys.goToPreviousTab",
         "goToNextTab": "shortkeys.goToNextTab"
       },
-      "link": "https://icij.gitbook.io/datashare/all/use-keyboard-shortcuts#navigate-a-documents-tabs",
+      "link": "https://icij.gitbook.io/datashare/usage/use-keyboard-shortcuts#navigate-a-documents-tabs",
       "page": "search"
     }
   },
@@ -109,7 +109,7 @@
         "findPreviousOccurrence": "shortkeys.findPreviousOccurrence",
         "findNextOccurrence": "shortkeys.findNextOccurrence"
       },
-      "link": "https://icij.gitbook.io/datashare/all/use-keyboard-shortcuts#find-in-document",
+      "link": "https://icij.gitbook.io/datashare/usage/use-keyboard-shortcuts#find-in-document",
       "page": "search"
     }
   }


### PR DESCRIPTION
Some documentation links changed, e.g. section `all` moved to `usage`, so links from the right panel no longer work. I fixed links to articles about search and addition of new documents.