### PR TITLE
feat: visited links class helper for documents

### DIFF
--- a/src/components/Document/DocumentCard/DocumentCard.vue
+++ b/src/components/Document/DocumentCard/DocumentCard.vue
@@ -93,7 +93,7 @@ const showTitle = computed(() => props.properties?.includes('title'))
         :name="routeName"
         :modal="modal"
         :target="target"
-        class="document-card__properties__title"
+        class="document-card__properties__title link-visitable"
       >
         {{ document.title }}
       </router-link-document>

--- a/src/components/Document/DocumentRow/DocumentRowTitle.vue
+++ b/src/components/Document/DocumentRow/DocumentRowTitle.vue
@@ -17,7 +17,7 @@ const to = computed(() => {
 <template>
   <td>
     <hook name="document-row-title:before" :bind="{ document }" />
-    <router-link :to="to" class="document-row-title fw-medium">
+    <router-link :to="to" class="document-row-title fw-medium link-visitable">
       {{ document.title }}
     </router-link>
     <hook name="document-row-title:after" :bind="{ document }" />

--- a/src/components/RouterLink/RouterLinkDocument.vue
+++ b/src/components/RouterLink/RouterLinkDocument.vue
@@ -58,7 +58,7 @@ const handleClick = (event) => {
 </script>
 
 <template>
-  <a :href="href" @click.exact="handleClick">
+  <a :href="href" class="link-visitable" @click.exact="handleClick">
     <slot />
   </a>
 </template>

--- a/src/main.scss
+++ b/src/main.scss
@@ -18,6 +18,16 @@
 @import './utils/buttons.scss';
 @import './utils/nprogress.scss';
 
+.link-visitable:visited {
+  color: mix($purple, white, 80%);
+}
+
+@include color-mode(dark) {
+  .link-visitable:visited {
+    color: mix($purple, $body-color-dark, 50%);
+  }
+}
+
 .dropdown-item {
   border-radius: var(--bs-border-radius);
 


### PR DESCRIPTION
The `.link-visitable` class help follows the same name convention than [Bootstrap](https://getbootstrap.com/docs/5.3/utilities/link/).

| Light mode | Dark mode |
| --- | --- |
| ![Screenshot 2025-06-03 at 13-34-36 Search documents - Datashare](https://github.com/user-attachments/assets/14764ac4-b79c-4e31-ab5f-1c12f1993a02) | ![Screenshot 2025-06-03 at 13-35-24 Search documents - Datashare](https://github.com/user-attachments/assets/0a7e3f97-d297-4b52-b206-0adfe8522df1) |