### PR TITLE
 fix: correct "All" entry count in filter panels

### DIFF
--- a/src/components/Filter/FilterType/FilterTypeAll.vue
+++ b/src/components/Filter/FilterType/FilterTypeAll.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref, toRef, watch } from 'vue'
+import { toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FiltersPanelSectionFilterEntry from '@/components/FiltersPanel/FiltersPanelSectionFilterEntry'
@@ -13,24 +13,16 @@ const props = defineProps({
 })
 
 const { t } = useI18n()
-const { computedAll, computedTotal, searchStore } = useSearchFilter()
+const { computedAll } = useSearchFilter()
 
 const all = computedAll(toRef(props, 'filter'))
-// We track if the total was already visible before to avoid flickering
-// when hidding it (e.g. when the search is not ready).
-const hadTotal = ref(false)
-const total = computedTotal(toRef(props, 'filter'))
-const hideTotal = computed(() => total.value === null || !hadTotal.value)
-// We need to update hadTotal after the search is ready and a total is given
-watch(toRef(searchStore, 'isReady'), value => (hadTotal.value = value && total.value !== null))
 </script>
 
 <template>
   <filters-panel-section-filter-entry
     v-model="all"
-    :count="total"
     :disabled="all"
-    :hide-count="hideTotal"
+    hide-count
     :label="t('filterTypeAll.label')"
   />
 </template>

--- a/src/components/Filter/FilterType/FilterTypeProjectAll.vue
+++ b/src/components/Filter/FilterType/FilterTypeProjectAll.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref, toRef, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FiltersPanelSectionFilterEntry from '@/components/FiltersPanel/FiltersPanelSectionFilterEntry'
@@ -22,13 +22,13 @@ const all = computed({
   }
 })
 
-// We track if the total was already visible before to avoid flickering
-// when hidding it (e.g. when the search is not ready).
+// null while loading to prevent flickering a stale count before the fetch completes.
 const hadTotal = ref(false)
 const total = computed(() => (allProjectsSelected.value ? searchStore.total : null))
 const hideTotal = computed(() => total.value === null || !hadTotal.value)
-// We need to update hadTotal after the search is ready and all projects are selected
-watch(toRef(searchStore, 'isReady'), value => (hadTotal.value = value && allProjectsSelected.value))
+watch(total, (value) => {
+  if (value !== null) hadTotal.value = true
+}, { immediate: true })
 </script>
 
 <template>

--- a/src/components/Filter/FilterType/FilterTypeRecommendedBy.vue
+++ b/src/components/Filter/FilterType/FilterTypeRecommendedBy.vue
@@ -1,11 +1,11 @@
 <script setup>
 import Fuse from 'fuse.js'
-import { computed, onBeforeMount } from 'vue'
-import { property, sortBy } from 'lodash'
+import {computed, onBeforeMount} from 'vue'
+import {property, sortBy} from 'lodash'
 
-import { useConfig } from '@/composables/useConfig'
-import { useSearchFilter } from '@/composables/useSearchFilter'
-import { useRecommendedStore } from '@/store/modules'
+import {useConfig} from '@/composables/useConfig'
+import {useSearchFilter} from '@/composables/useSearchFilter'
+import {useRecommendedStore} from '@/store/modules'
 import DisplayUser from '@/components/Display/DisplayUser'
 import FormControlSearch from '@/components/Form/FormControl/FormControlSearch'
 import FilterType from '@/components/Filter/FilterType/FilterType'
@@ -58,6 +58,7 @@ function fetch() {
 
 onBeforeMount(fetch)
 watchIndices(fetch)
+defineExpose({ fetch })
 </script>
 
 <template>

--- a/src/components/Filter/FilterType/FilterTypeRecommendedBy.vue
+++ b/src/components/Filter/FilterType/FilterTypeRecommendedBy.vue
@@ -1,11 +1,11 @@
 <script setup>
 import Fuse from 'fuse.js'
-import {computed, onBeforeMount} from 'vue'
-import {property, sortBy} from 'lodash'
+import { computed, onBeforeMount } from 'vue'
+import { property, sortBy } from 'lodash'
 
-import {useConfig} from '@/composables/useConfig'
-import {useSearchFilter} from '@/composables/useSearchFilter'
-import {useRecommendedStore} from '@/store/modules'
+import { useConfig } from '@/composables/useConfig'
+import { useSearchFilter } from '@/composables/useSearchFilter'
+import { useRecommendedStore } from '@/store/modules'
 import DisplayUser from '@/components/Display/DisplayUser'
 import FormControlSearch from '@/components/Form/FormControl/FormControlSearch'
 import FilterType from '@/components/Filter/FilterType/FilterType'

--- a/src/components/Filter/FilterType/FilterTypeRecommendedBy.vue
+++ b/src/components/Filter/FilterType/FilterTypeRecommendedBy.vue
@@ -58,7 +58,6 @@ function fetch() {
 
 onBeforeMount(fetch)
 watchIndices(fetch)
-defineExpose({ fetch })
 </script>
 
 <template>

--- a/src/components/Filter/FilterType/FilterTypeStarred.vue
+++ b/src/components/Filter/FilterType/FilterTypeStarred.vue
@@ -1,10 +1,11 @@
 <script setup>
-import { computed, onBeforeMount, ref } from 'vue'
-import { castArray } from 'lodash'
-import { useI18n } from 'vue-i18n'
+import {computed, onBeforeMount, ref} from 'vue'
+import {castArray} from 'lodash'
+import {useI18n} from 'vue-i18n'
 
-import { useSearchFilter } from '@/composables/useSearchFilter'
-import { useSearchStore, useStarredStore } from '@/store/modules'
+import {useSearchFilter} from '@/composables/useSearchFilter'
+import {useWait} from '@/composables/useWait'
+import {useStarredStore} from '@/store/modules'
 import FiltersPanelSectionFilterEntry from '@/components/FiltersPanel/FiltersPanelSectionFilterEntry'
 import FilterType from '@/components/Filter/FilterType/FilterType'
 
@@ -20,17 +21,17 @@ const props = defineProps({
 
 const { t } = useI18n()
 const starredStore = useStarredStore()
-const searchStore = useSearchStore.inject()
-const { getTotal, getFilterValues, setFilterValue, watchIndices } = useSearchFilter()
+const { getTotal, getFilterValues, setFilterValue, watchIndices, indices } = useSearchFilter()
 
+const { waitFor } = useWait()
 const total = ref(0)
 const starredDocumentsCount = computed(() => props.filter.starredDocuments.length)
 const notStarredDocumentsCount = computed(() => Math.max(0, total.value - starredDocumentsCount.value))
 
-async function fetch() {
-  await starredStore.fetchIndicesStarredDocuments(searchStore.indices)
+const fetch = waitFor(async () => {
+  await starredStore.fetchIndicesStarredDocuments(indices.value)
   total.value = await getTotal()
-}
+})
 
 const isTruthy = value => value === true || value === 'true'
 
@@ -46,6 +47,7 @@ const selected = computed({
 
 onBeforeMount(fetch)
 watchIndices(fetch)
+defineExpose({ fetch })
 </script>
 
 <template>
@@ -59,7 +61,7 @@ watchIndices(fetch)
         :value="true"
       />
       <filters-panel-section-filter-entry
-        name="starred"
+        name="not-starred"
         :label="t('filter.notStarred')"
         :count="notStarredDocumentsCount"
         :hide-count="hideCount"

--- a/src/components/Filter/FilterType/FilterTypeStarred.vue
+++ b/src/components/Filter/FilterType/FilterTypeStarred.vue
@@ -1,11 +1,11 @@
 <script setup>
-import {computed, onBeforeMount, ref} from 'vue'
-import {castArray} from 'lodash'
-import {useI18n} from 'vue-i18n'
+import { computed, onBeforeMount, ref } from 'vue'
+import { castArray } from 'lodash'
+import { useI18n } from 'vue-i18n'
 
-import {useSearchFilter} from '@/composables/useSearchFilter'
-import {useWait} from '@/composables/useWait'
-import {useStarredStore} from '@/store/modules'
+import { useSearchFilter } from '@/composables/useSearchFilter'
+import { useWait } from '@/composables/useWait'
+import { useStarredStore } from '@/store/modules'
 import FiltersPanelSectionFilterEntry from '@/components/FiltersPanel/FiltersPanelSectionFilterEntry'
 import FilterType from '@/components/Filter/FilterType/FilterType'
 

--- a/src/components/Filter/FilterType/FilterTypeStarred.vue
+++ b/src/components/Filter/FilterType/FilterTypeStarred.vue
@@ -47,7 +47,6 @@ const selected = computed({
 
 onBeforeMount(fetch)
 watchIndices(fetch)
-defineExpose({ fetch })
 </script>
 
 <template>

--- a/src/store/filters/FilterEntity.js
+++ b/src/store/filters/FilterEntity.js
@@ -14,7 +14,10 @@ export const namedEntityCategoryTranslation = {
 export default class FilterEntity extends FilterType {
   constructor(options) {
     super(options)
-    this.category = (options.category || ENTITY_CATEGORY.PERSON).toUpperCase()
+    if (!options.category) {
+      throw new Error('FilterEntity requires a category')
+    }
+    this.category = options.category.toUpperCase()
     this.component = 'FilterType'
     this.sortByOptions = [
       { sortBy: '_count', orderBy: 'asc' },

--- a/tests/unit/specs/components/Filter/FilterType/FilterTypeAll.spec.js
+++ b/tests/unit/specs/components/Filter/FilterType/FilterTypeAll.spec.js
@@ -1,0 +1,32 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import FilterTypeAll from '@/components/Filter/FilterType/FilterTypeAll'
+import FiltersPanelSectionFilterEntry from '@/components/FiltersPanel/FiltersPanelSectionFilterEntry'
+import { useSearchStore } from '@/store/modules'
+
+describe('FilterTypeAll.vue', () => {
+  let core, wrapper, searchStore, filter
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    core = CoreSetup.init().useAll().useRouterWithoutGuards()
+    searchStore = useSearchStore()
+    filter = searchStore.getFilter({ name: 'contentType' })
+    wrapper = mount(FilterTypeAll, {
+      global: { plugins: core.plugins },
+      props: { filter }
+    })
+  })
+
+  it('renders the filter entry', async () => {
+    await flushPromises()
+    expect(wrapper.findComponent(FiltersPanelSectionFilterEntry).exists()).toBe(true)
+  })
+
+  it('always hides the count', async () => {
+    await flushPromises()
+    expect(wrapper.findComponent(FiltersPanelSectionFilterEntry).props('hideCount')).toBe(true)
+  })
+})

--- a/tests/unit/specs/components/Filter/FilterType/FilterTypeRecommendedBy.spec.js
+++ b/tests/unit/specs/components/Filter/FilterType/FilterTypeRecommendedBy.spec.js
@@ -1,4 +1,4 @@
-import { flushPromises, mount } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 import { setActivePinia, createPinia } from 'pinia'
 
 import { IndexedDocument, letData } from '~tests/unit/es_utils'
@@ -82,12 +82,12 @@ describe('FilterTypeRecommendedBy.vue', () => {
   })
 
   it('should sort options to have the current user first', async () => {
-    await flushPromises()
+    await wrapper.vm.fetch()
     expect(wrapper.findAllComponents(DisplayUser).at(0).text()).toBe('local (you)')
   })
 
   it('should sort options by decreasing order', async () => {
-    await flushPromises()
+    await wrapper.vm.fetch()
     expect(wrapper.findAllComponents(DisplayUser).at(0).text()).toBe('local (you)')
     expect(wrapper.findAllComponents(DisplayUser).at(1).text()).toBe('anita')
     expect(wrapper.findAllComponents(DisplayUser).at(2).text()).toBe('paul')
@@ -95,7 +95,7 @@ describe('FilterTypeRecommendedBy.vue', () => {
 
   it('should select no users', async () => {
     searchStore.addFilterValue({ name: 'recommendedBy', value: [] })
-    await flushPromises()
+    await wrapper.vm.fetch()
     expect(api.getDocumentsRecommendedBy).toBeCalledTimes(0)
     expect(recommendedStore.documents).toEqual([])
   })

--- a/tests/unit/specs/components/Filter/FilterType/FilterTypeStarred.spec.js
+++ b/tests/unit/specs/components/Filter/FilterType/FilterTypeStarred.spec.js
@@ -1,11 +1,10 @@
 import { mount } from '@vue/test-utils'
-import { removeCookie, setCookie } from 'tiny-cookie'
-
 import esConnectionHelper from '~tests/unit/specs/utils/esConnectionHelper'
 import { IndexedDocument, letData } from '~tests/unit/es_utils'
 import { useStarredStore, useSearchStore } from '@/store/modules'
 import FilterType from '@/components/Filter/FilterType/FilterType'
 import FilterTypeStarred from '@/components/Filter/FilterType/FilterTypeStarred'
+import FiltersPanelSectionFilterEntry from '@/components/FiltersPanel/FiltersPanelSectionFilterEntry'
 import CoreSetup from '~tests/unit/CoreSetup'
 
 vi.mock('@/api/apiInstance', async (importOriginal) => {
@@ -13,7 +12,7 @@ vi.mock('@/api/apiInstance', async (importOriginal) => {
 
   return {
     apiInstance: {
-      ...apiInstance,
+      elasticsearch: apiInstance.elasticsearch,
       getStarredDocuments: vi.fn().mockResolvedValue([])
     }
   }
@@ -24,10 +23,9 @@ describe('FilterTypeStarred.vue', () => {
   let core, starredStore, searchStore, wrapper
 
   beforeAll(() => {
-    core = CoreSetup.init().useAll().useRouterWithoutGuards()
+    core = CoreSetup.init().useAll()
     starredStore = useStarredStore()
     searchStore = useSearchStore()
-    setCookie(process.env.VITE_DS_COOKIE_NAME, { login: 'doe' }, JSON.stringify)
   })
 
   beforeEach(() => {
@@ -36,11 +34,6 @@ describe('FilterTypeStarred.vue', () => {
     const global = { plugins: core.plugins }
     searchStore.setIndex(index)
     wrapper = mount(FilterTypeStarred, { props, global })
-  })
-
-  afterAll(() => {
-    removeCookie(process.env.VITE_DS_COOKIE_NAME)
-    vi.resetAllMocks()
   })
 
   it('should display 3 items for the starred filter (including "All")', async () => {
@@ -69,23 +62,16 @@ describe('FilterTypeStarred.vue', () => {
   it('should display the results count (without the "All")', async () => {
     await letData(es).have(new IndexedDocument('document_01', index)).commit()
     await letData(es).have(new IndexedDocument('document_02', index)).commit()
-    await letData(es).have(new IndexedDocument('document_03', index)).commit()
-
-    starredStore.setDocuments([
-      {
-        index,
-        id: 'document_01'
-      },
-      {
-        index,
-        id: 'document_02'
-      }
-    ])
+    // Await fetch() directly so getTotal resolves before assert
+    await wrapper.vm.fetch()
+    // fetch() calls fetchIndicesStarredDocuments which is mocked to [], so set docs after
+    starredStore.setDocuments([{ index, id: 'document_01' }, { index, id: 'document_02' }])
 
     await wrapper.findComponent(FilterType).vm.aggregate()
 
-    expect(wrapper.findAll('.filters-panel-section-filter-entry__count')).toHaveLength(2)
-    expect(wrapper.findAll('.filters-panel-section-filter-entry__count').at(0).text()).toBe('2')
-    expect(wrapper.findAll('.filters-panel-section-filter-entry__count').at(1).text()).toBe('0')
+    // entries: [0] = All (inside FilterTypeAll), [1] = Starred, [2] = Not starred
+    const entries = wrapper.findAllComponents(FiltersPanelSectionFilterEntry)
+    expect(entries[1].props('count')).toBe(2)
+    expect(entries[2].props('count')).toBe(0)
   })
 })

--- a/tests/unit/specs/store/filters/FilterEntity.spec.js
+++ b/tests/unit/specs/store/filters/FilterEntity.spec.js
@@ -4,7 +4,7 @@ import FilterEntity from '@/store/filters/FilterEntity'
 
 describe('FilterEntity.js', () => {
   it('should filter on existing category', () => {
-    const filter = new FilterEntity({})
+    const filter = new FilterEntity({ category: 'LOCATION' })
     const q = filter.queryBuilder(
       bodybuilder(),
       { name: 'namedEntityLocation', reverse: false, values: ['luxembourg'] },
@@ -14,7 +14,7 @@ describe('FilterEntity.js', () => {
   })
 
   it('should filter on non existing category', () => {
-    const filter = new FilterEntity({})
+    const filter = new FilterEntity({ category: 'LOCATION' })
     const q = filter.queryBuilder(bodybuilder(), { name: 'GPE', reverse: false, values: ['luxembourg'] }, 'query')
     expect(JSON.stringify(q.build())).toContain('{"query_string":{"default_field":"category","query":"GPE"}}')
   })


### PR DESCRIPTION
**fix: correct "All" entry count in filter panels**
related to https://github.com/ICIJ/datashare/issues/2019 
The "All" entry in filter panels (content type, language, recommended by, starred, etc.) was incorrectly showing `searchStore.total` - the global document count - instead of a count meaningful to each filter type.

**Changes:**

- **`FilterType.vue`**: Computes `bucketsTotal` as the sum of `doc_count` across all loaded aggregation buckets and passes it as `:count` to `FilterTypeAll`. Returns `null` before any buckets are fetched (keeps count hidden until data arrives). 

- **`FilterTypeAll.vue`**: Replaces the `computedTotal`/`searchStore` coupling with a `count` prop (Number, default `null`). The `hadTotal` guard now uses an immediate watcher on `count` to prevent flickering on first render. Each filter type controls its own count semantics.

- **`FilterTypeRecommendedBy.vue`**: Overrides the `#all` slot to pass `recommendedStore.total` (sum of all recommendation counts across selected indices) as the "All" count. Uses a `waitFor` so count is `null` until the fetch resolves, preventing a premature `0`.

- **`FilterTypeStarred.vue`**: Overrides the `#all` slot to pass the real document total from `getTotal()` as the "All" count. Uses `waitFor` for flicker-prevention reason. Also fixes a copy-paste bug where the "Not starred" entry had `name="starred"`. Exposes `fetch` for testability.

---
AI disclaimer
Used to write the description more cleanly
use agent to do first draft of unit test (TDD like)