### PR TITLE
fix: delete task confirmation

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -880,10 +880,8 @@
     "noResults": "No results.",
     "emptyStateLabel": "You have not yet started any tasks. {link}",
     "emptyStateLabelLink": "Read more.",
-    "remove": {
-      "success": "Task has been removed",
-      "error": "Task has not been removed"
-    },
+    "removeSuccess": "Task has been removed",
+    "removeError": "Task has not been removed",
     "settings": {
       "createdAt": "Created on",
       "name": "Name",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -880,6 +880,10 @@
     "noResults": "No results.",
     "emptyStateLabel": "You have not yet started any tasks. {link}",
     "emptyStateLabelLink": "Read more.",
+    "remove": {
+      "success": "Task has been removed",
+      "error": "Task has not been removed"
+    },
     "settings": {
       "createdAt": "Created on",
       "name": "Name",

--- a/src/views/Task/TaskDocuments/TaskDocumentsList.vue
+++ b/src/views/Task/TaskDocuments/TaskDocumentsList.vue
@@ -31,10 +31,10 @@ const { t } = useI18n()
 async function stopTask(uuid) {
   return taskStore.stopTask(uuid)
 }
-const successMessage = t('task.remove.success')
-const errorMessage = t('task.remove.error')
+
 function remove(id) {
-  return toastedPromise(api.removeTask(id), { successMessage, errorMessage })
+  return toastedPromise(api.removeTask(id), { successMessage: t('task.remove.success'),
+    errorMessage: t('task.remove.error') })
 }
 function getProject(item) {
   return item.args.defaultProject

--- a/src/views/Task/TaskDocuments/TaskDocumentsList.vue
+++ b/src/views/Task/TaskDocuments/TaskDocumentsList.vue
@@ -46,7 +46,7 @@ function isRunning(item) {
 }
 
 function removeWithConfirmation(id, callback) {
-  afterConfirmation(async () => {
+  return afterConfirmation(async () => {
     await remove(id)
     await callback()
   })

--- a/src/views/Task/TaskDocuments/TaskDocumentsList.vue
+++ b/src/views/Task/TaskDocuments/TaskDocumentsList.vue
@@ -33,8 +33,8 @@ async function stopTask(uuid) {
 }
 
 function remove(id) {
-  const successMessage = t('task.remove.success')
-  const errorMessage = t('task.remove.error')
+  const successMessage = t('task.removeSuccess')
+  const errorMessage = t('task.removeError')
   return toastedPromise(api.removeTask(id), { successMessage, errorMessage })
 }
 function getProject(item) {
@@ -45,6 +45,12 @@ function isRunning(item) {
   return item.state === TASK_STATUS.RUNNING
 }
 
+function removeWithConfirmation(id, callback) {
+  afterConfirmation(async () => {
+    await remove(id)
+    await callback()
+  })
+}
 </script>
 
 <template>
@@ -100,9 +106,7 @@ function isRunning(item) {
             @stop="stopTask(item.id)"
           />
           <button-row-action-delete
-            @click="afterConfirmation(async ()=>{
-              await remove(item.id)
-              await refresh()})"
+            @click="removeWithConfirmation(item.id, refresh)"
           />
         </template>
       </page-table-generic>

--- a/src/views/Task/TaskDocuments/TaskDocumentsList.vue
+++ b/src/views/Task/TaskDocuments/TaskDocumentsList.vue
@@ -33,8 +33,9 @@ async function stopTask(uuid) {
 }
 
 function remove(id) {
-  return toastedPromise(api.removeTask(id), { successMessage: t('task.remove.success'),
-    errorMessage: t('task.remove.error') })
+  const successMessage = t('task.remove.success')
+  const errorMessage = t('task.remove.error')
+  return toastedPromise(api.removeTask(id), { successMessage, errorMessage })
 }
 function getProject(item) {
   return item.args.defaultProject

--- a/src/views/Task/TaskEntities/TaskEntitiesList.vue
+++ b/src/views/Task/TaskEntities/TaskEntitiesList.vue
@@ -45,7 +45,7 @@ function isRunning(item) {
 }
 
 function removeWithConfirmation(id, callback) {
-  afterConfirmation(async () => {
+  return afterConfirmation(async () => {
     await remove(id)
     await callback()
   })

--- a/src/views/Task/TaskEntities/TaskEntitiesList.vue
+++ b/src/views/Task/TaskEntities/TaskEntitiesList.vue
@@ -13,12 +13,12 @@ import PageTableGeneric from '@/components/PageTable/PageTableGeneric'
 import { ENTITY_CATEGORY } from '@/enums/entityCategories'
 import { TASK_NAME } from '@/enums/taskNames'
 import TaskPage from '@/views/Task/TaskPage'
-import ButtonRowActionStop from "@/components/Button/ButtonRowAction/ButtonRowActionStop.vue";
-import ButtonRowActionDelete from "@/components/Button/ButtonRowAction/ButtonRowActionDelete.vue";
-import {apiInstance as api} from "@/api/apiInstance.js";
-import {TASK_STATUS} from "@/enums/taskStatus.js";
-import {useConfirmModal} from "@/composables/useConfirmModal.js";
-import {useCore} from "@/composables/useCore.js";
+import ButtonRowActionStop from '@/components/Button/ButtonRowAction/ButtonRowActionStop.vue'
+import ButtonRowActionDelete from '@/components/Button/ButtonRowAction/ButtonRowActionDelete.vue'
+import { apiInstance as api } from '@/api/apiInstance.js'
+import { TASK_STATUS } from '@/enums/taskStatus.js'
+import { useConfirmModal } from '@/composables/useConfirmModal.js'
+import { useCore } from '@/composables/useCore.js'
 
 const settingName = 'entities'
 const { propertiesModelValueOptions } = useTaskSettings(settingName)

--- a/src/views/Task/TaskEntities/TaskEntitiesList.vue
+++ b/src/views/Task/TaskEntities/TaskEntitiesList.vue
@@ -35,12 +35,20 @@ function getProject(item) {
 }
 
 function remove(id) {
-  return toastedPromise(api.removeTask(id), { successMessage: t('task.remove.success'),
-    errorMessage: t('task.remove.error') })
+  const successMessage = t('task.removeSuccess')
+  const errorMessage = t('task.removeError')
+  return toastedPromise(api.removeTask(id), { successMessage, errorMessage })
 }
 
 function isRunning(item) {
   return item.state === TASK_STATUS.RUNNING
+}
+
+function removeWithConfirmation(id, callback) {
+  afterConfirmation(async () => {
+    await remove(id)
+    await callback()
+  })
 }
 </script>
 
@@ -106,9 +114,7 @@ function isRunning(item) {
             @stop="stopTask(item.id)"
           />
           <button-row-action-delete
-            @click="afterConfirmation(async ()=>{
-              await remove(item.id)
-              await refresh()})"
+            @click="removeWithConfirmation(item.id, refresh)"
           />
         </template>
       </page-table-generic>

--- a/tests/unit/specs/components/Task/TaskEntities/TaskEntitiesList.spec.js
+++ b/tests/unit/specs/components/Task/TaskEntities/TaskEntitiesList.spec.js
@@ -66,10 +66,18 @@ describe('TaskEntitiesList.vue', () => {
     await flushPromises()
     const firstRow = wrapper.find('.page-table-generic__row')
     const columns = firstRow.findAll('.page-table-generic__row__field')
+    const stopButton = firstRow.find('button[aria-label="Stop"]')
+    const deleteButton = firstRow.find('button[aria-label="Delete"]')
     expect(columns.at(0).text()).toBe('Running')
     expect(columns.at(2).text()).toBe('EMAIL')
     expect(columns.at(3).text()).toContain('Local Datashare')
     expect(columns.at(4).text()).toBe('0%')
     expect(columns.at(5).text()).toBe('a few seconds ago')
+    expect(stopButton.exists()).toBeTruthy()
+    expect(deleteButton.exists()).toBeTruthy()
+    expect(stopButton.attributes('disabled')).toBeDefined()
+    expect(deleteButton.attributes('disabled')).toBeUndefined()
+
+
   })
 })

--- a/tests/unit/specs/components/Task/TaskEntities/TaskEntitiesList.spec.js
+++ b/tests/unit/specs/components/Task/TaskEntities/TaskEntitiesList.spec.js
@@ -77,7 +77,5 @@ describe('TaskEntitiesList.vue', () => {
     expect(deleteButton.exists()).toBeTruthy()
     expect(stopButton.attributes('disabled')).toBeDefined()
     expect(deleteButton.attributes('disabled')).toBeUndefined()
-
-
   })
 })


### PR DESCRIPTION
This PR aims to fix the delete task buttons in Document Task page, it additionally adds a confirmation before deleting.
The PR also implements the latter in the Entity Task page. 