### PR TITLE
feat: pageless filters

### DIFF
--- a/src/components/Filter/FilterType/FilterType.vue
+++ b/src/components/Filter/FilterType/FilterType.vue
@@ -176,11 +176,9 @@ const entries = computed(() => {
 const infiniteId = ref(uniqueId('infinite-search-filter-'))
 const reachedBucketsEnd = computed(() => pages.length && lastPageBuckets.value.length < size.value)
 
-const noInfiniteScroll = computed(
-  () => filter.pagelessBucketSize != null
-    || !pages.length
-    || reachedBucketsEnd.value
-)
+const isPageless = computed(() => filter.pagelessBucketSize != null)
+const hasNoPages = computed(() => !pages.length)
+const noInfiniteScroll = computed(() => isPageless.value || hasNoPages.value || reachedBucketsEnd.value)
 const noBucketTranslation = computed(() => filter?.noBucketTranslation ?? false)
 const fromElasticSearch = computed(() => filter?.fromElasticSearch ?? false)
 const count = computed(() => filter.values.length)

--- a/src/components/Filter/FilterType/FilterType.vue
+++ b/src/components/Filter/FilterType/FilterType.vue
@@ -176,12 +176,16 @@ const entries = computed(() => {
 const infiniteId = ref(uniqueId('infinite-search-filter-'))
 const reachedBucketsEnd = computed(() => pages.length && lastPageBuckets.value.length < size.value)
 
-const noInfiniteScroll = computed(() => filter.noInfiniteScroll || !pages.length || reachedBucketsEnd.value)
+const noInfiniteScroll = computed(
+  () => filter.pagelessBucketSize != null
+    || !pages.length
+    || reachedBucketsEnd.value
+)
 const noBucketTranslation = computed(() => filter?.noBucketTranslation ?? false)
 const fromElasticSearch = computed(() => filter?.fromElasticSearch ?? false)
 const count = computed(() => filter.values.length)
 const offset = computed(() => buckets.value?.length ?? 0)
-const size = computed(() => settings.filter.bucketSize)
+const size = computed(() => filter.pagelessBucketSize ?? settings.filter.bucketSize)
 
 const debouncedCollapse = computed({
   get: () => collapse.value,

--- a/src/store/filters/FilterContentType.js
+++ b/src/store/filters/FilterContentType.js
@@ -6,7 +6,17 @@ import DisplayContentType from '@/components/Display/DisplayContentType'
 import types from '@/utils/contentTypes.json'
 import { getDocumentTypeLabel } from '@/utils/utils'
 
+/**
+ * Filter on MIME `contentType`. Resolves human-readable labels via the
+ * `contentTypes.json` map and lets users search by either the MIME key
+ * or the translated label.
+ */
 export default class FilterContentType extends FilterText {
+  /**
+   * Map a label-based search query to matching MIME keys.
+   * @param {string} query - Lowercased user query.
+   * @returns {string[]} MIME keys whose label contains the query (may include `undefined`).
+   */
   keyAliases(query) {
     return map(types, (item, key) => {
       if (toLower(item.label).includes(query)) {
@@ -15,10 +25,15 @@ export default class FilterContentType extends FilterText {
     })
   }
 
+  /**
+   * @param {{key: string}} item - Bucket with the MIME key.
+   * @returns {string} Translation key for the MIME type label.
+   */
   itemLabel(item) {
     return getDocumentTypeLabel(item.key)
   }
 
+  /** @returns {object} Display component used to render selected values. */
   static get display() {
     return DisplayContentType
   }

--- a/src/store/filters/FilterDate.js
+++ b/src/store/filters/FilterDate.js
@@ -2,16 +2,33 @@ import FilterDocument from './FilterDocument'
 
 import DisplayDatetimeMonth from '@/components/Display/DisplayDatetimeMonth'
 
+/**
+ * Filter over a date field using a `date_histogram` aggregation. Each
+ * selected bucket becomes a month (by default) `range` query; the zero
+ * bucket is mapped to "field does not exist".
+ */
 export default class FilterDate extends FilterDocument {
   constructor(options) {
     super(options)
     this.component = 'FilterType'
   }
 
+  /**
+   * @param {object} item - Histogram bucket.
+   * @param {string} item.key_as_string - Pre-formatted bucket key.
+   * @returns {string} The bucket's key string used as the display label.
+   */
   itemLabel(item) {
     return item.key_as_string
   }
 
+  /**
+   * Build one `range` query per selected bucket; treat `0` as "field missing".
+   * @param {object} body - Bodybuilder instance.
+   * @param {{values: (string|number)[]}} param - Current selection of bucket keys.
+   * @param {string} func - Bodybuilder chain method (`query` or `notQuery`).
+   * @returns {object} The mutated body.
+   */
   queryBuilder(body, param, func) {
     return body.query('bool', (sub) => {
       param.values.forEach((date) => {
@@ -29,6 +46,14 @@ export default class FilterDate extends FilterDocument {
     })
   }
 
+  /**
+   * Attach a `date_histogram` aggregation over this filter's date field.
+   * @param {object} body - Bodybuilder instance.
+   * @param {object} [options]
+   * @param {number} [options.size=0] - Maximum buckets returned (0 = unlimited).
+   * @param {string} [options.interval='month'] - Histogram interval: `day`, `month`, or `year`.
+   * @returns {object} The mutated body.
+   */
   body(body, { size = 0, interval = 'month' } = {}) {
     return body
       .query('match', 'type', 'Document')
@@ -37,6 +62,11 @@ export default class FilterDate extends FilterDocument {
       })
   }
 
+  /**
+   * Aggregation options for the histogram: interval + sort by most recent.
+   * @param {string} [interval='month'] - Histogram interval.
+   * @returns {object} Elasticsearch aggregation options.
+   */
   static getIntervalAgg(interval = 'month') {
     return {
       ...FilterDate.getIntervalOption(interval),
@@ -47,6 +77,11 @@ export default class FilterDate extends FilterDocument {
     }
   }
 
+  /**
+   * Elasticsearch interval options (fixed/calendar) for the given granularity.
+   * @param {string} [interval='month'] - One of `day`, `month`, `year`.
+   * @returns {object} Bucket interval + format configuration.
+   */
   static getIntervalOption(interval = 'month') {
     switch (interval) {
       case 'day':
@@ -58,6 +93,7 @@ export default class FilterDate extends FilterDocument {
     }
   }
 
+  /** @returns {object} Display component used to render selected values. */
   static get display() {
     return DisplayDatetimeMonth
   }

--- a/src/store/filters/FilterDateRange.js
+++ b/src/store/filters/FilterDateRange.js
@@ -5,13 +5,27 @@ import FilterDate from './FilterDate'
 
 import DisplayDatetimeRange from '@/components/Display/DisplayDatetimeRange'
 
+/**
+ * Date filter driven by a single `min:max` range instead of discrete
+ * histogram buckets. Expects one string value in the form `"gte:lte"`.
+ */
 export default class FilterDateRange extends FilterDate {
+  /**
+   * @param {object} options - See `FilterText` for base options.
+   * @param {string} [options.interval='year'] - Histogram granularity for the range picker.
+   */
   constructor({ interval = 'year', ...options }) {
     super(options)
     this.component = 'FilterTypeDateRange'
     this.interval = interval
   }
 
+  /**
+   * Format a bucket key as a localized date string.
+   * @param {object} item - Histogram bucket.
+   * @param {number|string} item.key - Epoch milliseconds or pre-formatted string.
+   * @returns {string} Localized date label.
+   */
   itemLabel(item) {
     if (isInteger(item.key)) {
       const timestamp = item.key + new Date().getTimezoneOffset() * 60 * 1000
@@ -23,6 +37,13 @@ export default class FilterDateRange extends FilterDate {
     }
   }
 
+  /**
+   * Build a single `range` query from the first selected `"gte:lte"` value.
+   * @param {object} body - Bodybuilder instance.
+   * @param {{values: string[]}} param - Selection with a single `"min:max"` string.
+   * @param {string} func - Bodybuilder chain method (`query` or `notQuery`).
+   * @returns {object} The mutated body (or the original body if no value is selected).
+   */
   queryBuilder(body, param, func) {
     if (!param?.values?.length) return body
 
@@ -33,16 +54,33 @@ export default class FilterDateRange extends FilterDate {
     return body.query('bool', sub => sub[func]('range', this.key, { gte, lte }))
   }
 
+  /**
+   * Attach a `date_histogram` aggregation so the UI can display a range picker.
+   * @param {object} body - Bodybuilder instance.
+   * @param {object} [options]
+   * @param {string} [options.interval] - Histogram interval (defaults to the instance's `interval`).
+   * @returns {object} The mutated body.
+   */
   body(body, { interval = this.interval } = {}) {
     return body
       .query('match', 'type', 'Document')
       .agg('date_histogram', this.key, FilterDateRange.getIntervalAgg(interval), this.key)
   }
 
+  /**
+   * Aggregation options for the histogram without the descending sort.
+   * @param {string} [interval] - Histogram interval.
+   * @returns {object} Elasticsearch aggregation options.
+   */
   static getIntervalAgg(interval = this.interval) {
     return { ...FilterDate.getIntervalOption(interval), min_doc_count: 1 }
   }
 
+  /**
+   * Elasticsearch interval options for the given granularity.
+   * @param {string} [interval] - One of `day`, `month`, `year`.
+   * @returns {object} Bucket interval + format configuration.
+   */
   static getIntervalOption(interval = this.interval) {
     switch (interval) {
       case 'day':
@@ -54,6 +92,7 @@ export default class FilterDateRange extends FilterDate {
     }
   }
 
+  /** @returns {object} Display component used to render the selected range. */
   static get display() {
     return DisplayDatetimeRange
   }

--- a/src/store/filters/FilterDocument.js
+++ b/src/store/filters/FilterDocument.js
@@ -1,11 +1,21 @@
 import FilterType from './FilterType'
 
+/**
+ * Filter whose include clause wraps the child filter in a `has_parent`
+ * query so it resolves against the parent `Document`.
+ */
 export default class FilterDocument extends FilterType {
   constructor(options) {
     super(options)
     this.component = 'FilterTypeDocument'
   }
 
+  /**
+   * Wrap the child include filter in `has_parent` so it resolves on the Document.
+   * @param {object} body - Bodybuilder instance.
+   * @param {{values: string[]}} param - Current selection.
+   * @returns {object} The mutated body.
+   */
   addParentIncludeFilter(body, param) {
     return body.query('has_parent', { parent_type: 'Document' }, q => this.addChildIncludeFilter(q, param))
   }

--- a/src/store/filters/FilterEntity.js
+++ b/src/store/filters/FilterEntity.js
@@ -11,7 +11,17 @@ export const namedEntityCategoryTranslation = {
   namedEntityEmail: ENTITY_CATEGORY.EMAIL
 }
 
+/**
+ * Filter over `NamedEntity` child documents. Matches on `mentionNorm`
+ * scoped to a required entity `category` (person, organization, location,
+ * email).
+ */
 export default class FilterEntity extends FilterType {
+  /**
+   * @param {object} options - See `FilterText` for base options.
+   * @param {string} options.category - Required entity category (case-insensitive).
+   * @throws {Error} If `options.category` is missing.
+   */
   constructor(options) {
     super(options)
     if (!options.category) {
@@ -27,6 +37,10 @@ export default class FilterEntity extends FilterType {
     ]
   }
 
+  /**
+   * @param {object} body - Bodybuilder instance.
+   * @returns {boolean} `true` when the body already targets this filter's category.
+   */
   isSelfAffected(body) {
     return includes(
       JSON.stringify(body.build()),
@@ -34,6 +48,13 @@ export default class FilterEntity extends FilterType {
     )
   }
 
+  /**
+   * Build a bool-query that matches on `mentionNorm` scoped to the entity category.
+   * @param {object} body - Bodybuilder instance.
+   * @param {{name: string, values: string[]}} param - Current selection.
+   * @param {string} func - Bodybuilder chain method (e.g. `query`, `notQuery`).
+   * @returns {object} The mutated body.
+   */
   queryBuilder(body, param, func) {
     return body[func]('bool', (b) => {
       b.orQuery('has_child', 'type', 'NamedEntity', {}, (sub) => {
@@ -56,10 +77,23 @@ export default class FilterEntity extends FilterType {
     })
   }
 
+  /**
+   * Include matching entities when running directly against NamedEntity docs.
+   * @param {object} body - Bodybuilder instance.
+   * @param {{name: string, values: string[]}} param - Current selection.
+   * @returns {object} The mutated body.
+   */
   addChildIncludeFilter(body, param) {
     return this.queryBuilder(body, param, 'query')
   }
 
+  /**
+   * Include documents that have at least one matching NamedEntity child.
+   * Collapses to a direct `terms` query when the body already targets this category.
+   * @param {object} body - Bodybuilder instance.
+   * @param {{values: string[]}} param - Current selection.
+   * @returns {object} The mutated body.
+   */
   addParentIncludeFilter(body, param) {
     if (this.isSelfAffected(body)) {
       return body.query('terms', 'mentionNorm', param.values)
@@ -72,6 +106,12 @@ export default class FilterEntity extends FilterType {
     })
   }
 
+  /**
+   * Exclude documents that have any matching NamedEntity child.
+   * @param {object} body - Bodybuilder instance.
+   * @param {{values: string[]}} param - Current selection.
+   * @returns {object} The mutated body.
+   */
   addParentExcludeFilter(body, param) {
     return body.query('has_parent', { parent_type: 'Document' }, (q) => {
       return q.notQuery('has_child', 'type', 'NamedEntity', {}, (r) => {
@@ -80,6 +120,14 @@ export default class FilterEntity extends FilterType {
     })
   }
 
+  /**
+   * Attach a `terms` aggregation over `mentionNorm` scoped to this category.
+   * @param {object} body - Bodybuilder instance.
+   * @param {object} [options] - Extra aggregation options.
+   * @param {number} [from=0] - Pagination offset.
+   * @param {number} [size=50] - Number of buckets returned.
+   * @returns {object} The mutated body.
+   */
   body(body, options, from = 0, size = 50) {
     return body
       .query('term', 'type', 'NamedEntity')

--- a/src/store/filters/FilterExtractionLevel.js
+++ b/src/store/filters/FilterExtractionLevel.js
@@ -5,19 +5,30 @@ import FilterText from './FilterText'
 import DisplayExtractionLevel from '@/components/Display/DisplayExtractionLevel'
 import { getExtractionLevelTranslationKey } from '@/utils/utils'
 
+/**
+ * Filter by extraction depth (root document, first-level attachment, etc.).
+ * Sorts by bucket key ascending by default so levels appear in natural order.
+ */
 export default class FilterExtractionLevel extends FilterText {
+  /**
+   * @param {{key: number}} item - Bucket whose key is the extraction level.
+   * @returns {string} Translation key for the level label.
+   */
   itemLabel(item) {
     return getExtractionLevelTranslationKey(item.key)
   }
 
+  /** @returns {string} Sort field, defaulting to `_key` for natural order. */
   get sortBy() {
     return get(this, ['state', 'sortFilters', this.name, 'sortBy'], '_key')
   }
 
+  /** @returns {string} Sort direction, defaulting to `asc`. */
   get orderBy() {
     return get(this, ['state', 'sortFilters', this.name, 'orderBy'], 'asc')
   }
 
+  /** @returns {object} Display component used to render selected values. */
   static get display() {
     return DisplayExtractionLevel
   }

--- a/src/store/filters/FilterLanguage.js
+++ b/src/store/filters/FilterLanguage.js
@@ -4,15 +4,30 @@ import FilterText from './FilterText'
 
 import DisplayLanguage from '@/components/Display/DisplayLanguage'
 
+/**
+ * Filter on the document `language` field. Accepts a user-entered search
+ * in any case and matches it against uppercase ISO language codes.
+ */
 export default class FilterLanguage extends FilterText {
+  /**
+   * Translate the user query into an uppercase regex-escaped token so it
+   * can match ISO language codes regardless of input casing.
+   * @param {string} query - Raw user query.
+   * @returns {string[]} Single-item array with the escaped uppercase query.
+   */
   keyAliases(query) {
     return [escapeRegExp(query.toUpperCase())]
   }
 
+  /**
+   * @param {{key: string}} item - Bucket whose key is an ISO language code.
+   * @returns {string} Translation key for the language label.
+   */
   itemLabel(item) {
     return `filter.lang.${item.key}`
   }
 
+  /** @returns {object} Display component used to render selected values. */
   static get display() {
     return DisplayLanguage
   }

--- a/src/store/filters/FilterPath.js
+++ b/src/store/filters/FilterPath.js
@@ -4,6 +4,11 @@ import uniq from 'lodash/uniq'
 
 import FilterDocument from './FilterDocument'
 
+/**
+ * Filter by directory path using the `dirname.tree` prefix tokenizer.
+ * Matches both the original and lowercased forms for retro-compatibility
+ * with indices predating the 9.4.2 lowercase analyzer change.
+ */
 export default class FilterPath extends FilterDocument {
   constructor(options) {
     super(options)
@@ -11,6 +16,13 @@ export default class FilterPath extends FilterDocument {
     this.component = 'FilterTypePath'
   }
 
+  /**
+   * Match each selected path against the `dirname.tree` prefix tokens.
+   * @param {object} body - Bodybuilder instance.
+   * @param {{values: string[]}} param - Selected directory paths.
+   * @param {string} func - Bodybuilder chain method (`query` or `notQuery`).
+   * @returns {object} The mutated body.
+   */
   queryBuilder(body, param, func) {
     return body.query('bool', (sub) => {
       compact(param.values).forEach((dirname) => {

--- a/src/store/filters/FilterProject.js
+++ b/src/store/filters/FilterProject.js
@@ -2,12 +2,17 @@ import FilterText from './FilterText'
 
 import DisplayProject from '@/components/Display/DisplayProject'
 
+/**
+ * Filter on the Elasticsearch `_index` so the user can restrict a search
+ * to one or more Datashare projects.
+ */
 export default class FilterProject extends FilterText {
   constructor(options) {
     super(options)
     this.component = 'FilterTypeProject'
   }
 
+  /** @returns {object} Display component used to render selected values. */
   static get display() {
     return DisplayProject
   }

--- a/src/store/filters/FilterRecommendedBy.js
+++ b/src/store/filters/FilterRecommendedBy.js
@@ -3,24 +3,44 @@ import FilterText from './FilterText'
 import DisplayRecommendedBy from '@/components/Display/DisplayRecommendedBy'
 import { useRecommendedStore } from '@/store/modules/recommended'
 
+/**
+ * Filter restricting results to documents recommended by a set of users.
+ * Pulls the recommended document ids from the recommended store at query time.
+ */
 export default class FilterRecommendedBy extends FilterText {
   constructor(options) {
     super(options)
     this.component = 'FilterTypeRecommendedBy'
   }
 
+  /**
+   * Keep only documents whose id is in the recommended store.
+   * @param {object} body - Bodybuilder instance.
+   * @returns {object} The mutated body.
+   */
   addChildIncludeFilter(body) {
     return body.addFilter('terms', this.key, useRecommendedStore().documents)
   }
 
+  /**
+   * Drop documents whose id is in the recommended store.
+   * @param {object} body - Bodybuilder instance.
+   * @returns {object} The mutated body.
+   */
   addChildExcludeFilter(body) {
     return body.notFilter('terms', this.key, useRecommendedStore().documents)
   }
 
+  /**
+   * Apply this filter through the base class pipeline.
+   * @param {object} body - Bodybuilder instance.
+   * @returns {object|null} The mutated body.
+   */
   applyTo(body) {
     return super.applyTo(body)
   }
 
+  /** @returns {object} Display component used to render selected values. */
   static get display() {
     return DisplayRecommendedBy
   }

--- a/src/store/filters/FilterStarred.js
+++ b/src/store/filters/FilterStarred.js
@@ -5,12 +5,23 @@ import FilterText from './FilterText'
 import DisplayStarred from '@/components/Display/DisplayStarred'
 import { useStarredStore } from '@/store/modules'
 
+/**
+ * Boolean filter toggling between starred and not-starred documents.
+ * Resolves the starred document ids from the starred store at query time.
+ */
 export default class FilterStarred extends FilterText {
   constructor(options) {
     super(options)
     this.component = 'FilterTypeStarred'
   }
 
+  /**
+   * Include starred, excluded starred, or leave the body untouched when both
+   * options are selected.
+   * @param {object} body - Bodybuilder instance.
+   * @param {{values: (boolean|string)[]}} selection - Selected toggle values.
+   * @returns {object} The (possibly) mutated body.
+   */
   addChildIncludeFilter(body, { values }) {
     const hasBool = bool => values.includes(bool) || values.includes(bool.toString())
 
@@ -29,18 +40,25 @@ export default class FilterStarred extends FilterText {
     return body
   }
 
+  /**
+   * @param {{key: (boolean|string)}} item - Bucket whose key is `true` or `false`.
+   * @returns {string} Translation key for the starred/not-starred label.
+   */
   itemLabel(item) {
     return get(FilterStarred.starredLabels, item.key, item.key)
   }
 
+  /** @returns {object[]} Starred documents from the starred store. */
   get starredDocuments() {
     return useStarredStore().documents
   }
 
+  /** @returns {string[]} Ids of the currently starred documents. */
   get starredDocumentIds() {
     return map(this.starredDocuments, 'id')
   }
 
+  /** @returns {{true: string, false: string}} Translation keys for each boolean option. */
   static get starredLabels() {
     return {
       true: 'filter.starred',
@@ -48,6 +66,7 @@ export default class FilterStarred extends FilterText {
     }
   }
 
+  /** @returns {object} Display component used to render selected values. */
   static get display() {
     return DisplayStarred
   }

--- a/src/store/filters/FilterTag.js
+++ b/src/store/filters/FilterTag.js
@@ -2,7 +2,12 @@ import FilterText from './FilterText'
 
 import DisplayTags from '@/components/Display/DisplayTags'
 
+/**
+ * Filter on document `tags`. Inherits the default terms-aggregation
+ * behavior from `FilterText` and only overrides the display component.
+ */
 export default class FilterTag extends FilterText {
+  /** @returns {object} Display component used to render selected values. */
   static get display() {
     return DisplayTags
   }

--- a/src/store/filters/FilterText.js
+++ b/src/store/filters/FilterText.js
@@ -22,7 +22,8 @@ export default class FilterText {
     fromElasticSearch = true,
     preference = '_local',
     forceExclude = false,
-    modes = null
+    modes = null,
+    pagelessBucketSize = null
   } = {}) {
     this.name = name
     this.key = key
@@ -40,6 +41,7 @@ export default class FilterText {
     this.preference = preference
     this.forceExclude = forceExclude
     this.modes = modes
+    this.pagelessBucketSize = pagelessBucketSize
   }
 
   itemParam({ key }) {

--- a/src/store/filters/FilterText.js
+++ b/src/store/filters/FilterText.js
@@ -6,7 +6,33 @@ import some from 'lodash/some'
 const _VALUES = typeof Symbol === 'function' ? Symbol('_values') : '_values'
 const _STORE = typeof Symbol === 'function' ? Symbol('_store') : '_store'
 
+/**
+ * Base filter class. Builds an Elasticsearch `terms` aggregation over a
+ * keyword field and translates selected values into include/exclude queries.
+ * Subclasses customize the aggregation shape, key/label mapping, or how
+ * filter values are turned into Elasticsearch queries.
+ */
 export default class FilterText {
+  /**
+   * @param {object} [options]
+   * @param {string} options.name - Unique filter name (route query key, i18n key).
+   * @param {string} options.key - Elasticsearch field (or `_index` / `_id`) aggregated on.
+   * @param {object} [options.icon] - Icon component rendered next to the filter title.
+   * @param {boolean} [options.hideAll=false] - Hide the "all" toggle in the UI.
+   * @param {boolean} [options.hideContextualize=false] - Hide the "contextualize" toggle.
+   * @param {boolean} [options.hideExclude=false] - Hide the "exclude" toggle.
+   * @param {boolean} [options.hideExpand=false] - Hide the "expand in modal" action.
+   * @param {boolean} [options.hideSearch=false] - Hide the search-within-filter field.
+   * @param {boolean} [options.hideSort=false] - Hide the sort dropdown.
+   * @param {number} [options.order=null] - Display order in the filter panel.
+   * @param {string} [options.section=null] - Panel section this filter belongs to.
+   * @param {boolean} [options.fromElasticSearch=true] - Whether buckets come from an ES aggregation.
+   * @param {string} [options.preference='_local'] - Preference key for persisted UI state.
+   * @param {boolean} [options.forceExclude=false] - Force an exclusive match even when the UI toggle is off.
+   * @param {string[]} [options.modes=null] - Restrict this filter to specific Datashare modes.
+   * @param {number|null} [options.pagelessBucketSize=null] - When set, fetch this many buckets in one
+   *   aggregation request and disable infinite scroll. When `null`, paginate with the default size.
+   */
   constructor({
     name,
     key,
@@ -44,34 +70,85 @@ export default class FilterText {
     this.pagelessBucketSize = pagelessBucketSize
   }
 
+  /**
+   * Build the search-state param stored for a selected bucket.
+   * @param {object} item - Bucket or item produced by the UI.
+   * @param {string} item.key - Bucket key (raw Elasticsearch term).
+   * @returns {{name: string, value: string}} Param recorded in the search store.
+   */
   itemParam({ key }) {
     return { name: this.name, value: key }
   }
 
+  /**
+   * Extra bucket-key tokens matched against when the user searches within the
+   * filter. Override in subclasses that want label-based matching.
+   * @returns {string[]} List of regex-escaped token candidates.
+   */
   keyAliases() {
     return []
   }
 
+  /**
+   * Resolve the translation key used to display a bucket label.
+   * @param {object} [item] - Bucket-like shape.
+   * @param {string} [item.key] - Bucket key.
+   * @param {string} [item.value] - Alternative value when used from a param.
+   * @returns {string|null} The label identifier (i18n key or raw value).
+   */
   itemLabel({ key = null, value = null } = {}) {
     return key || value
   }
 
+  /**
+   * Restrict the query to documents whose field contains any of the selected values.
+   * @param {object} body - Bodybuilder instance being mutated.
+   * @param {{values: string[]}} param - Current selection.
+   * @returns {object} The mutated body (chainable).
+   */
   addChildIncludeFilter(body, param) {
     return body.addFilter('terms', this.key, param.values)
   }
 
+  /**
+   * Same as `addChildIncludeFilter` but wrapped in `has_parent` so it resolves
+   * against parent `Document` records from a child aggregation.
+   * @param {object} body - Bodybuilder instance being mutated.
+   * @param {{values: string[]}} param - Current selection.
+   * @returns {object} The mutated body.
+   */
   addParentIncludeFilter(body, param) {
     return body.query('has_parent', { parent_type: 'Document' }, q => q.query('terms', this.key, param.values))
   }
 
+  /**
+   * Same as `addParentIncludeFilter` but negated.
+   * @param {object} body - Bodybuilder instance being mutated.
+   * @param {{values: string[]}} param - Current selection.
+   * @returns {object} The mutated body.
+   */
   addParentExcludeFilter(body, param) {
     return body.query('has_parent', { parent_type: 'Document' }, q => q.notQuery('terms', this.key, param.values))
   }
 
+  /**
+   * Same as `addChildIncludeFilter` but negated.
+   * @param {object} body - Bodybuilder instance being mutated.
+   * @param {{values: string[]}} param - Current selection.
+   * @returns {object} The mutated body.
+   */
   addChildExcludeFilter(body, param) {
     return body.notFilter('terms', this.key, param.values)
   }
 
+  /**
+   * Attach this filter's `terms` aggregation to the query body.
+   * @param {object} body - Bodybuilder instance.
+   * @param {object} [options] - Extra aggregation options (e.g. `include`, `order`).
+   * @param {number} [from=0] - Pagination offset.
+   * @param {number} [size=8] - Number of buckets to return.
+   * @returns {object} The mutated body.
+   */
   body(body, options, from = 0, size = 8) {
     return body.query('match', 'type', 'Document').agg(
       'terms',
@@ -91,6 +168,12 @@ export default class FilterText {
     )
   }
 
+  /**
+   * Dispatch to the right include/exclude variant based on the shape of the body.
+   * No-op when no value is selected.
+   * @param {object} body - Bodybuilder instance.
+   * @returns {object|null} The mutated body, or `null` if no matching method exists.
+   */
   addFilter(body) {
     if (this.hasValues()) {
       const filterType = this.isNamedEntityAggregation(body) ? 'Parent' : 'Child'
@@ -102,58 +185,113 @@ export default class FilterText {
     }
   }
 
+  /**
+   * @returns {boolean} `true` when at least one value is currently selected.
+   */
   hasValues() {
     return this.values.length > 0
   }
 
+  /**
+   * Detect a NamedEntity aggregation so filters know to wrap in `has_parent`.
+   * @param {object} body - Bodybuilder instance.
+   * @returns {boolean} `true` when the body already targets `type: NamedEntity`.
+   */
   isNamedEntityAggregation(body) {
     return some(['"must":{"term":{"type":"NamedEntity"}}', '"must":[{"term":{"type":"NamedEntity"}}'], str =>
       includes(JSON.stringify(body.build()), str)
     )
   }
 
+  /**
+   * Apply this filter to a query body. Override when a filter needs custom placement.
+   * @param {object} body - Bodybuilder instance.
+   * @returns {object|null} The mutated body.
+   */
   applyTo(body) {
     return this.addFilter(body)
   }
 
+  /**
+   * Bind the filter to a search store so it can read values and sort state.
+   * @param {object} store - Slice of the search store.
+   * @param {object} store.values - Map of filter name to selected values.
+   * @param {string[]} store.excludeFilters - Names of excluded filters.
+   * @param {string[]} store.contextualizeFilters - Names of contextualized filters.
+   * @param {object} store.sortFilters - Map of filter name to `{ sortBy, orderBy }`.
+   * @returns {this} `this`, chainable.
+   */
   bindStore({ values, excludeFilters, contextualizeFilters, sortFilters }) {
     this[_STORE] = { values, excludeFilters, contextualizeFilters, sortFilters }
     return this
   }
 
+  /**
+   * @returns {object|null} The bound search store, or `null` if not bound yet.
+   */
   get store() {
     return this[_STORE] ?? null
   }
 
+  /**
+   * Currently selected values. Prefers a local override set via the setter;
+   * falls back to the bound store.
+   * @returns {string[]} Non-empty selected values.
+   */
   get values() {
     return compact(this[_VALUES] || this.store.values[this.name] || [])
   }
 
+  /**
+   * Override the selected values locally without going through the store.
+   * @param {string[]} values - New local values.
+   */
   set values(values) {
     this[_VALUES] = values
   }
 
+  /**
+   * Chainable alternative to the `values` setter.
+   * @param {string[]} values - New local values.
+   * @returns {this} `this`, chainable.
+   */
   setValues(values) {
     this.values = values
     return this
   }
 
+  /**
+   * @returns {boolean} `true` when this filter is configured as an exclusion.
+   */
   get excluded() {
     return this.store?.excludeFilters.indexOf(this.name) > -1
   }
 
+  /**
+   * @returns {boolean} `true` when this filter's aggregation is contextualized
+   *   by the other active filters.
+   */
   get contextualized() {
     return this.store?.contextualizeFilters.indexOf(this.name) > -1
   }
 
+  /**
+   * @returns {{sortBy: string, orderBy: string}|undefined} Current sort or undefined.
+   */
   get sort() {
     return this.store?.sortFilters[this.name]
   }
 
+  /**
+   * @returns {string} Bucket sort field (defaults to `_count`).
+   */
   get sortBy() {
     return this.sort?.sortBy ?? '_count'
   }
 
+  /**
+   * @returns {string} Bucket sort direction, `asc` or `desc` (defaults to `desc`).
+   */
   get orderBy() {
     return this.sort?.orderBy ?? 'desc'
   }

--- a/src/store/filters/FilterType.js
+++ b/src/store/filters/FilterType.js
@@ -1,15 +1,32 @@
 import FilterText from './FilterText'
 
+/**
+ * Filter that builds bool-query include/exclude clauses via `queryBuilder`.
+ * Default base for filters that need richer query construction than plain
+ * `terms` matching.
+ */
 export default class FilterType extends FilterText {
   constructor(...args) {
     super(...args)
     this.component = 'FilterType'
   }
 
+  /**
+   * Delegate to `queryBuilder` as an `orQuery` for inclusive matching.
+   * @param {object} body - Bodybuilder instance.
+   * @param {{values: string[]}} param - Current selection.
+   * @returns {object} The mutated body.
+   */
   addChildIncludeFilter(body, param) {
     return this.queryBuilder(body, param, 'orQuery')
   }
 
+  /**
+   * Delegate to `queryBuilder` as a `notQuery` for exclusive matching.
+   * @param {object} body - Bodybuilder instance.
+   * @param {{values: string[]}} param - Current selection.
+   * @returns {object} The mutated body.
+   */
   addChildExcludeFilter(body, param) {
     return this.queryBuilder(body, param, 'notQuery')
   }

--- a/src/store/filters/index.js
+++ b/src/store/filters/index.js
@@ -117,7 +117,8 @@ export default [
       icon: markRaw(IPhFile),
       order: 40,
       section: 'documentsInfo',
-      preference: 'filter-content-type'
+      preference: 'filter-content-type',
+      pagelessBucketSize: 1000
     }
   },
   {
@@ -144,7 +145,8 @@ export default [
       icon: markRaw(IPhGlobe),
       order: 60,
       section: 'documentsInfo',
-      preference: 'filter-language'
+      preference: 'filter-language',
+      pagelessBucketSize: 1000
     }
   },
   {
@@ -204,7 +206,8 @@ export default [
       hideSearch: true,
       order: 110,
       section: 'documentsInfo',
-      preference: 'filter-extraction-level'
+      preference: 'filter-extraction-level',
+      pagelessBucketSize: 10
     }
   },
   {

--- a/tests/unit/specs/components/Filter/FilterType/FilterType.spec.js
+++ b/tests/unit/specs/components/Filter/FilterType/FilterType.spec.js
@@ -1,6 +1,7 @@
 import find from 'lodash/find'
 import { shallowMount } from '@vue/test-utils'
 import { removeCookie, setCookie } from 'tiny-cookie'
+import { vi } from 'vitest'
 
 import { IndexedDocument, letData } from '~tests/unit/es_utils'
 import CoreSetup from '~tests/unit/CoreSetup'
@@ -393,6 +394,49 @@ describe('FilterType.vue', () => {
       const entries = wrapper.findAllComponents(FiltersPanelSectionFilterEntry)
       expect(entries).toHaveLength(2)
       expect(entries.at(0).attributes('label')).toBe('Fichier sur disque')
+    })
+  })
+
+  describe('pageless behavior (pagelessBucketSize option)', () => {
+    let filterWrapper, searchStoreSpy
+
+    beforeEach(() => {
+      const filter = searchStore.getFilter({ name: 'language' })
+      // simulate an opted-in config by mutating the instance
+      filter.pagelessBucketSize = 1000
+
+      searchStoreSpy = vi.spyOn(searchStore, 'queryFilter')
+
+      filterWrapper = shallowMount(FilterType, {
+        global: {
+          plugins: core.plugins,
+          renderStubDefaultSlot: true
+        },
+        props: { filter }
+      })
+
+      searchStore.decontextualizeFilter('language')
+      searchStore.setIndex(index)
+      searchStore.reset()
+      searchStore.resetFilters()
+    })
+
+    afterEach(() => {
+      searchStoreSpy.mockRestore()
+    })
+
+    it('requests `pagelessBucketSize` buckets in one page', async () => {
+      await filterWrapper.vm.aggregateOver()
+
+      expect(searchStoreSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'language', from: 0, size: 1000 })
+      )
+    })
+
+    it('does not render the infinite-loading component', async () => {
+      await filterWrapper.vm.aggregateOver()
+
+      expect(filterWrapper.findComponent({ name: 'InfiniteLoading' }).exists()).toBe(false)
     })
   })
 })

--- a/tests/unit/specs/store/filters/FilterText.spec.js
+++ b/tests/unit/specs/store/filters/FilterText.spec.js
@@ -1,0 +1,15 @@
+import FilterText from '@/store/filters/FilterText'
+
+describe('FilterText.js', () => {
+  describe('pagelessBucketSize', () => {
+    it('defaults to null when not provided', () => {
+      const filter = new FilterText({ name: 'foo', key: 'foo' })
+      expect(filter.pagelessBucketSize).toBeNull()
+    })
+
+    it('stores the provided numeric value', () => {
+      const filter = new FilterText({ name: 'foo', key: 'foo', pagelessBucketSize: 500 })
+      expect(filter.pagelessBucketSize).toBe(500)
+    })
+  })
+})

--- a/tests/unit/specs/store/filters/index.spec.js
+++ b/tests/unit/specs/store/filters/index.spec.js
@@ -1,0 +1,28 @@
+import filters from '@/store/filters'
+
+describe('filters index', () => {
+  const getOptions = name => filters.find(f => f.options.name === name)?.options
+
+  describe('pageless opt-ins', () => {
+    it('configures language with pagelessBucketSize 1000', () => {
+      expect(getOptions('language')?.pagelessBucketSize).toBe(1000)
+    })
+
+    it('configures contentType with pagelessBucketSize 1000', () => {
+      expect(getOptions('contentType')?.pagelessBucketSize).toBe(1000)
+    })
+
+    it('configures extractionLevel with pagelessBucketSize 10', () => {
+      expect(getOptions('extractionLevel')?.pagelessBucketSize).toBe(10)
+    })
+  })
+
+  describe('other filters stay paginated', () => {
+    it.each(['tags', 'path', 'namedEntityPerson', 'namedEntityOrganization', 'namedEntityLocation', 'namedEntityEmail'])(
+      '%s has no pagelessBucketSize',
+      (name) => {
+        expect(getOptions(name)?.pagelessBucketSize).toBeUndefined()
+      }
+    )
+  })
+})


### PR DESCRIPTION
This PR adds the ability to have "pageless" filters which load all the aggregations buckets at once for a given filter. This also add JSDoc to filter classes.