### PR TITLE
feat: add option to select search operator

### DIFF
--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -4,6 +4,7 @@ import es from 'elasticsearch-browser'
 import { getCookie } from 'tiny-cookie'
 
 import { EventBus } from '@/utils/eventBus'
+import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 import settings from '@/utils/settings'
 
 // Content fields to exclude from search results (large text fields)
@@ -145,7 +146,8 @@ export function datasharePlugin(Client) {
     from = 0,
     perPage = 25,
     sort = { _score: { order: 'desc' } },
-    fields = []
+    fields = [],
+    operator = SEARCH_OPERATORS.OR
   }) {
     const body = this._buildSearchBody({
       query: normalizeQuery(query),
@@ -153,7 +155,8 @@ export function datasharePlugin(Client) {
       fields,
       from,
       size: perPage,
-      sort
+      sort,
+      operator
     })
     return this._search({ index, body })
   }
@@ -320,15 +323,17 @@ export function datasharePlugin(Client) {
    * @param {Object} body - The bodybuilder instance
    * @param {string} query - The query string
    * @param {string[]} [fields=[]] - Fields to search in
+   * @param operator
    */
-  Client.prototype._applyQueryString = function (body, query, fields = []) {
+  Client.prototype._applyQueryString = function (body, query, fields = [], operator = undefined) {
     if (isEqual(fields, ['path'])) {
       query = replace(query, /\//g, '\\/')
     }
     body.query('match_all').addQuery('bool', b =>
       b.orQuery('query_string', {
         query,
-        fields: fields.length ? fields : undefined
+        fields: fields.length ? fields : undefined,
+        ...(operator ? { default_operator: operator } : {})
       })
     )
   }
@@ -345,14 +350,14 @@ export function datasharePlugin(Client) {
    * @param {Object} options.sort - Sort configuration
    * @returns {Object} The built search body
    */
-  Client.prototype._buildSearchBody = function ({ query, filters, fields, from, size, sort }) {
+  Client.prototype._buildSearchBody = function ({ query, filters, fields, from, size, sort, operator }) {
     const body = bodybuilder()
 
     // Apply filters
     filters.forEach(filter => filter.applyTo(body))
 
     // Apply query string
-    this._applyQueryString(body, query, fields)
+    this._applyQueryString(body, query, fields, operator)
 
     // Filter to documents only
     body.query('match', 'type', 'Document')

--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -323,7 +323,7 @@ export function datasharePlugin(Client) {
    * @param {Object} body - The bodybuilder instance
    * @param {string} query - The query string
    * @param {string[]} [fields=[]] - Fields to search in
-   * @param operator
+   * @param {string} operator - Default search operator for the query string (AND or OR)
    */
   Client.prototype._applyQueryString = function (body, query, fields = [], operator = undefined) {
     if (isEqual(fields, ['path'])) {
@@ -348,6 +348,7 @@ export function datasharePlugin(Client) {
    * @param {number} options.from - Starting offset
    * @param {number} options.size - Number of results
    * @param {Object} options.sort - Sort configuration
+   * @param {string} options.operator - Default search operator for the query string (AND or OR)
    * @returns {Object} The built search body
    */
   Client.prototype._buildSearchBody = function ({ query, filters, fields, from, size, sort, operator }) {

--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -387,10 +387,11 @@ export function datasharePlugin(Client) {
    * @param {Array} filters - Array of filter objects
    * @param {string} [query='*'] - Query string
    * @param {string[]} [fields=[]] - Fields to search in
+   * @param {string} [operator = undefined] - Default search operator
    * @returns {Promise<{estimatedCount: number, estimatedSize: number}>} The estimated count and size
    */
-  Client.prototype.estimateDownloadSize = async function (index, filters, query = DEFAULT_QUERY, fields = []) {
-    const body = this.rootSearch(filters, normalizeQuery(query), fields)
+  Client.prototype.estimateDownloadSize = async function (index, filters, query = DEFAULT_QUERY, fields = [], operator = undefined) {
+    const body = this.rootSearch(filters, normalizeQuery(query), fields, operator)
     body.size(0)
     body.rawOption('track_total_hits', true)
     body.aggregation('sum', 'contentLength', 'total_content_length')
@@ -438,12 +439,13 @@ export function datasharePlugin(Client) {
    * @param {Array} filters - Array of filter objects
    * @param {string} query - The query string
    * @param {string[]} [fields=[]] - Fields to search in
+   * @param {string} [operator = undefined] - Default search operator
    * @returns {Object} The bodybuilder instance
    */
-  Client.prototype.rootSearch = function (filters, query, fields = []) {
+  Client.prototype.rootSearch = function (filters, query, fields = [], operator = undefined) {
     const body = bodybuilder()
     this._addFiltersToBody(filters, body)
-    this._addQueryToBody(query, body, fields)
+    this._applyQueryString(body, query, fields, operator)
     body.query('match', 'type', 'Document')
     return body
   }

--- a/src/components/Search/SearchBreadcrumbForm/SearchBreadcrumbFormEntry.vue
+++ b/src/components/Search/SearchBreadcrumbForm/SearchBreadcrumbFormEntry.vue
@@ -51,7 +51,7 @@ const props = defineProps({
 
 const emit = defineEmits(['click:x'])
 
-const showOccurences = computed(() => {
+const showOccurrences = computed(() => {
   return !props.noOccurrences && props.occurrences !== null
 })
 
@@ -75,7 +75,7 @@ const showCaret = computed(() => {
     />
     <div class="text-nowrap">
       <search-breadcrumb-form-entry-occurrences
-        v-if="showOccurences"
+        v-if="showOccurrences"
         class="search-breadcrumb-form-entry__occurences"
         :occurrences="occurrences"
         :previous-occurrences="previousOccurrences"

--- a/src/components/Search/SearchParameter/SearchParameterQueryAst.vue
+++ b/src/components/Search/SearchParameter/SearchParameterQueryAst.vue
@@ -5,6 +5,7 @@ import SearchParameterFilter from './SearchParameterFilter'
 import SearchParameterQueryTerm from './SearchParameterQueryTerm'
 
 import { VARIANT, variantValidator } from '@/enums/variants'
+import { useSearchStore } from '@/store/modules'
 
 defineOptions({
   name: 'SearchParameterQueryAst'
@@ -47,10 +48,16 @@ const props = defineProps({
 
 const emit = defineEmits(['click:x'])
 
+const searchStore = useSearchStore()
+
 const isLeft = computed(() => !!props.ast.left)
 const isRight = computed(() => !!props.ast.right)
 const isFilter = computed(() => props.ast.field !== '<implicit>' && !!props.ast.term)
 const isTerm = computed(() => !!props.ast.term && !isFilter.value)
+const effectiveRightOperator = computed(() => {
+  const op = props.ast.operator
+  return op === '<implicit>' ? searchStore.searchOperator : op
+})
 </script>
 
 <template>
@@ -103,7 +110,7 @@ const isTerm = computed(() => !!props.ast.term && !isFilter.value)
       v-bind="$attrs"
       :ast="ast.right"
       :counter="counter"
-      :operator="ast.operator"
+      :operator="effectiveRightOperator"
       :no-icon="noIcon"
       :no-x-icon="noXIcon"
       :size="size"

--- a/src/components/Search/SearchParameter/SearchParameterQueryTerm.vue
+++ b/src/components/Search/SearchParameter/SearchParameterQueryTerm.vue
@@ -72,7 +72,7 @@ const style = computed(() => {
 })
 
 const showOperator = computed(() => {
-  return props.operator === 'AND'
+  return !!props.operator
 })
 </script>
 

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -332,6 +332,10 @@ export function useSearchFilter() {
     return watch(() => JSON.stringify(searchStore.values), callback, options)
   }
 
+  function watchOperator(callback) {
+    return watch(() => searchStore.searchOperator, callback)
+  }
+
   function onAfterRouteQueryUpdate(callback, options) {
     return onAfterRouteUpdate((to, from) => {
       if (
@@ -411,6 +415,7 @@ export function useSearchFilter() {
     watchFilters,
     watchQuery,
     watchIndices,
+    watchOperator,
     onAfterRouteQueryUpdate,
     onAfterRouteQueryFromUpdate,
     watchValues,

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -128,6 +128,10 @@ export function useSearchFilter() {
     return getOrderBy()[1]
   }
 
+  function getSearchOperator() {
+    return appStore.getSettings('search', 'searchOperator')
+  }
+
   async function getTotal({ query = 'type:Document' } = {}) {
     const index = indices.value
     const body = { track_total_hits: true, query: { query_string: { query } } }
@@ -227,8 +231,8 @@ export function useSearchFilter() {
 
   function refreshSearchFromRoute() {
     // Extract the query parameters that must be saved in the app state
-    const { perPage = getPerPage(), sort = getSort(), order = getOrder() } = route.query
-    appStore.setSettings('search', { perPage, orderBy: [sort, order] })
+    const { perPage = getPerPage(), sort = getSort(), order = getOrder(), searchOperator = getSearchOperator() } = route.query
+    appStore.setSettings('search', { perPage, orderBy: [sort, order], searchOperator })
     // Update the search store using the route query
     searchStore.updateFromRouteQuery(route.query)
     // And finally, refresh the search if t
@@ -237,8 +241,8 @@ export function useSearchFilter() {
 
   function refreshSearchFromRouteStart() {
     // Extract the query parameters that must be saved in the app state
-    const { perPage = getPerPage(), sort = getSort(), order = getOrder() } = route.query
-    appStore.setSettings('search', { perPage, orderBy: [sort, order] })
+    const { perPage = getPerPage(), sort = getSort(), order = getOrder(), searchOperator = getSearchOperator() } = route.query
+    appStore.setSettings('search', { perPage, orderBy: [sort, order], searchOperator })
     // Update the search store using the route query and reset the `from` parameter
     searchStore.updateFromRouteQuery({ ...route.query, from: 0 })
     // And finally, refresh the search if t

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -4,6 +4,7 @@ import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 
 import settings from '@/utils/settings'
+import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 import { useCore } from '@/composables/useCore'
 import { onAfterRouteUpdate } from '@/composables/onAfterRouteUpdate'
 import FilterType from '@/components/Filter/FilterType/FilterType'
@@ -229,9 +230,14 @@ export function useSearchFilter() {
     return router.push({ name, query })
   }
 
+  function toValidSearchOperator(value) {
+    return Object.values(SEARCH_OPERATORS).includes(value) ? value : SEARCH_OPERATORS.OR
+  }
+
   function refreshSearchFromRoute() {
     // Extract the query parameters that must be saved in the app state
-    const { perPage = getPerPage(), sort = getSort(), order = getOrder(), searchOperator = getSearchOperator() } = route.query
+    const { perPage = getPerPage(), sort = getSort(), order = getOrder() } = route.query
+    const searchOperator = toValidSearchOperator(route.query.searchOperator ?? getSearchOperator())
     appStore.setSettings('search', { perPage, orderBy: [sort, order], searchOperator })
     // Update the search store using the route query
     searchStore.updateFromRouteQuery(route.query)
@@ -241,7 +247,8 @@ export function useSearchFilter() {
 
   function refreshSearchFromRouteStart() {
     // Extract the query parameters that must be saved in the app state
-    const { perPage = getPerPage(), sort = getSort(), order = getOrder(), searchOperator = getSearchOperator() } = route.query
+    const { perPage = getPerPage(), sort = getSort(), order = getOrder() } = route.query
+    const searchOperator = toValidSearchOperator(route.query.searchOperator ?? getSearchOperator())
     appStore.setSettings('search', { perPage, orderBy: [sort, order], searchOperator })
     // Update the search store using the route query and reset the `from` parameter
     searchStore.updateFromRouteQuery({ ...route.query, from: 0 })

--- a/src/composables/useSearchProperties.js
+++ b/src/composables/useSearchProperties.js
@@ -16,7 +16,6 @@ import IPhPaperclip from '~icons/ph/paperclip'
 import IPhGlobeHemisphereWest from '~icons/ph/globe-hemisphere-west'
 import IPhCirclesThreePlus from '~icons/ph/circles-three-plus'
 import IPhFiles from '~icons/ph/files'
-
 import { useViewProperties } from '@/composables/useViewProperties'
 import { SORT_TYPE_KEY, useViewSettings } from '@/composables/useViewSettings'
 

--- a/src/composables/useViewSettings.js
+++ b/src/composables/useViewSettings.js
@@ -73,7 +73,7 @@ export function useViewSettings() {
   const tSearchOperator = {
     label: computed(() => t('viewSettings.searchOperator.label')),
     or: computed(() => t('viewSettings.searchOperator.or')),
-    and: computed(() => t('viewSettings.searchOperator.and')),
+    and: computed(() => t('viewSettings.searchOperator.and'))
   }
 
   return {

--- a/src/composables/useViewSettings.js
+++ b/src/composables/useViewSettings.js
@@ -70,6 +70,11 @@ export function useViewSettings() {
     table: computed(() => t('viewSettings.layout.table')),
     list: computed(() => t('viewSettings.layout.list'))
   }
+  const tSearchOperator = {
+    label: computed(() => t('viewSettings.searchOperator.label')),
+    or: computed(() => t('viewSettings.searchOperator.or')),
+    and: computed(() => t('viewSettings.searchOperator.and')),
+  }
 
   return {
     fieldsToPropertiesOptions,
@@ -78,6 +83,7 @@ export function useViewSettings() {
     sortByLabel,
     visiblePropertiesLabel,
     tLayout,
+    tSearchOperator,
     perPageLabel
   }
 }

--- a/src/enums/searchOperators.js
+++ b/src/enums/searchOperators.js
@@ -1,0 +1,4 @@
+const OR = 'or'
+const AND = 'and'
+
+export const SEARCH_OPERATORS = Object.freeze({ OR, AND })

--- a/src/enums/searchOperators.js
+++ b/src/enums/searchOperators.js
@@ -1,4 +1,4 @@
-const OR = 'or'
-const AND = 'and'
+const OR = 'OR'
+const AND = 'AND'
 
 export const SEARCH_OPERATORS = Object.freeze({ OR, AND })

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1674,6 +1674,11 @@
       "table": "Table",
       "list": "List"
     },
+    "searchOperator": {
+      "label": "Search operator",
+      "and": "AND",
+      "or": "OR"
+    },
     "sortBy": {
       "label": "Sort by",
       "format": "{name} ({order})"

--- a/src/router/guards/checkSearchSort.js
+++ b/src/router/guards/checkSearchSort.js
@@ -14,8 +14,10 @@ export const checkSearchSort = (to) => {
   const { name, params } = to
   const { property: sort = null, desc } = find(settings.legacySearchSortFields, { name: to.query.sort }) ?? {}
   const order = desc ? 'desc' : 'asc'
-  // Only redirect if the sort field is found
-  if (sort) {
+  // Only redirect if the sort field is found and the query would actually change.
+  // Without the second check, a legacy name that maps to the same property (e.g. "path" → "path")
+  // would redirect to an identical URL, causing an infinite navigation loop.
+  if (sort && (sort !== to.query.sort || order !== to.query.order)) {
     const query = { ...to.query, sort, order }
     return { name, params, query }
   }

--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -10,7 +10,7 @@ import { SEARCH_OPERATORS } from '@/enums/searchOperators'
  * will require resetting user settings to defaults. This is useful if for instance you add new settings
  * or change the structure of existing settings and want to ensure users get the latest defaults.
  */
-const SETTINGS_VERSION = 0
+const SETTINGS_VERSION = 1
 
 /**
  * Defines the application-wide store for managing UI state and user preferences.

--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -3,6 +3,7 @@ import { ref, reactive } from 'vue'
 import { defineStore } from 'pinia'
 
 import { LAYOUTS } from '@/enums/layouts'
+import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 
 /**
  * Version of the settings schema. Increment this value when making changes to the settings structure which
@@ -31,7 +32,8 @@ export const useAppStore = defineStore(
           layout: LAYOUTS.LIST,
           orderBy: ['_score', 'desc'],
           perPage: '25',
-          properties: ['title', 'thumbnail', 'highlights', 'project']
+          properties: ['title', 'thumbnail', 'highlights', 'project'],
+          searchOperator: SEARCH_OPERATORS.OR
         },
         searchSavedList: {
           orderBy: ['creation_date', 'desc'],

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -110,6 +110,7 @@ export const useSearchStore = defineSuffixedStore('search', () => {
       perPage: `${perPage.value}`,
       sort: sortBy.value,
       order: orderBy.value,
+      searchOperator: searchOperator.value,
       ...toBaseRouteQuery.value
     }
   })

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -951,7 +951,7 @@ export const useSearchStore = defineSuffixedStore('search', () => {
    */
   function runBatchDownload(uri = null) {
     const batchDownloadQuery = ['', null, undefined].indexOf(q.value) === -1 ? q.value : '*'
-    const { query } = api.elasticsearch.rootSearch(instantiatedFilters.value, batchDownloadQuery, fields.value).build()
+    const { query } = api.elasticsearch.rootSearch(instantiatedFilters.value, batchDownloadQuery, fields.value, searchOperator.value).build()
     return api.runBatchDownload({ projectIds: indices.value, query, uri })
   }
 
@@ -962,7 +962,7 @@ export const useSearchStore = defineSuffixedStore('search', () => {
    */
   function estimateDownloadSize() {
     const estimateQuery = ['', null, undefined].indexOf(q.value) === -1 ? q.value : '*'
-    return api.elasticsearch.estimateDownloadSize(indices.value, instantiatedFilters.value, estimateQuery, fields.value)
+    return api.elasticsearch.estimateDownloadSize(indices.value, instantiatedFilters.value, estimateQuery, fields.value, searchOperator.value)
   }
 
   /**

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -24,6 +24,7 @@ import filterDefs, * as filterTypes from '@/store/filters'
 import { useAppStore, useSearchBreadcrumbStore } from '@/store/modules'
 import { apiInstance as api } from '@/api/apiInstance'
 import { defineSuffixedStore } from '@/store/defineSuffixedStore'
+import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 import settings from '@/utils/settings'
 
 export const useSearchStore = defineSuffixedStore('search', () => {
@@ -51,6 +52,8 @@ export const useSearchStore = defineSuffixedStore('search', () => {
       indices.value = [value]
     }
   })
+
+  const searchOperator = computed(() => appStore.getSettings('search', 'searchOperator') ?? SEARCH_OPERATORS.OR)
 
   const fields = computed(() => {
     return find(settings.searchFields, { key: field.value }).fields
@@ -142,7 +145,8 @@ export const useSearchStore = defineSuffixedStore('search', () => {
       from: from.value,
       perPage: perPage.value,
       sort: sort.value,
-      fields: fields.value
+      fields: fields.value,
+      operator: searchOperator.value
     }
   })
 
@@ -1006,6 +1010,7 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     instantiatedFilters,
     activeFilters,
     fields,
+    searchOperator,
     filterValuesAsRouteQuery,
     toBaseRouteQuery,
     toRouteQuery,

--- a/src/views/Search/Search.vue
+++ b/src/views/Search/Search.vue
@@ -38,6 +38,7 @@ const {
   refreshSearchFromRouteStart,
   watchIndices,
   watchFilters,
+  watchOperator,
   onAfterRouteQueryUpdate,
   onAfterRouteQueryFromUpdate
 } = useSearchFilter()
@@ -105,6 +106,8 @@ const documentViewFloatingId = provideDocumentViewFloatingId()
 watchFilters(refreshRouteFromStart)
 // Refresh route query when projects change
 watchIndices(refreshRouteFromStart)
+// Refresh route query when search operator changes
+watchOperator(refreshRouteFromStart)
 // Refresh search when route query changes. Among all the "watcher" (it's a post-navigation filter)
 // of this view, it probably the most important one. It will trigger the search API call
 // when the route query changes which mean that **only route changes** can trigger a search. This

--- a/src/views/Search/SearchSettings.vue
+++ b/src/views/Search/SearchSettings.vue
@@ -18,7 +18,7 @@ import PageSettingsSection from '@/components/PageSettings/PageSettingsSection'
 import { useAppStore, useSearchStore } from '@/store/modules'
 import { useSearchProperties } from '@/composables/useSearchProperties'
 import { useViewSettings, INPUT_CHECKBOX, INPUT_RADIO } from '@/composables/useViewSettings'
-import {SEARCH_OPERATORS} from "@/enums/searchOperators.js";
+import { SEARCH_OPERATORS } from '@/enums/searchOperators.js'
 
 const { t } = useI18n()
 const appStore = useAppStore()
@@ -134,7 +134,6 @@ const properties = ref({
     set: properties => appStore.setSettings(VIEW, { properties })
   })
 })
-
 
 defineProps({
   hide: {

--- a/src/views/Search/SearchSettings.vue
+++ b/src/views/Search/SearchSettings.vue
@@ -23,7 +23,7 @@ import { SEARCH_OPERATORS } from '@/enums/searchOperators.js'
 const { t } = useI18n()
 const appStore = useAppStore()
 const searchStore = useSearchStore()
-const { tLayout, tSearchOperator } = useViewSettings(t)
+const { tLayout, tSearchOperator } = useViewSettings()
 const { propertiesOptions, sortByOptions } = useSearchProperties()
 const VIEW = 'search'
 

--- a/src/views/Search/SearchSettings.vue
+++ b/src/views/Search/SearchSettings.vue
@@ -7,6 +7,9 @@ import IPhList from '~icons/ph/list'
 import IPhDotsNine from '~icons/ph/dots-nine'
 import IPhTable from '~icons/ph/table'
 
+import IPhUniteSquare from '~icons/ph/unite-square-fill'
+import IPhIntersectSquare from '~icons/ph/intersect-square-fill'
+
 import { LAYOUTS } from '@/enums/layouts'
 import { useUrlParamWithStore } from '@/composables/useUrlParamWithStore'
 import { useUrlParamsWithStore } from '@/composables/useUrlParamsWithStore'
@@ -15,11 +18,12 @@ import PageSettingsSection from '@/components/PageSettings/PageSettingsSection'
 import { useAppStore, useSearchStore } from '@/store/modules'
 import { useSearchProperties } from '@/composables/useSearchProperties'
 import { useViewSettings, INPUT_CHECKBOX, INPUT_RADIO } from '@/composables/useViewSettings'
+import {SEARCH_OPERATORS} from "@/enums/searchOperators.js";
 
 const { t } = useI18n()
 const appStore = useAppStore()
 const searchStore = useSearchStore()
-const { tLayout } = useViewSettings(t)
+const { tLayout, tSearchOperator } = useViewSettings(t)
 const { propertiesOptions, sortByOptions } = useSearchProperties()
 const VIEW = 'search'
 
@@ -47,6 +51,30 @@ const layout = ref({
       text: tLayout.table,
       icon: IPhTable
     }
+  ]
+})
+
+const searchOperator = ref({
+  label: tSearchOperator.label,
+  type: INPUT_RADIO,
+  open: true,
+  modelValue: computed({
+    get: () => appStore.getSettings(VIEW, 'searchOperator'),
+    set: searchOperator => appStore.setSettings(VIEW, { searchOperator })
+  }),
+  options: [
+    {
+      value: SEARCH_OPERATORS.OR,
+      icon: IPhUniteSquare,
+      key: 'searchOperatorOr',
+      text: tSearchOperator.or
+    },
+    {
+      value: SEARCH_OPERATORS.AND,
+      icon: IPhIntersectSquare,
+      key: 'searchOperatorAnd',
+      text: tSearchOperator.and
+    },
   ]
 })
 
@@ -107,6 +135,7 @@ const properties = ref({
   })
 })
 
+
 defineProps({
   hide: {
     type: Function,
@@ -166,6 +195,14 @@ function reset() {
       :type="properties.type"
       :options="properties.options"
       :label="properties.label"
+    />
+    <page-settings-section
+      v-model="searchOperator.modelValue"
+      v-model:open="searchOperator.open"
+      class="search-settings__section search-settings__section--properties"
+      :type="searchOperator.type"
+      :options="searchOperator.options"
+      :label="searchOperator.label"
     />
   </page-settings>
 </template>

--- a/src/views/Search/SearchSettings.vue
+++ b/src/views/Search/SearchSettings.vue
@@ -66,15 +66,13 @@ const searchOperator = ref({
     {
       value: SEARCH_OPERATORS.OR,
       icon: IPhUniteSquare,
-      key: 'searchOperatorOr',
       text: tSearchOperator.or
     },
     {
       value: SEARCH_OPERATORS.AND,
       icon: IPhIntersectSquare,
-      key: 'searchOperatorAnd',
       text: tSearchOperator.and
-    },
+    }
   ]
 })
 
@@ -198,7 +196,7 @@ function reset() {
     <page-settings-section
       v-model="searchOperator.modelValue"
       v-model:open="searchOperator.open"
-      class="search-settings__section search-settings__section--properties"
+      class="search-settings__section search-settings__section--search-operator"
       :type="searchOperator.type"
       :options="searchOperator.options"
       :label="searchOperator.label"

--- a/tests/unit/specs/api/elasticsearch.spec.js
+++ b/tests/unit/specs/api/elasticsearch.spec.js
@@ -276,5 +276,26 @@ describe('elasticsearch', () => {
 
       expect(result).toEqual({ estimatedCount: 0, estimatedSize: 0 })
     })
+
+    it('passes operator to default_operator in the query body', async () => {
+      searchSpy.mockResolvedValue({
+        hits: { total: { value: 0 } },
+        aggregations: { total_content_length: { value: 0 } }
+      })
+
+      await elasticsearch.estimateDownloadSize(index, [], 'foo bar', [], 'AND')
+
+      const body = searchSpy.mock.calls[0][0].body
+      const queryString = body.query.bool.must[1].bool.should[0].query_string
+      expect(queryString.default_operator).toBe('AND')
+    })
+  })
+
+  describe('rootSearch', () => {
+    it('passes operator to default_operator in the body', () => {
+      const body = elasticsearch.rootSearch([], 'foo bar', [], 'AND').build()
+      const queryString = body.query.bool.must[1].bool.should[0].query_string
+      expect(queryString.default_operator).toBe('AND')
+    })
   })
 })

--- a/tests/unit/specs/api/elasticsearch.spec.js
+++ b/tests/unit/specs/api/elasticsearch.spec.js
@@ -89,6 +89,25 @@ describe('elasticsearch', () => {
     })
   })
 
+  it('should set default_operator to "AND" in ES query when operator is "AND"', async () => {
+    const spy = vi.spyOn(elasticsearch, 'search').mockResolvedValue({ hits: { hits: [] } })
+    await elasticsearch.searchDocs({ index, query: 'apple orange', operator: 'AND' })
+    const body = spy.mock.calls[0][0].body
+    const queryString = body.query.bool.must[1].bool.should[0].query_string
+    expect(queryString.default_operator).toBe('AND')
+    spy.mockRestore()
+  })
+
+  it('should default default_operator to "OR" when no operator is provided', async () => {
+    const spy = vi.spyOn(elasticsearch, 'search').mockResolvedValue({ hits: { hits: [] } })
+    await elasticsearch.searchDocs({ index, query: 'apple orange' })
+    const body = spy.mock.calls[0][0].body
+    const queryString = body.query.bool.must[1].bool.should[0].query_string
+    expect(queryString.default_operator).toBe('OR')
+    spy.mockRestore()
+  })
+
+
   it('should build a simple ES query and escape slash in it', async () => {
     const body = bodybuilder().from(0).size(25)
 

--- a/tests/unit/specs/api/elasticsearch.spec.js
+++ b/tests/unit/specs/api/elasticsearch.spec.js
@@ -107,7 +107,6 @@ describe('elasticsearch', () => {
     spy.mockRestore()
   })
 
-
   it('should build a simple ES query and escape slash in it', async () => {
     const body = bodybuilder().from(0).size(25)
 

--- a/tests/unit/specs/components/Search/SearchParameter/SearchParameterQueryAst.spec.js
+++ b/tests/unit/specs/components/Search/SearchParameter/SearchParameterQueryAst.spec.js
@@ -1,0 +1,54 @@
+import { mount } from '@vue/test-utils'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import SearchParameterQueryAst from '@/components/Search/SearchParameter/SearchParameterQueryAst'
+import { useAppStore } from '@/store/modules'
+import { SEARCH_OPERATORS } from '@/enums/searchOperators'
+
+describe('SearchParameterQueryAst.vue', () => {
+  let plugins, appStore
+
+  beforeEach(() => {
+    const core = CoreSetup.init().useAll().useRouterWithoutGuards()
+    plugins = core.plugins
+    appStore = useAppStore()
+  })
+
+  function mountAst(ast) {
+    return mount(SearchParameterQueryAst, {
+      props: { ast },
+      global: { plugins }
+    })
+  }
+
+  const term = (value) => ({ field: '<implicit>', term: value })
+
+  describe('operator display', () => {
+    it('shows OR operator between terms when ast.operator is implicit and store defaults to OR', () => {
+      const ast = { left: term('foo'), operator: '<implicit>', right: term('bar') }
+      const wrapper = mountAst(ast)
+      expect(wrapper.text()).toContain('OR')
+    })
+
+    it('shows AND operator between terms when ast.operator is implicit and store is set to AND', () => {
+      appStore.setSettings('search', 'searchOperator', SEARCH_OPERATORS.AND)
+      const ast = { left: term('foo'), operator: '<implicit>', right: term('bar') }
+      const wrapper = mountAst(ast)
+      expect(wrapper.text()).toContain('AND')
+    })
+
+    it('shows explicit AND operator regardless of store setting', () => {
+      appStore.setSettings('search', 'searchOperator', SEARCH_OPERATORS.OR)
+      const ast = { left: term('foo'), operator: 'AND', right: term('bar') }
+      const wrapper = mountAst(ast)
+      expect(wrapper.text()).toContain('AND')
+    })
+
+    it('shows explicit OR operator regardless of store setting', () => {
+      appStore.setSettings('search', 'searchOperator', SEARCH_OPERATORS.AND)
+      const ast = { left: term('foo'), operator: 'OR', right: term('bar') }
+      const wrapper = mountAst(ast)
+      expect(wrapper.text()).toContain('OR')
+    })
+  })
+})

--- a/tests/unit/specs/components/Search/SearchParameter/SearchParameterQueryAst.spec.js
+++ b/tests/unit/specs/components/Search/SearchParameter/SearchParameterQueryAst.spec.js
@@ -21,7 +21,7 @@ describe('SearchParameterQueryAst.vue', () => {
     })
   }
 
-  const term = (value) => ({ field: '<implicit>', term: value })
+  const term = value => ({ field: '<implicit>', term: value })
 
   describe('operator display', () => {
     it('shows OR operator between terms when ast.operator is implicit and store defaults to OR', () => {

--- a/tests/unit/specs/composables/useSearchFilter.spec.js
+++ b/tests/unit/specs/composables/useSearchFilter.spec.js
@@ -13,9 +13,7 @@ describe('useSearchFilter', () => {
         return {}
       }
     })
-    plugins.forEach(plugin => {
-      Array.isArray(plugin) ? app.use(...plugin) : app.use(plugin)
-    })
+    plugins.forEach(plugin => app.use(plugin))
     app.mount(document.createElement('div'))
   }
 

--- a/tests/unit/specs/composables/useSearchFilter.spec.js
+++ b/tests/unit/specs/composables/useSearchFilter.spec.js
@@ -2,19 +2,21 @@ import { createApp, nextTick } from 'vue'
 
 import CoreSetup from '~tests/unit/CoreSetup'
 import { useSearchFilter } from '@/composables/useSearchFilter'
-import { useAppStore } from '@/store/modules'
+import { useAppStore, useSearchStore } from '@/store/modules'
 import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 
 describe('useSearchFilter', () => {
   function withSetup(composable, plugins) {
+    let result
     const app = createApp({
       setup() {
-        composable()
+        result = composable()
         return {}
       }
     })
     plugins.forEach(plugin => app.use(plugin))
     app.mount(document.createElement('div'))
+    return result
   }
 
   describe('watchOperator', () => {
@@ -48,6 +50,21 @@ describe('useSearchFilter', () => {
       await nextTick()
 
       expect(callback).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('refreshSearchFromRoute', () => {
+    it('restores searchOperator from route query to app settings', async () => {
+      const core = CoreSetup.init().useAll().useRouterWithoutGuards()
+      const { refreshSearchFromRoute } = withSetup(() => useSearchFilter(), core.plugins)
+      const searchStore = useSearchStore()
+      vi.spyOn(searchStore, 'query').mockResolvedValue(undefined)
+
+      await core.router.push({ name: 'search', query: { searchOperator: SEARCH_OPERATORS.AND } })
+      await refreshSearchFromRoute()
+
+      expect(useAppStore().getSettings('search', 'searchOperator')).toBe(SEARCH_OPERATORS.AND)
+      vi.restoreAllMocks()
     })
   })
 })

--- a/tests/unit/specs/composables/useSearchFilter.spec.js
+++ b/tests/unit/specs/composables/useSearchFilter.spec.js
@@ -36,6 +36,25 @@ describe('useSearchFilter', () => {
       expect(callback).toHaveBeenCalledOnce()
     })
 
+    it('calls callback when search operator changes from AND to OR', async () => {
+      const core = CoreSetup.init().useAll().useRouterWithoutGuards()
+      const callback = vi.fn()
+
+      withSetup(() => {
+        const { watchOperator } = useSearchFilter()
+        watchOperator(callback)
+      }, core.plugins)
+
+      const appStore = useAppStore()
+      appStore.setSettings('search', 'searchOperator', SEARCH_OPERATORS.AND)
+      await nextTick()
+      callback.mockClear()
+      appStore.setSettings('search', 'searchOperator', SEARCH_OPERATORS.OR)
+      await nextTick()
+
+      expect(callback).toHaveBeenCalledOnce()
+    })
+
     it('does not call callback when an unrelated setting changes', async () => {
       const core = CoreSetup.init().useAll().useRouterWithoutGuards()
       const callback = vi.fn()
@@ -64,6 +83,45 @@ describe('useSearchFilter', () => {
       await refreshSearchFromRoute()
 
       expect(useAppStore().getSettings('search', 'searchOperator')).toBe(SEARCH_OPERATORS.AND)
+      vi.restoreAllMocks()
+    })
+
+    it('ignores invalid searchOperator values from route query', async () => {
+      const core = CoreSetup.init().useAll().useRouterWithoutGuards()
+      const { refreshSearchFromRoute } = withSetup(() => useSearchFilter(), core.plugins)
+      const searchStore = useSearchStore()
+      vi.spyOn(searchStore, 'query').mockResolvedValue(undefined)
+
+      await core.router.push({ name: 'search', query: { searchOperator: 'FOOBAR' } })
+      await refreshSearchFromRoute()
+
+      expect(useAppStore().getSettings('search', 'searchOperator')).toBe(SEARCH_OPERATORS.OR)
+      vi.restoreAllMocks()
+    })
+
+    it('restores searchOperator from route query using refreshSearchFromRouteStart', async () => {
+      const core = CoreSetup.init().useAll().useRouterWithoutGuards()
+      const { refreshSearchFromRouteStart } = withSetup(() => useSearchFilter(), core.plugins)
+      const searchStore = useSearchStore()
+      vi.spyOn(searchStore, 'query').mockResolvedValue(undefined)
+
+      await core.router.push({ name: 'search', query: { searchOperator: SEARCH_OPERATORS.AND } })
+      await refreshSearchFromRouteStart()
+
+      expect(useAppStore().getSettings('search', 'searchOperator')).toBe(SEARCH_OPERATORS.AND)
+      vi.restoreAllMocks()
+    })
+
+    it('ignores invalid searchOperator values from route query in refreshSearchFromRouteStart', async () => {
+      const core = CoreSetup.init().useAll().useRouterWithoutGuards()
+      const { refreshSearchFromRouteStart } = withSetup(() => useSearchFilter(), core.plugins)
+      const searchStore = useSearchStore()
+      vi.spyOn(searchStore, 'query').mockResolvedValue(undefined)
+
+      await core.router.push({ name: 'search', query: { searchOperator: 'FOOBAR' } })
+      await refreshSearchFromRouteStart()
+
+      expect(useAppStore().getSettings('search', 'searchOperator')).toBe(SEARCH_OPERATORS.OR)
       vi.restoreAllMocks()
     })
   })

--- a/tests/unit/specs/composables/useSearchFilter.spec.js
+++ b/tests/unit/specs/composables/useSearchFilter.spec.js
@@ -1,0 +1,55 @@
+import { createApp, nextTick } from 'vue'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import { useSearchFilter } from '@/composables/useSearchFilter'
+import { useAppStore } from '@/store/modules'
+import { SEARCH_OPERATORS } from '@/enums/searchOperators'
+
+describe('useSearchFilter', () => {
+  function withSetup(composable, plugins) {
+    const app = createApp({
+      setup() {
+        composable()
+        return {}
+      }
+    })
+    plugins.forEach(plugin => {
+      Array.isArray(plugin) ? app.use(...plugin) : app.use(plugin)
+    })
+    app.mount(document.createElement('div'))
+  }
+
+  describe('watchOperator', () => {
+    it('calls callback when search operator changes from OR to AND', async () => {
+      const core = CoreSetup.init().useAll().useRouterWithoutGuards()
+      const callback = vi.fn()
+
+      withSetup(() => {
+        const { watchOperator } = useSearchFilter()
+        watchOperator(callback)
+      }, core.plugins)
+
+      const appStore = useAppStore()
+      appStore.setSettings('search', 'searchOperator', SEARCH_OPERATORS.AND)
+      await nextTick()
+
+      expect(callback).toHaveBeenCalledOnce()
+    })
+
+    it('does not call callback when an unrelated setting changes', async () => {
+      const core = CoreSetup.init().useAll().useRouterWithoutGuards()
+      const callback = vi.fn()
+
+      withSetup(() => {
+        const { watchOperator } = useSearchFilter()
+        watchOperator(callback)
+      }, core.plugins)
+
+      const appStore = useAppStore()
+      appStore.setSettings('search', 'perPage', '50')
+      await nextTick()
+
+      expect(callback).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/specs/store/modules/app.spec.js
+++ b/tests/unit/specs/store/modules/app.spec.js
@@ -1,6 +1,7 @@
 import { setActivePinia, createPinia } from 'pinia'
 
 import { useAppStore } from '@/store/modules'
+import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 
 describe('AppStore', () => {
   let store
@@ -79,5 +80,15 @@ describe('AppStore', () => {
     store.setSettings('search', 'orderBy', ['relevance', 'desc'])
     store.resetSettings('search')
     expect(store.getSettings('search', 'orderBy')).toEqual(originalValue)
+  })
+
+  it('should default search operator to OR', () => {
+    expect(store.getSettings('search', 'searchOperator')).toBe(SEARCH_OPERATORS.OR)
+  })
+
+  it('should reset search operator to OR after change', () => {
+    store.setSettings('search', 'searchOperator', SEARCH_OPERATORS.AND)
+    store.resetSettings('search')
+    expect(store.getSettings('search', 'searchOperator')).toBe(SEARCH_OPERATORS.OR)
   })
 })

--- a/tests/unit/specs/store/modules/search.spec.js
+++ b/tests/unit/specs/store/modules/search.spec.js
@@ -3,6 +3,7 @@ import { setActivePinia, createPinia } from 'pinia'
 
 import { IndexedDocument, IndexedDocuments, letData } from '~tests/unit/es_utils'
 import esConnectionHelper from '~tests/unit/specs/utils/esConnectionHelper'
+import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 import Document from '@/api/resources/Document'
 import EsDocList from '@/api/resources/EsDocList'
 import NamedEntity from '@/api/resources/NamedEntity'
@@ -361,6 +362,15 @@ describe('SearchStore', () => {
         perPage: '25',
         from: '0'
       })
+    })
+
+    it('should include searchOperator in the route query', () => {
+      expect(searchStore.toRouteQuery).toMatchObject({ searchOperator: SEARCH_OPERATORS.OR })
+    })
+
+    it('should reflect AND searchOperator in the route query when set', () => {
+      appStore.setSettings('search', 'searchOperator', SEARCH_OPERATORS.AND)
+      expect(searchStore.toRouteQuery).toMatchObject({ searchOperator: SEARCH_OPERATORS.AND })
     })
 
     it('should return an advanced and filtered query parameters', () => {
@@ -1102,19 +1112,25 @@ describe('SearchStore', () => {
     it('should pass the selected field to the elasticsearch query', async () => {
       searchStore.setField('content')
       await searchStore.runBatchDownload()
-      expect(rootSearchSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), ['content'])
+      expect(rootSearchSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), ['content'], expect.anything())
     })
 
     it('should pass empty fields when searching in all fields', async () => {
       searchStore.setField('all')
       await searchStore.runBatchDownload()
-      expect(rootSearchSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), [])
+      expect(rootSearchSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), [], expect.anything())
     })
 
     it('should pass the field-specific fields array to the batch download query', async () => {
       searchStore.setField('path')
       await searchStore.runBatchDownload()
-      expect(rootSearchSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), ['path'])
+      expect(rootSearchSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), ['path'], expect.anything())
+    })
+
+    it('passes the search operator to the elasticsearch query', async () => {
+      appStore.setSettings('search', 'searchOperator', SEARCH_OPERATORS.AND)
+      await searchStore.runBatchDownload()
+      expect(rootSearchSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), SEARCH_OPERATORS.AND)
     })
   })
 
@@ -1138,44 +1154,51 @@ describe('SearchStore', () => {
         searchStore.indices,
         searchStore.instantiatedFilters,
         '*',
-        []
+        [],
+        SEARCH_OPERATORS.OR
       )
     })
 
     it('passes "*" when the query is empty', async () => {
       searchStore.setQuery('')
       await searchStore.estimateDownloadSize()
-      expect(estimateSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), '*', expect.anything())
+      expect(estimateSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), '*', expect.anything(), expect.anything())
     })
 
     it('passes "*" when the query is null', async () => {
       searchStore.setQuery(null)
       await searchStore.estimateDownloadSize()
-      expect(estimateSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), '*', expect.anything())
+      expect(estimateSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), '*', expect.anything(), expect.anything())
     })
 
     it('passes "*" when the query is undefined', async () => {
       searchStore.setQuery(undefined)
       await searchStore.estimateDownloadSize()
-      expect(estimateSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), '*', expect.anything())
+      expect(estimateSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), '*', expect.anything(), expect.anything())
     })
 
     it('passes the literal query when set', async () => {
       searchStore.setQuery('hello world')
       await searchStore.estimateDownloadSize()
-      expect(estimateSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'hello world', expect.anything())
+      expect(estimateSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'hello world', expect.anything(), expect.anything())
     })
 
     it('passes the selected field as the fields array', async () => {
       searchStore.setField('content')
       await searchStore.estimateDownloadSize()
-      expect(estimateSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), ['content'])
+      expect(estimateSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), ['content'], expect.anything())
     })
 
     it('passes an empty fields array when searching all fields', async () => {
       searchStore.setField('all')
       await searchStore.estimateDownloadSize()
-      expect(estimateSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), [])
+      expect(estimateSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), [], expect.anything())
+    })
+
+    it('passes the search operator to the elasticsearch client', async () => {
+      appStore.setSettings('search', 'searchOperator', SEARCH_OPERATORS.AND)
+      await searchStore.estimateDownloadSize()
+      expect(estimateSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), expect.anything(), SEARCH_OPERATORS.AND)
     })
 
     it('forwards the API response', async () => {


### PR DESCRIPTION
Implements ICIJ/datashare#1497 - adds an option to switch Elasticsearch's default_operator between OR (default) and AND.                                                     
                                                                                                                                                                               
  - New setting: a searchOperator setting (`OR` , `AND`) added to SearchSettings, stored in `appStore` under `views.search`, with `SETTINGS_VERSION` bumped to 1 to trigger a clean hydration on upgrade.                                                                                                                                                        
  - Elasticsearch integration: the operator is threaded from the `app store` -> `searchDocs` -> `_buildSearchBody` -> `_applyQueryString`, where it sets `default_operator` in the `query_string` DSL clause. Batch download and download size estimation also respect the operator.                                                                              
  - Route persistence: `searchOperator` is included in `toRouteQuery` so it appears in the URL and is restored when navigating back or sharing a link. Invalid values in the URL are silently ignored and fall back to `OR`.
  - Reactivity: a `watchOperator` watcher in `useSearchFilter` triggers `refreshRouteFromStart` whenever the operator changes, so results update immediately after toggling.
  - UI display: `SearchParameterQueryAst` now resolves `'<implicit>'` AST operators to the active store value, so the query breadcrumb always shows the effective operator (OR or  AND). 


<img width="1517" height="487" alt="image" src="https://github.com/user-attachments/assets/4c4d54cb-c974-45aa-9508-96fd523c08bd" />

<img width="1517" height="487" alt="image" src="https://github.com/user-attachments/assets/65b927d8-302e-455a-9680-0994268a6d84" />

