### PR TITLE
style: update `DocumentCarousel` layout styling

### DIFF
--- a/src/components/Document/DocumentCarousel/DocumentCarousel.vue
+++ b/src/components/Document/DocumentCarousel/DocumentCarousel.vue
@@ -37,18 +37,18 @@ const adjustedPosition = computed({
 </script>
 
 <template>
-  <div class="document-carousel">
+  <div class="document-carousel rounded-top">
     <tiny-pagination
       v-model="adjustedPosition"
       :per-page="1"
       :total-rows="total"
-      class="document-carousel__pagination mx-auto py-1"
+      class="document-carousel__pagination py-1"
     >
       <template #page>
         {{ t('documentCarousel.page') }}
       </template>
     </tiny-pagination>
-    <div class="document-carousel__content p-3">
+    <div class="document-carousel__content p-3 rounded-bottom">
       <document-carousel-nav
         :icon="PhCaretLeft"
         class="document-carousel__content__nav"
@@ -76,6 +76,9 @@ const adjustedPosition = computed({
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  margin: auto;
+  opacity: 0.98;
+  max-width: min(800px,90%);
   position: relative;
 
   &:hover {


### PR DESCRIPTION
prevent carrousel to take the all width of the document page

before:
<img width="1570" height="569" alt="image" src="https://github.com/user-attachments/assets/df40ab0d-6aaa-4b97-8629-41d2f738bb49" />
after
<img width="900" height="424" alt="image" src="https://github.com/user-attachments/assets/995b321b-613c-4642-81f8-9dbe79073d63" />
