### PR TITLE
feat: search results performances

### DIFF
--- a/src/components/Document/DocumentActionsGroup/DocumentActionsGroupEntryDownload.vue
+++ b/src/components/Document/DocumentActionsGroup/DocumentActionsGroupEntryDownload.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { computed, nextTick } from 'vue'
+import { computed, nextTick, useTemplateRef } from 'vue'
+import { whenever } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 
 import IPhDownloadSimple from '~icons/ph/download-simple'
@@ -7,6 +8,7 @@ import IPhDownloadSimple from '~icons/ph/download-simple'
 import DocumentActionsGroupEntry from './DocumentActionsGroupEntry'
 
 import { useDocumentDownload } from '@/composables/useDocumentDownload'
+import { useElementVisibilityOnce } from '@/composables/useElementVisibilityOnce'
 import DocumentDownloadPopover from '@/components/Document/DocumentDownloadPopover/DocumentDownloadPopover'
 import { breakpointSizeValidator, SIZE } from '@/enums/sizes'
 
@@ -37,7 +39,10 @@ const { document } = defineProps({
 
 const { t } = useI18n()
 
-const { isDownloadAllowed, isRootTooBig, documentFullUrl } = useDocumentDownload(document)
+const element = useTemplateRef('element')
+const isVisible = useElementVisibilityOnce(element)
+const { isDownloadAllowed, isRootTooBig, documentFullUrl, fetchStatuses } = useDocumentDownload(document, { immediate: false })
+whenever(isVisible, fetchStatuses, { once: true })
 const hasDownload = computed(() => isDownloadAllowed.value && !isRootTooBig.value)
 const href = computed(() => (hasDownload.value ? documentFullUrl.value : null))
 const blur = () => nextTick(() => window.document?.activeElement.blur())

--- a/src/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.vue
+++ b/src/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.vue
@@ -34,6 +34,11 @@ const props = defineProps({
 })
 const { t } = useI18n()
 
+const popoverRef = useTemplateRef('popover')
+
+// Lazy rendering: only mount the popover after it's been opened once
+const activated = ref(false)
+
 const {
   description,
   executionWarning,
@@ -45,17 +50,15 @@ const {
   isRootTooBig,
   downloadTextContent,
   hasTranslations,
-  downloadTranslatedContent
-} = useDocumentDownload(props.document)
-
-const popoverRef = useTemplateRef('popover')
-
-// Lazy rendering: only mount the popover after it's been opened once
-const activated = ref(false)
+  downloadTranslatedContent,
+  fetchStatuses
+} = useDocumentDownload(props.document, { immediate: !props.lazy })
 const mounted = computed(() => !props.lazy || activated.value)
 
 // Activate when modelValue becomes true
 whenever(modelValue, () => (activated.value = true), { once: true })
+// Fetch download status and translations when activated
+whenever(activated, fetchStatuses, { once: true })
 
 async function activate() {
   activated.value = true

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -6,7 +6,7 @@ import { useDocumentDownloadStore, useDocumentStore } from '@/store/modules'
 import settings from '@/utils/settings'
 import byteSize from '@/utils/byteSize'
 
-export function useDocumentDownload(document) {
+export function useDocumentDownload(document, { immediate = true } = {}) {
   const documentStore = useDocumentStore()
   const documentDownloadStore = useDocumentDownloadStore()
   const core = useCore()
@@ -75,7 +75,7 @@ export function useDocumentDownload(document) {
     return byteSize(embeddedDocumentDownloadMaxSize.value)
   })
 
-  async function fetchStatus() {
+  async function fetchDownloadStatus() {
     const { index = null } = documentRef.value
     // If the index is null, this means the document is not loaded yet
     // and therefore, we should not fetch the status
@@ -102,7 +102,7 @@ export function useDocumentDownload(document) {
     return availableTranslations.value.length > 0
   })
 
-  async function fetchTranslations() {
+  async function fetchTranslationStatus() {
     const { index, id, routing } = documentRef.value
     if (!index || !id) return
     try {
@@ -129,10 +129,17 @@ export function useDocumentDownload(document) {
     a.click()
   }
 
-  watchEffect(fetchStatus)
-  watchEffect(fetchTranslations)
+  async function fetchStatuses() {
+    await Promise.all([fetchDownloadStatus(), fetchTranslationStatus()])
+  }
+
+  if (immediate) {
+    watchEffect(fetchDownloadStatus)
+    watchEffect(fetchTranslationStatus)
+  }
 
   return {
+    fetchStatuses,
     extensionWarning,
     description,
     showExtensionWarning,

--- a/src/store/modules/documentPathBanners.js
+++ b/src/store/modules/documentPathBanners.js
@@ -14,7 +14,10 @@ export const useDocumentPathBannersStore = defineStore('documentPathBanners', ()
    * Delete all path banners for each project
    * @returns {void}
    */
-  const reset = () => Object.keys(pathBanners).forEach(key => delete pathBanners[key])
+  const reset = () => {
+    Object.keys(pathBanners).forEach(key => delete pathBanners[key])
+    Object.keys(fetchPromises).forEach(key => delete fetchPromises[key])
+  }
 
   /**
    * Set a list of path banners for a given project

--- a/src/store/modules/documentPathBanners.js
+++ b/src/store/modules/documentPathBanners.js
@@ -6,6 +6,9 @@ import { apiInstance as api } from '@/api/apiInstance'
 
 export const useDocumentPathBannersStore = defineStore('documentPathBanners', () => {
   const pathBanners = reactive({})
+  // Cache of in-flight fetch promises keyed by project, used to
+  // deduplicate concurrent calls to fetchPathBannersOnce for the same project.
+  const fetchPromises = {}
 
   /**
    * Delete all path banners for each project
@@ -61,7 +64,9 @@ export const useDocumentPathBannersStore = defineStore('documentPathBanners', ()
   }
 
   /**
-   * Fetch path banners once from the API for a given project
+   * Fetch path banners once from the API for a given project.
+   * Memoized: returns cached path banners if already fetched and
+   * deduplicates concurrent calls for the same project.
    * @param {Object} options
    * @param {string} options.project - The project name
    * @returns {Promise<Array>} The path banners set
@@ -70,7 +75,8 @@ export const useDocumentPathBannersStore = defineStore('documentPathBanners', ()
     if (hasIn(pathBanners, project)) {
       return pathBanners[project]
     }
-    return await fetchPathBanners({ project })
+    fetchPromises[project] ??= fetchPathBanners({ project })
+    return await fetchPromises[project]
   }
 
   /**

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -648,6 +648,11 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     return includeFilter(name)
   }
 
+  // In-flight refresh promise, used to deduplicate concurrent calls
+  // (e.g. when both onBeforeRouteUpdate and the fullPath watcher fire
+  // for the same navigation).
+  let refreshPromise = null
+
   /**
    * Refresh the search results based on the current search parameters.
    *
@@ -664,8 +669,31 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     // This check is to avoid unnecessary searches when the query has not changed.
     // We compare the current route query with the last applied query, which is stored
     // in the `lastAppliedQuery` ref. If they are the same, we skip the refresh.
-    if (sameAppliedQuery(toRouteQueryWithStamp.value)) return
+    if (sameAppliedQuery(toRouteQueryWithStamp.value)) {
+      return
+    }
+    // If a refresh is already in flight for the same search parameters,
+    // return the existing promise to avoid duplicate API calls. The stamp
+    // is excluded because it changes on every call and would prevent
+    // deduplication. When the query differs (e.g. user started a new search),
+    // we let it through so the new search is not blocked by the previous one.
+    if (refreshPromise && sameAppliedQuery(toRouteQueryWithStamp.value, ['stamp'])) {
+      return refreshPromise
+    }
 
+    refreshPromise = doRefresh(save)
+    return refreshPromise
+  }
+
+  /**
+   * Internal implementation of refresh. Performs the actual search query,
+   * fetches root documents, and updates the response state.
+   * Called exclusively by refresh() which handles deduplication.
+   *
+   * @param {boolean} save - Whether to save the current query state in the search breadcrumb store.
+   * @returns {Promise<void>} - A promise that resolves when the search is complete.
+   */
+  async function doRefresh(save) {
     setIsReady(false)
     setError()
 
@@ -684,6 +712,7 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     }
     finally {
       setIsReady(true)
+      refreshPromise = null
     }
   }
 

--- a/tests/unit/specs/composables/useDocumentDownload.spec.js
+++ b/tests/unit/specs/composables/useDocumentDownload.spec.js
@@ -23,11 +23,11 @@ describe('useDocumentDownload composable', () => {
     apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue(response)
   }
 
-  function mountComposable(document) {
+  function mountComposable(document, options) {
     let result
     const TestComponent = {
       setup() {
-        result = useDocumentDownload(document)
+        result = useDocumentDownload(document, options)
         return result
       },
       template: '<div></div>'
@@ -35,6 +35,40 @@ describe('useDocumentDownload composable', () => {
     mount(TestComponent, { global: { plugins } })
     return result
   }
+
+  describe('fetchStatuses', () => {
+    it('should not fetch download status when immediate is false', async () => {
+      apiInstance.isDownloadAllowed = vi.fn().mockResolvedValue()
+      mockGetSource({ content_translated: [] })
+      const doc = new Document({
+        _id: 'doc1',
+        _index: 'test-index',
+        _source: { title: 'test' }
+      })
+      mountComposable(doc, { immediate: false })
+      await flushPromises()
+      expect(apiInstance.isDownloadAllowed).not.toHaveBeenCalled()
+    })
+
+    it('should fetch download status and translations when fetchStatuses is called', async () => {
+      apiInstance.isDownloadAllowed = vi.fn().mockResolvedValue()
+      mockGetSource({ content_translated: [{ target_language: 'ENGLISH' }] })
+      const doc = new Document({
+        _id: 'doc1',
+        _index: 'test-index',
+        _source: { title: 'test' }
+      })
+      const { fetchStatuses, hasTranslations } = mountComposable(doc, { immediate: false })
+      await flushPromises()
+      expect(apiInstance.isDownloadAllowed).not.toHaveBeenCalled()
+      expect(hasTranslations.value).toBe(false)
+
+      await fetchStatuses()
+      await flushPromises()
+      expect(apiInstance.isDownloadAllowed).toHaveBeenCalledWith('test-index')
+      expect(hasTranslations.value).toBe(true)
+    })
+  })
 
   describe('hasTranslations', () => {
     it('should be true when API returns translations', async () => {

--- a/tests/unit/specs/store/modules/documentPathBanners.spec.js
+++ b/tests/unit/specs/store/modules/documentPathBanners.spec.js
@@ -40,6 +40,16 @@ describe('DocumentPathBannersStore', () => {
     expect(api.getPathBanners).toBeCalledWith(project)
   })
 
+  it('should call the API endpoint only once even with concurrent calls', async () => {
+    await Promise.all([
+      store.fetchPathBannersOnce({ project }),
+      store.fetchPathBannersOnce({ project })
+    ])
+
+    expect(api.getPathBanners).toBeCalledTimes(1)
+    expect(api.getPathBanners).toBeCalledWith(project)
+  })
+
   it('should filter on document path', async () => {
     const note = 'note'
     const variant = 'variant'

--- a/tests/unit/specs/store/modules/search.spec.js
+++ b/tests/unit/specs/store/modules/search.spec.js
@@ -128,6 +128,15 @@ describe('SearchStore', () => {
       expect(searchStore.response.hits[2]).toBeUndefined()
     })
 
+    it('should only search once when query is called concurrently with the same parameters', async () => {
+      await letData(es).have(new IndexedDocument('document', index).withContent('bar')).commit()
+      const spy = vi.spyOn(api.elasticsearch, 'searchDocs')
+
+      await Promise.all([searchStore.query('bar'), searchStore.query('bar')])
+
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
     it('should return document from local project', async () => {
       await letData(es).have(new IndexedDocument('document', index).withContent('bar')).commit()
       await searchStore.query('bar')


### PR DESCRIPTION
To address performances issues raised in https://github.com/ICIJ/datashare/issues/2109. This PR tries to reduce HTTP request during search by using 3 strategies:

1. **Lazy download status fetching**: Download status and translations are no longer fetched for every document on mount. Instead, each entry only fetches when it scrolls into view, and the popover only fetches when opened for the first time.
2. **Search deduplication**: Search results were queried twice on every page load due to two route watchers firing for the same navigation. Concurrent calls now share a single request.
3. **Document notes deduplication**: Concurrent calls to fetch notes for the same project now share a single API request instead of each triggering its own.

## Changes

- feat: add `immediate` option to `useDocumentDownload` composable, allowing callers to opt out of automatic `watchEffect`-driven status fetching on mount
- feat: expose a `fetchStatuses` function from `useDocumentDownload` that runs both download status and translation status checks in parallel
- perf: defer status fetching in `DocumentActionsGroupEntryDownload` until the element becomes visible, using `useElementVisibilityOnce`
- perf: defer status fetching in `DocumentDownloadPopover` until the popover is activated (opened for the first time) rather than on mount
- fix: deduplicate concurrent `refresh()` calls in the search store by sharing an in-flight promise, preventing duplicate `searchDocs` API calls when multiple triggers fire for the same navigation
- fix: deduplicate concurrent `fetchNotesOnce()` calls in the document notes store with a per-project promise cache, preventing redundant `retrieveNotes` API calls
- test: add tests covering deduplication of concurrent calls in `useDocumentDownload`, the search store, and the document notes store

## AI Disclosure

Only used to write/format the PR.