### PR TITLE
feat: add ability to enter batch search queries manually

### DIFF
--- a/src/components/Task/TaskBatchSearch/TaskBatchSearchFormQueries.vue
+++ b/src/components/Task/TaskBatchSearch/TaskBatchSearchFormQueries.vue
@@ -1,11 +1,14 @@
 <script setup>
 import { useI18n } from 'vue-i18n'
 
+import { BATCH_SEARCH_CSV_FILE, BATCH_SEARCH_CSV_STRING } from '@/enums/batchSearch'
 import FormStep from '@/components/Form/FormStep/FormStep'
 import TabGroupEntry from '@/components/TabGroup/TabGroupEntry'
 import TabGroup from '@/components/TabGroup/TabGroup'
 
 const csvFile = defineModel('csvFile', { type: File })
+const csvString = defineModel('csvString', { type: String })
+const csvTab = defineModel('csvTab', { type: String, default: BATCH_SEARCH_CSV_FILE })
 const { t } = useI18n()
 </script>
 
@@ -14,9 +17,12 @@ const { t } = useI18n()
     :title="t('task.batch-search.form.sections.queries')"
     :index="2"
   >
-    <tab-group>
+    <tab-group
+      v-model="csvTab"
+      lazy
+    >
       <tab-group-entry
-        active
+        :id="BATCH_SEARCH_CSV_FILE"
         :title="t('task.batch-search.form.csvFile.label')"
       >
         <b-form-file
@@ -40,10 +46,17 @@ const { t } = useI18n()
           </ul>
         </div>
       </tab-group-entry>
-      <tab-group-entry :title="t('task.batch-search.form.listQueries.label')">
-        <div class="text-secondary text-center p-3">
-          {{ t('task.batch-search.form.listQueries.placeholder') }}
-        </div>
+      <tab-group-entry
+        :id="BATCH_SEARCH_CSV_STRING"
+        :title="t('task.batch-search.form.csvString.label')"
+      >
+        <b-form-textarea
+          v-model="csvString"
+          class="form-control"
+          :rows="7"
+          :placeholder="t('task.batch-search.form.csvString.placeholder')"
+          required
+        />
       </tab-group-entry>
     </tab-group>
   </form-step>

--- a/src/enums/batchSearch.js
+++ b/src/enums/batchSearch.js
@@ -1,0 +1,2 @@
+export const BATCH_SEARCH_CSV_FILE = 'file'
+export const BATCH_SEARCH_CSV_STRING = 'string'

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1127,9 +1127,10 @@
           "label": "Use a CSV",
           "placeholder": "Drop your CSV"
         },
-        "listQueries": {
+        "csvString": {
           "label": "Or type your queries",
-          "placeholder": "New feature coming soon!"
+          "placeholder": "Enter one search term per line here...",
+          "new": "New"
         },
         "phraseChanges": {
           "label": "Sentence changes",


### PR DESCRIPTION
As explained in icij/datashare#1884, this PR add support for manually entering batch search queries. It leverage the [File](https://developer.mozilla.org/en-US/docs/Web/API/File/File), which is widely supported, to create a CSV file directly in Javascript so it is sent through multipart form data.

[Screencast from 2025-09-04 18-28-43.webm](https://github.com/user-attachments/assets/9a61ac5b-30e2-467a-947b-0d1469a6a35c)
