### PR TITLE
fix: always fetch total_directories in compact mode

### DIFF
--- a/src/components/PathTree/PathTree.vue
+++ b/src/components/PathTree/PathTree.vue
@@ -312,10 +312,11 @@ function getDirectoriesBodybuilder({ from = 0, size = PER_PAGE } = {}) {
   if (!props.includeChildrenDocuments) {
     bb.andQuery('match', 'extractionLevel', 0)
   }
-  // In "full" mode (not compact), add top-level totals across all buckets
+  // Always include total_directories for pagination label computation (even in compact mode)
+  bb.agg('cardinality', 'dirname', 'total_directories')
+  // In "full" mode (not compact), also add size total
   if (!props.compact || props.noStats) {
     bb.agg('sum', 'contentLength', 'total_size')
-    bb.agg('cardinality', 'dirname', 'total_directories')
   }
   // Allow any last-minute tweaks (e.g. additional filters),
   // then return the configured bodybuilder instance
@@ -649,7 +650,7 @@ defineExpose({ isLoading, loadData, loadDataWithSpinner, reloadData })
           :layout="layout"
           :flat="flat"
           :level="nextLevel"
-          :per-page="perPage"
+          :per-page="PER_PAGE"
           :page="page"
           :total="totalDirectories"
           @click="nextLoadData"

--- a/tests/unit/specs/components/PathTree/PathTree.spec.js
+++ b/tests/unit/specs/components/PathTree/PathTree.spec.js
@@ -130,6 +130,62 @@ describe('PathTree.vue', () => {
     })
   })
 
+  describe('compact mode (filter column)', () => {
+    const { index } = esConnectionHelper.build()
+    let core, searchSpy
+
+    const fullPageOfBuckets = Array.from({ length: 50 }, (_, i) => ({
+      key: `/home/foo/dir${String(i).padStart(2, '0')}`,
+      doc_count: 1,
+      size: { value: 100 }
+    }))
+
+    beforeEach(() => {
+      core = CoreSetup.init().useAll()
+      core.config.set('dataDir', '/home/foo')
+      api.tree.mockClear()
+      api.tree.mockResolvedValue(HOME_TREE)
+      searchSpy = vi.spyOn(api.elasticsearch, 'search').mockResolvedValue({
+        hits: { total: { value: 0 }, hits: [] },
+        aggregations: {
+          total_directories: { value: 201 },
+          dirname: { buckets: fullPageOfBuckets }
+        }
+      })
+    })
+
+    afterEach(() => {
+      searchSpy.mockRestore()
+    })
+
+    it('includes total_directories in ES query even in compact mode', async () => {
+      const wrapper = mount(PathTree, {
+        props: { projects: [index], path: '/home/foo', compact: true, noDocuments: true },
+        global: { plugins: core.plugins, renderStubDefaultSlot: true }
+      })
+
+      await wrapper.vm.loadData({ clearPages: true })
+      await flushPromises()
+
+      const { body } = searchSpy.mock.calls[0][0]
+      expect(body.aggs).toHaveProperty('total_directories')
+    })
+
+    it('shows remaining directory count in "show more" button in compact mode', async () => {
+      const wrapper = mount(PathTree, {
+        props: { projects: [index], path: '/home/foo', compact: true, noDocuments: true },
+        global: { plugins: core.plugins, renderStubDefaultSlot: true }
+      })
+
+      await wrapper.vm.loadData({ clearPages: true })
+      await flushPromises()
+
+      // Before the fix, compact mode omitted total_directories from ES query,
+      // causing totalDirectories=0 -> directoriesLeft=0 -> "No more directories"
+      expect(wrapper.find('.path-tree-view-entry-more').text()).toMatch(/Show \d+ of \d+ more director/)
+    })
+  })
+
   describe('Windows', () => {
     const { index, es } = esConnectionHelper.build('spec', true)
     let wrapper, core, searchStore


### PR DESCRIPTION
Related to https://github.com/ICIJ/datashare/issues/2129

In compact mode (filter column), total_directories was gated behind the !compact condition so it was never requested from ES. This left totalDirectories at 0, which caused PathTreeViewEntryMore to render "No more directories" instead of the correct count. 
Also fix perPage reference in the template (undefined variable → PER_PAGE constant).

AI disclaimer:
Writing tests to ensure the tests are covering the fix

in compact mode
<img width="274" height="397" alt="image" src="https://github.com/user-attachments/assets/67d27457-319d-480a-97cc-6972537747cb" />
in the modal 
<img width="794" height="281" alt="image" src="https://github.com/user-attachments/assets/1c7e6d8b-24c4-418c-85fe-fec39ae9b7a3" />
