### PR TITLE
feat: admin update project metadata

### DIFF
--- a/src/components/Display/DisplayRole.vue
+++ b/src/components/Display/DisplayRole.vue
@@ -23,7 +23,7 @@ const role = computed(() => formatRole(props.value))
 </script>
 
 <template>
-  <span class="d-inline-flex gap-1">
+  <span class="display-role d-inline-flex gap-1">
     <app-icon
       v-if="!noIcon"
       :size="iconSize"

--- a/src/components/Display/DisplayRole.vue
+++ b/src/components/Display/DisplayRole.vue
@@ -3,6 +3,8 @@ import { computed } from 'vue'
 import { AppIcon } from '@icij/murmur-next'
 
 import { usePolicies } from '@/composables/usePolicies.js'
+import {ROLE_KEY} from "@/enums/roles.js";
+import {useI18n} from "vue-i18n";
 
 const props = defineProps({
   value: {
@@ -19,7 +21,8 @@ const props = defineProps({
 })
 
 const { formatRole } = usePolicies()
-const role = computed(() => formatRole(props.value))
+const { t } = useI18n()
+const role = computed(() => formatRole(t(ROLE_KEY[props.value])))
 </script>
 
 <template>

--- a/src/components/Display/DisplayRole.vue
+++ b/src/components/Display/DisplayRole.vue
@@ -3,8 +3,8 @@ import { computed } from 'vue'
 import { AppIcon } from '@icij/murmur-next'
 
 import { usePolicies } from '@/composables/usePolicies.js'
-import {ROLE_KEY} from "@/enums/roles.js";
-import {useI18n} from "vue-i18n";
+import { ROLE_KEY } from '@/enums/roles.js'
+import { useI18n } from 'vue-i18n'
 
 const props = defineProps({
   value: {

--- a/src/components/Display/DisplayRoles.vue
+++ b/src/components/Display/DisplayRoles.vue
@@ -31,7 +31,7 @@ const rolesTitle = computed(() => t('displayRoles.yourRoles', { roles: formatRol
 <template>
   <span
     v-if="roles"
-    class="text-secondary-emphasis d-inline-flex align-items-center gap-1"
+    class="display-roles d-inline-flex align-items-center gap-1"
     :title="rolesTitle"
   >
     <app-icon

--- a/src/components/Display/DisplayRoles.vue
+++ b/src/components/Display/DisplayRoles.vue
@@ -1,10 +1,10 @@
 <script setup>
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 import { AppIcon } from '@icij/murmur-next'
 
 import DisplayRole from '@/components/Display/DisplayRole.vue'
 import { usePolicies } from '@/composables/usePolicies.js'
+import {useI18n} from "vue-i18n";
 
 const props = defineProps({
   project: {

--- a/src/components/Display/DisplayRoles.vue
+++ b/src/components/Display/DisplayRoles.vue
@@ -4,7 +4,7 @@ import { AppIcon } from '@icij/murmur-next'
 
 import DisplayRole from '@/components/Display/DisplayRole.vue'
 import { usePolicies } from '@/composables/usePolicies.js'
-import {useI18n} from "vue-i18n";
+import { useI18n } from 'vue-i18n'
 
 const props = defineProps({
   project: {

--- a/src/components/Mode/RestrictedOnly.vue
+++ b/src/components/Mode/RestrictedOnly.vue
@@ -1,0 +1,25 @@
+<script setup>
+import { useMode } from '@/composables/useMode'
+import { usePolicies } from '@/composables/usePolicies.js'
+import { computed } from 'vue'
+
+const props = defineProps({
+  admin: {
+    type: Boolean,
+    default: true
+  },
+  project: {
+    type: Object,
+    required: true
+  }
+})
+
+const { isServer, isLocal } = useMode()
+const { isProjectAdmin } = usePolicies()
+const isAdmin = computed(() => isProjectAdmin(props.project.name))
+const isVisible = computed(() => (props.admin && isAdmin.value && isServer.value) || isLocal.value)
+</script>
+
+<template>
+  <slot v-if="isVisible" />
+</template>

--- a/src/components/Policy/PolicyOnly.vue
+++ b/src/components/Policy/PolicyOnly.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { useMode } from '@/composables/useMode'
+import { useMode } from '@/composables/useMode.js'
 import { usePolicies } from '@/composables/usePolicies.js'
 import { computed } from 'vue'
 

--- a/src/components/Project/ProjectJumbotron/ProjectJumbotron.vue
+++ b/src/components/Project/ProjectJumbotron/ProjectJumbotron.vue
@@ -17,7 +17,7 @@ import ProjectLabel from '@/components/Project/ProjectLabel'
 import ProjectThumbnail from '@/components/Project/ProjectThumbnail'
 import ModeServerOnly from '@/components/Mode/ModeServerOnly.vue'
 import DisplayRoles from '@/components/Display/DisplayRoles.vue'
-import RestrictedOnly from '@/components/Mode/RestrictedOnly.vue'
+import PolicyOnly from '@/components/Policy/PolicyOnly.vue'
 import ModeLocalOnly from '@/components/Mode/ModeLocalOnly.vue'
 
 const { breakpointDown } = useBreakpoints()
@@ -103,7 +103,7 @@ const promptProjectDeletion = async () => {
             @click="promptProjectDeletion"
           />
         </mode-local-only>
-        <restricted-only
+        <policy-only
           admin
           :project="project"
         >
@@ -114,7 +114,7 @@ const promptProjectDeletion = async () => {
             :to="toEdit"
             :label="t('projectJumbotron.edit')"
           />
-        </restricted-only>
+        </policy-only>
         <project-jumbotron-pin v-model:pinned="pinned" />
       </div>
     </div>

--- a/src/components/Project/ProjectJumbotron/ProjectJumbotron.vue
+++ b/src/components/Project/ProjectJumbotron/ProjectJumbotron.vue
@@ -15,9 +15,9 @@ import Hook from '@/components/Hook/Hook'
 import DisplayDatetime from '@/components/Display/DisplayDatetime'
 import ProjectLabel from '@/components/Project/ProjectLabel'
 import ProjectThumbnail from '@/components/Project/ProjectThumbnail'
-import ModeLocalOnly from '@/components/Mode/ModeLocalOnly'
 import ModeServerOnly from '@/components/Mode/ModeServerOnly.vue'
 import DisplayRoles from '@/components/Display/DisplayRoles.vue'
+import RestrictedOnly from '@/components/Mode/RestrictedOnly.vue'
 
 const { breakpointDown } = useBreakpoints()
 const router = useRouter()
@@ -68,6 +68,7 @@ const promptProjectDeletion = async () => {
     router.push({ name: 'project.list' })
   }
 }
+
 </script>
 
 <template>
@@ -91,7 +92,10 @@ const promptProjectDeletion = async () => {
           :bind="{ project }"
         />
       </h3>
-      <mode-local-only>
+      <RestrictedOnly
+        admin
+        :project="project"
+      >
         <button-row-action-delete
           class="ms-auto"
           size="md"
@@ -107,7 +111,7 @@ const promptProjectDeletion = async () => {
           :to="toEdit"
           :label="t('projectJumbotron.edit')"
         />
-      </mode-local-only>
+      </RestrictedOnly>
       <project-jumbotron-pin v-model:pinned="pinned" />
     </div>
     <div class="project-jumbotron__content d-flex gap-3 align-items-start">

--- a/src/components/Project/ProjectJumbotron/ProjectJumbotron.vue
+++ b/src/components/Project/ProjectJumbotron/ProjectJumbotron.vue
@@ -18,7 +18,7 @@ import ProjectThumbnail from '@/components/Project/ProjectThumbnail'
 import ModeServerOnly from '@/components/Mode/ModeServerOnly.vue'
 import DisplayRoles from '@/components/Display/DisplayRoles.vue'
 import RestrictedOnly from '@/components/Mode/RestrictedOnly.vue'
-import ModeLocalOnly from "@/components/Mode/ModeLocalOnly.vue";
+import ModeLocalOnly from '@/components/Mode/ModeLocalOnly.vue'
 
 const { breakpointDown } = useBreakpoints()
 const router = useRouter()

--- a/src/components/Project/ProjectJumbotron/ProjectJumbotron.vue
+++ b/src/components/Project/ProjectJumbotron/ProjectJumbotron.vue
@@ -18,6 +18,7 @@ import ProjectThumbnail from '@/components/Project/ProjectThumbnail'
 import ModeServerOnly from '@/components/Mode/ModeServerOnly.vue'
 import DisplayRoles from '@/components/Display/DisplayRoles.vue'
 import RestrictedOnly from '@/components/Mode/RestrictedOnly.vue'
+import ModeLocalOnly from "@/components/Mode/ModeLocalOnly.vue";
 
 const { breakpointDown } = useBreakpoints()
 const router = useRouter()
@@ -92,10 +93,7 @@ const promptProjectDeletion = async () => {
           :bind="{ project }"
         />
       </h3>
-      <RestrictedOnly
-        admin
-        :project="project"
-      >
+      <mode-local-only>
         <button-row-action-delete
           class="ms-auto"
           size="md"
@@ -104,6 +102,11 @@ const promptProjectDeletion = async () => {
           :label="t('projectJumbotron.delete')"
           @click="promptProjectDeletion"
         />
+      </mode-local-only>
+      <restricted-only
+        admin
+        :project="project"
+      >
         <button-row-action-edit
           size="md"
           :hide-label="false"
@@ -111,7 +114,7 @@ const promptProjectDeletion = async () => {
           :to="toEdit"
           :label="t('projectJumbotron.edit')"
         />
-      </RestrictedOnly>
+      </restricted-only>
       <project-jumbotron-pin v-model:pinned="pinned" />
     </div>
     <div class="project-jumbotron__content d-flex gap-3 align-items-start">

--- a/src/components/Project/ProjectJumbotron/ProjectJumbotron.vue
+++ b/src/components/Project/ProjectJumbotron/ProjectJumbotron.vue
@@ -93,29 +93,30 @@ const promptProjectDeletion = async () => {
           :bind="{ project }"
         />
       </h3>
-      <mode-local-only>
-        <button-row-action-delete
-          class="ms-auto"
-          size="md"
-          :hide-label="false"
-          :square="false"
-          :label="t('projectJumbotron.delete')"
-          @click="promptProjectDeletion"
-        />
-      </mode-local-only>
-      <restricted-only
-        admin
-        :project="project"
-      >
-        <button-row-action-edit
-          size="md"
-          :hide-label="false"
-          :square="false"
-          :to="toEdit"
-          :label="t('projectJumbotron.edit')"
-        />
-      </restricted-only>
-      <project-jumbotron-pin v-model:pinned="pinned" />
+      <div>
+        <mode-local-only>
+          <button-row-action-delete
+            size="md"
+            :hide-label="false"
+            :square="false"
+            :label="t('projectJumbotron.delete')"
+            @click="promptProjectDeletion"
+          />
+        </mode-local-only>
+        <restricted-only
+          admin
+          :project="project"
+        >
+          <button-row-action-edit
+            size="md"
+            :hide-label="false"
+            :square="false"
+            :to="toEdit"
+            :label="t('projectJumbotron.edit')"
+          />
+        </restricted-only>
+        <project-jumbotron-pin v-model:pinned="pinned" />
+      </div>
     </div>
     <div class="project-jumbotron__content d-flex gap-3 align-items-start">
       <hook
@@ -144,7 +145,7 @@ const promptProjectDeletion = async () => {
           <div class="d-flex flex-wrap gap-3 text-body-secondary">
             <span
               v-if="creationDate"
-              class="text-nowrap"
+              class="text-nowrap d-inline-flex align-items-center gap-1"
             >
               <app-icon><i-ph-calendar-blank /></app-icon>
               {{ t('projectJumbotron.creationDate') }}
@@ -152,7 +153,7 @@ const promptProjectDeletion = async () => {
             </span>
             <span
               v-if="updateDate"
-              class="text-nowrap"
+              class="text-nowrap d-inline-flex align-items-center gap-1"
             >
               <app-icon>
                 <i-ph-calendar-check />
@@ -163,7 +164,7 @@ const promptProjectDeletion = async () => {
             <mode-server-only>
               <display-roles
                 :project="project"
-                class="text-body-secondary"
+                class="text-blue"
               />
             </mode-server-only>
           </div>

--- a/src/components/Project/ProjectJumbotron/ProjectJumbotron.vue
+++ b/src/components/Project/ProjectJumbotron/ProjectJumbotron.vue
@@ -164,7 +164,6 @@ const promptProjectDeletion = async () => {
             <mode-server-only>
               <display-roles
                 :project="project"
-                class="text-blue"
               />
             </mode-server-only>
           </div>

--- a/src/composables/useMode.js
+++ b/src/composables/useMode.js
@@ -3,8 +3,8 @@ import { computed } from 'vue'
 import { useCore } from '@/composables/useCore'
 import { MODE_NAME } from '@/mode'
 
-export function useMode(coreRef) {
-  const core = coreRef ?? useCore()
+export function useMode(coreValue) {
+  const core = coreValue ?? useCore()
   const mode = computed(() => core.mode)
   const modeName = computed(() => mode.value.modeName)
   const isServer = computed(() => modeName.value === MODE_NAME.SERVER)

--- a/src/composables/useMode.js
+++ b/src/composables/useMode.js
@@ -3,8 +3,8 @@ import { computed } from 'vue'
 import { useCore } from '@/composables/useCore'
 import { MODE_NAME } from '@/mode'
 
-export function useMode() {
-  const core = useCore()
+export function useMode(coreRef) {
+  const core = coreRef ?? useCore()
   const mode = computed(() => core.mode)
   const modeName = computed(() => mode.value.modeName)
   const isServer = computed(() => modeName.value === MODE_NAME.SERVER)

--- a/src/composables/usePolicies.js
+++ b/src/composables/usePolicies.js
@@ -1,7 +1,7 @@
 import { useConfig } from '@/composables/useConfig.js'
 import { computed } from 'vue'
 import { camelCase, find, upperFirst } from 'lodash'
-import {DEFAULT_ROLE} from "@/enums/roles.js";
+import { DEFAULT_ROLE } from '@/enums/roles.js'
 
 export function usePolicies() {
   const config = useConfig()
@@ -13,8 +13,6 @@ export function usePolicies() {
   function getPolicyByProject(projectId) {
     return find(userPolicies.value, { projectId })
   }
-
-
 
   function formatRole(role) {
     return upperFirst(camelCase(role))

--- a/src/composables/usePolicies.js
+++ b/src/composables/usePolicies.js
@@ -9,7 +9,10 @@ export function usePolicies() {
   const userPolicies = computed(() => config.get('policies', []))
 
   function getRolesByProject(projectId) {
-    return find(userPolicies.value, { projectId })?.roles ?? [DEFAULT_ROLE]
+    return getPolicyByProject(projectId)?.roles ?? [DEFAULT_ROLE]
+  }
+  function getPolicyByProject(projectId) {
+    return find(userPolicies.value, { projectId })
   }
 
   function formatRole(role) {

--- a/src/composables/usePolicies.js
+++ b/src/composables/usePolicies.js
@@ -1,14 +1,7 @@
 import { useConfig } from '@/composables/useConfig.js'
 import { computed } from 'vue'
 import { camelCase, find, upperFirst } from 'lodash'
-
-const DEFAULT_ROLE = 'READER'
-
-const ROLE_MAP = {
-  ADMIN: 'ADMIN',
-  WRITER: 'EDITOR',
-  READER: 'VIEWER'
-}
+import {DEFAULT_ROLE} from "@/enums/roles.js";
 
 export function usePolicies() {
   const config = useConfig()
@@ -21,8 +14,10 @@ export function usePolicies() {
     return find(userPolicies.value, { projectId })
   }
 
+
+
   function formatRole(role) {
-    return upperFirst(camelCase(ROLE_MAP[role]))
+    return upperFirst(camelCase(role))
   }
 
   function formatRoles(roles) {

--- a/src/composables/usePolicies.js
+++ b/src/composables/usePolicies.js
@@ -20,5 +20,9 @@ export function usePolicies() {
     return roles.map(formatRole).join(', ')
   }
 
-  return { getRolesByProject, formatRole, formatRoles }
+  function isProjectAdmin(projectName) {
+    return getPolicyByProject(projectName)?.admin === true
+  }
+
+  return { getRolesByProject, formatRole, formatRoles, isProjectAdmin }
 }

--- a/src/composables/usePolicies.js
+++ b/src/composables/usePolicies.js
@@ -2,7 +2,13 @@ import { useConfig } from '@/composables/useConfig.js'
 import { computed } from 'vue'
 import { camelCase, find, upperFirst } from 'lodash'
 
-const DEFAULT_ROLE = 'VIEWER'
+const DEFAULT_ROLE = 'READER'
+
+const ROLE_MAP = {
+  ADMIN: 'ADMIN',
+  WRITER: 'EDITOR',
+  READER: 'VIEWER'
+}
 
 export function usePolicies() {
   const config = useConfig()
@@ -16,7 +22,7 @@ export function usePolicies() {
   }
 
   function formatRole(role) {
-    return upperFirst(camelCase(role))
+    return upperFirst(camelCase(ROLE_MAP[role]))
   }
 
   function formatRoles(roles) {

--- a/src/enums/roles.js
+++ b/src/enums/roles.js
@@ -1,0 +1,14 @@
+
+export const ROLE = Object.freeze({
+  ADMIN :"ADMIN" ,
+  WRITER :"WRITER" ,
+  READER :"READER"
+})
+
+export const DEFAULT_ROLE= ROLE.READER;
+
+export const ROLE_KEY = Object.freeze({
+  ADMIN: 'roles.admin',
+  WRITER: 'roles.writer',
+  READER: 'roles.reader'
+})

--- a/src/enums/roles.js
+++ b/src/enums/roles.js
@@ -1,11 +1,10 @@
-
 export const ROLE = Object.freeze({
-  ADMIN :"ADMIN" ,
-  WRITER :"WRITER" ,
-  READER :"READER"
+  ADMIN: 'ADMIN',
+  WRITER: 'WRITER',
+  READER: 'READER'
 })
 
-export const DEFAULT_ROLE= ROLE.READER;
+export const DEFAULT_ROLE = ROLE.READER
 
 export const ROLE_KEY = Object.freeze({
   ADMIN: 'roles.admin',

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -292,6 +292,11 @@
       }
     }
   },
+  "roles": {
+    "admin": "Admin",
+    "writer": "Editor",
+    "reader": "Viewer"
+  },
   "searchFormControl": {
     "submitLabel": "Search"
   },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -24,6 +24,7 @@ import { checkSearchOrder } from '@/router/guards/checkSearchOrder'
 import { checkSearchSort } from '@/router/guards/checkSearchSort'
 import { prefillSearchStore } from '@/router/guards/prefillSearchStore'
 import { replaceSizeToPerPage } from '@/router/guards/replaceSizeToPerPage'
+import {ROLE} from "@/enums/roles.js";
 
 export const routes = [
   {
@@ -429,7 +430,7 @@ export const routes = [
                 meta: {
                   icon: markRaw(IPhPencilSimple),
                   title: 'projectViewEdit.title',
-                  allowedRoles: ['ADMIN']
+                  allowedRoles: [ROLE.ADMIN]
                 }
               }
             ]

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -429,7 +429,7 @@ export const routes = [
                 meta: {
                   icon: markRaw(IPhPencilSimple),
                   title: 'projectViewEdit.title',
-                  allowedModes: [MODE_NAME.LOCAL, MODE_NAME.EMBEDDED]
+                  allowedRoles: ['ADMIN']
                 }
               }
             ]

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -24,7 +24,7 @@ import { checkSearchOrder } from '@/router/guards/checkSearchOrder'
 import { checkSearchSort } from '@/router/guards/checkSearchSort'
 import { prefillSearchStore } from '@/router/guards/prefillSearchStore'
 import { replaceSizeToPerPage } from '@/router/guards/replaceSizeToPerPage'
-import {ROLE} from "@/enums/roles.js";
+import { ROLE } from '@/enums/roles.js'
 
 export const routes = [
   {


### PR DESCRIPTION
Related to feature ICIJ/datashare#1919

:warning: Merge first backend changes https://github.com/ICIJ/datashare/pull/2011  

Changes: in server mode, admins are now allowed to update project metadata in project edit page

The project view when user is not admin:
<img width="1081" height="221" alt="image" src="https://github.com/user-attachments/assets/17e46131-ec5c-44c3-a713-d846d1464d9b" />
User still can't access edit page http://localhost:9009/#/projects/local-datashare/edit (Something went wrong)

when user is admin, they see the Edit button:
<img width="984" height="219" alt="image" src="https://github.com/user-attachments/assets/7398f9ac-7c53-41b3-83a9-94b062f34f8c" />

They can access the edit project page:
<img width="1018" height="600" alt="image" src="https://github.com/user-attachments/assets/719727e2-1b68-4d7a-a050-5f1c7a606be3" />

Project is updated when hitting save (project must exist in the DB first)
<img width="1018" height="600" alt="image" src="https://github.com/user-attachments/assets/8ce55513-7b47-4d58-808b-45d418e16a66" />
