### PR TITLE
feat: back to search without refresh

### DIFF
--- a/src/components/Button/ButtonBackToSearch.vue
+++ b/src/components/Button/ButtonBackToSearch.vue
@@ -3,7 +3,7 @@ import { ButtonIcon } from '@icij/murmur-next'
 import { useI18n } from 'vue-i18n'
 
 import { useSearchNav } from '@/composables/useSearchNav'
-const { searchRoute } = useSearchNav()
+const { searchRouteWithoutRefresh } = useSearchNav()
 const { t } = useI18n()
 </script>
 
@@ -11,7 +11,7 @@ const { t } = useI18n()
   <button-icon
     :icon-left="PhCaretLeft"
     :label="t('buttonBackToSearch.label')"
-    :to="searchRoute"
+    :to="searchRouteWithoutRefresh"
     variant="link"
   />
 </template>

--- a/src/components/Document/DocumentActionsGroup/DocumentActionsGroup.vue
+++ b/src/components/Document/DocumentActionsGroup/DocumentActionsGroup.vue
@@ -128,14 +128,14 @@ const classList = computed(() => {
 })
 
 const modalController = useModalController()
-const { searchRoute } = useSearchNav()
+const { searchRouteWithoutRefresh } = useSearchNav()
 const router = useRouter()
 
 async function onClose() {
   if (modal) {
     return modalController.hide()
   }
-  return router.push(searchRoute.value)
+  return router.push(searchRouteWithoutRefresh.value)
 }
 </script>
 

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -334,7 +334,14 @@ export function useSearchFilter() {
 
   function onAfterRouteQueryUpdate(callback, options) {
     return onAfterRouteUpdate((to, from) => {
-      if (to.name === 'search' && !searchStore.sameAppliedQuery(to.query, ['from'])) {
+      if (
+        // We don't want to trigger the callback when the route is not "search"
+        to.name === 'search'
+        // or when the `noRefresh` query parameter is set
+        && !to.query?.noRefresh
+        // or when the query is not changed (except for the `from` parameter)
+        && !searchStore.sameAppliedQuery(to.query, ['from'])
+      ) {
         callback(to, from)
       }
     }, options)
@@ -345,6 +352,8 @@ export function useSearchFilter() {
       if (
         // We don't want to trigger the callback when the route is not "search"
         to.name === 'search'
+        // or when the `noRefresh` query parameter is set
+        && !to.query?.noRefresh
         // or when the previous route is not a document in a modal (for instance,
         // when the user navigates from a document in grid view)
         && !(from.name === 'document' && from.query.modal)

--- a/src/composables/useSearchNav.js
+++ b/src/composables/useSearchNav.js
@@ -27,6 +27,8 @@ export function useSearchNav(currentDocument = null) {
 
   // Route to the search page with the current search query
   const searchRoute = computed(() => ({ name: 'search', query: searchStore.toRouteQuery }))
+  // Route to the search that will not trigger a refresh of the store
+  const searchRouteWithoutRefresh = computed(() => ({ name: 'search', query: { ...searchStore.toRouteQuery, noRefresh: 1 } }))
   // Check if the current route is a child of the search route (or the search route itself)
   const isSearchChildRoute = computed(() => route.matched.some(route => route.name === 'search'))
   // Position of the document in the hits array
@@ -145,6 +147,7 @@ export function useSearchNav(currentDocument = null) {
 
   return {
     searchRoute,
+    searchRouteWithoutRefresh,
     isSearchChildRoute,
     disabledNext,
     disabledPrevious,

--- a/src/views/Document/DocumentView/DocumentView.vue
+++ b/src/views/Document/DocumentView/DocumentView.vue
@@ -161,7 +161,6 @@ onBeforeMount(whenSearchHasNoEntries(redirectToDocumentStandalone))
 // Ensure the document is always in sync with the route
 onBeforeMount(fetchRouteDocument)
 onBeforeRouteUpdate(fetchRouteDocument)
-
 </script>
 
 <template>

--- a/src/views/Document/DocumentView/DocumentViewTabs/DocumentViewTabs.vue
+++ b/src/views/Document/DocumentView/DocumentViewTabs/DocumentViewTabs.vue
@@ -19,7 +19,7 @@ const { tabs } = defineProps({
 const appStore = useAppStore()
 const router = useRouter()
 const route = useRoute()
-const { searchRoute } = useSearchNav()
+const { searchRouteWithoutRefresh } = useSearchNav()
 const { wheneverRouteActionShortcut } = useKeyboardShortcuts()
 
 const modal = inject('modal', undefined)
@@ -33,7 +33,7 @@ const currentTabIndex = computed(() => {
 })
 
 // We must close the current document on "escape" key press only if we are in list view (ie. not in a modal)
-wheneverRouteActionShortcut('back', () => !modal && router.push(searchRoute.value))
+wheneverRouteActionShortcut('back', () => !modal && router.push(searchRouteWithoutRefresh.value))
 
 const previousTabIndex = computed(() => (currentTabIndex.value || tabs.length) - (1 % tabs.length))
 const previousTabRoute = computed(() => tabRoute(tabs[previousTabIndex.value]))


### PR DESCRIPTION
This PR adds a "noRefresh" query parameter to explicitly skip refresh of the search store when coming back to the search results (from the document view).