### PR TITLE
fix: navigation in search results reset filters

### DIFF
--- a/src/views/Search/Search.vue
+++ b/src/views/Search/Search.vue
@@ -85,7 +85,7 @@ const page = useUrlPageFromWithStore({
   perPage: toValue(perPage),
   // The "to" query parameter is used to ensure that when the page is changed, the route query is updated
   // to be on the search route. Here we use the store's `toRouteQuery` to ensure that the route query is updated
-  // with the current search parameters. This allow us to navigate from child routes where the query parameters 
+  // with the current search parameters. This allow us to navigate from child routes where the query parameters
   // are not the same as the search route.
   to: () => {
     const name = 'search'

--- a/src/views/Search/Search.vue
+++ b/src/views/Search/Search.vue
@@ -83,9 +83,15 @@ const total = computed(() => parseInt(searchStore.response.total))
 const perPage = computed(() => parseInt(appStore.getSettings('search', 'perPage')))
 const page = useUrlPageFromWithStore({
   perPage: toValue(perPage),
-  // The "from" query parameter is updated to reflect the current state
-  // which while force the route to redirect to "search".
-  to: 'search',
+  // The "to" query parameter is used to ensure that when the page is changed, the route query is updated
+  // to be on the search route. Here we use the store's `toRouteQuery` to ensure that the route query is updated
+  // with the current search parameters. This allow us to navigate from child routes where the query parameters 
+  // are not the same as the search route.
+  to: () => {
+    const name = 'search'
+    const { toRouteQuery: query } = searchStore
+    return { name, query }
+  },
   // The value of the "from" query parameter is directly taken from the store
   get: () => searchStore.from,
   // The value of the "from" query parameter is mutated with the store

--- a/src/views/Search/Search.vue
+++ b/src/views/Search/Search.vue
@@ -83,9 +83,9 @@ const total = computed(() => parseInt(searchStore.response.total))
 const perPage = computed(() => parseInt(appStore.getSettings('search', 'perPage')))
 const page = useUrlPageFromWithStore({
   perPage: toValue(perPage),
-  // The "to" query parameter is used to ensure that when the page is changed, the route query is updated
-  // to be on the search route. Here we use the store's `toRouteQuery` to ensure that the route query is updated
-  // with the current search parameters. This allow us to navigate from child routes where the query parameters
+  // The "to" parameter is used to ensure that when the page is changed, the route query is updated
+  // to be on a given route. Here we use the store's `toRouteQuery` to ensure that the route query is updated
+  // with the current search parameters. This allows us to navigate from child routes where the query parameters
   // are not the same as the search route.
   to: () => {
     const name = 'search'


### PR DESCRIPTION
When a user was on a child/document route and changed page (e.g. "next page" in results), we navigated back to search but lost the active filters/query params because the route navigation didn't merge the current search state.

You can see the problem when recording navigation timeline:

<img width="1536" height="446" alt="Screenshot 2025-07-22 at 13-14-06 Search documents - Datashare" src="https://github.com/user-attachments/assets/bfdd37c5-8143-4b9c-b197-64257013b93d" />


This PR leverages the `to` parameter of the `useUrlPageFromWithStore` composable to dynamically insert search store's query filters into the route we navigate to.