### PR TITLE
feat: project paths page

### DIFF
--- a/src/components/AppSidebar/AppSidebar.vue
+++ b/src/components/AppSidebar/AppSidebar.vue
@@ -1,7 +1,8 @@
 <script setup>
-import { computed, onBeforeMount, watch } from 'vue'
+import { computed, onBeforeMount, watch, useTemplateRef } from 'vue'
 import { onBeforeRouteLeave, onBeforeRouteUpdate } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { useElementSize } from '@vueuse/core'
 
 import AppSidebarFooter from './AppSidebarFooter'
 import AppSidebarSection from './AppSidebarSection'
@@ -23,6 +24,8 @@ import { useAppStore } from '@/store/modules'
 import settings from '@/utils/settings'
 
 const appStore = useAppStore()
+const element = useTemplateRef('element')
+const { width } = useElementSize(element)
 const { core } = useCore()
 const { searchRoute, isSearchChildRoute } = useSearchNav()
 const { isServer } = useMode()
@@ -111,6 +114,13 @@ onBeforeRouteUpdate(autoClose)
 onBeforeRouteLeave(autoClose)
 // Ensure the sidebar is closed by default on mobile devices
 onBeforeMount(() => (appStore.sidebar.closed = appStore.sidebar.closed || isOffCanvas.value))
+
+defineExpose({
+  // Exposing the width of the sidebar. When the sidebar is in off-canvas mode,
+  // its width is considered to be 0 so it doesn't take space in the layout.
+  // @see App.vue for usage in CSS variable.
+  width: computed(() => isOffCanvas.value ? 0 : width.value)
+})
 </script>
 
 <template>
@@ -119,6 +129,7 @@ onBeforeMount(() => (appStore.sidebar.closed = appStore.sidebar.closed || isOffC
     :active="isOffCanvas"
   >
     <div
+      ref="element"
       class="app-sidebar"
       :class="classList"
     >

--- a/src/components/Document/DocumentCard/DocumentCardPropertiesEntryProject.vue
+++ b/src/components/Document/DocumentCard/DocumentCardPropertiesEntryProject.vue
@@ -20,7 +20,7 @@ defineProps({
   >
     <project-button
       :project="document.project"
-      no-link
+      no-search
       disabled
     />
   </document-card-properties-entry>

--- a/src/components/Document/DocumentCard/DocumentCardPropertiesEntryProject.vue
+++ b/src/components/Document/DocumentCard/DocumentCardPropertiesEntryProject.vue
@@ -20,7 +20,7 @@ defineProps({
   >
     <project-button
       :project="document.project"
-      no-search
+      no-link
       disabled
     />
   </document-card-properties-entry>

--- a/src/components/Document/DocumentRow/DocumentRowProject.vue
+++ b/src/components/Document/DocumentRow/DocumentRowProject.vue
@@ -12,7 +12,7 @@ defineProps({
   <td>
     <project-button
       :project="document.project"
-      no-search
+      no-link
       disabled
     />
   </td>

--- a/src/components/Document/DocumentRow/DocumentRowProject.vue
+++ b/src/components/Document/DocumentRow/DocumentRowProject.vue
@@ -12,7 +12,7 @@ defineProps({
   <td>
     <project-button
       :project="document.project"
-      no-link
+      no-search
       disabled
     />
   </td>

--- a/src/components/Filter/FilterType/FilterTypePath.vue
+++ b/src/components/Filter/FilterType/FilterTypePath.vue
@@ -83,7 +83,7 @@ watchIndices(reset)
         no-documents
         no-label
         no-link
-        elasticsearch-only
+        no-tree
         select-mode
         multiple
       />

--- a/src/components/Filter/FilterType/FilterTypePath.vue
+++ b/src/components/Filter/FilterType/FilterTypePath.vue
@@ -7,6 +7,7 @@ import PathTree from '@/components/PathTree/PathTree'
 import { useSearchFilter } from '@/composables/useSearchFilter'
 import { useCore } from '@/composables/useCore'
 import { useSearchStore } from '@/store/modules'
+import { LAYOUTS } from '@/enums/pathTree'
 
 const { core } = useCore()
 const searchStore = useSearchStore.inject()
@@ -50,6 +51,13 @@ const preBodyBuild = whenFilterContextualized(props.filter, (body) => {
 const reloadData = () => tree.value.reloadData()
 const reset = () => (selectedPaths.value = [])
 
+const layout = computed({
+  get: () => nested.value ? LAYOUTS.TREE : LAYOUTS.LIST,
+  set: (value) => {
+    nested.value = value === LAYOUTS.TREE
+  }
+})
+
 watchFilterContextualized(props.filter, reloadData)
 // When the filter is excluded/included and it's contextualized then reload the data with a spinner
 watchFilterExcluded(props.filter, whenFilterContextualized(props.filter, reloadData))
@@ -79,7 +87,7 @@ watchIndices(reset)
         :sort-by="filter.sortBy"
         :order-by="filter.orderBy"
         :no-stats="hideCount"
-        :nested="nested"
+        :layout="layout"
         no-documents
         no-label
         no-link

--- a/src/components/Filter/FilterType/FilterTypePath.vue
+++ b/src/components/Filter/FilterType/FilterTypePath.vue
@@ -90,7 +90,7 @@ watchIndices(reset)
         :layout="layout"
         no-documents
         no-label
-        no-link
+        no-search
         no-tree
         select-mode
         multiple

--- a/src/components/Filter/FilterType/FilterTypePath.vue
+++ b/src/components/Filter/FilterType/FilterTypePath.vue
@@ -80,6 +80,7 @@ watchIndices(reset)
         :order-by="filter.orderBy"
         :no-stats="hideCount"
         :nested="nested"
+        no-documents
         no-label
         no-link
         elasticsearch-only

--- a/src/components/Form/FormControl/FormControlPath.vue
+++ b/src/components/Form/FormControl/FormControlPath.vue
@@ -75,6 +75,7 @@ function onOk() {
     >
       <path-tree-breadcrumb
         :model-value="display"
+        :max-entries="1"
         datadir-label
         no-link
       />

--- a/src/components/Form/FormControl/FormControlPath.vue
+++ b/src/components/Form/FormControl/FormControlPath.vue
@@ -19,7 +19,7 @@ const props = defineProps({
   multiple: {
     type: Boolean
   },
-  elasticsearchOnly: {
+  noTree: {
     type: Boolean,
     default: false
   },
@@ -95,7 +95,7 @@ function onOk() {
         nested
         no-stats
         select-mode
-        :elasticsearch-only="elasticsearchOnly"
+        :no-tree="noTree"
       />
     </app-modal>
   </div>

--- a/src/components/PageContainer/PageContainer.vue
+++ b/src/components/PageContainer/PageContainer.vue
@@ -67,7 +67,7 @@ const classList = computed(() => {
   }
 
   &--fluid {
-    max-width: 100vw;
+    max-width: 100%;
   }
 
   &--compact {

--- a/src/components/PathTree/PathTree.vue
+++ b/src/components/PathTree/PathTree.vue
@@ -498,15 +498,15 @@ const clearPagesAndLoadTree = async () => {
 }
 
 const totalDocuments = computed(() => {
-  return get(lastPage.value, 'hits.total.value', 0)
+  return get(pages.value, '0.directories.hits.total.value', 0)
 })
 
 const totalDirectories = computed(() => {
-  return Math.max(0, get(lastPage.value, 'aggregations.total_directories.value', 0) - 1)
+  return Math.max(0, get(pages.value, '0.directories.aggregations.total_directories.value', 0) - 1)
 })
 
 const totalSize = computed(() => {
-  return get(lastPage.value, 'aggregations.total_size.value', 0)
+  return get(pages.value, '0.directories.aggregations.total_size.value', 0)
 })
 
 onBeforeMount(() => {

--- a/src/components/PathTree/PathTree.vue
+++ b/src/components/PathTree/PathTree.vue
@@ -97,7 +97,7 @@ const props = defineProps({
    * If true, the tree will only display directories that have documents
    * indexed in Elasticsearch.
    */
-  elasticsearchOnly: { type: Boolean },
+  noTree: { type: Boolean },
   /**
    * The level of the tree (for recursive rendering of this component)
    */
@@ -522,7 +522,7 @@ const shouldLoadTree = computed(() => {
   // load directories from the /tree API when they are
   // already present in next result page of the
   // ElasticSearch aggregation.
-  return reachedTheEnd.value && !isServer.value && !props.elasticsearchOnly
+  return reachedTheEnd.value && !isServer.value && !props.noTree
 })
 
 const clearPagesAndLoadTree = async () => {
@@ -634,7 +634,7 @@ defineExpose({ loadData, loadDataWithSpinner, reloadData, isLoading })
               :pre-body-build="preBodyBuild"
               :sort-by="sortBy"
               :order-by="orderBy"
-              :elasticsearch-only="elasticsearchOnly"
+              :no-tree="noTree"
               :include-children-documents="includeChildrenDocuments"
             />
           </template>

--- a/src/components/PathTree/PathTree.vue
+++ b/src/components/PathTree/PathTree.vue
@@ -26,6 +26,7 @@ import { useCore } from '@/composables/useCore'
 import { usePath } from '@/composables/usePath'
 import { useMode } from '@/composables/useMode'
 import { useWait } from '@/composables/useWait'
+import { apiInstance as api } from '@/api/apiInstance'
 import { wildcardRegExpPattern, iwildcardMatch } from '@/utils/strings'
 
 const query = defineModel('query', { type: String })
@@ -332,7 +333,7 @@ async function fetchDirectories({ clearPages = false } = {}) {
   const from = clearPages ? 0 : offset.value
   const body = getDirectoriesBodybuilder({ from }).build()
   const preference = 'tree-view-directories'
-  const res = await core.api.elasticsearch.search({ index, body, preference })
+  const res = await api.elasticsearch.search({ index, body, preference })
   if (!props.compact) {
     const dirs = res.aggregations.dirname.buckets.map(property('key'))
     await fetchEmptyDirectories(dirs)
@@ -381,7 +382,7 @@ async function fetchEmptyDirectories(dirs = []) {
   const index = props.projects.join(',')
   const preference = 'tree-view-empty-directories'
   const body = getEmptyDirectoriesBodybuilder(dirs).build()
-  const res = await core.api.elasticsearch.search({ index, body, preference })
+  const res = await api.elasticsearch.search({ index, body, preference })
   const buckets = get(res, 'aggregations.doc_count_by_dirname.buckets', {})
   Object.entries(buckets).forEach(([key, { doc_count }]) => {
     directoryIsEmpty.value[key] = !!doc_count
@@ -425,7 +426,7 @@ async function fetchDocuments() {
   const body = getDocumentsBodybuilder({ from, size }).build()
   const preference = 'tree-view-documents'
   const _source = 'title,dirname,path,contentType,contentLenght,extractionLevel'
-  return core.api.elasticsearch.search({ index, body, preference, _source })
+  return api.elasticsearch.search({ index, body, preference, _source })
 }
 
 /**
@@ -491,7 +492,7 @@ async function nextLoadData($infiniteLoadingState) {
  */
 async function loadTree() {
   tree.value = shouldLoadTree.value
-    ? await core.api.tree(trimmedPath.value).then(property('contents')).catch(() => [])
+    ? await api.tree(trimmedPath.value).then(property('contents')).catch(() => [])
     : []
 }
 

--- a/src/components/PathTree/PathTreeBreadcrumb/PathTreeBreadcrumb.vue
+++ b/src/components/PathTree/PathTreeBreadcrumb/PathTreeBreadcrumb.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { basename } from 'path'
 import { computed } from 'vue'
-import { isArray } from 'lodash'
+import { isArray, last } from 'lodash'
 import { useI18n } from 'vue-i18n'
 
 import PathTreeBreadcrumbDropdown from './PathTreeBreadcrumbDropdown.vue'
@@ -89,6 +89,9 @@ const treeOptions = computed(() => {
   return props.noDatadir ? options : [dataDirOption, ...options]
 })
 
+const hiddenTreeOptions = computed(() => treeOptions.value.slice(0, -props.maxDirectories))
+const visibleTreeOptions = computed(() => treeOptions.value.slice(-props.maxDirectories))
+const lastTreeOption = computed(() => last(treeOptions.value))
 const hasDropdown = computed(() => treeOptions.value.length > props.maxDirectories)
 </script>
 
@@ -102,15 +105,16 @@ const hasDropdown = computed(() => treeOptions.value.length > props.maxDirectori
       <path-tree-breadcrumb-dropdown
         :compact="compact"
         :disabled="dropdownDisabled"
-        :options="treeOptions.slice(0, -maxDirectories)"
+        :options="hiddenTreeOptions"
         @select="modelValue = $event"
       />
     </path-tree-breadcrumb-entry>
     <path-tree-breadcrumb-entry
-      v-for="{ text, value } in treeOptions.slice(-maxDirectories)"
+      v-for="{ text, value } in visibleTreeOptions"
       :key="value"
       :compact="compact"
-      :no-link="noLink"
+      :no-search-link="noLink"
+      :last="lastTreeOption.value === value"
       @select="modelValue = value"
     >
       {{ text }}

--- a/src/components/PathTree/PathTreeBreadcrumb/PathTreeBreadcrumb.vue
+++ b/src/components/PathTree/PathTreeBreadcrumb/PathTreeBreadcrumb.vue
@@ -18,7 +18,7 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
-  maxDirectories: {
+  maxEntries: {
     type: Number,
     default: 5
   },
@@ -89,10 +89,10 @@ const treeOptions = computed(() => {
   return props.noDatadir ? options : [dataDirOption, ...options]
 })
 
-const hiddenTreeOptions = computed(() => treeOptions.value.slice(0, -props.maxDirectories))
-const visibleTreeOptions = computed(() => treeOptions.value.slice(-props.maxDirectories))
+const hiddenTreeOptions = computed(() => treeOptions.value.slice(0, -props.maxEntries))
+const visibleTreeOptions = computed(() => treeOptions.value.slice(-props.maxEntries))
 const lastTreeOption = computed(() => last(treeOptions.value))
-const hasDropdown = computed(() => treeOptions.value.length > props.maxDirectories)
+const hasDropdown = computed(() => treeOptions.value.length > props.maxEntries)
 </script>
 
 <template>
@@ -104,7 +104,7 @@ const hasDropdown = computed(() => treeOptions.value.length > props.maxDirectori
     >
       <path-tree-breadcrumb-dropdown
         :compact="compact"
-        :disabled="dropdownDisabled"
+        :disabled="noLink || dropdownDisabled"
         :options="hiddenTreeOptions"
         @select="modelValue = $event"
       />

--- a/src/components/PathTree/PathTreeBreadcrumb/PathTreeBreadcrumb.vue
+++ b/src/components/PathTree/PathTreeBreadcrumb/PathTreeBreadcrumb.vue
@@ -113,7 +113,7 @@ const hasDropdown = computed(() => treeOptions.value.length > props.maxDirectori
       v-for="{ text, value } in visibleTreeOptions"
       :key="value"
       :compact="compact"
-      :no-search-link="noLink"
+      :no-link="noLink"
       :last="lastTreeOption.value === value"
       @select="modelValue = value"
     >

--- a/src/components/PathTree/PathTreeBreadcrumb/PathTreeBreadcrumbEntry.vue
+++ b/src/components/PathTree/PathTreeBreadcrumb/PathTreeBreadcrumbEntry.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed } from 'vue'
+import { PhosphorIcon } from '@icij/murmur-next'
 
 import PathTreeBreadcrumbEntryLabel from './PathTreeBreadcrumbEntryLabel.vue'
 import PathTreeBreadcrumbEntryLink from './PathTreeBreadcrumbEntryLink.vue'
@@ -9,6 +10,10 @@ const props = defineProps({
     type: Boolean
   },
   compact: {
+    type: Boolean,
+    default: false
+  },
+  last: {
     type: Boolean,
     default: false
   }
@@ -29,7 +34,7 @@ const component = computed(() => {
 
 <template>
   <li
-    class="path-tree-breadcrumb-entry list-inline-item"
+    class="path-tree-breadcrumb-entry list-inline-item text-body-secondary"
     :class="classList"
   >
     <component
@@ -38,32 +43,33 @@ const component = computed(() => {
     >
       <slot />
     </component>
+    <phosphor-icon
+      v-if="!props.last"
+      size="1em"
+      :name="PhCaretRight"
+      class="text-body-secondary"
+    />
   </li>
 </template>
 
 <style lang="scss" scoped>
 .path-tree-breadcrumb-entry {
-  --margin-x: #{$spacer-xs};
+  --spacer: #{$spacer-xs};
 
-  margin-right: var(--margin-x);
   padding: 0;
+  margin: 0;
   display: inline-flex;
+  align-items: center;
   line-height: 1;
-  display: inline-block;
+  gap: var(--spacer);
+  margin-right: var(--spacer);
 
   &--compact {
-    --margin-x: #{$spacer-xxs};
+    --spacer: #{$spacer-xxs};
   }
 
   &:last-child {
     font-weight: bold;
-  }
-
-  &:not(:last-child):after {
-    content: '›';
-    font-weight: bold;
-    opacity: $hr-opacity;
-    margin-left: var(--margin-x);
   }
 }
 </style>

--- a/src/components/PathTree/PathTreeLayouts/PathTreeLayouts.vue
+++ b/src/components/PathTree/PathTreeLayouts/PathTreeLayouts.vue
@@ -7,13 +7,20 @@ const modelValue = defineModel('modelValue', {
   default: LAYOUTS.TREE,
   validator: layoutValidator
 })
+
+defineProps({
+  name: {
+    type: String,
+    default: 'path-tree-layouts'
+  }
+})
 </script>
 
 <template>
-  <div>
+  <div class="path-tree-layouts">
     <b-form-radio-group
       v-model="modelValue"
-      name="path-tree-layouts"
+      :name="name"
     >
       <b-form-radio :value="LAYOUTS.TREE">
         <phosphor-icon name="tree-view" /> {{ $t('pathTreeLayouts.tree') }}

--- a/src/components/PathTree/PathTreeLayouts/PathTreeLayouts.vue
+++ b/src/components/PathTree/PathTreeLayouts/PathTreeLayouts.vue
@@ -9,6 +9,9 @@ const modelValue = defineModel('modelValue', {
 })
 
 defineProps({
+  /**
+   * Name attribute for the radio group
+   */
   name: {
     type: String,
     default: 'path-tree-layouts'

--- a/src/components/PathTree/PathTreeLayouts/PathTreeLayouts.vue
+++ b/src/components/PathTree/PathTreeLayouts/PathTreeLayouts.vue
@@ -1,0 +1,29 @@
+<script setup>
+import { LAYOUTS, layoutValidator } from '@/enums/pathTree'
+import { PhosphorIcon } from '@icij/murmur-next'
+
+const modelValue = defineModel('modelValue', {
+  type: String,
+  default: LAYOUTS.TREE,
+  validator: layoutValidator
+})
+</script>
+
+<template>
+  <div>
+    <b-form-radio-group
+      v-model="modelValue"
+      name="path-tree-layouts"
+    >
+      <b-form-radio :value="LAYOUTS.TREE">
+        <phosphor-icon name="tree-view" /> {{ $t('pathTreeLayouts.tree') }}
+      </b-form-radio>
+      <b-form-radio :value="LAYOUTS.LIST">
+        <phosphor-icon name="list-bullets" /> {{ $t('pathTreeLayouts.list') }}
+      </b-form-radio>
+      <b-form-radio :value="LAYOUTS.GRID">
+        <phosphor-icon name="folder" /> {{ $t('pathTreeLayouts.grid') }}
+      </b-form-radio>
+    </b-form-radio-group>
+  </div>
+</template>

--- a/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholder.vue
+++ b/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholder.vue
@@ -1,0 +1,57 @@
+<script setup>
+import { computed } from 'vue'
+
+import { LAYOUTS, layoutValidator } from '@/enums/pathTree'
+import PathTreePlaceholderGrid from './PathTreePlaceholderGrid'
+import PathTreePlaceholderList from './PathTreePlaceholderList'
+import PathTreePlaceholderTree from './PathTreePlaceholderTree'
+
+const { layout } = defineProps({
+  layout: {
+    type: String,
+    default: LAYOUTS.TREE,
+    validator: layoutValidator
+  },
+  compact: {
+    type: Boolean,
+    default: false
+  },
+  entries: {
+    type: Number,
+    default: 3
+  },
+  flat: {
+    type: Boolean,
+    default: false
+  },
+  level: {
+    type: Number,
+    default: 0
+  },
+  noStats: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const is = computed(() => {
+  switch (layout) {
+    case LAYOUTS.GRID:
+      return PathTreePlaceholderGrid
+    case LAYOUTS.LIST:
+      return PathTreePlaceholderList
+  }
+  return PathTreePlaceholderTree
+})
+</script>
+
+<template>
+  <component
+    :is="is"
+    :compact="compact"
+    :flat="flat"
+    :level="level"
+    :entries="entries"
+    :no-stats="noStats"
+  />
+</template>

--- a/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholder.vue
+++ b/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholder.vue
@@ -7,27 +7,45 @@ import PathTreePlaceholderList from './PathTreePlaceholderList'
 import PathTreePlaceholderTree from './PathTreePlaceholderTree'
 
 const { layout } = defineProps({
+  /**
+   * Layout to use for rendering the placeholder
+   */
   layout: {
     type: String,
     default: LAYOUTS.TREE,
     validator: layoutValidator
   },
+  /**
+   * Whether to render in compact mode (no gaps between entries)
+   */
   compact: {
     type: Boolean,
     default: false
   },
+  /**
+   * Number of entries to render (including breadcrumb if level is 0)
+   */
   entries: {
     type: Number,
     default: 3
   },
+  /**
+   * Whether to render as a flat list (no indentation)
+   */
   flat: {
     type: Boolean,
     default: false
   },
+  /**
+   * Current nesting level (0 = root)
+   */
   level: {
     type: Number,
     default: 0
   },
+  /**
+   * Whether to hide the stats (size, date) on each entry
+   */
   noStats: {
     type: Boolean,
     default: false

--- a/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderGrid.vue
+++ b/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderGrid.vue
@@ -1,0 +1,102 @@
+<script setup>
+import { computed } from 'vue'
+import { random } from 'lodash'
+
+import AppPlaceholder from '@/components/AppPlaceholder/AppPlaceholder'
+import PathTreePlaceholderListEntry from './PathTreePlaceholderListEntry'
+
+const { compact } = defineProps({
+  compact: {
+    type: Boolean,
+    default: false
+  },
+  entries: {
+    type: Number,
+    default: 1
+  },
+  flat: {
+    type: Boolean,
+    default: false
+  },
+  noStats: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const classList = computed(() => {
+  return {
+    'path-tree-placeholder-grid--compact': compact
+  }
+})
+</script>
+
+<template>
+  <div
+    class="path-tree-placeholder-grid"
+    :class="classList"
+  >
+    <path-tree-placeholder-list-entry
+      class="path-tree-placeholder-grid__breadcrumb"
+      :compact="compact"
+      :flat="flat"
+      :level="0"
+      no-stats
+      flush
+    />
+    <div class="path-tree-placeholder-grid__grid">
+      <div
+        v-for="i in entries"
+        :key="i"
+        class="path-tree-placeholder-grid__grid__entry"
+      >
+        <div class="path-tree-placeholder-grid__grid__entry__name">
+          <app-placeholder
+            :width="random(40, 70)"
+          />
+        </div>
+        <div class="path-tree-placeholder-grid__grid__entry__preview">
+          <app-placeholder
+            width="100%"
+            height="100%"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.path-tree-placeholder-grid {
+  --path-tree-placeholder-grid-gap: #{$spacer-xl};
+  --path-tree-placeholder-grid-entry-border: 1px solid var(--bs-border-color);
+  --path-tree-placeholder-grid-entry-border-radius: var(--bs-border-radius);
+  --path-tree-placeholder-grid-entry-name-padding: #{$spacer-sm} #{$spacer};
+
+  &--compact {
+    --path-tree-placeholder-grid-gap: #{$spacer};
+  }
+
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+    gap: var(--path-tree-placeholder-grid-gap);
+
+    &__entry {
+      border: var(--path-tree-placeholder-grid-entry-border);
+      border-radius: var(--path-tree-placeholder-grid-entry-border-radius);
+
+      &__name {
+        padding: var(--path-tree-placeholder-grid-entry-name-padding);
+      }
+
+      &__preview {
+        border-top: 1px solid var(--bs-border-color);
+        aspect-ratio: 1 / 1;
+        overflow: auto;
+        padding: $spacer;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderGrid.vue
+++ b/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderGrid.vue
@@ -6,18 +6,30 @@ import AppPlaceholder from '@/components/AppPlaceholder/AppPlaceholder'
 import PathTreePlaceholderListEntry from './PathTreePlaceholderListEntry'
 
 const { compact } = defineProps({
+  /**
+   * Whether to render in compact mode (no gaps between entries)
+   */
   compact: {
     type: Boolean,
     default: false
   },
+  /**
+   * Number of entries to render (including breadcrumb if level is 0)
+   */
   entries: {
     type: Number,
     default: 1
   },
+  /**
+   * Whether to render as a flat list (no indentation)
+   */
   flat: {
     type: Boolean,
     default: false
   },
+  /**
+   * Whether to hide the stats (size, date) on each entry
+   */
   noStats: {
     type: Boolean,
     default: false

--- a/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderList.vue
+++ b/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderList.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue'
 
 import PathTreePlaceholderListEntry from './PathTreePlaceholderListEntry.vue'
 
-const { compact, entries, level } = defineProps({
+const props = defineProps({
   compact: {
     type: Boolean,
     default: false
@@ -36,26 +36,26 @@ const { compact, entries, level } = defineProps({
 
 const classList = computed(() => {
   return {
-    'path-tree-placeholder-list--compact': compact
+    'path-tree-placeholder-list--compact': props.compact
   }
 })
 
 const hasBreadcrumb = computed(() => {
-  return level === 0
+  return props.level === 0
 })
 
 const childEntries = computed(() => {
   if (hasBreadcrumb.value) {
-    return Math.max(0, entries - 1)
+    return Math.max(0, props.entries - 1)
   }
-  return entries
+  return props.entries
 })
 
 const childLevel = computed(() => {
   if (hasBreadcrumb.value) {
-    return level + 1
+    return props.level + 1
   }
-  return level
+  return props.level
 })
 </script>
 

--- a/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderList.vue
+++ b/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderList.vue
@@ -4,30 +4,51 @@ import { computed } from 'vue'
 import PathTreePlaceholderListEntry from './PathTreePlaceholderListEntry.vue'
 
 const props = defineProps({
+  /**
+   * Whether to render in compact mode (no gaps between entries)
+   */
   compact: {
     type: Boolean,
     default: false
   },
+  /**
+   * Number of entries to render (including breadcrumb if level is 0)
+   */
   entries: {
     type: Number,
     default: 1
   },
+  /**
+   * Whether to render as a flat list (no indentation)
+   */
   flat: {
     type: Boolean,
     default: false
   },
+  /**
+   * Current nesting level (0 = root)
+   */
   level: {
     type: Number,
     default: 0
   },
+  /**
+   * Whether the list is nested inside another list (adds a left border)
+   */
   nested: {
     type: Boolean,
     default: false
   },
+  /**
+   * Whether to hide the stats (size, date) on each entry
+   */
   noStats: {
     type: Boolean,
     default: false
   },
+  /**
+   * Whether to render entries without a gap between them
+   */
   flush: {
     type: Boolean,
     default: false

--- a/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderList.vue
+++ b/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderList.vue
@@ -1,0 +1,101 @@
+<script setup>
+import { computed } from 'vue'
+
+import PathTreePlaceholderListEntry from './PathTreePlaceholderListEntry.vue'
+
+const { compact, entries, level } = defineProps({
+  compact: {
+    type: Boolean,
+    default: false
+  },
+  entries: {
+    type: Number,
+    default: 1
+  },
+  flat: {
+    type: Boolean,
+    default: false
+  },
+  level: {
+    type: Number,
+    default: 0
+  },
+  nested: {
+    type: Boolean,
+    default: false
+  },
+  noStats: {
+    type: Boolean,
+    default: false
+  },
+  flush: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const classList = computed(() => {
+  return {
+    'path-tree-placeholder-list--compact': compact
+  }
+})
+
+const hasBreadcrumb = computed(() => {
+  return level === 0
+})
+
+const childEntries = computed(() => {
+  if (hasBreadcrumb.value) {
+    return Math.max(0, entries - 1)
+  }
+  return entries
+})
+
+const childLevel = computed(() => {
+  if (hasBreadcrumb.value) {
+    return level + 1
+  }
+  return level
+})
+</script>
+
+<template>
+  <div
+    class="path-tree-placeholder-list"
+    :class="classList"
+  >
+    <path-tree-placeholder-list-entry
+      v-if="hasBreadcrumb.value"
+      :nested="nested"
+      :compact="compact"
+      :level="level"
+      :no-stats="noStats"
+      :flat="flat"
+      open
+    />
+    <path-tree-placeholder-list-entry
+      v-for="i in childEntries"
+      :key="i"
+      :compact="compact"
+      :flush="flush"
+      :level="childLevel"
+      :nested="nested"
+      :no-stats="noStats"
+      :flat="flat"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.path-tree-placeholder-list {
+  --path-tree-placeholder-list-gap: 1px;
+
+  display: flex;
+  flex-direction: column;
+  gap: var(--path-tree-placeholder-list-gap);
+
+  &--compact {
+    --path-tree-placeholder-list-gap: 0;
+  }
+}
+</style>

--- a/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderListEntry.vue
+++ b/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderListEntry.vue
@@ -1,0 +1,152 @@
+<script setup>
+import { computed } from 'vue'
+import { random } from 'lodash'
+import { PhosphorIcon } from '@icij/murmur-next'
+
+import AppPlaceholder from '@/components/AppPlaceholder/AppPlaceholder'
+
+const { compact, flat, flush, level, open } = defineProps({
+  compact: {
+    type: Boolean,
+    default: false
+  },
+  flat: {
+    type: Boolean,
+    default: false
+  },
+  flush: {
+    type: Boolean,
+    default: false
+  },
+  level: {
+    type: Number,
+    default: 0
+  },
+  nested: {
+    type: Boolean,
+    default: false
+  },
+  noStats: {
+    type: Boolean,
+    default: false
+  },
+  open: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const style = computed(() => ({
+  '--path-tree-placeholder-list-entry-indent-factor': level
+}))
+
+const classList = computed(() => {
+  return {
+    'path-tree-placeholder-list-entry--compact': compact,
+    'path-tree-placeholder-list-entry--flush': flush,
+    'path-tree-placeholder-list-entry--flat': flat
+  }
+})
+
+const caretIcon = computed(() => {
+  return open ? PhCaretDown : PhCaretRight
+})
+</script>
+
+<template>
+  <div
+    class="path-tree-placeholder-list-entry"
+    :class="classList"
+    :style="style"
+  >
+    <div class="path-tree-placeholder-list-entry__name">
+      <phosphor-icon
+        v-if="nested"
+        :name="caretIcon"
+        weight="fill"
+        width="1em"
+      />
+      <app-placeholder width="1em" />
+      <app-placeholder :width="random(40, 70)" />
+    </div>
+    <div
+      v-if="!noStats"
+      class="path-tree-placeholder-list-entry__stats"
+    >
+      <app-placeholder width="100%" />
+      <template v-if="!compact">
+        <app-placeholder width="100%" />
+        <app-placeholder width="100%" />
+      </template>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.path-tree-placeholder-list-entry {
+  --path-tree-placeholder-list-entry-background: transparent;
+  --path-tree-placeholder-list-entry-border-radius: var(--bs-border-radius);
+  --path-tree-placeholder-list-entry-border: 0;
+  --path-tree-placeholder-list-entry-height: 3.5rem;
+  --path-tree-placeholder-list-entry-line-height: 1;
+  --path-tree-placeholder-list-entry-padding: #{$spacer-sm} #{$spacer};
+  --path-tree-placeholder-list-entry-stats-width: 1rem;
+  --path-tree-placeholder-list-entry-stats-flex: 0 0 var(--path-tree-placeholder-list-entry-stats-width);
+
+  --path-tree-placeholder-list-entry-indent-width: #{$spacer};
+  --path-tree-placeholder-list-entry-indent-factor: 0;
+  --path-tree-placeholder-list-entry-margin-left: calc(var(--path-tree-placeholder-list-entry-indent-width) * var(--path-tree-placeholder-list-entry-indent-factor));
+
+  &--flush {
+    --path-tree-placeholder-list-entry-padding: #{$spacer-sm} 0;
+  }
+
+  &--flat {
+    --path-tree-placeholder-list-entry-margin-left: 0;
+  }
+
+  &--compact {
+    --path-tree-placeholder-list-entry-padding: 2px 0;
+    --path-tree-placeholder-list-entry-height: 1.75rem;
+    --path-tree-placeholder-list-entry-stats-width: 30px;
+  }
+
+  display: flex;
+  align-items: center;
+  gap: $spacer;
+  background: var(--path-tree-placeholder-list-entry-background);
+  height: var(--path-tree-placeholder-list-entry-height);
+  line-height: var(--path-tree-placeholder-list-entry-line-height);
+  padding: var(--path-tree-placeholder-list-entry-padding);
+  border: var(--path-tree-placeholder-list-entry-border);
+  border-radius: var(--path-tree-placeholder-list-entry-border-radius);
+  margin-left: var(--path-tree-placeholder-list-entry-margin-left);
+
+  &__name {
+    flex: 1 0 auto;
+    display: flex;
+    gap: $spacer-xs;
+    align-items: center;
+    color: var(--bs-tertiary-bg-subtle);
+  }
+
+  &__stats {
+    max-width: var(--path-tree-placeholder-list-entry-stats-width);
+    flex: var(--path-tree-placeholder-list-entry-stats-flex);
+    width: 100%;
+    display: flex;
+    gap: $spacer;
+    align-items: center;
+    margin-left: auto;
+  }
+
+  &:not(.path-tree-placeholder-list-entry--compact) &__stats {
+    --path-tree-placeholder-list-entry-stats-width: 300px;
+
+    @include media-breakpoint-down(md) {
+      --path-tree-placeholder-list-entry-stats-width: 260px;
+      --path-tree-placeholder-list-entry-stats-flex: 1 0 0;
+    }
+  }
+}
+</style>

--- a/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderListEntry.vue
+++ b/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderListEntry.vue
@@ -6,30 +6,51 @@ import { PhosphorIcon } from '@icij/murmur-next'
 import AppPlaceholder from '@/components/AppPlaceholder/AppPlaceholder'
 
 const { compact, flat, flush, level, open } = defineProps({
+  /**
+   * Whether to render in compact mode (no gaps between entries)
+   */
   compact: {
     type: Boolean,
     default: false
   },
+  /**
+   * Whether to render as a flat list (no indentation)
+   */
   flat: {
     type: Boolean,
     default: false
   },
+  /**
+   * Whether to render entries without a padding
+   */
   flush: {
     type: Boolean,
     default: false
   },
+  /**
+   * Current nesting level (0 = root)
+   */
   level: {
     type: Number,
     default: 0
   },
+  /**
+   * Whether the entry is nested inside another list (adds a left border)
+   */
   nested: {
     type: Boolean,
     default: false
   },
+  /**
+   * Whether to hide the stats (size, date) on each entry
+   */
   noStats: {
     type: Boolean,
     default: false
   },
+  /**
+   * Whether the entry is "open" (shows down caret instead of right caret)
+   */
   open: {
     type: Boolean,
     default: false

--- a/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderTree.vue
+++ b/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderTree.vue
@@ -1,0 +1,50 @@
+<script setup>
+import { computed } from 'vue'
+
+import PathTreePlaceholderList from './PathTreePlaceholderList'
+
+const { compact, entries, level } = defineProps({
+  compact: {
+    type: Boolean,
+    default: false
+  },
+  entries: {
+    type: Number,
+    default: 1
+  },
+  flat: {
+    type: Boolean,
+    default: false
+  },
+  level: {
+    type: Number,
+    default: 0
+  },
+  noStats: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const classList = computed(() => {
+  return {
+    'path-tree-placeholder-list--compact': compact
+  }
+})
+</script>
+
+<template>
+  <div
+    class="path-tree-placeholder-tree"
+    :class="classList"
+  >
+    <path-tree-placeholder-list
+      :compact="compact"
+      :entries="entries"
+      :flat="flat"
+      :level="level"
+      :no-stats="noStats"
+      nested
+    />
+  </div>
+</template>

--- a/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderTree.vue
+++ b/src/components/PathTree/PathTreePlaceholder/PathTreePlaceholderTree.vue
@@ -4,22 +4,37 @@ import { computed } from 'vue'
 import PathTreePlaceholderList from './PathTreePlaceholderList'
 
 const { compact, entries, level } = defineProps({
+  /**
+   * Whether to render in compact mode (no gaps between entries)
+   */
   compact: {
     type: Boolean,
     default: false
   },
+  /**
+   * Number of entries to render (including breadcrumb if level is 0)
+   */
   entries: {
     type: Number,
     default: 1
   },
+  /**
+   * Whether to render as a flat list (no indentation)
+   */
   flat: {
     type: Boolean,
     default: false
   },
+  /**
+   * Current nesting level (0 = root)
+   */
   level: {
     type: Number,
     default: 0
   },
+  /**
+   * Whether to hide the stats (size, date) on each entry
+   */
   noStats: {
     type: Boolean,
     default: false

--- a/src/components/PathTree/PathTreeView/PathTreeView.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeView.vue
@@ -3,9 +3,10 @@ import { computed, provide, watch } from 'vue'
 
 import PathTreeViewLabel from './PathTreeViewLabel'
 import PathTreeViewSearch from './PathTreeViewSearch'
+import { LAYOUTS, layoutValidator } from '@/enums/pathTree'
 
 const query = defineModel('query', { type: String })
-const nested = defineModel('nested', { type: Boolean })
+const layout = defineModel('layout', { type: String, default: LAYOUTS.TREE, validator: layoutValidator })
 
 const props = defineProps({
   label: {
@@ -58,7 +59,7 @@ const classList = computed(() => {
   >
     <path-tree-view-label
       v-if="!noLabel"
-      v-model:nested="nested"
+      v-model:layout="layout"
       :label="label"
       :icon="icon"
     />

--- a/src/components/PathTree/PathTreeView/PathTreeView.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeView.vue
@@ -3,6 +3,7 @@ import { computed, provide, watch } from 'vue'
 
 import PathTreeViewLabel from './PathTreeViewLabel'
 import PathTreeViewSearch from './PathTreeViewSearch'
+import PathTreePlaceholder from '@/components/PathTree/PathTreePlaceholder/PathTreePlaceholder.vue'
 import { LAYOUTS, layoutValidator } from '@/enums/pathTree'
 
 const query = defineModel('query', { type: String })
@@ -21,10 +22,26 @@ const props = defineProps({
   compact: {
     type: Boolean
   },
+  flat: {
+    type: Boolean
+  },
+  level: {
+    type: Number,
+    default: 0
+  },
   noLabel: {
     type: Boolean
   },
+  noPlaceholder: {
+    type: Boolean
+  },
+  noStats: {
+    type: Boolean
+  },
   noSearch: {
+    type: Boolean
+  },
+  isLoading: {
     type: Boolean
   }
 })
@@ -47,7 +64,8 @@ watch(
 
 const classList = computed(() => {
   return {
-    'path-tree-view--compact': props.compact
+    'path-tree-view--compact': props.compact,
+    [`path-tree-view--${props.layout}`]: true
   }
 })
 </script>
@@ -68,9 +86,20 @@ const classList = computed(() => {
       v-model="query"
       :shadow="!compact"
     />
-    <div>
+    <slot name="before" />
+    <div v-if="isLoading && !noPlaceholder">
+      <path-tree-placeholder
+        :compact="compact"
+        :layout="layout"
+        :flat="flat"
+        :level="1"
+        :no-stats="noStats"
+      />
+    </div>
+    <div v-else>
       <slot v-bind="{ selectMode }" />
     </div>
+    <slot name="after" />
   </div>
 </template>
 
@@ -79,7 +108,7 @@ const classList = computed(() => {
   gap: $spacer-lg;
 
   &--compact {
-    gap: $spacer;
+    gap: $spacer-sm;
   }
 }
 </style>

--- a/src/components/PathTree/PathTreeView/PathTreeView.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeView.vue
@@ -10,37 +10,70 @@ const query = defineModel('query', { type: String })
 const layout = defineModel('layout', { type: String, default: LAYOUTS.TREE, validator: layoutValidator })
 
 const props = defineProps({
+  /**
+   * Optional label to display above the tree
+   */
   label: {
     type: String
   },
+  /**
+   * Optional icon to display next to the label (string name or icon object)
+   */
   icon: {
     type: [String, Object, Array]
   },
+  /**
+   * Whether to enable select mode (checkboxes next to entries)
+   */
   selectMode: {
     type: Boolean
   },
+  /**
+   * Use compact mode (no gaps between entries)
+   */
   compact: {
     type: Boolean
   },
+  /**
+   * Whether to render as a flat list (no indentation)
+   */
   flat: {
     type: Boolean
   },
+  /**
+   * Current nesting level (0 = root)
+   */
   level: {
     type: Number,
     default: 0
   },
+  /**
+   * Whether to hide the label
+   */
   noLabel: {
     type: Boolean
   },
+  /**
+   * Whether to hide the placeholder when loading
+   */
   noPlaceholder: {
     type: Boolean
   },
+  /**
+   * Whether to hide the search box
+   */
   noStats: {
     type: Boolean
   },
+  /**
+   * Whether to hide the search box
+   */
   noSearch: {
     type: Boolean
   },
+  /**
+   * Whether the tree is currently loading (shows placeholder if true)
+   */
   isLoading: {
     type: Boolean
   }

--- a/src/components/PathTree/PathTreeView/PathTreeViewDocument.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewDocument.vue
@@ -1,10 +1,11 @@
 <script setup>
 import { computed } from 'vue'
 
-import { useDocumentModal } from '@/composables/useDocumentModal'
 import DisplayContentTypeIcon from '@/components/Display/DisplayContentTypeIcon'
 import Document from '@/api/resources/Document'
 import PathTreeViewEntry from '@/components/PathTree/PathTreeView/PathTreeViewEntry'
+import { useDocumentModal } from '@/composables/useDocumentModal'
+import { LAYOUTS, layoutValidator } from '@/enums/pathTree'
 
 const selected = defineModel('selected', { type: Boolean })
 
@@ -21,9 +22,10 @@ const { entry, selectMode } = defineProps({
     type: Boolean,
     default: false
   },
-  nested: {
-    type: Boolean,
-    default: false
+  layout: {
+    type: String,
+    default: LAYOUTS.TREE,
+    validator: layoutValidator
   },
   selectMode: {
     type: Boolean,
@@ -70,7 +72,7 @@ const handleClick = (event) => {
     type="document"
     :to="to"
     :level="level"
-    :nested="nested"
+    :layout="layout"
     :compact="compact"
     :name="document.title"
     :path="document.path"

--- a/src/components/PathTree/PathTreeView/PathTreeViewDocument.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewDocument.vue
@@ -55,6 +55,9 @@ const handleClick = (event) => {
     event.stopPropagation()
     showDocumentModal(params.index, params.id, params.routing)
   }
+  else {
+    selected.value = !selected.value
+  }
 }
 </script>
 
@@ -72,7 +75,7 @@ const handleClick = (event) => {
     :name="document.title"
     :path="document.path"
     :projects="[document.project]"
-    @click="handleClick"
+    @click.capture="handleClick"
   >
     <template #icon>
       <display-content-type-icon

--- a/src/components/PathTree/PathTreeView/PathTreeViewDocument.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewDocument.vue
@@ -11,31 +11,52 @@ import { LAYOUTS, layoutValidator } from '@/enums/pathTree'
 const selected = defineModel('selected', { type: Boolean })
 
 const { entry, compact, layout, noLink, selectMode } = defineProps({
+  /**
+   * Document or entry object to render
+   */
   entry: {
     type: Object,
     required: true
   },
+  /**
+   * Level of indentation (0 = root level)
+   */
   level: {
     type: Number,
     default: 0
   },
+  /**
+   * Whether to render in compact mode (no gaps between entries)
+   */
   compact: {
     type: Boolean,
     default: false
   },
+  /**
+   * Whether to disable the link (always render as plain text)
+   */
   noLink: {
     type: Boolean,
     default: false
   },
+  /**
+   * Layout to use for rendering the entry
+   */
   layout: {
     type: String,
     default: LAYOUTS.TREE,
     validator: layoutValidator
   },
+  /**
+   * Whether to enable select mode (checkboxes next to entries)
+   */
   selectMode: {
     type: Boolean,
     default: false
   },
+  /**
+   * Whether to render with squared corners (for nested list)
+   */
   squared: {
     type: Boolean,
     default: false

--- a/src/components/PathTree/PathTreeView/PathTreeViewDocument.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewDocument.vue
@@ -1,0 +1,84 @@
+<script setup>
+import { computed } from 'vue'
+
+import { useDocumentModal } from '@/composables/useDocumentModal'
+import DisplayContentTypeIcon from '@/components/Display/DisplayContentTypeIcon'
+import Document from '@/api/resources/Document'
+import PathTreeViewEntry from '@/components/PathTree/PathTreeView/PathTreeViewEntry'
+
+const selected = defineModel('selected', { type: Boolean })
+
+const { entry, selectMode } = defineProps({
+  entry: {
+    type: Object,
+    required: true
+  },
+  level: {
+    type: Number,
+    default: 0
+  },
+  compact: {
+    type: Boolean,
+    default: false
+  },
+  nested: {
+    type: Boolean,
+    default: false
+  },
+  selectMode: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const { show: showDocumentModal } = useDocumentModal()
+
+const document = computed(() => {
+  return entry instanceof Document ? entry : Document.create(entry)
+})
+
+const isLink = computed(() => {
+  const { routerParams: params } = document.value
+  return params.id && params.index && !selectMode
+})
+
+const to = computed(() => {
+  const { routerParams: params } = document.value
+  const name = 'document-standalone'
+  return isLink.value ? { name, params } : null
+})
+
+const handleClick = (event) => {
+  const { routerParams: params } = document.value
+  if (isLink.value) {
+    event.preventDefault()
+    event.stopPropagation()
+    showDocumentModal(params.index, params.id, params.routing)
+  }
+}
+</script>
+
+<template>
+  <path-tree-view-entry
+    v-model:selected="selected"
+    no-link
+    no-stats
+    collapse
+    type="document"
+    :to="to"
+    :level="level"
+    :nested="nested"
+    :compact="compact"
+    :name="document.title"
+    :path="document.path"
+    :projects="[document.project]"
+    @click="handleClick"
+  >
+    <template #icon>
+      <display-content-type-icon
+        :value="document.contentType"
+        colorize
+      />
+    </template>
+  </path-tree-view-entry>
+</template>

--- a/src/components/PathTree/PathTreeView/PathTreeViewDocumentPreview.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewDocumentPreview.vue
@@ -4,7 +4,10 @@ import { computed } from 'vue'
 import Document from '@/api/resources/Document'
 import DocumentThumbnail from '@/components/Document/DocumentThumbnail/DocumentThumbnail'
 
-const { entry } = defineProps({
+const props = defineProps({
+  /**
+   * Document or entry object to render
+   */
   entry: {
     type: Object,
     required: true
@@ -12,7 +15,7 @@ const { entry } = defineProps({
 })
 
 const document = computed(() => {
-  return entry instanceof Document ? entry : Document.create(entry)
+  return props.entry instanceof Document ? props.entry : Document.create(props.entry)
 })
 </script>
 

--- a/src/components/PathTree/PathTreeView/PathTreeViewDocumentPreview.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewDocumentPreview.vue
@@ -1,0 +1,41 @@
+<script setup>
+import { computed } from 'vue'
+
+import Document from '@/api/resources/Document'
+import DocumentThumbnail from '@/components/Document/DocumentThumbnail/DocumentThumbnail'
+
+const { entry } = defineProps({
+  entry: {
+    type: Object,
+    required: true
+  }
+})
+
+const document = computed(() => {
+  return entry instanceof Document ? entry : Document.create(entry)
+})
+</script>
+
+<template>
+  <div class="path-tree-view-document-preview rounded-bottom">
+    <document-thumbnail
+      class="path-tree-view-document-preview__thumbnail"
+      size="lg"
+      :clickable="false"
+      :document="document"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.path-tree-view-document-preview {
+  background: transparent;
+  border-top: 1px solid var(--bs-border-color);
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  overflow: hidden;
+  padding: $spacer;
+}
+</style>

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntry.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntry.vue
@@ -1,21 +1,21 @@
 <script setup>
-import { computed, inject, ref } from 'vue'
+import { computed, inject, ref, useSlots } from 'vue'
 
 import PathTreeViewEntryName from './PathTreeViewEntryName'
+import PathTreeViewEntrySearchLink from './PathTreeViewEntrySearchLink'
+import PathTreeViewEntryPreview from './PathTreeViewEntryPreview'
 import PathTreeViewEntryStats from './PathTreeViewEntryStats'
-import { LAYOUTS, layoutValidator } from '@/enums/pathTree'
+import { LAYOUTS, layoutValidator, SORT_BY, sortByValidator, ORDER_BY, orderByValidator } from '@/enums/pathTree'
 
 const collapse = defineModel('collapse', { type: Boolean })
 const selected = defineModel('selected', { type: Boolean })
 const indeterminate = defineModel('indeterminate', { type: Boolean })
+const path = defineModel('path', { type: String, required: true })
 
 const props = defineProps({
   name: {
     type: String,
     required: true
-  },
-  path: {
-    type: String
   },
   projects: {
     type: Array,
@@ -37,6 +37,9 @@ const props = defineProps({
     type: Number,
     default: 0
   },
+  flush: {
+    type: Boolean
+  },
   size: {
     type: Number,
     default: 0
@@ -47,10 +50,22 @@ const props = defineProps({
   loading: {
     type: Boolean
   },
-  noStats: {
+  noCaret: {
+    type: Boolean
+  },
+  noDocuments: {
     type: Boolean
   },
   noLink: {
+    type: Boolean
+  },
+  noPreview: {
+    type: Boolean
+  },
+  noStats: {
+    type: Boolean
+  },
+  noSearchLink: {
     type: Boolean
   },
   layout: {
@@ -62,30 +77,52 @@ const props = defineProps({
     type: Number,
     default: 0
   },
-  type: {
-    type: String,
-    default: 'directory'
+  squared: {
+    type: Boolean
+  },
+  stretched: {
+    type: Boolean
   },
   to: {
     type: Object,
     default: null
+  },
+  sortBy: {
+    type: String,
+    default: SORT_BY.KEY,
+    validator: sortByValidator
+  },
+  orderBy: {
+    type: String,
+    default: ORDER_BY.ASC,
+    validator: orderByValidator
   }
 })
 
 const active = ref(false)
+const slots = useSlots()
 
 const classList = computed(() => {
   return {
     'path-tree-view-entry--active': active.value,
     'path-tree-view-entry--selected': selected.value,
     'path-tree-view-entry--compact': compactOrInjected.value,
-    [`path-tree-view-entry--${props.type}`]: true
+    'path-tree-view-entry--no-link': props.noLink,
+    'path-tree-view-entry--squared': props.squared,
+    'path-tree-view-entry--stretched': props.stretched,
+    'path-tree-view-entry--flush': props.flush && props.level === 0,
+    [`path-tree-view-entry--root`]: isRoot.value,
+    [`path-tree-view-entry--${props.layout}`]: true
   }
 })
 
 const selectModeOrInjected = computed(() => props.selectMode ?? inject('selectMode', false))
 const compactOrInjected = computed(() => props.compact ?? inject('compact', false))
-const tag = computed(() => (props.to ? 'router-link' : 'div'))
+const tag = computed(() => (props.to && !props.noLink ? 'router-link' : 'div'))
+const isGridView = computed(() => props.layout === LAYOUTS.GRID)
+const isRoot = computed(() => props.level === 0)
+const hasPreview = computed(() => isGridView.value && !isRoot.value)
+const hasChildren = computed(() => !!slots.default)
 </script>
 
 <template>
@@ -97,7 +134,7 @@ const tag = computed(() => (props.to ? 'router-link' : 'div'))
   >
     <div
       v-if="!noHeader"
-      class="path-tree-view-entry__header d-flex align-items-center position-relative"
+      class="path-tree-view-entry__header d-flex align-items-center"
       @mouseenter="active = true"
       @mouseleave="active = false"
     >
@@ -111,19 +148,27 @@ const tag = computed(() => (props.to ? 'router-link' : 'div'))
         :select-mode="selectModeOrInjected"
         :layout="layout"
         :level="level"
-        :type="type"
+        :no-caret="noCaret"
+        :no-link="noLink"
+        :no-search-link="noSearchLink"
       >
         <template #icon>
           <slot name="icon" />
         </template>
         <slot name="name" />
       </path-tree-view-entry-name>
-      <path-tree-view-entry-stats
-        v-if="!noStats"
-        class="ms-auto"
+      <path-tree-view-entry-search-link
+        v-if="!noSearchLink && isGridView"
+        class="path-tree-view-entry__header__search-link"
         :path="path"
         :projects="projects"
-        :no-link="noLink"
+      />
+      <path-tree-view-entry-stats
+        v-if="!noStats && !isGridView"
+        :path="path"
+        class="ms-auto"
+        :projects="projects"
+        :no-search-link="noSearchLink"
         :compact="compactOrInjected"
         :documents="documents"
         :directories="directories"
@@ -132,7 +177,20 @@ const tag = computed(() => (props.to ? 'router-link' : 'div'))
         :active="compactOrInjected ? selected : active"
       />
     </div>
+    <div v-if="!noPreview && hasPreview">
+      <slot name="preview">
+        <path-tree-view-entry-preview
+          v-model:path="path"
+          :compact="compact"
+          :no-documents="noDocuments"
+          :projects="projects"
+          :sort-by="sortBy"
+          :order-by="orderBy"
+        />
+      </slot>
+    </div>
     <b-collapse
+      v-if="hasChildren"
       :model-value="!collapse"
       class="path-tree-view-entry__subdirectories"
     >
@@ -141,31 +199,110 @@ const tag = computed(() => (props.to ? 'router-link' : 'div'))
   </component>
 </template>
 
-<style lang="scss" scoped>
+<style lang="scss">
 .path-tree-view-entry {
-  margin-top: 1px;
+  --path-tree-view-entry-bg: transparent;
+  --path-tree-view-entry-border: none;
+  --path-tree-view-entry-border-radius: none;
+  --path-tree-view-entry-cursor: default;
+  --path-tree-view-entry-margin-top: 1px;
+  --path-tree-view-entry-header-height: 3.5rem;
+  --path-tree-view-entry-header-line-height: 1;
+  --path-tree-view-entry-header-padding: #{$spacer-sm} #{$spacer};
+  --path-tree-view-entry-header-bg: transparent;
+  --path-tree-view-entry-header-color: inherit;
+  --path-tree-view-entry-header-border-radius: var(--bs-border-radius);
+  --path-tree-view-entry-header-search-link-visibility: hidden;
+  --path-tree-view-entry-header-search-link-offset: -#{$spacer};
+  --path-tree-view-entry-subdirectories-gap: #{$spacer-xl};
+
+  border: var(--path-tree-view-entry-border);
+  border-radius: var(--path-tree-view-entry-border-radius);
+  background: var(--path-tree-view-entry-bg);
+  cursor: var(--path-tree-view-entry-cursor);
+  margin-top: var(--path-tree-view-entry-margin-top);
   display: block;
+  position: relative;
 
   &--compact {
-    margin-top: 0;
+    --path-tree-view-entry-margin-top: 0;
+    --path-tree-view-entry-header-padding: 2px 0;
+    --path-tree-view-entry-header-height: 1.75rem;
+    --path-tree-view-entry-header-search-link-offset: -#{$spacer-sm};
   }
 
-  &__header {
-    border-radius: var(--bs-border-radius);
-    padding: $spacer-sm $spacer;
-
-    .path-tree-view-entry--compact & {
-      padding: 2px 0;
-    }
+  &--squared {
+    --path-tree-view-entry-border-radius: 0;
+    --path-tree-view-entry-header-border-radius: 0;
+    --path-tree-view-entry-margin-top: 0;
   }
 
-  &--active:not(&--compact) > &__header {
-    background: var(--bs-tertiary-bg-subtle);
+  &--stretched > &__header:after {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+    content: "";
   }
 
-  &--selected:not(&--compact) > &__header {
-    background: var(--bs-action);
-    color: var(--bs-white);
+  &--flush {
+    --path-tree-view-entry-header-padding: #{$spacer-sm} 0;
+    --path-tree-view-entry-header-search-link-offset: -#{$spacer-sm};
+  }
+
+  &--grid:not(&--root) {
+    --path-tree-view-entry-border: 1px solid var(--bs-border-color);
+    --path-tree-view-entry-border-radius: var(--bs-border-radius);
+    --path-tree-view-entry-header-border-radius: var(--bs-border-radius) var(--bs-border-radius) 0 0;
+  }
+
+  &--grid > .path-tree-view-entry__subdirectories {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+    gap: var(--path-tree-view-entry-subdirectories-gap);
+  }
+
+  &--grid.path-tree-view-entry--compact {
+    --path-tree-view-entry-subdirectories-gap: #{$spacer};
+  }
+
+  &--active {
+    --path-tree-view-entry-header-search-link-visibility: visible
+  }
+
+  &--active:not(&--no-link) {
+    --path-tree-view-entry-cursor: pointer;
+  }
+
+  &--active:not(&--compact):not(&--no-link) {
+    --path-tree-view-entry-header-bg: var(--bs-tertiary-bg-subtle);
+  }
+
+  &--active.path-tree-view-entry--grid:not(&--no-link) {
+    --path-tree-view-entry-bg: var(--bs-secondary-bg-subtle);
+    --path-tree-view-entry-header-bg: transparent;
+  }
+
+  &--selected:not(&--compact),
+  &--selected:not(&--compact).path-tree-view-entry--active {
+    --path-tree-view-entry-header-bg: var(--bs-action);
+    --path-tree-view-entry-header-color: var(--bs-white);
+  }
+
+  & > &__header {
+    border-radius: var(--path-tree-view-entry-header-border-radius);
+    padding: var(--path-tree-view-entry-header-padding);
+    background: var(--path-tree-view-entry-header-bg);
+    color: var(--path-tree-view-entry-header-color);
+    height: var(--path-tree-view-entry-header-height);
+    line-height: var(--path-tree-view-entry-header-line-height);
+  }
+
+  & > &__header > &__header__search-link {
+    visibility: var(--path-tree-view-entry-header-search-link-visibility);
+    margin-right: var(--path-tree-view-entry-header-search-link-offset);
   }
 }
 </style>

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntry.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntry.vue
@@ -3,6 +3,7 @@ import { computed, inject, ref } from 'vue'
 
 import PathTreeViewEntryName from './PathTreeViewEntryName'
 import PathTreeViewEntryStats from './PathTreeViewEntryStats'
+import { LAYOUTS, layoutValidator } from '@/enums/pathTree'
 
 const collapse = defineModel('collapse', { type: Boolean })
 const selected = defineModel('selected', { type: Boolean })
@@ -52,8 +53,10 @@ const props = defineProps({
   noLink: {
     type: Boolean
   },
-  nested: {
-    type: Boolean
+  layout: {
+    type: String,
+    default: LAYOUTS.TREE,
+    validator: layoutValidator
   },
   level: {
     type: Number,
@@ -106,7 +109,7 @@ const tag = computed(() => (props.to ? 'router-link' : 'div'))
         :name="name"
         :loading="loading"
         :select-mode="selectModeOrInjected"
-        :nested="nested"
+        :layout="layout"
         :level="level"
         :type="type"
       >

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntry.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntry.vue
@@ -13,85 +13,154 @@ const indeterminate = defineModel('indeterminate', { type: Boolean })
 const path = defineModel('path', { type: String, required: true })
 
 const props = defineProps({
+  /**
+   * Name of the entry (file or directory name)
+   */
   name: {
     type: String,
     required: true
   },
+  /**
+   * Array of project IDs the entry belongs to
+   */
   projects: {
     type: Array,
     default: () => []
   },
+  /**
+   * Whether the entry is currently in select mode (checkboxes visible)
+   */
   selectMode: {
     type: Boolean,
     default: null
   },
+  /**
+   * Whether to render in compact mode (no gaps between entries)
+   */
   compact: {
     type: Boolean,
     default: null
   },
+  /**
+   * Number of documents in the directory (only for directories)
+   */
   documents: {
     type: Number,
     default: 0
   },
+  /**
+   * Number of subdirectories in the directory (only for directories)
+   */
   directories: {
     type: Number,
     default: 0
   },
+  /**
+   * Whether to render with flushed styles (no padding)
+   */
   flush: {
     type: Boolean
   },
+  /**
+   * Total size of all documents in the directory (only for directories)
+   */
   size: {
     type: Number,
     default: 0
   },
+  /**
+   * Whether to hide the header (name, stats)
+   */
   noHeader: {
     type: Boolean
   },
+  /**
+   * Whether the entry is in loading state
+   */
   loading: {
     type: Boolean
   },
+  /**
+   * Whether to display the caret (for collapsing/expanding)
+   */
   noCaret: {
     type: Boolean
   },
+  /**
+   * Whether to display documents in the nested directory preview
+   */
   noDocuments: {
     type: Boolean
   },
+  /**
+   * Whether to disable the link (always render as plain text)
+   */
   noLink: {
     type: Boolean
   },
+  /**
+   * Whether to hide the preview of the entry in grid view
+   */
   noPreview: {
     type: Boolean
   },
+  /**
+   * Whether to hide the stats (size, date) on the entry
+   */
   noStats: {
     type: Boolean
   },
+  /**
+   * Whether to hide the search link (magnifying glass icon)
+   */
   noSearchLink: {
     type: Boolean
   },
+  /**
+   * Layout to use for rendering the entry
+   */
   layout: {
     type: String,
     default: LAYOUTS.TREE,
     validator: layoutValidator
   },
+  /**
+   * Current nesting level (0 = root)
+   */
   level: {
     type: Number,
     default: 0
   },
+  /**
+   * Whether the entry has squared corners (for nested list)
+   */
   squared: {
     type: Boolean
   },
+  /**
+   * Whether to stretch the clickable area of the entry (only with link)
+   */
   stretched: {
     type: Boolean
   },
+  /**
+   * Router link target (if different from path)
+   */
   to: {
     type: Object,
     default: null
   },
+  /**
+   * Sort field to use for documents in the nested directory preview
+   */
   sortBy: {
     type: String,
     default: SORT_BY.KEY,
     validator: sortByValidator
   },
+  /**
+   * Sort order to use for documents in the nested directory preview
+   */
   orderBy: {
     type: String,
     default: ORDER_BY.ASC,

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntry.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntry.vue
@@ -58,6 +58,14 @@ const props = defineProps({
   level: {
     type: Number,
     default: 0
+  },
+  type: {
+    type: String,
+    default: 'directory'
+  },
+  to: {
+    type: Object,
+    default: null
   }
 })
 
@@ -67,16 +75,20 @@ const classList = computed(() => {
   return {
     'path-tree-view-entry--active': active.value,
     'path-tree-view-entry--selected': selected.value,
-    'path-tree-view-entry--compact': compactOrInjected.value
+    'path-tree-view-entry--compact': compactOrInjected.value,
+    [`path-tree-view-entry--${props.type}`]: true
   }
 })
 
 const selectModeOrInjected = computed(() => props.selectMode ?? inject('selectMode', false))
 const compactOrInjected = computed(() => props.compact ?? inject('compact', false))
+const tag = computed(() => (props.to ? 'router-link' : 'div'))
 </script>
 
 <template>
-  <div
+  <component
+    :is="tag"
+    :to="to"
     class="path-tree-view-entry"
     :class="classList"
   >
@@ -96,7 +108,11 @@ const compactOrInjected = computed(() => props.compact ?? inject('compact', fals
         :select-mode="selectModeOrInjected"
         :nested="nested"
         :level="level"
+        :type="type"
       >
+        <template #icon>
+          <slot name="icon" />
+        </template>
         <slot name="name" />
       </path-tree-view-entry-name>
       <path-tree-view-entry-stats
@@ -119,12 +135,13 @@ const compactOrInjected = computed(() => props.compact ?? inject('compact', fals
     >
       <slot v-bind="{ collapse, selected, active }" />
     </b-collapse>
-  </div>
+  </component>
 </template>
 
 <style lang="scss" scoped>
 .path-tree-view-entry {
   margin-top: 1px;
+  display: block;
 
   &--compact {
     margin-top: 0;

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryBreadcrumb.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryBreadcrumb.vue
@@ -5,14 +5,17 @@ import PathTreeBreadcrumb from '@/components/PathTree/PathTreeBreadcrumb/PathTre
 
 const modelValue = defineModel({ type: String })
 
-const { compact } = defineProps({
+const props = defineProps({
+  /**
+   * Whether to render in compact mode (no gaps between entries)
+   */
   compact: {
     type: Boolean
   }
 })
 
 const maxDirectories = computed(() => {
-  return compact ? 2 : 3
+  return props.compact ? 2 : 3
 })
 </script>
 

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryBreadcrumb.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryBreadcrumb.vue
@@ -26,7 +26,7 @@ const maxDirectories = computed(() => {
     <path-tree-breadcrumb
       v-model="modelValue"
       :compact="compact"
-      :max-directories="maxDirectories"
+      :max-entries="maxDirectories"
       datadir-label
     />
   </div>

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryMore.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryMore.vue
@@ -6,31 +6,53 @@ import { ButtonIcon } from '@icij/murmur-next'
 import { LAYOUTS, layoutValidator } from '@/enums/pathTree'
 
 const props = defineProps({
+  /**
+   * Whether to render as a flat list (no indentation)
+   */
   flat: {
     type: Boolean,
     default: false
   },
+  /**
+   * Current page number (1-based)
+   */
   page: {
     type: Number,
     default: 1
   },
+  /**
+   * Number of entries to load per page
+   */
   perPage: {
     type: Number,
     default: 25
   },
+  /**
+   * Total number of entries available
+   */
   total: {
     type: Number,
     default: 0
   },
+  /**
+   * Whether to render in compact mode (no gaps between entries). If null, will
+   * inherit from the parent PathTreeView component.
+   */
   compact: {
     type: Boolean,
     default: null
   },
+  /**
+   * Layout to use for rendering the entry
+   */
   layout: {
     type: String,
     default: LAYOUTS.TREE,
     validator: layoutValidator
   },
+  /**
+   * Current nesting level (0 = root)
+   */
   level: {
     type: Number,
     default: 0

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryMore.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryMore.vue
@@ -19,10 +19,19 @@ const props = defineProps({
   compact: {
     type: Boolean,
     default: null
-  }
+  },
+  level: {
+    type: Number,
+    default: 0
+  },
 })
 
 const { t } = useI18n()
+
+const style = computed(() => ({
+  '--level-indent-factor': props.level
+}))
+
 const nextPageSize = computed(() => {
   return Math.min(props.perPage, props.total - props.page * props.perPage)
 })
@@ -37,15 +46,25 @@ const size = computed(() => (compactOrInjected.value ? 'sm' : 'md'))
 
 <template>
   <button-icon
-    v-if="directoriesLeft > 0"
     :icon-left="PhCaretDown"
     icon-left-variant="primary"
-    class="shadow-lg text-nowrap"
+    class="path-tree-view-entry-more shadow-lg text-nowrap"
     variant="outline-tertiary"
     :size="size"
+    :style="style"
   >
     <slot>
       {{ t('pathViewEntryMore.label', { nextPageSize, directoriesLeft }, directoriesLeft) }}
     </slot>
   </button-icon>
 </template>
+
+<style lang="scss" scoped>
+.path-tree-view-entry-more {
+  --level-indent-width: #{$spacer};
+  --level-indent-factor: 0;
+
+  margin-left: calc(var(--level-indent-width) * var(--level-indent-factor));
+  margin-bottom: $spacer;
+}
+</style>

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryMore.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryMore.vue
@@ -3,7 +3,13 @@ import { computed, inject } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ButtonIcon } from '@icij/murmur-next'
 
+import { LAYOUTS, layoutValidator } from '@/enums/pathTree'
+
 const props = defineProps({
+  flat: {
+    type: Boolean,
+    default: false
+  },
   page: {
     type: Number,
     default: 1
@@ -20,6 +26,11 @@ const props = defineProps({
     type: Boolean,
     default: null
   },
+  layout: {
+    type: String,
+    default: LAYOUTS.TREE,
+    validator: layoutValidator
+  },
   level: {
     type: Number,
     default: 0
@@ -28,8 +39,15 @@ const props = defineProps({
 
 const { t } = useI18n()
 
+const classList = computed(() => {
+  return {
+    'path-tree-view-entry-more--flat': props.flat,
+    [`path-tree-view-entry-more--${props.layout}`]: true
+  }
+})
+
 const style = computed(() => ({
-  '--level-indent-factor': props.level
+  '--path-tree-view-entry-more-indent-factor': props.level
 }))
 
 const nextPageSize = computed(() => {
@@ -45,26 +63,48 @@ const size = computed(() => (compactOrInjected.value ? 'sm' : 'md'))
 </script>
 
 <template>
-  <button-icon
-    :icon-left="PhCaretDown"
-    icon-left-variant="primary"
-    class="path-tree-view-entry-more shadow-lg text-nowrap"
-    variant="outline-tertiary"
-    :size="size"
+  <div
+    class="path-tree-view-entry-more"
     :style="style"
+    :class="classList"
   >
-    <slot>
-      {{ t('pathViewEntryMore.label', { nextPageSize, directoriesLeft }, directoriesLeft) }}
-    </slot>
-  </button-icon>
+    <button-icon
+      :icon-left="PhCaretDown"
+      icon-left-variant="primary"
+      class="shadow-lg text-nowrap above-stretched-link"
+      variant="outline-tertiary"
+      :size="size"
+    >
+      <slot>
+        {{ t('pathViewEntryMore.label', { nextPageSize, directoriesLeft }, directoriesLeft) }}
+      </slot>
+    </button-icon>
+  </div>
 </template>
 
 <style lang="scss" scoped>
 .path-tree-view-entry-more {
-  --level-indent-width: #{$spacer};
-  --level-indent-factor: 0;
+  --path-tree-view-entry-more-indent-width: #{$spacer-xl};
+  --path-tree-view-entry-more-indent-factor: 0;
+  --path-tree-view-entry-more-padding-x: calc(var(--path-tree-view-entry-more-indent-width) * var(--path-tree-view-entry-more-indent-factor));
+  --path-tree-view-entry-more-padding-y: #{$spacer-xs};
+  --path-tree-view-entry-more-justify-content: flex-start;
 
-  margin-left: calc(var(--level-indent-width) * var(--level-indent-factor));
-  margin-bottom: $spacer;
+  display: flex;
+  justify-content: var(--path-tree-view-entry-more-justify-content);
+  padding-inline: var(--path-tree-view-entry-more-padding-x);
+  padding-block: var(--path-tree-view-entry-more-padding-y);
+  grid-column: 1 / -1;
+
+  &--flat {
+    --path-tree-view-entry-more-padding-x: 0;
+    --path-tree-view-entry-more-justify-content: center;
+  }
+
+  &--grid {
+    --path-tree-view-entry-more-padding-x: 0;
+    --path-tree-view-entry-more-padding-y: 0;
+    --path-tree-view-entry-more-justify-content: center;
+  }
 }
 </style>

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryName.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryName.vue
@@ -25,6 +25,18 @@ const props = defineProps({
   loading: {
     type: Boolean
   },
+  noLink: {
+    type: Boolean,
+    default: false
+  },
+  noSearchLink: {
+    type: Boolean,
+    default: false
+  },
+  noCaret: {
+    type: Boolean,
+    default: false
+  },
   layout: {
     type: String,
     default: LAYOUTS.TREE,
@@ -44,23 +56,27 @@ const icon = computed(() => {
   if (props.type === 'document') {
     return PhFile
   }
-  return collapse.value ? PhFolder : PhFolderOpen
+  return [collapse.value ? PhFolder : PhFolderOpen, 'fill']
 })
 
 const classList = computed(() => ({
   'path-tree-view-entry-name--collapse': collapse.value,
   'path-tree-view-entry-name--compact': compactOrInjected.value,
   'path-tree-view-entry-name--selected': selected.value,
-  'path-tree-view-entry-name--nested': props.layout === LAYOUTS.TREE,
-  [`path-tree-view-entry-name--${props.type}`]: true
+  'path-tree-view-entry-name--no-link': props.noLink,
+  'path-tree-view-entry-name--no-search-link': props.noSearchLink,
+  'path-tree-view-entry-name--no-caret': props.noCaret,
+  [`path-tree-view-entry-name--${props.type}`]: true,
+  [`path-tree-view-entry-name--${props.layout}`]: true
 }))
 
 const style = computed(() => ({
-  '--level-indent-factor': props.level
+  '--path-tree-view-entry-name-indent-factor': props.level
 }))
 
 const selectModeOrInjected = computed(() => props.selectMode ?? inject('selectMode', false))
 const compactOrInjected = computed(() => props.compact ?? inject('compact', false))
+const hasIcon = computed(() => !selectModeOrInjected.value || (selectModeOrInjected.value && !compactOrInjected.value))
 
 const toggle = () => {
   collapse.value = !collapse.value
@@ -96,7 +112,8 @@ const toggle = () => {
           v-bind="{ icon }"
         >
           <phosphor-icon
-            v-if="!compactOrInjected"
+            v-if="hasIcon"
+            class="path-tree-view-entry-name__value__icon"
             :name="icon"
           />
         </slot>
@@ -108,30 +125,60 @@ const toggle = () => {
 
 <style lang="scss" scoped>
 .path-tree-view-entry-name {
-  --level-indent-width: #{$spacer};
-  --level-indent-factor: 0;
+  --path-tree-view-entry-name-font-weight: normal;
+  --path-tree-view-entry-name-color: inherit;
+  --path-tree-view-entry-name-icon-color: inherit;
+  --path-tree-view-entry-name-cursor: default;
 
-  margin-left: calc(var(--level-indent-width) * var(--level-indent-factor));
+  --path-tree-view-entry-name-indent-width: 0px;
+  --path-tree-view-entry-name-indent-factor: 0;
+  --path-tree-view-entry-name-margin: 0;
+  --path-tree-view-entry-name-caret-visibility: visible;
+  --path-tree-view-entry-name-margin: calc(var(--path-tree-view-entry-name-indent-width) * var(--path-tree-view-entry-name-indent-factor));
 
-  &--document &__caret {
-    visibility: hidden;
-  }
+  font-weight: var(--path-tree-view-entry-name-font-weight);
+  color: var(--path-tree-view-entry-name-color);
+  cursor: var(--path-tree-view-entry-name-cursor);
+  margin-left: var(--path-tree-view-entry-name-margin);
 
   &--compact {
-    --level-indent-width: #{$spacer-xs};
+    --path-tree-view-entry-name-indent-width: #{$spacer-xs};
+  }
+
+  &:not(&--grid) {
+    --path-tree-view-entry-name-indent-width: #{$spacer};
+  }
+
+  &--no-caret {
+    --path-tree-view-entry-name-caret-visibility: hidden;
+  }
+
+  &__caret {
+    visibility: var(--path-tree-view-entry-name-caret-visibility);
+  }
+
+  &__icon {
+    color: var(--path-tree-view-entry-name-icon-color);
   }
 
   &--compact.path-tree-view-entry-name--selected {
-    font-weight: 500;
-    color: var(--bs-action-text-emphasis);
+    --path-tree-view-entry-name-font-weight: 500;
+    --path-tree-view-entry-name-color: var(--bs-action-text-emphasis);
   }
 
-  &:not(&--nested):not(&--selected) &__value {
-    cursor: pointer;
-    color: var(--bs-link-color);
+  &--grid:not(&--selected) {
+    --path-tree-view-entry-name-font-weight: 500;
+    --path-tree-view-entry-name-color: var(--bs-body-color);
+    --path-tree-view-entry-name-icon-color: var(--bs-secondary);
+  }
+
+  &--list:not(&--selected):not(&--no-link),
+  &--grid:not(&--selected):not(&--no-link) {
+    --path-tree-view-entry-name-cursor: pointer;
+    --path-tree-view-entry-name-color: var(--bs-link-color);
 
     &:hover {
-      color: var(--bs-link-hover-color);
+      --path-tree-view-entry-name-color: var(--bs-link-hover-color);
     }
   }
 }

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryName.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryName.vue
@@ -5,6 +5,7 @@ import { PhFolder, PhFolderOpen } from '@phosphor-icons/vue'
 
 import PathTreeViewEntryNameCaret from './PathTreeViewEntryNameCaret'
 import PathTreeViewEntryNameCheckbox from './PathTreeViewEntryNameCheckbox'
+import { LAYOUTS, layoutValidator } from '@/enums/pathTree'
 
 const collapse = defineModel('collapse', { type: Boolean })
 const selected = defineModel('selected', { type: Boolean })
@@ -24,8 +25,10 @@ const props = defineProps({
   loading: {
     type: Boolean
   },
-  nested: {
-    type: Boolean
+  layout: {
+    type: String,
+    default: LAYOUTS.TREE,
+    validator: layoutValidator
   },
   level: {
     type: Number,
@@ -48,7 +51,7 @@ const classList = computed(() => ({
   'path-tree-view-entry-name--collapse': collapse.value,
   'path-tree-view-entry-name--compact': compactOrInjected.value,
   'path-tree-view-entry-name--selected': selected.value,
-  'path-tree-view-entry-name--nested': props.nested,
+  'path-tree-view-entry-name--nested': props.layout === LAYOUTS.TREE,
   [`path-tree-view-entry-name--${props.type}`]: true
 }))
 
@@ -71,7 +74,7 @@ const toggle = () => {
     :style="style"
   >
     <path-tree-view-entry-name-caret
-      v-if="nested"
+      v-if="props.layout === LAYOUTS.TREE"
       :collapse="collapse"
       :loading="loading"
       class="path-tree-view-entry-name__caret flex-shrink-0"

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryName.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryName.vue
@@ -12,40 +12,72 @@ const selected = defineModel('selected', { type: Boolean })
 const indeterminate = defineModel('indeterminate', { type: Boolean })
 
 const props = defineProps({
+  /**
+   * Whether to render in compact mode (no gaps between entries). If null, will
+   * inherit from the parent PathTreeView component.
+   */
   compact: {
     type: Boolean,
     default: null
   },
+  /**
+   * Name of the entry to display
+   */
   name: {
     type: String
   },
+  /**
+   * Whether the entry is in select mode (checkbox next to entry). If null, will
+   * inherit from the parent PathTreeView component.
+   */
   selectMode: {
     type: Boolean
   },
+  /**
+   * Whether the entry is currently loading (replace the caret with a spinner)
+   */
   loading: {
     type: Boolean
   },
+  /**
+   * Whether to disable the link (always render as plain text)
+   */
   noLink: {
     type: Boolean,
     default: false
   },
+  /**
+   * Whether to disable the search link (always render as plain text)
+   */
   noSearchLink: {
     type: Boolean,
     default: false
   },
+  /**
+   * Whether to hide the caret (for entries that cannot be expanded/collapsed)
+   */
   noCaret: {
     type: Boolean,
     default: false
   },
+  /**
+   * Layout to use for rendering the entry
+   */
   layout: {
     type: String,
     default: LAYOUTS.TREE,
     validator: layoutValidator
   },
+  /**
+   * Current nesting level (0 = root)
+   */
   level: {
     type: Number,
     default: 0
   },
+  /**
+   * Type of entry (document or directory)
+   */
   type: {
     type: String,
     default: 'directory'

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryName.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryName.vue
@@ -30,16 +30,26 @@ const props = defineProps({
   level: {
     type: Number,
     default: 0
+  },
+  type: {
+    type: String,
+    default: 'directory'
   }
 })
 
-const icon = computed(() => (collapse.value ? PhFolder : PhFolderOpen))
+const icon = computed(() => {
+  if (props.type === 'document') {
+    return PhFile
+  }
+  return collapse.value ? PhFolder : PhFolderOpen
+})
 
 const classList = computed(() => ({
   'path-tree-view-entry-name--collapse': collapse.value,
   'path-tree-view-entry-name--compact': compactOrInjected.value,
   'path-tree-view-entry-name--selected': selected.value,
-  'path-tree-view-entry-name--nested': props.nested
+  'path-tree-view-entry-name--nested': props.nested,
+  [`path-tree-view-entry-name--${props.type}`]: true
 }))
 
 const style = computed(() => ({
@@ -64,7 +74,7 @@ const toggle = () => {
       v-if="nested"
       :collapse="collapse"
       :loading="loading"
-      class="flex-shrink-0"
+      class="path-tree-view-entry-name__caret flex-shrink-0"
       @click="toggle"
     />
     <path-tree-view-entry-name-checkbox
@@ -78,10 +88,15 @@ const toggle = () => {
         class="path-tree-view-entry-name__value text-truncate stretched-link"
         @click="toggle"
       >
-        <phosphor-icon
-          v-if="!compactOrInjected"
-          :name="icon"
-        />
+        <slot
+          name="icon"
+          v-bind="{ icon }"
+        >
+          <phosphor-icon
+            v-if="!compactOrInjected"
+            :name="icon"
+          />
+        </slot>
         {{ name }}
       </div>
     </slot>
@@ -94,6 +109,10 @@ const toggle = () => {
   --level-indent-factor: 0;
 
   margin-left: calc(var(--level-indent-width) * var(--level-indent-factor));
+
+  &--document &__caret {
+    visibility: hidden;
+  }
 
   &--compact {
     --level-indent-width: #{$spacer-xs};

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryNameCaret.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryNameCaret.vue
@@ -4,9 +4,15 @@ import { PhosphorIcon } from '@icij/murmur-next'
 import { PhCaretDown, PhCircleNotch } from '@phosphor-icons/vue'
 
 const props = defineProps({
+  /**
+   * Whether the caret is in the "collapsed" state (points to the right)
+   */
   collapse: {
     type: Boolean
   },
+  /**
+   * Whether the entry is currently loading (replace the caret with a spinner)
+   */
   loading: {
     type: Boolean
   }

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryNameCheckbox.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryNameCheckbox.vue
@@ -3,9 +3,15 @@ const modelValue = defineModel({ type: Boolean })
 const indeterminate = defineModel('indeterminate', { type: Boolean })
 
 defineProps({
+  /**
+   * Whether to disable the checkbox
+   */
   disabled: {
     type: Boolean
   },
+  /**
+   * ID to assign to the checkbox input
+   */
   id: {
     type: String
   }

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryPreview.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryPreview.vue
@@ -7,28 +7,46 @@ import { useElementVisibilityOnce } from '@/composables/useElementVisibilityOnce
 
 const path = defineModel('path', { type: String, required: true })
 
-const { compact } = defineProps({
+const props = defineProps({
+  /**
+   * List of projects to use with the nested PathTree component
+   */
   projects: {
     type: Array,
     default: () => []
   },
+  /**
+   * Whether to render in compact mode (no gaps between entries)
+   */
   compact: {
     type: Boolean,
     default: false
   },
+  /**
+   * Whether to hide documents in the nested PathTree (only show directories)
+   */
   noDocuments: {
     type: Boolean,
     default: false
   },
+  /**
+   * Whether to disable links in the nested PathTree (always render as plain text)
+   */
   noLink: {
     type: Boolean,
     default: false
   },
+  /**
+   * Sort to use for rendering the nested PathTree component
+   */
   sortBy: {
     type: String,
     default: SORT_BY.KEY,
     validator: sortByValidator
   },
+  /**
+   * Order to use for rendering the nested PathTree component
+   */
   orderBy: {
     type: String,
     default: ORDER_BY.ASC,
@@ -39,7 +57,7 @@ const { compact } = defineProps({
 const element = useTemplateRef('element')
 const wasVisibleOnce = useElementVisibilityOnce(element)
 const classList = computed(() => ({
-  'path-tree-view-entry-preview--compact': compact
+  'path-tree-view-entry-preview--compact': props.compact
 }))
 </script>
 

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryPreview.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryPreview.vue
@@ -1,0 +1,89 @@
+<script setup>
+import { computed, useTemplateRef } from 'vue'
+
+import PathTree from '@/components/PathTree/PathTree.vue'
+import { LAYOUTS, SORT_BY, sortByValidator, ORDER_BY, orderByValidator } from '@/enums/pathTree'
+import { useElementVisibilityOnce } from '@/composables/useElementVisibilityOnce'
+
+const path = defineModel('path', { type: String, required: true })
+
+const { compact } = defineProps({
+  projects: {
+    type: Array,
+    default: () => []
+  },
+  compact: {
+    type: Boolean,
+    default: false
+  },
+  noDocuments: {
+    type: Boolean,
+    default: false
+  },
+  noLink: {
+    type: Boolean,
+    default: false
+  },
+  sortBy: {
+    type: String,
+    default: SORT_BY.KEY,
+    validator: sortByValidator
+  },
+  orderBy: {
+    type: String,
+    default: ORDER_BY.ASC,
+    validator: orderByValidator
+  }
+})
+
+const element = useTemplateRef('element')
+const wasVisibleOnce = useElementVisibilityOnce(element)
+const classList = computed(() => ({
+  'path-tree-view-entry-preview--compact': compact
+}))
+</script>
+
+<template>
+  <div
+    ref="element"
+    class="path-tree-view-entry-preview"
+    :class="classList"
+  >
+    <path-tree
+      v-if="wasVisibleOnce"
+      v-model:path="path"
+      :projects="projects"
+      :layout="LAYOUTS.LIST"
+      :compact="compact"
+      :no-documents="noDocuments"
+      :no-link="noLink"
+      :sort-by="sortBy"
+      :order-by="orderBy"
+      flat
+      no-preview
+      no-breadcrumb
+      no-label
+      no-search
+      no-search-link
+      no-stats
+      squared
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.path-tree-view-entry-preview {
+  --path-tree-view-entry-preview-padding-x: 0;
+  --path-tree-view-entry-preview-padding-y: 0;
+
+  border-top: 1px solid var(--bs-border-color);
+  aspect-ratio: 1 / 1;
+  overflow: auto;
+  padding-inline: var(--path-tree-view-entry-preview-padding-x);
+  padding-block: var(--path-tree-view-entry-preview-padding-y);
+
+  &--compact {
+    --path-tree-view-entry-preview-padding-x: #{$spacer-xs};
+  }
+}
+</style>

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntrySearchLink.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntrySearchLink.vue
@@ -4,10 +4,16 @@ import { useI18n } from 'vue-i18n'
 import { ButtonIcon } from '@icij/murmur-next'
 
 const props = defineProps({
+  /**
+   * List of projects to use with the search link
+   */
   projects: {
     type: Array,
     default: () => []
   },
+  /**
+   * Current path to use with the search link
+   */
   path: {
     type: String
   }

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntrySearchLink.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntrySearchLink.vue
@@ -1,0 +1,34 @@
+<script setup>
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { ButtonIcon } from '@icij/murmur-next'
+
+const props = defineProps({
+  projects: {
+    type: Array,
+    default: () => []
+  },
+  path: {
+    type: String
+  }
+})
+
+const { t } = useI18n()
+
+const to = computed(() => {
+  const indices = props.projects.join(',')
+  const query = { 'f[path]': props.path, indices }
+  return { name: 'search', query }
+})
+</script>
+
+<template>
+  <button-icon
+    :icon-left="PhMagnifyingGlass"
+    :to="to"
+    variant="link"
+    hide-label
+    :label="t('pathTreeViewEntrySearchLink.label')"
+    class="path-tree-view-entry-search-link above-stretched-link"
+  />
+</template>

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryStats.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryStats.vue
@@ -6,35 +6,62 @@ import PathTreeViewEntryStatsDirectories from './PathTreeViewEntryStatsDirectori
 import PathTreeViewEntryStatsSize from './PathTreeViewEntryStatsSize'
 
 const props = defineProps({
+  /**
+   * Current path (used for the search link)
+   */
   path: {
     type: String
   },
+  /**
+   * List of projects to use with the search link
+   */
   projects: {
     type: Array,
     default: () => []
   },
+  /**
+   * Number of documents in the entry
+   */
   documents: {
     type: Number,
     default: 0
   },
+  /**
+   * Number of directories in the entry
+   */
   directories: {
     type: Number,
     default: 0
   },
+  /**
+   * Size of the entry (in bytes)
+   */
   size: {
     type: Number,
     default: 0
   },
+  /**
+   * Whether the entry is selected (affects styling)
+   */
   selected: {
     type: Boolean
   },
+  /**
+   * Whether the entry is active (affects styling)
+   */
   active: {
     type: Boolean
   },
+  /**
+   * Whether to render in compact mode (no gaps between entries)
+   */
   compact: {
     type: Boolean,
     default: null
   },
+  /**
+   * Whether to hide the search link in the documents stat
+   */
   noSearchLink: {
     type: Boolean
   }

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryStats.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryStats.vue
@@ -35,7 +35,7 @@ const props = defineProps({
     type: Boolean,
     default: null
   },
-  noLink: {
+  noSearchLink: {
     type: Boolean
   }
 })
@@ -59,7 +59,7 @@ const classList = computed(() => {
     <path-tree-view-entry-stats-documents
       :active="active"
       :compact="compactOrInjected"
-      :no-link="noLink"
+      :no-search-link="noSearchLink"
       :path="path"
       :projects="projects"
       :value="documents"

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryStatsDirectories.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryStatsDirectories.vue
@@ -4,6 +4,9 @@ import { PhosphorIcon } from '@icij/murmur-next'
 import DisplayNumber from '@/components/Display/DisplayNumber'
 
 defineProps({
+  /**
+   * Number of directories in the entry
+   */
   value: {
     type: Number,
     default: 0

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryStatsDocuments.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryStatsDocuments.vue
@@ -5,24 +5,43 @@ import { PhosphorIcon } from '@icij/murmur-next'
 import DisplayNumber from '@/components/Display/DisplayNumber'
 
 const props = defineProps({
+  /**
+   * Number of documents in the entry
+   */
   value: {
     type: Number,
     required: true
   },
+  /**
+   * List of projects to use with the search link
+   */
   projects: {
     type: Array,
     default: () => []
   },
+  /**
+   * Current path (used for the search link)
+   */
   path: {
     type: String
   },
+  /**
+   * Whether the entry is active (affects styling)
+   */
   active: {
     type: Boolean
   },
+  /**
+   * Whether to render in compact mode (no gaps between entries). If null, will
+   * inherit from the parent PathTreeView component.
+   */
   compact: {
     type: Boolean,
     default: null
   },
+  /**
+   * Whether to hide the search link
+   */
   noSearchLink: {
     type: Boolean
   }

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryStatsDocuments.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryStatsDocuments.vue
@@ -23,14 +23,14 @@ const props = defineProps({
     type: Boolean,
     default: null
   },
-  noLink: {
+  noSearchLink: {
     type: Boolean
   }
 })
 
 const compactOrInjected = computed(() => props.compact ?? inject('compact', false))
 
-const is = computed(() => (props.noLink || props.compact ? 'span' : 'router-link'))
+const is = computed(() => (props.noSearchLink || props.compact ? 'span' : 'router-link'))
 
 const to = computed(() => {
   if (is.value === 'span') {
@@ -45,7 +45,7 @@ const to = computed(() => {
 const classList = computed(() => {
   return {
     'path-tree-view-entry-stats-documents--active': props.active,
-    'path-tree-view-entry-stats-documents--no-link': props.noLink,
+    'path-tree-view-entry-stats-documents--no-search-link': props.noSearchLink,
     'path-tree-view-entry-stats-documents--compact': compactOrInjected.value
   }
 })
@@ -110,13 +110,13 @@ const classList = computed(() => {
     }
   }
 
-  &--active:not(&--no-link) &__link {
+  &--active:not(&--no-search-link) &__link {
     background: var(--bs-action);
     color: var(--bs-white);
   }
 
-  &--active:not(&--compact):not(&--no-link) &__link,
-  &:not(&--compact):not(&--no-link) &__link:hover {
+  &--active:not(&--compact):not(&--no-search-link) &__link,
+  &:not(&--compact):not(&--no-search-link) &__link:hover {
     background: var(--bs-body-bg);
     color: var(--bs-body-color);
 
@@ -125,7 +125,7 @@ const classList = computed(() => {
     }
   }
 
-  &:not(&--compact):not(&--no-link) &__link:hover {
+  &:not(&--compact):not(&--no-search-link) &__link:hover {
     .path-tree-view-entry-stats-documents__link__icon--default {
       display: none;
     }

--- a/src/components/PathTree/PathTreeView/PathTreeViewEntryStatsSize.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewEntryStatsSize.vue
@@ -2,6 +2,9 @@
 import DisplayContentLength from '@/components/Display/DisplayContentLength'
 
 defineProps({
+  /**
+   * Size of the entry in bytes
+   */
   value: {
     type: Number,
     required: true

--- a/src/components/PathTree/PathTreeView/PathTreeViewLabel.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewLabel.vue
@@ -1,10 +1,12 @@
 <script setup>
+import { computed } from 'vue'
 import { PhosphorIcon } from '@icij/murmur-next'
 import { useI18n } from 'vue-i18n'
 
 import ButtonTogglePathTreeView from '@/components/Button/ButtonTogglePathTreeView'
+import { LAYOUTS, layoutValidator } from '@/enums/pathTree'
 
-const nested = defineModel('nested', { type: Boolean })
+const layout = defineModel('layout', { type: String, default: LAYOUTS.TREE, validator: layoutValidator })
 
 defineProps({
   label: {
@@ -13,6 +15,13 @@ defineProps({
   icon: {
     type: [String, Object, Array],
     default: PhTreeStructure
+  }
+})
+
+const nested = computed({
+  get: () => layout.value === LAYOUTS.TREE,
+  set: (value) => {
+    layout.value = value ? LAYOUTS.TREE : LAYOUTS.LIST
   }
 })
 

--- a/src/components/PathTree/PathTreeView/PathTreeViewLabel.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewLabel.vue
@@ -9,9 +9,15 @@ import { LAYOUTS, layoutValidator } from '@/enums/pathTree'
 const layout = defineModel('layout', { type: String, default: LAYOUTS.TREE, validator: layoutValidator })
 
 defineProps({
+  /**
+   * Optional label to display above the tree
+   */
   label: {
     type: String
   },
+  /**
+   * Optional icon to display next to the label (string name or icon object)
+   */
   icon: {
     type: [String, Object, Array],
     default: PhTreeStructure

--- a/src/components/PathTree/PathTreeView/PathTreeViewSearch.vue
+++ b/src/components/PathTree/PathTreeView/PathTreeViewSearch.vue
@@ -6,6 +6,9 @@ import FormControlSearch from '@/components/Form/FormControl/FormControlSearch'
 const modelValue = defineModel({ type: String })
 
 defineProps({
+  /**
+   * Whether to add a shadow to the search box
+   */
   shadow: {
     type: Boolean,
     default: true

--- a/src/components/Task/TaskDocuments/TaskDocumentsForm.vue
+++ b/src/components/Task/TaskDocuments/TaskDocumentsForm.vue
@@ -107,7 +107,6 @@ watch(toRef(form, 'defaultProject'), p => form.path = getProjectSourcePath(core.
       <form-control-path
         v-model="form.path"
         :path="sourcePath"
-        hide-folder-icon
       />
     </form-fieldset-i18n>
     <form-fieldset-i18n

--- a/src/components/Widget/WidgetDiskUsage.vue
+++ b/src/components/Widget/WidgetDiskUsage.vue
@@ -1,35 +1,7 @@
-<template>
-  <div class="widget widget--disk-usage">
-    <widget-barometer-disk-usage
-      v-b-modal.modal-disk-usage
-      clickable
-      :size="size"
-    />
-    <app-modal
-      id="modal-disk-usage"
-      lazy
-      scrollable
-      no-header
-      no-footer
-      size="lg"
-    >
-      <path-tree
-        v-model:path="path"
-        :projects="[project]"
-        nested
-        no-tree
-      />
-    </app-modal>
-  </div>
-</template>
-
 <script>
 import bodybuilder from 'bodybuilder'
 
 import WidgetBarometerDiskUsage from './WidgetBarometerDiskUsage'
-
-import AppModal from '@/components/AppModal/AppModal'
-import PathTree from '@/components/PathTree/PathTree'
 
 /**
  * Widget to display the disk space occupied by indexed files on the insights page.
@@ -37,8 +9,6 @@ import PathTree from '@/components/PathTree/PathTree'
 export default {
   name: 'WidgetDiskUsage',
   components: {
-    AppModal,
-    PathTree,
     WidgetBarometerDiskUsage
   },
   props: {
@@ -58,23 +28,10 @@ export default {
   },
   data() {
     return {
-      onDisk: null,
-      path: null,
       size: null
     }
   },
-  computed: {
-    dataDir() {
-      return this.$config.get('mountedDataDir') || this.$config.get('dataDir')
-    }
-  },
-  watch: {
-    project() {
-      this.path = this.dataDir
-    }
-  },
   async created() {
-    this.path = this.dataDir
     await this.loadData()
   },
   methods: {
@@ -97,6 +54,18 @@ export default {
   }
 }
 </script>
+
+<template>
+  <router-link
+    class="widget widget--disk-usage d-block"
+    :to="{ name: 'project.view.overview.paths' }"
+  >
+    <widget-barometer-disk-usage
+      clickable
+      :size="size"
+    />
+  </router-link>
+</template>
 
 <style lang="scss" scoped>
 .widget {

--- a/src/components/Widget/WidgetDiskUsage.vue
+++ b/src/components/Widget/WidgetDiskUsage.vue
@@ -5,6 +5,8 @@ import bodybuilder from 'bodybuilder'
 import { apiInstance as api } from '@/api/apiInstance'
 import WidgetBarometerDiskUsage from './WidgetBarometerDiskUsage'
 
+defineOptions({ name: 'WidgetDiskUsage' })
+
 const props = defineProps({
   /**
    * The widget definition object.

--- a/src/components/Widget/WidgetDiskUsage.vue
+++ b/src/components/Widget/WidgetDiskUsage.vue
@@ -17,7 +17,7 @@
         v-model:path="path"
         :projects="[project]"
         nested
-        elasticsearch-only
+        no-tree
       />
     </app-modal>
   </div>

--- a/src/components/Widget/WidgetDocumentsByCreationDateByPath.vue
+++ b/src/components/Widget/WidgetDocumentsByCreationDateByPath.vue
@@ -42,6 +42,8 @@
           :path="dataDir"
           :projects="projects"
           select-mode
+          nested
+          no-documents
           elasticsearch-only
         />
       </app-modal>

--- a/src/components/Widget/WidgetDocumentsByCreationDateByPath.vue
+++ b/src/components/Widget/WidgetDocumentsByCreationDateByPath.vue
@@ -44,7 +44,7 @@
           select-mode
           nested
           no-documents
-          elasticsearch-only
+          no-tree
         />
       </app-modal>
     </template>

--- a/src/components/Widget/WidgetPaths.vue
+++ b/src/components/Widget/WidgetPaths.vue
@@ -1,0 +1,48 @@
+<script setup>
+import { ref } from 'vue'
+
+import { useConfig } from '@/composables/useConfig'
+import PathTree from '@/components/PathTree/PathTree'
+
+/**
+ * A placeholder widget for the insights page. This widget is not intended to be used directly.
+ */
+defineProps({
+  /**
+   * The widget definition object.
+   */
+  widget: {
+    type: Object
+  },
+  /**
+   * The project name.
+   */
+  project: {
+    type: String,
+    required: true
+  }
+})
+
+const config = useConfig()
+const path = ref(config.get('mountedDataDir') || config.get('dataDir'))
+</script>
+
+<template>
+  <div class="widget widget--paths p-5">
+    <path-tree
+      v-model:path="path"
+      :projects="[project]"
+      no-label
+      nested
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.widget--paths, .widget--paths > * {
+  width: 100%;
+  flex-grow: 1;
+  flex-shrink: 0;
+  flex-basis: auto;
+}
+</style>

--- a/src/components/Widget/WidgetPaths.vue
+++ b/src/components/Widget/WidgetPaths.vue
@@ -1,13 +1,16 @@
 <script setup>
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
-import { useConfig } from '@/composables/useConfig'
 import PathTree from '@/components/PathTree/PathTree'
+import PathTreeLayouts from '@/components/PathTree/PathTreeLayouts/PathTreeLayouts'
+import { useConfig } from '@/composables/useConfig'
+import { useCore } from '@/composables/useCore'
+import { LAYOUTS } from '@/enums/pathTree'
 
 /**
  * A placeholder widget for the insights page. This widget is not intended to be used directly.
  */
-defineProps({
+const props = defineProps({
   /**
    * The widget definition object.
    */
@@ -23,18 +26,34 @@ defineProps({
   }
 })
 
+const { core } = useCore()
+const { sourcePath } = core.findProject(props.project)
 const config = useConfig()
-const path = ref(config.get('mountedDataDir') || config.get('dataDir'))
+const dataDir = config.get('mountedDataDir') || config.get('dataDir')
+const defaultPath = sourcePath ? decodeURI(sourcePath.split('//').pop()) : dataDir
+const path = ref(defaultPath)
+const layout = ref(LAYOUTS.GRID)
+const projects = [props.project]
+const flush = computed(() => layout.value === LAYOUTS.GRID)
 </script>
 
 <template>
   <div class="widget widget--paths p-5">
     <path-tree
       v-model:path="path"
-      :projects="[project]"
+      v-model:layout="layout"
+      :default-path="defaultPath"
+      :projects="projects"
+      :flush="flush"
       no-label
-      nested
-    />
+    >
+      <template #before>
+        <path-tree-layouts
+          v-model="layout"
+          class="ms-auto"
+        />
+      </template>
+    </path-tree>
   </div>
 </template>
 

--- a/src/composables/usePath.js
+++ b/src/composables/usePath.js
@@ -1,0 +1,128 @@
+import { trimEnd } from 'lodash'
+import { computed, toRef } from 'vue'
+
+import { useConfig } from '@/composables/useConfig'
+
+/**
+ * Composable for managing and manipulating file and directory paths.
+ *
+ * @param {import('vue').Ref<string[]|null>} selectedPathsRef - A ref containing the currently selected paths.
+ * @param {Object} options - Configuration options.
+ * @param {boolean} options.multiple - Whether multiple paths can be selected. Default is false.
+ * @returns {Object} An object containing path manipulation methods and properties.
+ */
+export function usePath(selectedPathsRef, { multiple = false } = {}) {
+  const config = useConfig()
+  const selectedPaths = toRef(selectedPathsRef ?? [])
+
+  const pathSeparator = computed(() => {
+    return config.get('pathSeparator', '/')
+  })
+
+  /**
+   * Returns the last segment of a path.
+   * Similar to Node.js `path.basename`.
+   *
+   * @param {string} path
+   * @returns {string}
+   */
+  function getBasename(path) {
+    return path.split(pathSeparator.value).filter(Boolean).pop() || ''
+  }
+
+  /**
+   * Normalizes a directory path by ensuring it ends with a separator.
+   *
+   * @param {string} path
+   * @returns {string}
+   */
+  function normalizeDirectory(path) {
+    return trimEnd(path, pathSeparator.value) + pathSeparator.value
+  }
+
+  /**
+   * Checks if a path is selected.
+   *
+   * @param {string} path
+   * @returns {boolean}
+   */
+  function isSelectedPath(path) {
+    return selectedPaths
+      .value
+      .map(normalizeDirectory)
+      .includes(normalizeDirectory(path))
+  }
+
+  /**
+   * Checks if a directory is in an indeterminate state.
+   * A directory is indeterminate if some, but not all, of its children are selected.
+   *
+   * @param {string} path
+   * @returns {boolean}
+   */
+  function isIndeterminateDirectory(path) {
+    const normalized = normalizeDirectory(path)
+
+    return selectedPaths.value.some((selected) => {
+      return normalizeDirectory(selected).startsWith(normalized) && !isSelectedPath(path)
+    })
+  }
+
+  /**
+   * Selects a path. If `multiple` is false, it will replace the current selection.
+   *
+   * @param {string} path
+   */
+  function selectPath(path) {
+    const normalized = normalizeDirectory(path)
+
+    if (multiple) {
+      selectedPaths.value = [...selectedPaths.value, normalized]
+    }
+    else {
+      selectedPaths.value = [normalized]
+    }
+  }
+
+  /**
+   * Unselects a path.
+   *
+   * @param {string} path
+   */
+  function unselectPath(path) {
+    const normalized = normalizeDirectory(path)
+    const index = selectedPaths.value.indexOf(normalized)
+    if (index > -1) {
+      selectedPaths.value = selectedPaths.value.toSpliced(index, 1)
+    }
+  }
+
+  /**
+   * Toggles the selection state of a path. If selected, it will
+   * be unselected and vice versa.
+   *
+   * @param {string} path
+   */
+  function togglePath(path) {
+    if (isSelectedPath(path)) {
+      unselectPath(path)
+    }
+    else {
+      selectPath(path)
+    }
+  }
+
+  return {
+    pathSeparator,
+    getBasename,
+    normalizeDirectory,
+    isSelectedPath,
+    isIndeterminateDirectory,
+    selectPath,
+    unselectPath,
+    togglePath,
+    selectedPaths,
+  }
+}
+
+export default usePath

--- a/src/composables/usePath.js
+++ b/src/composables/usePath.js
@@ -37,7 +37,17 @@ export function usePath(selectedPathsRef, { multiple = false } = {}) {
    * @returns {string}
    */
   function normalizeDirectory(path) {
-    return trimEnd(path, pathSeparator.value) + pathSeparator.value
+    return trimDirectory(path) + pathSeparator.value
+  }
+
+  /**
+   * Trims the trailing path separator from a directory path.
+   *
+   * @param {string} path
+   * @returns {string}
+   */
+  function trimDirectory(path) {
+    return trimEnd(path, pathSeparator.value)
   }
 
   /**
@@ -116,6 +126,7 @@ export function usePath(selectedPathsRef, { multiple = false } = {}) {
     pathSeparator,
     getBasename,
     normalizeDirectory,
+    trimDirectory,
     isSelectedPath,
     isIndeterminateDirectory,
     selectPath,

--- a/src/enums/pathTree.js
+++ b/src/enums/pathTree.js
@@ -1,0 +1,19 @@
+const TREE = 'tree'
+const LIST = 'list'
+const GRID = 'grid'
+
+export const LAYOUTS = Object.freeze({ LIST, GRID, TREE })
+export const layoutValidator = l => Object.values(LAYOUTS).includes(l)
+
+const SIZE = 'size'
+const COUNT = '_count'
+const KEY = '_key'
+
+export const SORT_BY = Object.freeze({ SIZE, COUNT, KEY })
+export const sortByValidator = order => Object.values(SORT_BY).includes(order)
+
+const DESC = 'desc'
+const ASC = 'asc'
+
+export const ORDER_BY = Object.freeze({ ASC, DESC })
+export const orderByValidator = order => Object.values(ORDER_BY).includes(order)

--- a/src/enums/pathTree.js
+++ b/src/enums/pathTree.js
@@ -1,19 +1,70 @@
+// The path tree can be visualized in three different layouts:
+//
+// - TREE : hierarchical display of nested directories and files.
 const TREE = 'tree'
+// - LIST : flat list of entries without hierarchy.
 const LIST = 'list'
+// - GRID : tiled view with a preview for each directory or file.
 const GRID = 'grid'
+//
+// Note: these layouts can overlap in behavior. For example, the TREE
+// layout internally renders entries as a list, while the GRID layout
+// uses list semantics but displays richer previews.
 
 export const LAYOUTS = Object.freeze({ LIST, GRID, TREE })
 export const layoutValidator = l => Object.values(LAYOUTS).includes(l)
 
+// The path tree entries can be sorted by three possible fields:
+//
+// - SIZE  : total byte size of documents within a directory or file size.
 const SIZE = 'size'
+// - COUNT : number of items contained in a directory.
 const COUNT = '_count'
+// - KEY   : the directory or file name (string key).
 const KEY = '_key'
+//
+// By default, the field depends on the data source (see SOURCES_SORT_BY).
 
 export const SORT_BY = Object.freeze({ SIZE, COUNT, KEY })
 export const sortByValidator = order => Object.values(SORT_BY).includes(order)
 
-const DESC = 'desc'
+// Sorting can be applied in two directions:
+// - ASC  : ascending (smallest → largest, A → Z).
 const ASC = 'asc'
+// - DESC : descending (largest → smallest, Z → A).
+const DESC = 'desc'
 
 export const ORDER_BY = Object.freeze({ ASC, DESC })
 export const orderByValidator = order => Object.values(ORDER_BY).includes(order)
+
+// The path tree can be constructed from three different sources:
+//
+// - SOURCE_DIRS : Elasticsearch "dirname" aggregation (returns directories with aggregated metadata).
+export const SOURCE_DIRS = 'dirs'
+// - SOURCE_DOCS : Elasticsearch document hits (returns individual files as indexed documents).
+export const SOURCE_DOCS = 'docs'
+// - SOURCE_TREE : API endpoint that enumerates the file system tree (returns a full disk-based listing).
+export const SOURCE_TREE = 'tree'
+
+// Each source supports only a subset of the sorting fields.
+// The SOURCES_SORT_BY map defines which field is available for
+// each source when sorting by SIZE, COUNT, or KEY:
+export const SOURCES_SORT_BY = Object.freeze({
+  [SIZE]: Object.freeze({
+    [SOURCE_DIRS]: SIZE,
+    [SOURCE_TREE]: 'size',
+    [SOURCE_DOCS]: 'contentLength',
+  }),
+  [COUNT]: Object.freeze({
+    [SOURCE_DIRS]: COUNT,
+    // SOURCE_TREE does not support COUNT sorting
+    [SOURCE_TREE]: 'name',
+    // SOURCE_DOCS does not support COUNT sorting
+    [SOURCE_DOCS]: 'path',
+  }),
+  [KEY]: Object.freeze({
+    [SOURCE_DIRS]: KEY,
+    [SOURCE_TREE]: 'name',
+    [SOURCE_DOCS]: 'path',
+  }),
+})

--- a/src/lang/ach.json
+++ b/src/lang/ach.json
@@ -1018,8 +1018,7 @@
           "label": "crwdns8882:0crwdne8882:0"
         },
         "path": {
-          "label": "crwdns8884:0crwdne8884:0",
-          "description": "crwdns8886:0crwdne8886:0"
+          "label": "crwdns8884:0crwdne8884:0"
         },
         "extractingLanguage": {
           "label": "crwdns8888:0crwdne8888:0"

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -1018,8 +1018,7 @@
           "label": "Projekt auswählen"
         },
         "path": {
-          "label": "Select the folder or subfolder to analyze",
-          "description": "The entire Datashare home will be indexed by default."
+          "label": "Select the folder or subfolder to analyze"
         },
         "extractingLanguage": {
           "label": "Choose the language to extract"

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1034,8 +1034,7 @@
           "label": "Select a project"
         },
         "path": {
-          "label": "Select the folder or subfolder to analyze",
-          "description": "The entire Datashare home will be indexed by default."
+          "label": "Select the folder or subfolder to analyze"
         },
         "extractingLanguage": {
           "label": "Choose the language to extract"

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1666,8 +1666,16 @@
   "widgetDocumentsByCreationDateByPath": {
     "title": "Number of documents by creation date"
   },
+  "pathTreeLayouts": {
+    "tree": "Tree view",
+    "list": "List view",
+    "grid": "Folder view"
+  },
   "pathTreeBreadcrumb": {
     "datadir": "Home"
+  },
+  "pathTreeViewEntrySearchLink": {
+    "label": "Search in this folder"
   },
   "projectCardUpdateDate": {
     "label": "Updated"

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -1018,8 +1018,7 @@
           "label": "Seleccione un proyecto"
         },
         "path": {
-          "label": "Seleccione la carpeta o subcarpeta para analizar",
-          "description": "Todo el directorio principal de Datashare se indexará por defecto."
+          "label": "Seleccione la carpeta o subcarpeta para analizar"
         },
         "extractingLanguage": {
           "label": "Elija el idioma a extraer"

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -1018,8 +1018,7 @@
           "label": "Sélectionnez un projet"
         },
         "path": {
-          "label": "Sélectionnez le dossier ou le sous-dossier à analyser",
-          "description": "Par défaut, le dossier \"Datashare\" dans son entier sera indexé."
+          "label": "Sélectionnez le dossier ou le sous-dossier à analyser"
         },
         "extractingLanguage": {
           "label": "Choisissez la langue à utiliser pour extraire le texte"

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -1018,8 +1018,7 @@
           "label": "Select a project"
         },
         "path": {
-          "label": "Select the folder or subfolder to analyze",
-          "description": "The entire Datashare home will be indexed by default."
+          "label": "Select the folder or subfolder to analyze"
         },
         "extractingLanguage": {
           "label": "Choose the language to extract"

--- a/src/lang/zh.json
+++ b/src/lang/zh.json
@@ -1018,8 +1018,7 @@
           "label": "Select a project"
         },
         "path": {
-          "label": "Select the folder or subfolder to analyze",
-          "description": "The entire Datashare home will be indexed by default."
+          "label": "Select the folder or subfolder to analyze"
         },
         "extractingLanguage": {
           "label": "Choose the language to extract"

--- a/src/store/widgets/WidgetPaths.js
+++ b/src/store/widgets/WidgetPaths.js
@@ -1,0 +1,22 @@
+import WidgetEmpty from './WidgetEmpty'
+
+import Component from '@/components/Widget/WidgetPaths'
+
+/**
+ * Widget to navigate inside the project files and directories.
+ */
+class WidgetPaths extends WidgetEmpty {
+  /**
+   * Create a new WidgetPaths
+   * @param options {Object} - See WidgetEmpty for others options
+   */
+  constructor({ ...options }) {
+    super(options)
+  }
+
+  get component() {
+    return Component
+  }
+}
+
+export default WidgetPaths

--- a/src/store/widgets/index.js
+++ b/src/store/widgets/index.js
@@ -7,6 +7,7 @@ export { default as WidgetDocuments } from './WidgetDocuments'
 export { default as WidgetDocumentsByCreationDateByPath } from './WidgetDocumentsByCreationDateByPath'
 export { default as WidgetEmpty } from './WidgetEmpty'
 export { default as WidgetEntities } from './WidgetEntities'
+export { default as WidgetPaths } from './WidgetPaths'
 export { default as WidgetProject } from './WidgetProject'
 export { default as WidgetSearchBar } from './WidgetSearchBar'
 export { default as WidgetText } from './WidgetText'
@@ -89,6 +90,13 @@ const widgets = [
     cols: 12,
     type: 'WidgetRecommendedBy',
     modes: [MODE_NAME.SERVER]
+  },
+  {
+    name: 'paths',
+    section: 'paths',
+    card: true,
+    cols: 12,
+    type: 'WidgetPaths'
   },
   {
     name: 'details',

--- a/src/stories/components/PathTree/PathTreePlaceholder/PathTreePlaceholder.stories.js
+++ b/src/stories/components/PathTree/PathTreePlaceholder/PathTreePlaceholder.stories.js
@@ -1,0 +1,40 @@
+import PathTreePlaceholder from '@/components/PathTree/PathTreePlaceholder/PathTreePlaceholder'
+import { LAYOUTS } from '@/enums/pathTree'
+
+export default {
+  title: 'Components/PathTree/PathTreePlaceholder/PathTreePlaceholder',
+  tags: ['autodocs'],
+  component: PathTreePlaceholder,
+  argTypes: {
+    compact: Boolean,
+    entries: {
+      control: {
+        type: 'number',
+        min: 1,
+        max: 100,
+        step: 1
+      }
+    },
+    layout: {
+      control: 'select',
+      options: Object.values(LAYOUTS)
+    },
+    level: {
+      control: {
+        type: 'number',
+        min: 0,
+        max: 10,
+        step: 1
+      }
+    }
+  },
+  args: {
+    compact: false,
+    layout: LAYOUTS.TREE,
+    level: 0,
+    entries: 6,
+    noStats: false
+  }
+}
+
+export const Default = {}

--- a/src/stories/components/PathTree/PathTreeView/PathTreeView.stories.js
+++ b/src/stories/components/PathTree/PathTreeView/PathTreeView.stories.js
@@ -12,7 +12,7 @@ export default {
   args: {
     query: '',
     compact: false,
-    nested: true,
+    layout: 'tree',
     selectMode: false,
     noLabel: false,
     noSearch: false
@@ -28,29 +28,29 @@ export default {
     setup: () => ({ args }),
     template: `
       <path-tree-view v-bind="args" @update:query="args.query = $event">
-        <path-tree-view-entry :nested="args.nested" :level="0" name="Flowera" :documents="9104" :directories="3" :size="2110000000">
+        <path-tree-view-entry :layout="args.layout" :level="0" name="Flowera" :documents="9104" :directories="3" :size="2110000000">
           <template #name>
             <div class="text-truncate">
               <phosphor-icon name="circles-three-plus" class="me-1" />
               <project-label project="Flowera" hide-thumbnail />
             </div>
           </template>
-          <path-tree-view-entry :nested="args.nested" :level="1" name="Contract" :documents="2109" :directories="4" :size="1010000000">
-            <path-tree-view-entry :nested="args.nested" :level="2" name="2021" :documents="1567" :directories="3" :size="500000000">
-              <path-tree-view-entry :nested="args.nested" :level="3" name="Note" collapse :documents="678" :directories="4" :size="76000000" />
-              <path-tree-view-entry :nested="args.nested" :level="4" name="Signature" collapse  :documents="142" :directories="4" :size="378000000" />
-              <path-tree-view-entry :nested="args.nested" :level="4" name="Others" :documents="747" :directories="4" :size="54000000">
-                <path-tree-view-entry :nested="args.nested" :level="5" name="Images" collapse :documents="36" :directories="7" :size="8000000" />
-                <path-tree-view-entry :nested="args.nested" :level="5" name="Attachments" collapse :documents="356" :directories="1" :size="5000000" />
-                <path-tree-view-entry :nested="args.nested" :level="5" name="ID Cards" collapse :documents="145" :directories="6" :size="4000000" />
-                <path-tree-view-entry :nested="args.nested" :level="5" name="Permits" collapse :documents="210" :directories="0" :size="7000000" />
-                <path-tree-view-entry :nested="args.nested" :level="5" name="Balance Sheets" collapse :documents="34" :directories="0" :size="400000" />
+          <path-tree-view-entry :layout="args.layout" :level="1" name="Contract" :documents="2109" :directories="4" :size="1010000000">
+            <path-tree-view-entry :layout="args.layout" :level="2" name="2021" :documents="1567" :directories="3" :size="500000000">
+              <path-tree-view-entry :layout="args.layout" :level="3" name="Note" collapse :documents="678" :directories="4" :size="76000000" />
+              <path-tree-view-entry :layout="args.layout" :level="4" name="Signature" collapse  :documents="142" :directories="4" :size="378000000" />
+              <path-tree-view-entry :layout="args.layout" :level="4" name="Others" :documents="747" :directories="4" :size="54000000">
+                <path-tree-view-entry :layout="args.layout" :level="5" name="Images" collapse :documents="36" :directories="7" :size="8000000" />
+                <path-tree-view-entry :layout="args.layout" :level="5" name="Attachments" collapse :documents="356" :directories="1" :size="5000000" />
+                <path-tree-view-entry :layout="args.layout" :level="5" name="ID Cards" collapse :documents="145" :directories="6" :size="4000000" />
+                <path-tree-view-entry :layout="args.layout" :level="5" name="Permits" collapse :documents="210" :directories="0" :size="7000000" />
+                <path-tree-view-entry :layout="args.layout" :level="5" name="Balance Sheets" collapse :documents="34" :directories="0" :size="400000" />
                 <path-tree-view-entry-more :level="5" :total="14" :per-page="5" class="mx-3 my-2" />
               </path-tree-view-entry>
             </path-tree-view-entry>
-            <path-tree-view-entry :level="2" :nested="args.nested" name="2020" collapse />
-            <path-tree-view-entry :level="2" :nested="args.nested" name="2019" collapse />
-            <path-tree-view-entry :level="2" :nested="args.nested" name="2018" collapse />
+            <path-tree-view-entry :level="2" :layout="args.layout" name="2020" collapse />
+            <path-tree-view-entry :level="2" :layout="args.layout" name="2019" collapse />
+            <path-tree-view-entry :level="2" :layout="args.layout" name="2018" collapse />
           </path-tree-view-entry>
         </path-tree-view-entry>
       </path-tree-view>

--- a/src/views/App.vue
+++ b/src/views/App.vue
@@ -1,8 +1,11 @@
 <template>
-  <div class="app d-flex">
+  <div
+    class="app"
+    :style="style"
+  >
     <hook name="app:before" />
-    <app-sidebar />
-    <div class="app__view flex-grow-1">
+    <app-sidebar ref="sidebar" />
+    <div class="app__view">
       <router-view v-slot="{ Component }">
         <component :is="Component">
           <template
@@ -36,7 +39,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, onBeforeUnmount } from 'vue'
+import { computed, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'
 import { compact, get, property } from 'lodash'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -52,6 +55,7 @@ const { core } = useCore()
 const appStore = useAppStore()
 const { t } = useI18n()
 const route = useRoute()
+const sidebar = useTemplateRef('sidebar')
 
 const signinUrl = computed(() => import.meta.env.VITE_DS_AUTH_SIGNIN)
 
@@ -65,6 +69,12 @@ const handleHttpError = (err) => {
     core.toast.error(body, { href, linkLabel, autoClose: false })
   }
 }
+
+const style = computed(() => {
+  return {
+    '--app-sidebar-width': `${sidebar.value?.width ?? 0}px`
+  }
+})
 
 const hasSettings = computed(() => {
   return route?.meta?.settings !== false && !!settingComponent.value
@@ -99,12 +109,19 @@ onBeforeUnmount(() => {
 <style lang="scss" scoped>
 .app {
   --app-nav-height: #{$app-nav-height};
+  --app-sidebar-width: 0px;
 
   min-height: 100vh;
+  display: flex;
 
-  &__view:has(.table-responsive) {
-    max-width: 100vw;
-    overflow-x: hidden;
+  &__view {
+    flex: 1 1 auto;
+    max-width: calc(100vw - var(--app-sidebar-width));
+
+    &:has(.table-responsive) {
+      overflow-x: hidden;
+    }
   }
+
 }
 </style>

--- a/src/views/Project/ProjectView/ProjectViewOverview/ProjectViewOverviewPaths.vue
+++ b/src/views/Project/ProjectView/ProjectViewOverview/ProjectViewOverviewPaths.vue
@@ -9,10 +9,10 @@ defineProps({
 </script>
 
 <template>
-  <div class="project-view-overview-path">
+  <div class="project-view-overview-paths">
     <project-view-overview-widgets
       :name="name"
-      section="path"
+      section="paths"
     />
   </div>
 </template>

--- a/tests/unit/specs/components/PathTree/PathTree.spec.js
+++ b/tests/unit/specs/components/PathTree/PathTree.spec.js
@@ -47,6 +47,10 @@ vi.mock('@/api/apiInstance', async (importOriginal) => {
 })
 
 describe('PathTree.vue', () => {
+  afterAll(() => {
+    vi.resetAllMocks()
+  })
+
   describe('Posix', () => {
     const { index, es } = esConnectionHelper.build()
     let wrapper, core, searchStore
@@ -74,10 +78,6 @@ describe('PathTree.vue', () => {
           renderStubDefaultSlot: true
         }
       })
-    })
-
-    afterAll(() => {
-      vi.resetAllMocks()
     })
 
     it('should be a Vue instance', () => {

--- a/tests/unit/specs/components/PathTree/PathTree.spec.js
+++ b/tests/unit/specs/components/PathTree/PathTree.spec.js
@@ -64,10 +64,10 @@ describe('PathTree.vue', () => {
           projects: [index],
           path: '/home/foo',
           selectedPaths: ['path_01', 'path_02'],
-          size: true,
           count: true,
           nested: true,
-          infiniteScroll: false
+          infiniteScroll: false,
+          noDocuments: true
         },
         global: {
           plugins: core.plugins,
@@ -82,20 +82,6 @@ describe('PathTree.vue', () => {
 
     it('should be a Vue instance', () => {
       expect(wrapper).toBeTruthy()
-    })
-
-    it('should display 3 directories including the current', async () => {
-      await letData(es)
-        .have(new IndexedDocuments().setBaseName('/home/foo/bar/doc_01').withIndex(index).count(5))
-        .commit()
-      await letData(es)
-        .have(new IndexedDocuments().setBaseName('/home/foo/baz/doc_02').withIndex(index).count(5))
-        .commit()
-      await wrapper.vm.loadData()
-
-      expect(wrapper.find('.path-tree-view-entry-stats-documents').exists()).toBeTruthy()
-      expect(wrapper.find('.path-tree-view-entry-stats-documents').text()).toBe('10')
-      expect(wrapper.findAll('.path-tree-view-entry')).toHaveLength(3)
     })
 
     it('should display 4 directories including one from the tree', async () => {
@@ -162,10 +148,10 @@ describe('PathTree.vue', () => {
         props: {
           projects: [index],
           path: 'C:\\home\\foo',
-          size: true,
           count: true,
           nested: true,
-          infiniteScroll: false
+          infiniteScroll: false,
+          noDocuments: true
         },
         global: {
           plugins: core.plugins,

--- a/tests/unit/specs/components/PathTree/PathTreeBreadcrumb/PathTreeBreadcrumb.spec.js
+++ b/tests/unit/specs/components/PathTree/PathTreeBreadcrumb/PathTreeBreadcrumb.spec.js
@@ -38,7 +38,7 @@ describe('PathTreeBreadcrumb.vue', () => {
   })
 
   it('should display 3 entries (including the abbreviation)', async () => {
-    const props = { modelValue: '/home/foo/bar/baz/lo/rem', maxDirectories: 2, datadirLabel: true }
+    const props = { modelValue: '/home/foo/bar/baz/lo/rem', maxEntries: 2, datadirLabel: true }
     const wrapper = mount(PathTreeBreadcrumb, { global: { plugins }, props })
     expect(wrapper.findAll('.path-tree-breadcrumb-entry')).toHaveLength(3)
     expect(wrapper.find('.path-tree-breadcrumb-dropdown').exists()).toBeTruthy()
@@ -61,7 +61,7 @@ describe('PathTreeBreadcrumb.vue', () => {
     config.set('pathSeparator', '\\')
     const props = {
       modelValue: 'C:\\Users\\dev\\AppData\\Roaming\\Datashare\\foo\\bar\\baz\\lo\\rem',
-      maxDirectories: 2,
+      maxEntries: 2,
       datadirLabel: true
     }
     const wrapper = mount(PathTreeBreadcrumb, { global: { plugins }, props })

--- a/tests/unit/specs/components/Task/TaskDocuments/TaskDocumentsFormOcrAlert.spec.js
+++ b/tests/unit/specs/components/Task/TaskDocuments/TaskDocumentsFormOcrAlert.spec.js
@@ -47,7 +47,6 @@ describe('TaskDocumentsFormOcrAlert.vue', () => {
     })
 
     it('should display an alert indicating that no OCR is installed for italian', () => {
-      console.log(wrapper.html())
       expect(wrapper.text()).toContain('OCR for "Italian" is not installed.')
     })
   })

--- a/tests/unit/specs/components/Widget/WidgetDiskUsage.spec.js
+++ b/tests/unit/specs/components/Widget/WidgetDiskUsage.spec.js
@@ -1,4 +1,4 @@
-import { mount, flushPromises } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 
 import { IndexedDocument, letData } from '~tests/unit/es_utils'
 import esConnectionHelper from '~tests/unit/specs/utils/esConnectionHelper'
@@ -7,7 +7,6 @@ import WidgetDiskUsage from '@/components/Widget/WidgetDiskUsage'
 
 describe('WidgetDiskUsage.vue', () => {
   const { index: project, es } = esConnectionHelper.build()
-  const { index: anotherProject } = esConnectionHelper.build()
   const props = { widget: { title: 'Hello world' }, project }
   let wrapper
 
@@ -25,13 +24,5 @@ describe('WidgetDiskUsage.vue', () => {
     await letData(es).have(new IndexedDocument('document', project).withContentLength(10)).commit()
     await wrapper.vm.loadData()
     expect(wrapper.find('.widget-barometer__value').text()).toBe('10.00 B')
-  })
-
-  it('should reset path on project change', async () => {
-    await wrapper.setData({ path: 'path_01' })
-    expect(wrapper.vm.path).toBe('path_01')
-    wrapper.setProps({ project: anotherProject })
-    await flushPromises()
-    expect(wrapper.vm.path).toBe('dataDir')
   })
 })

--- a/tests/unit/specs/composables/usePaths.spec.js
+++ b/tests/unit/specs/composables/usePaths.spec.js
@@ -1,0 +1,176 @@
+import { ref } from 'vue'
+
+import { usePath } from '@/composables/usePath'
+import { useConfig } from '@/composables/useConfig'
+
+describe('usePath', () => {
+  beforeEach(() => {
+    useConfig().set('pathSeparator', '/')
+  })
+
+  it('returns the same ref instance passed in', () => {
+    const selected = ref([])
+    const { selectedPaths } = usePath(selected)
+    expect(selectedPaths).toBe(selected)
+  })
+
+  it('exposes default path separator from config ("/")', () => {
+    const { pathSeparator } = usePath(ref([]))
+    expect(pathSeparator.value).toBe('/')
+  })
+
+  it('supports custom path separator from config (e.g., "\\\\")', () => {
+    useConfig().set('pathSeparator', '\\')
+    const { pathSeparator } = usePath(ref([]))
+    expect(pathSeparator.value).toBe('\\')
+  })
+
+  describe('getBasename', () => {
+    it('returns last segment for POSIX paths', () => {
+      const { getBasename } = usePath(ref([]))
+      expect(getBasename('/a/b/c.txt')).toBe('c.txt')
+      expect(getBasename('/a/b/')).toBe('b')
+      expect(getBasename('/')).toBe('')
+      expect(getBasename('')).toBe('')
+      expect(getBasename('notes.md')).toBe('notes.md')
+    })
+
+    it('returns last segment for Windows-style paths', () => {
+      useConfig().set('pathSeparator', '\\')
+      const { getBasename } = usePath(ref([]))
+      expect(getBasename('C:\\foo\\bar\\readme.md')).toBe('readme.md')
+      expect(getBasename('C:\\foo\\bar\\')).toBe('bar')
+    })
+  })
+
+  describe('normalizeDirectory', () => {
+    it('ensures a single trailing "/" and removes duplicates', () => {
+      const { normalizeDirectory } = usePath(ref([]))
+      expect(normalizeDirectory('/a/b')).toBe('/a/b/')
+      expect(normalizeDirectory('/a/b///')).toBe('/a/b/')
+      expect(normalizeDirectory('/')).toBe('/') // root stays single slash
+    })
+
+    it('ensures a single trailing "\\" on Windows paths', () => {
+      useConfig().set('pathSeparator', '\\')
+      const { normalizeDirectory } = usePath(ref([]))
+      expect(normalizeDirectory('C:\\a\\b')).toBe('C:\\a\\b\\')
+      expect(normalizeDirectory('C:\\a\\b\\\\\\\\')).toBe('C:\\a\\b\\')
+      expect(normalizeDirectory('C:\\')).toBe('C:\\')
+    })
+  })
+
+  describe('isSelectedPath', () => {
+    it('matches regardless of trailing slash (POSIX)', () => {
+      const selected = ref(['/docs/'])
+      const { isSelectedPath } = usePath(selected)
+      expect(isSelectedPath('/docs')).toBe(true)
+      expect(isSelectedPath('/docs/')).toBe(true)
+      expect(isSelectedPath('/docs/readme')).toBe(false)
+    })
+
+    it('works with Windows separator', () => {
+      useConfig().set('pathSeparator', '\\')
+      const selected = ref(['C:\\data\\'])
+      const { isSelectedPath } = usePath(selected)
+      expect(isSelectedPath('C:\\data')).toBe(true)
+      expect(isSelectedPath('C:\\data\\')).toBe(true)
+      expect(isSelectedPath('C:\\datax')).toBe(false)
+    })
+  })
+
+  describe('isIndeterminateDirectory', () => {
+    it('is true when some (but not all) children are selected and dir is not selected', () => {
+      const selected = ref(['/a/b', '/a/c']) // mixed trailing slashes are fine
+      const { isIndeterminateDirectory } = usePath(selected)
+      expect(isIndeterminateDirectory('/a')).toBe(true)
+    })
+
+    it('is false when directory itself is selected (even if children are too)', () => {
+      const selected = ref(['/a/', '/a/b/', '/a/c/'])
+      const { isIndeterminateDirectory } = usePath(selected)
+      expect(isIndeterminateDirectory('/a')).toBe(false)
+    })
+
+    it('is false when no children are selected', () => {
+      const selected = ref([])
+      const { isIndeterminateDirectory } = usePath(selected)
+      expect(isIndeterminateDirectory('/a')).toBe(false)
+    })
+
+    it('is true for deeper nesting when parent not selected', () => {
+      const selected = ref(['/a/b/d'])
+      const { isIndeterminateDirectory } = usePath(selected)
+      expect(isIndeterminateDirectory('/a/b')).toBe(true)
+      expect(isIndeterminateDirectory('/a')).toBe(true)
+    })
+  })
+
+  describe('selectPath', () => {
+    it('replaces selection when multiple=false (default)', () => {
+      const selected = ref(['/prev/'])
+      const { selectPath } = usePath(selected)
+      selectPath('/new')
+      expect(selected.value).toEqual(['/new/'])
+      selectPath('/another/')
+      expect(selected.value).toEqual(['/another/'])
+    })
+
+    it('appends when multiple=true', () => {
+      const selected = ref([])
+      const { selectPath } = usePath(selected, { multiple: true })
+      selectPath('/one')
+      selectPath('/two/')
+      expect(selected.value).toEqual(['/one/', '/two/'])
+    })
+
+    it('allows duplicates when multiple=true (current behavior)', () => {
+      const selected = ref([])
+      const { selectPath } = usePath(selected, { multiple: true })
+      selectPath('/one')
+      selectPath('/one/')
+      expect(selected.value).toEqual(['/one/', '/one/'])
+    })
+  })
+
+  describe('unselectPath', () => {
+    it('removes an existing normalized path', () => {
+      const selected = ref(['/one/', '/two/'])
+      const { unselectPath } = usePath(selected)
+      unselectPath('/two')
+      expect(selected.value).toEqual(['/one/'])
+    })
+
+    it('does nothing when path is not selected (documented expected behavior)', () => {
+      const selected = ref(['/one/', '/two/'])
+      const { unselectPath } = usePath(selected)
+      unselectPath('/absent')
+      expect(selected.value).toEqual(['/one/', '/two/'])
+    })
+  })
+
+  describe('togglePath', () => {
+    it('selects when not selected, unselects when selected (single mode)', () => {
+      const selected = ref([])
+      const { togglePath } = usePath(selected)
+
+      togglePath('/docs')
+      expect(selected.value).toEqual(['/docs/'])
+
+      togglePath('/docs/')
+      expect(selected.value).toEqual([])
+    })
+
+    it('works with multiple=true', () => {
+      const selected = ref([])
+      const { togglePath } = usePath(selected, { multiple: true })
+
+      togglePath('/a')
+      togglePath('/b')
+      expect(selected.value).toEqual(['/a/', '/b/'])
+
+      togglePath('/a/')
+      expect(selected.value).toEqual(['/b/'])
+    })
+  })
+})


### PR DESCRIPTION
As described in icij/datashare#1892, this PR enhances the `PathTree` view components to:

* display documents
* add a layout selector
* add a grid layout
* add a folder preview in the grid layout

## Preview

[Screencast from 2025-09-22 15-51-58.webm](https://github.com/user-attachments/assets/d8c8acf7-4282-4d94-8a96-6076ccdfa4be)

