### PR TITLE
feat: add a new "parts" field to path with a different analyzer

### DIFF
--- a/tests/unit/specs/utils/datashare_index_mappings.json
+++ b/tests/unit/specs/utils/datashare_index_mappings.json
@@ -27,7 +27,13 @@
       "type": "integer"
     },
     "path": {
-      "type": "keyword"
+      "type": "keyword",
+      "fields": {
+        "parts": {
+          "type": "text",
+          "analyzer": "path_parts_analyzer"
+        }
+      }
     },
     "title": {
       "type": "keyword"

--- a/tests/unit/specs/utils/datashare_index_settings.json
+++ b/tests/unit/specs/utils/datashare_index_settings.json
@@ -17,12 +17,17 @@
     "metadata.tika_metadata_resourcename",
     "name",
     "path",
+    "path.parts",
     "tags"
   ],
   "analysis": {
     "analyzer": {
       "path_analyzer": {
         "tokenizer": "path_tokenizer"
+      },
+      "path_parts_analyzer": {
+        "tokenizer": "path_parts_tokenizer",
+        "filter": ["lowercase"]
       },
       "folding": {
         "tokenizer": "standard",
@@ -32,6 +37,10 @@
     "tokenizer": {
       "path_tokenizer": {
         "type": "path_hierarchy"
+      },
+      "path_parts_tokenizer": {
+        "type": "pattern",
+        "pattern": "[/\\\\. ]+"
       }
     },
     "normalizer": {

--- a/tests/unit/specs/utils/datashare_index_settings_windows.json
+++ b/tests/unit/specs/utils/datashare_index_settings_windows.json
@@ -17,12 +17,17 @@
     "metadata.tika_metadata_resourcename",
     "name",
     "path",
+    "path.parts",
     "tags"
   ],
   "analysis": {
     "analyzer": {
       "path_analyzer": {
         "tokenizer": "path_tokenizer"
+      },
+      "path_parts_analyzer": {
+        "tokenizer": "path_parts_tokenizer",
+        "filter": ["lowercase"]
       },
       "folding": {
         "tokenizer": "standard",
@@ -33,6 +38,10 @@
       "path_tokenizer": {
         "type": "path_hierarchy",
         "delimiter": "\\"
+      },
+      "path_parts_tokenizer": {
+        "type": "pattern",
+        "pattern": "[/\\\\. ]+"
       }
     },
     "normalizer": {


### PR DESCRIPTION
This new field will allow to search in paths without using wildcard or regexes https://github.com/ICIJ/datashare/issues/1942. Because `path.parts` is added to `default_field`, that changes doesn't require any additional update on the front.