### PR TITLE
fix : add autocomplete tags

### DIFF
--- a/src/components/Document/DocumentUser/DocumentUserTags/DocumentUserTags.vue
+++ b/src/components/Document/DocumentUser/DocumentUserTags/DocumentUserTags.vue
@@ -30,6 +30,14 @@ const emit = defineEmits(['delete', 'add'])
 const { t } = useI18n()
 const { isServer } = useMode()
 const tagsLabels = computed(() => tags.map(property('label')))
+
+const onActionUpdate = (newLabels) => {
+  // Compare the updated selection with current tags to emit only the needed add/delete actions.
+  const added = newLabels.filter(l => !tagsLabels.value.includes(l))
+  const removed = tagsLabels.value.filter(l => !newLabels.includes(l))
+  added.forEach(l => emit('add', [l]))
+  removed.forEach(l => emit('delete', l))
+}
 const allTagsLabels = computed(() => allTags.map(property('label')))
 const matchesUsername = computed(() => matchesProperty('user.id', username))
 const yourTags = computed(() => tags.filter(matchesUsername.value))
@@ -73,7 +81,7 @@ const count = computed(() => tags.length)
         :model-value="tagsLabels"
         :options="allTagsLabels"
         class="d-inline-flex"
-        @update:model-value="emit('add', $event)"
+        @update:model-value="onActionUpdate($event)"
       />
     </template>
   </document-user-actions-card>

--- a/src/components/Document/DocumentUser/DocumentUserTags/DocumentUserTags.vue
+++ b/src/components/Document/DocumentUser/DocumentUserTags/DocumentUserTags.vue
@@ -36,8 +36,8 @@ const yourTagsLabels = computed(() => yourTags.value.map(property('label')))
 
 const onActionUpdate = (newLabels) => {
   // Compare against the current user's own tags only to avoid emitting delete for other users' tags.
-  const added = newLabels.filter(l => !yourTagsLabels.value.includes(l))
-  const removed = yourTagsLabels.value.filter(l => !newLabels.includes(l))
+  const added = newLabels.filter(l => !yourTagsLabels.value.some(t => t.toLowerCase() === l.toLowerCase()))
+  const removed = yourTagsLabels.value.filter(l => !newLabels.some(t => t.toLowerCase() === l.toLowerCase()))
   if (added.length) emit('add', added)
   removed.forEach(l => emit('delete', l))
 }

--- a/src/components/Document/DocumentUser/DocumentUserTags/DocumentUserTags.vue
+++ b/src/components/Document/DocumentUser/DocumentUserTags/DocumentUserTags.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed } from 'vue'
-import { matchesProperty, negate, property } from 'lodash'
+import { matchesProperty, negate, property, uniq } from 'lodash'
 import { useI18n } from 'vue-i18n'
 
 import IPhHash from '~icons/ph/hash'
@@ -12,7 +12,7 @@ import DocumentUserTagsAction from '@/components/Document/DocumentUser/DocumentU
 
 defineOptions({ name: 'DocumentUserTags' })
 
-const { tags, allTags, username } = defineProps({
+const props = defineProps({
   tags: {
     type: Array,
     default: () => []
@@ -29,20 +29,30 @@ const { tags, allTags, username } = defineProps({
 const emit = defineEmits(['delete', 'add'])
 const { t } = useI18n()
 const { isServer } = useMode()
-const matchesUsername = computed(() => matchesProperty('user.id', username))
-const yourTags = computed(() => tags.filter(matchesUsername.value))
-const othersTags = computed(() => tags.filter(negate(matchesUsername.value)))
+const matchesUsername = computed(() => matchesProperty('user.id', props.username))
+const yourTags = computed(() => props.tags.filter(matchesUsername.value))
+const othersTags = computed(() => props.tags.filter(negate(matchesUsername.value)))
 const yourTagsLabels = computed(() => yourTags.value.map(property('label')))
+
+function uniqLowerLabels(labels) {
+  return uniq(labels)
+    .map(l => l.toLowerCase())
+}
 
 const onActionUpdate = (newLabels) => {
   // Compare against the current user's own tags only to avoid emitting delete for other users' tags.
-  const added = newLabels.filter(l => !yourTagsLabels.value.some(t => t.toLowerCase() === l.toLowerCase()))
-  const removed = yourTagsLabels.value.filter(l => !newLabels.some(t => t.toLowerCase() === l.toLowerCase()))
+  const uniqLabels = uniqLowerLabels(newLabels)
+  const currentLowerTags = props.tags.map(t => t.label.toLowerCase())
+  const added = uniqLabels.filter((_, index) => !currentLowerTags.includes(uniqLabels[index]))
+
+  const yourLowerTagsLabels = yourTagsLabels.value.map(l => l.toLowerCase())
+  const removed = yourTagsLabels.value.filter((l, index) => !uniqLabels.includes(yourLowerTagsLabels[index]))
+
   if (added.length) emit('add', added)
   removed.forEach(l => emit('delete', l))
 }
-const allTagsLabels = computed(() => allTags.map(property('label')))
-const count = computed(() => tags.length)
+const allTagsLabels = computed(() => props.allTags.map(property('label')))
+const count = computed(() => props.tags.length)
 </script>
 
 <template>

--- a/src/components/Document/DocumentUser/DocumentUserTags/DocumentUserTags.vue
+++ b/src/components/Document/DocumentUser/DocumentUserTags/DocumentUserTags.vue
@@ -29,19 +29,19 @@ const { tags, allTags, username } = defineProps({
 const emit = defineEmits(['delete', 'add'])
 const { t } = useI18n()
 const { isServer } = useMode()
-const tagsLabels = computed(() => tags.map(property('label')))
+const matchesUsername = computed(() => matchesProperty('user.id', username))
+const yourTags = computed(() => tags.filter(matchesUsername.value))
+const othersTags = computed(() => tags.filter(negate(matchesUsername.value)))
+const yourTagsLabels = computed(() => yourTags.value.map(property('label')))
 
 const onActionUpdate = (newLabels) => {
-  // Compare the updated selection with current tags to emit only the needed add/delete actions.
-  const added = newLabels.filter(l => !tagsLabels.value.includes(l))
-  const removed = tagsLabels.value.filter(l => !newLabels.includes(l))
+  // Compare against the current user's own tags only to avoid emitting delete for other users' tags.
+  const added = newLabels.filter(l => !yourTagsLabels.value.includes(l))
+  const removed = yourTagsLabels.value.filter(l => !newLabels.includes(l))
   added.forEach(l => emit('add', [l]))
   removed.forEach(l => emit('delete', l))
 }
 const allTagsLabels = computed(() => allTags.map(property('label')))
-const matchesUsername = computed(() => matchesProperty('user.id', username))
-const yourTags = computed(() => tags.filter(matchesUsername.value))
-const othersTags = computed(() => tags.filter(negate(matchesUsername.value)))
 const count = computed(() => tags.length)
 </script>
 
@@ -78,7 +78,7 @@ const count = computed(() => tags.length)
     </template>
     <template #action>
       <document-user-tags-action
-        :model-value="tagsLabels"
+        :model-value="yourTagsLabels"
         :options="allTagsLabels"
         class="d-inline-flex"
         @update:model-value="onActionUpdate($event)"

--- a/src/components/Document/DocumentUser/DocumentUserTags/DocumentUserTags.vue
+++ b/src/components/Document/DocumentUser/DocumentUserTags/DocumentUserTags.vue
@@ -38,7 +38,7 @@ const onActionUpdate = (newLabels) => {
   // Compare against the current user's own tags only to avoid emitting delete for other users' tags.
   const added = newLabels.filter(l => !yourTagsLabels.value.includes(l))
   const removed = yourTagsLabels.value.filter(l => !newLabels.includes(l))
-  added.forEach(l => emit('add', [l]))
+  if (added.length) emit('add', added)
   removed.forEach(l => emit('delete', l))
 }
 const allTagsLabels = computed(() => allTags.map(property('label')))
@@ -70,7 +70,6 @@ const count = computed(() => tags.length)
         v-for="{ label } in othersTags"
         :key="label"
         :label="label"
-        @delete="emit('delete', label)"
       />
     </template>
     <template #action-warning>

--- a/src/components/Document/DocumentUser/DocumentUserTags/DocumentUserTagsAction.vue
+++ b/src/components/Document/DocumentUser/DocumentUserTags/DocumentUserTagsAction.vue
@@ -24,7 +24,7 @@ const { t } = useI18n()
     v-model="modelValue"
     :disabled="disabled"
     :options="options"
-    class="document-user-tags-actions w-100"
+    class="document-user-tags-action w-100"
     autofocus
     no-duplicates
     no-tags

--- a/src/components/Form/FormControl/FormControlTag/FormControlTag.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTag.vue
@@ -84,6 +84,7 @@ const inputElement = useTemplateRef('inputElement')
 
 const inputValueTrigger = ref('')
 const showDropdown = ref(false)
+const hasFocus = ref(false)
 const focusIndex = ref(-1)
 
 const emit = defineEmits(['update:modelValue', 'update:inputValue', 'update:focusIndex', 'blur', 'focus'])
@@ -111,7 +112,8 @@ function focus() {
 }
 
 const onFocus = (e) => {
-  if (props.options?.length) showDropdown.value = true
+  hasFocus.value = true
+  if (props.options.length) showDropdown.value = true
   emit('focus', e)
 }
 
@@ -190,7 +192,13 @@ watch(inputValue, value => (inputValueTrigger.value = value), { immediate: true 
 watch(inputValueTrigger, value => emit('update:inputValue', value))
 
 watch(useActiveElement(), async (activeElement) => {
-  showDropdown.value = showDropdown.value && element.value.contains(activeElement)
+  const contained = element.value.contains(activeElement)
+  hasFocus.value = contained
+  showDropdown.value = showDropdown.value && contained
+})
+
+watch(() => props.options, (options) => {
+  if (hasFocus.value && options.length) showDropdown.value = true
 })
 
 watch(focusIndex, (value) => {

--- a/src/components/Form/FormControl/FormControlTag/FormControlTag.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTag.vue
@@ -150,7 +150,8 @@ const tagCreateValidator = (tag) => {
 }
 
 const removeTag = (tag) => {
-  const modelValue = props.modelValue.filter(t => t !== tag)
+  const lower = tag.toLowerCase()
+  const modelValue = props.modelValue.filter(t => t.toLowerCase() !== lower)
   emit('update:modelValue', modelValue)
   focus()
 }

--- a/src/components/Form/FormControl/FormControlTag/FormControlTag.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTag.vue
@@ -142,7 +142,7 @@ const tagValidator = (tag) => {
 }
 
 const tagDuplicatesValidator = (tag) => {
-  return !props.noDuplicates || !props.modelValue.includes(tag.toLowerCase())
+  return !props.noDuplicates || !props.modelValue.some(t => t.toLowerCase() === tag.toLowerCase())
 }
 
 const tagCreateValidator = (tag) => {
@@ -199,7 +199,7 @@ watch(useActiveElement(), async (activeElement) => {
 
 watch(() => props.options, (options) => {
   if (hasFocus.value && options.length) showDropdown.value = true
-})
+}, { deep: true })
 
 watch(focusIndex, (value) => {
   if (value === -1) {

--- a/src/components/Form/FormControl/FormControlTag/FormControlTag.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTag.vue
@@ -258,6 +258,7 @@ defineExpose({ focus })
       @update:focus-index="focusIndex = $event"
       @update:show="showDropdown = $event"
       @add-tag="addTag($event)"
+      @remove-tag="removeTag($event)"
       @keydown.esc="onEsc"
     />
   </div>

--- a/src/components/Form/FormControl/FormControlTag/FormControlTag.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTag.vue
@@ -196,9 +196,6 @@ watch(focusIndex, (value) => {
   if (value === -1) {
     focus()
   }
-  else {
-    showDropdown.value = !!inputValueTrigger.value
-  }
 })
 
 defineExpose({ focus })

--- a/src/components/Form/FormControl/FormControlTag/FormControlTag.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTag.vue
@@ -146,7 +146,7 @@ const tagDuplicatesValidator = (tag) => {
 }
 
 const tagCreateValidator = (tag) => {
-  return !props.noCreate || props.options.map(getValue).includes(tag)
+  return !props.noCreate || props.options.map(getValue).some(v => v.toLowerCase() === tag.toLowerCase())
 }
 
 const removeTag = (tag) => {
@@ -200,7 +200,7 @@ watch(useActiveElement(), async (activeElement) => {
 
 watch(() => props.options, (options) => {
   if (hasFocus.value && options.length) showDropdown.value = true
-}, { deep: true })
+})
 
 watch(focusIndex, (value) => {
   if (value === -1) {
@@ -208,7 +208,7 @@ watch(focusIndex, (value) => {
   }
 })
 
-defineExpose({ focus })
+defineExpose({ focus, showDropdown, hasFocus, onFocus, tagDuplicatesValidator, tagCreateValidator, classList })
 </script>
 
 <template>

--- a/src/components/Form/FormControl/FormControlTag/FormControlTag.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTag.vue
@@ -50,7 +50,8 @@ const props = defineProps({
     default: null
   },
   options: {
-    type: Array
+    type: Array,
+    default: () => []
   },
   searchKeys: {
     type: Array,

--- a/src/components/Form/FormControl/FormControlTag/FormControlTag.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTag.vue
@@ -109,6 +109,11 @@ function focus() {
   inputElement.value.focus()
 }
 
+const onFocus = (e) => {
+  if (props.options?.length) showDropdown.value = true
+  emit('focus', e)
+}
+
 const inputTag = (tag) => {
   focusIndex.value = -1
   inputValueTrigger.value = tag
@@ -228,7 +233,7 @@ defineExpose({ focus })
       @remove-last-tag="removeLastTag()"
       @keydown.down.prevent="focusIndex = 0"
       @keydown.esc="onEsc"
-      @focus="$emit('focus', $event)"
+      @focus="onFocus"
       @blur="$emit('blur', $event)"
     >
       <!-- eslint-disable-next-line vue/no-template-shadow -->

--- a/src/components/Form/FormControl/FormControlTag/FormControlTagDropdown.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTagDropdown.vue
@@ -49,7 +49,8 @@ const nextFocusIndex = computed(() => {
 })
 
 const hasOption = (option) => {
-  return modelValue.value.includes(getOptionValue(option))
+  const value = getOptionValue(option).toLowerCase()
+  return modelValue.value.some(v => v.toLowerCase() === value)
 }
 
 const getOptionValue = ({ item }) => {

--- a/src/components/Form/FormControl/FormControlTag/FormControlTagDropdown.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTagDropdown.vue
@@ -48,9 +48,13 @@ const nextFocusIndex = computed(() => {
   return Math.min(filteredOptions.value.length - 1, focusIndex.value + 1)
 })
 
+const modelValueLowercasedSet = computed(() => {
+  return new Set((modelValue.value || []).map(v => String(v).toLowerCase()))
+})
+
 const hasOption = (option) => {
-  const value = getOptionValue(option).toLowerCase()
-  return modelValue.value.some(v => v.toLowerCase() === value)
+  const value = String(getOptionValue(option)).toLowerCase()
+  return modelValueLowercasedSet.value.has(value)
 }
 
 const getOptionValue = ({ item }) => {

--- a/src/components/Form/FormControl/FormControlTag/FormControlTagDropdown.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTagDropdown.vue
@@ -26,7 +26,7 @@ const props = defineProps({
   },
   trackBy: {
     type: [String, Function],
-    default: identity
+    default: () => identity
   },
   limit: {
     type: Number,
@@ -63,6 +63,10 @@ const getValue = (value) => {
   return get(value, props.trackBy)
 }
 
+const availableOptions = computed(() => {
+  return [...props.options].sort((a, b) => String(getValue(a)).localeCompare(String(getValue(b))))
+})
+
 const filteredOptions = computed(() => {
   if (!props.inputValue) {
     return availableOptions.value.slice(0, props.limit).map(item => ({ item }))
@@ -70,25 +74,24 @@ const filteredOptions = computed(() => {
   return fuse.value.search(props.inputValue).slice(0, props.limit)
 })
 
-const availableOptions = computed(() => {
-  if (props.noDuplicates) {
-    return props.options.filter(option => !hasOption(option))
-  }
-  return props.options
-})
-
 const fuse = computed(() => {
   return new Fuse(availableOptions.value, {
     distance: 100,
+    threshold: 0.4,
     shouldSort: true,
     keys: props.searchKeys
   })
 })
 
-const emit = defineEmits(['addTag', 'update:show', 'update:tag'])
+const emit = defineEmits(['addTag', 'removeTag', 'update:show', 'update:tag'])
 
 const addOption = (option) => {
-  addTag(getOptionValue(option))
+  if (props.noDuplicates && hasOption(option)) {
+    emit('removeTag', getOptionValue(option))
+  }
+  else {
+    addTag(getOptionValue(option))
+  }
 }
 
 const addFocusOption = () => {

--- a/src/components/Form/FormControl/FormControlTag/FormControlTagDropdown.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTagDropdown.vue
@@ -83,7 +83,7 @@ const fuse = computed(() => {
   })
 })
 
-const emit = defineEmits(['addTag', 'removeTag', 'update:show', 'update:tag'])
+const emit = defineEmits(['addTag', 'removeTag', 'update:show'])
 
 const addOption = (option) => {
   if (props.noDuplicates && hasOption(option)) {
@@ -105,9 +105,7 @@ const addTag = (tag) => {
 }
 
 watch(filteredOptions, (filteredOptions) => {
-  if (props.inputValue) {
-    emit('update:show', !!filteredOptions.length)
-  }
+  emit('update:show', !!filteredOptions.length)
 })
 
 watch(

--- a/src/components/Form/FormControl/FormControlTag/FormControlTagDropdown.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTagDropdown.vue
@@ -106,7 +106,9 @@ const addTag = (tag) => {
 }
 
 watch(filteredOptions, (filteredOptions) => {
-  emit('update:show', !!filteredOptions.length)
+  if (props.inputValue || filteredOptions.length) {
+    emit('update:show', !!filteredOptions.length)
+  }
 })
 
 watch(

--- a/src/components/Form/FormControl/FormControlTag/FormControlTagDropdown.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTagDropdown.vue
@@ -64,6 +64,9 @@ const getValue = (value) => {
 }
 
 const filteredOptions = computed(() => {
+  if (!props.inputValue) {
+    return availableOptions.value.slice(0, props.limit).map(item => ({ item }))
+  }
   return fuse.value.search(props.inputValue).slice(0, props.limit)
 })
 
@@ -99,7 +102,9 @@ const addTag = (tag) => {
 }
 
 watch(filteredOptions, (filteredOptions) => {
-  emit('update:show', !!filteredOptions.length)
+  if (props.inputValue) {
+    emit('update:show', !!filteredOptions.length)
+  }
 })
 
 watch(

--- a/src/components/Form/FormControl/FormControlTag/FormControlTagDropdown.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTagDropdown.vue
@@ -105,10 +105,9 @@ const addTag = (tag) => {
   emit('addTag', tag)
 }
 
-watch(filteredOptions, (filteredOptions) => {
-  if (props.inputValue || filteredOptions.length) {
-    emit('update:show', !!filteredOptions.length)
-  }
+watch(filteredOptions, (newVal, oldVal) => {
+  if (!props.inputValue && !newVal.length && !oldVal.length) return
+  emit('update:show', !!newVal.length)
 })
 
 watch(

--- a/src/components/Form/FormControl/FormControlTag/FormControlTagDropdownItem.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTagDropdownItem.vue
@@ -32,6 +32,7 @@ defineProps({
 
 <style lang="scss" scoped>
 .form-control-tag-dropdown-item--active {
+  // Couples to Bootstrap's .dropdown-item and .form-check-input class names.
   :deep(.dropdown-item:hover .form-check-input) {
     --bs-form-check-bg-image: #{escape-svg($form-check-input-indeterminate-bg-image)};
     background-color: $form-check-input-indeterminate-bg-color;

--- a/src/components/Form/FormControl/FormControlTag/FormControlTagDropdownItem.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTagDropdownItem.vue
@@ -19,6 +19,7 @@ defineProps({
     :class="{ 'form-control-tag-dropdown-item--active': active }"
   >
     <slot v-bind="{ active, value, item }">
+      <!-- pe-none + tabindex="-1": purely decorative; interaction is handled by the parent b-dropdown-item -->
       <b-form-checkbox
         :model-value="active"
         class="pe-none"

--- a/src/components/Form/FormControl/FormControlTag/FormControlTagDropdownItem.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTagDropdownItem.vue
@@ -15,7 +15,13 @@ defineProps({
 <template>
   <b-dropdown-item :active="active">
     <slot v-bind="{ active, value, item }">
-      {{ value }}
+      <b-form-checkbox
+        :model-value="active"
+        class="pe-none"
+        tabindex="-1"
+      >
+        {{ value }}
+      </b-form-checkbox>
     </slot>
   </b-dropdown-item>
 </template>

--- a/src/components/Form/FormControl/FormControlTag/FormControlTagDropdownItem.vue
+++ b/src/components/Form/FormControl/FormControlTag/FormControlTagDropdownItem.vue
@@ -13,7 +13,11 @@ defineProps({
 </script>
 
 <template>
-  <b-dropdown-item :active="active">
+  <b-dropdown-item
+    :active="active"
+    class="form-control-tag-dropdown-item"
+    :class="{ 'form-control-tag-dropdown-item--active': active }"
+  >
     <slot v-bind="{ active, value, item }">
       <b-form-checkbox
         :model-value="active"
@@ -25,3 +29,13 @@ defineProps({
     </slot>
   </b-dropdown-item>
 </template>
+
+<style lang="scss" scoped>
+.form-control-tag-dropdown-item--active {
+  :deep(.dropdown-item:hover .form-check-input) {
+    --bs-form-check-bg-image: #{escape-svg($form-check-input-indeterminate-bg-image)};
+    background-color: $form-check-input-indeterminate-bg-color;
+    border-color: $form-check-input-indeterminate-border-color;
+  }
+}
+</style>

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -416,7 +416,8 @@
     "noTags": "No tags added yet."
   },
   "documentUserTagsAction": {
-    "placeholder": "Add tags"
+    "placeholder": "Add tags",
+    "addError": "Failed to add tags"
   },
   "documentMetadataActions": {
     "copy": "Copy metadata value",

--- a/src/views/Document/DocumentView/DocumentViewUserActions.vue
+++ b/src/views/Document/DocumentView/DocumentViewUserActions.vue
@@ -75,7 +75,7 @@ watch(() => document.value, async () => {
   if (document.value?.index) {
     allTags.value = await fetchAllTagsByIndex(document.value.index)
   }
-})
+}, { immediate: true })
 
 </script>
 

--- a/src/views/Document/DocumentView/DocumentViewUserActions.vue
+++ b/src/views/Document/DocumentView/DocumentViewUserActions.vue
@@ -56,8 +56,11 @@ const deleteTag = (label) => {
   return documentStore.deleteTag({ documents: [document.value], label })
 }
 
-const addTags = (labels) => {
-  return documentStore.addTags({ documents: [document.value], labels })
+const addTags = async (labels) => {
+  await documentStore.addTags({ documents: [document.value], labels })
+  // Keep the local tag suggestions in sync by appending only labels that are not already present.
+  const newLabels = labels.filter(l => !allTags.value.some(t => t.label === l))
+  allTags.value = [...allTags.value, ...newLabels.map(label => ({ label }))]
 }
 
 const { fetchAllTagsByIndex } = useElasticSearchQuery()

--- a/src/views/Document/DocumentView/DocumentViewUserActions.vue
+++ b/src/views/Document/DocumentView/DocumentViewUserActions.vue
@@ -1,10 +1,12 @@
 <script setup>
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import { useAuth } from '@/composables/useAuth'
 import { useMode } from '@/composables/useMode'
 import { useElementObserver } from '@/composables/useElementObserver'
 import { useElasticSearchQuery } from '@/composables/useElasticSearchQuery'
+import { useToast } from '@/composables/useToast'
 import { useDocument } from '@/composables/useDocument'
 import { DOCUMENT_USER_ACTIONS } from '@/enums/documentUserActions'
 import DocumentUserActions from '@/components/Document/DocumentUser/DocumentUserActions/DocumentUserActions'
@@ -23,6 +25,8 @@ defineProps({
 const recommendedStore = useRecommendedStore()
 const documentStore = useDocumentStore()
 const { document, documentViewFloatingSelector } = useDocument()
+const { t } = useI18n()
+const { toastedPromise } = useToast()
 const { username } = useAuth()
 const { isServer } = useMode()
 const { waitForElementCreated } = useElementObserver()
@@ -58,9 +62,10 @@ const deleteTag = (label) => {
 
 const addTags = async (labels) => {
   try {
-    await documentStore.addTags({ documents: [document.value], labels })
-  }
-  catch {
+    await toastedPromise(documentStore.addTags({ documents: [document.value], labels }), {
+      errorMessage: t('documentUserTagsAction.addError')
+    })
+  } catch {
     return
   }
   // Keep the local tag suggestions in sync by appending only labels that are not already present.

--- a/src/views/Document/DocumentView/DocumentViewUserActions.vue
+++ b/src/views/Document/DocumentView/DocumentViewUserActions.vue
@@ -65,11 +65,12 @@ const addTags = async (labels) => {
     await toastedPromise(documentStore.addTags({ documents: [document.value], labels }), {
       errorMessage: t('documentUserTagsAction.addError')
     })
-  } catch {
+  }
+  catch {
     return
   }
   // Keep the local tag suggestions in sync by appending only labels that are not already present.
-  const newLabels = labels.filter(l => !allTags.value.some(t => t.label === l))
+  const newLabels = labels.filter(l => !allTags.value.some(t => t.label.toLowerCase() === l.toLowerCase()))
   allTags.value = [...allTags.value, ...newLabels.map(label => ({ label }))]
 }
 

--- a/src/views/Document/DocumentView/DocumentViewUserActions.vue
+++ b/src/views/Document/DocumentView/DocumentViewUserActions.vue
@@ -57,7 +57,12 @@ const deleteTag = (label) => {
 }
 
 const addTags = async (labels) => {
-  await documentStore.addTags({ documents: [document.value], labels })
+  try {
+    await documentStore.addTags({ documents: [document.value], labels })
+  }
+  catch {
+    return
+  }
   // Keep the local tag suggestions in sync by appending only labels that are not already present.
   const newLabels = labels.filter(l => !allTags.value.some(t => t.label === l))
   allTags.value = [...allTags.value, ...newLabels.map(label => ({ label }))]

--- a/tests/unit/specs/components/Document/DocumentUser/DocumentUserTags.spec.js
+++ b/tests/unit/specs/components/Document/DocumentUser/DocumentUserTags.spec.js
@@ -6,7 +6,7 @@ import DocumentUserTags from '@/components/Document/DocumentUser/DocumentUserTag
 describe('DocumentUserTags', () => {
   let plugins
 
-  beforeAll(() => {
+  beforeEach(() => {
     const core = CoreSetup.init().useAll()
     plugins = core.plugins
   })
@@ -40,5 +40,24 @@ describe('DocumentUserTags', () => {
 
     expect(wrapper.emitted('add')?.[0]).toEqual([['tag3']])
     expect(wrapper.emitted('delete')).toBeFalsy()
+  })
+
+  it('should not emit delete for a tag owned by another user', async () => {
+    const mixedTags = [
+      { label: 'my-tag', user: { id: 'user1' } },
+      { label: 'other-tag', user: { id: 'user2' } }
+    ]
+    const wrapper = mount(DocumentUserTags, {
+      global: { plugins },
+      props: { tags: mixedTags, username: 'user1' }
+    })
+
+    const action = wrapper.findComponent({ name: 'DocumentUserTagsAction' })
+    // Model value only reflects user1's tags; clicking away from my-tag removes it,
+    // but other-tag was never in the model so it should not be deleted.
+    await action.vm.$emit('update:modelValue', [])
+
+    expect(wrapper.emitted('delete')).toEqual([['my-tag']])
+    expect(wrapper.emitted('delete')?.flat()).not.toContain('other-tag')
   })
 })

--- a/tests/unit/specs/components/Document/DocumentUser/DocumentUserTags.spec.js
+++ b/tests/unit/specs/components/Document/DocumentUser/DocumentUserTags.spec.js
@@ -58,6 +58,5 @@ describe('DocumentUserTags', () => {
     await action.vm.$emit('update:modelValue', [])
 
     expect(wrapper.emitted('delete')).toEqual([['my-tag']])
-    expect(wrapper.emitted('delete')?.flat()).not.toContain('other-tag')
   })
 })

--- a/tests/unit/specs/components/Document/DocumentUser/DocumentUserTags.spec.js
+++ b/tests/unit/specs/components/Document/DocumentUser/DocumentUserTags.spec.js
@@ -1,0 +1,44 @@
+import { mount } from '@vue/test-utils'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import DocumentUserTags from '@/components/Document/DocumentUser/DocumentUserTags/DocumentUserTags'
+
+describe('DocumentUserTags', () => {
+  let plugins
+
+  beforeAll(() => {
+    const core = CoreSetup.init().useAll()
+    plugins = core.plugins
+  })
+
+  const tags = [
+    { label: 'tag1', user: { id: 'user1' } },
+    { label: 'tag2', user: { id: 'user1' } }
+  ]
+
+  it('should emit delete when a tag is removed via the action input', async () => {
+    const wrapper = mount(DocumentUserTags, {
+      global: { plugins },
+      props: { tags, username: 'user1' }
+    })
+
+    const action = wrapper.findComponent({ name: 'DocumentUserTagsAction' })
+    await action.vm.$emit('update:modelValue', ['tag2'])
+
+    expect(wrapper.emitted('delete')?.[0]).toEqual(['tag1'])
+    expect(wrapper.emitted('add')).toBeFalsy()
+  })
+
+  it('should emit add when a new tag is added via the action input', async () => {
+    const wrapper = mount(DocumentUserTags, {
+      global: { plugins },
+      props: { tags, username: 'user1' }
+    })
+
+    const action = wrapper.findComponent({ name: 'DocumentUserTagsAction' })
+    await action.vm.$emit('update:modelValue', ['tag1', 'tag2', 'tag3'])
+
+    expect(wrapper.emitted('add')?.[0]).toEqual([['tag3']])
+    expect(wrapper.emitted('delete')).toBeFalsy()
+  })
+})

--- a/tests/unit/specs/components/Document/DocumentUser/DocumentUserTags.spec.js
+++ b/tests/unit/specs/components/Document/DocumentUser/DocumentUserTags.spec.js
@@ -59,4 +59,33 @@ describe('DocumentUserTags', () => {
 
     expect(wrapper.emitted('delete')).toEqual([['my-tag']])
   })
+
+  it('should not emit add for duplicate tags added by mistake', async () => {
+    const wrapper = mount(DocumentUserTags, {
+      global: { plugins },
+      props: { tags, username: 'user1' }
+    })
+
+    const action = wrapper.findComponent({ name: 'DocumentUserTagsAction' })
+    // 'tag1' is already there, 'tag3' is added twice
+    await action.vm.$emit('update:modelValue', ['tag1', 'tag2', 'tag1', 'tag3', 'tag3'])
+
+    expect(wrapper.emitted('add')?.[0]).toEqual([['tag3']])
+    expect(wrapper.emitted('delete')).toBeFalsy()
+  })
+
+  it('should handle invalid tags prop gracefully', () => {
+    const invalidTags = [
+      { label: 'valid', user: { id: 'user1' } },
+      { label: 'invalid-no-user' },
+      null,
+      { label: 'invalid-user-null', user: null }
+    ]
+    const wrapper = mount(DocumentUserTags, {
+      global: { plugins },
+      props: { tags: invalidTags, username: 'user1' }
+    })
+
+    expect(wrapper.vm.yourTags).toEqual([{ label: 'valid', user: { id: 'user1' } }])
+  })
 })

--- a/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControlTagDropdown.spec.js
+++ b/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControlTagDropdown.spec.js
@@ -22,15 +22,6 @@ describe('FormControlTagDropdown', () => {
     expect(wrapper.vm.filteredOptions.map(o => o.item)).toEqual([...options].sort())
   })
 
-  it('shows all options when input is empty', () => {
-    const wrapper = mount(FormControlTagDropdown, {
-      global: { plugins },
-      props: { options, modelValue: [], inputValue: '', show: true }
-    })
-
-    expect(wrapper.vm.filteredOptions.map(o => o.item)).toEqual([...options].sort())
-  })
-
   it('filters options by the typed input value', async () => {
     const wrapper = mount(FormControlTagDropdown, {
       global: { plugins },

--- a/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControlTagDropdown.spec.js
+++ b/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControlTagDropdown.spec.js
@@ -1,0 +1,66 @@
+import { mount } from '@vue/test-utils'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import FormControlTagDropdown from '@/components/Form/FormControl/FormControlTag/FormControlTagDropdown'
+
+describe('FormControlTagDropdown', () => {
+  let plugins
+
+  beforeAll(() => {
+    const core = CoreSetup.init().useAll()
+    plugins = core.plugins
+  })
+
+  const options = ['apple', 'banana', 'apricot', 'cherry']
+
+  it('shows all options sorted alphabetically when input is empty', () => {
+    const wrapper = mount(FormControlTagDropdown, {
+      global: { plugins },
+      props: { options, modelValue: [], inputValue: '', show: true }
+    })
+
+    expect(wrapper.vm.filteredOptions.map(o => o.item)).toEqual([...options].sort())
+  })
+
+  it('shows all options when input is empty', () => {
+    const wrapper = mount(FormControlTagDropdown, {
+      global: { plugins },
+      props: { options, modelValue: [], inputValue: '', show: true }
+    })
+
+    expect(wrapper.vm.filteredOptions.map(o => o.item)).toEqual([...options].sort())
+  })
+
+  it('filters options by the typed input value', async () => {
+    const wrapper = mount(FormControlTagDropdown, {
+      global: { plugins },
+      props: { options, modelValue: [], inputValue: 'ap', show: true }
+    })
+
+    const items = wrapper.vm.filteredOptions.map(o => o.item)
+    expect(items).toContain('apple')
+    expect(items).toContain('apricot')
+    expect(items).not.toContain('banana')
+    expect(items).not.toContain('cherry')
+  })
+
+  it('emits update:show true when typed input has matching options', async () => {
+    const wrapper = mount(FormControlTagDropdown, {
+      global: { plugins },
+      props: { options, modelValue: [], inputValue: '', show: true }
+    })
+
+    await wrapper.setProps({ inputValue: 'ap' })
+    expect(wrapper.emitted('update:show')?.at(-1)).toEqual([true])
+  })
+
+  it('emits update:show false when typed input has no matching options', async () => {
+    const wrapper = mount(FormControlTagDropdown, {
+      global: { plugins },
+      props: { options, modelValue: [], inputValue: '', show: true }
+    })
+
+    await wrapper.setProps({ inputValue: 'zzz' })
+    expect(wrapper.emitted('update:show')?.at(-1)).toEqual([false])
+  })
+})

--- a/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControlTagDropdown.spec.js
+++ b/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControlTagDropdown.spec.js
@@ -6,7 +6,7 @@ import FormControlTagDropdown from '@/components/Form/FormControl/FormControlTag
 describe('FormControlTagDropdown', () => {
   let plugins
 
-  beforeAll(() => {
+  beforeEach(() => {
     const core = CoreSetup.init().useAll()
     plugins = core.plugins
   })

--- a/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControlTagDropdown.spec.js
+++ b/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControlTagDropdown.spec.js
@@ -84,4 +84,14 @@ describe('FormControlTagDropdown', () => {
     const items = wrapper.vm.filteredOptions.map(o => o.item)
     expect(items).toContain('apple')
   })
+
+  it('marks an option as active regardless of case', () => {
+    const wrapper = mount(FormControlTagDropdown, {
+      global: { plugins },
+      props: { options, modelValue: ['APPLE'], inputValue: '', show: true }
+    })
+
+    const appleOption = wrapper.vm.filteredOptions.find(o => o.item === 'apple')
+    expect(wrapper.vm.hasOption(appleOption)).toBe(true)
+  })
 })

--- a/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControlTagDropdown.spec.js
+++ b/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControlTagDropdown.spec.js
@@ -74,4 +74,14 @@ describe('FormControlTagDropdown', () => {
     const items = wrapper.vm.filteredOptions.map(o => o.item)
     expect(items).toContain('apple')
   })
+
+  it('includes already-selected options in Fuse search results with noDuplicates', async () => {
+    const wrapper = mount(FormControlTagDropdown, {
+      global: { plugins },
+      props: { options, modelValue: ['apple'], inputValue: 'ap', show: true, noDuplicates: true }
+    })
+
+    const items = wrapper.vm.filteredOptions.map(o => o.item)
+    expect(items).toContain('apple')
+  })
 })

--- a/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControlTagDropdown.spec.js
+++ b/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControlTagDropdown.spec.js
@@ -54,4 +54,24 @@ describe('FormControlTagDropdown', () => {
     await wrapper.setProps({ inputValue: 'zzz' })
     expect(wrapper.emitted('update:show')?.at(-1)).toEqual([false])
   })
+
+  it('emits update:show true when input is cleared after a no-match search', async () => {
+    const wrapper = mount(FormControlTagDropdown, {
+      global: { plugins },
+      props: { options, modelValue: [], inputValue: 'zzz', show: false }
+    })
+
+    await wrapper.setProps({ inputValue: '' })
+    expect(wrapper.emitted('update:show')?.at(-1)).toEqual([true])
+  })
+
+  it('includes already-selected options in filteredOptions when input is empty', () => {
+    const wrapper = mount(FormControlTagDropdown, {
+      global: { plugins },
+      props: { options, modelValue: ['apple'], inputValue: '', show: true, noDuplicates: true }
+    })
+
+    const items = wrapper.vm.filteredOptions.map(o => o.item)
+    expect(items).toContain('apple')
+  })
 })

--- a/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControltag.spec.js
+++ b/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControltag.spec.js
@@ -122,6 +122,24 @@ describe('FormControlTag', () => {
     expect(wrapper.vm.tagValidator('invalidTag')).toBeFalsy()
   })
 
+  it('should remove a tag when an active dropdown option is clicked', async () => {
+    const wrapper = mount(FormControlTag, {
+      global: { plugins },
+      props: {
+        modelValue: ['tag1', 'tag2'],
+        options: ['tag1', 'tag2', 'tag3'],
+        noDuplicates: true,
+        inputValue: ''
+      }
+    })
+
+    wrapper.vm.showDropdown = true
+    await wrapper.vm.$nextTick()
+    const dropdown = wrapper.findComponent({ name: 'FormControlTagDropdown' })
+    await dropdown.vm.addOption({ item: 'tag1' })
+    expect(wrapper.emitted()['update:modelValue'][0]).toEqual([['tag2']])
+  })
+
   it('should compute class list correctly', async () => {
     const wrapper = mount(FormControlTag, {
       global: {

--- a/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControltag.spec.js
+++ b/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControltag.spec.js
@@ -6,7 +6,7 @@ import FormControlTag from '@/components/Form/FormControl/FormControlTag/FormCon
 describe('FormControlTag', () => {
   let plugins
 
-  beforeAll(() => {
+  beforeEach(() => {
     const core = CoreSetup.init().useAll()
     plugins = core.plugins
   })
@@ -171,5 +171,26 @@ describe('FormControlTag', () => {
     wrapper.vm.hasFocus = true
     await wrapper.setProps({ options: ['tag1', 'tag2'] })
     expect(wrapper.vm.showDropdown).toBe(true)
+  })
+
+  it('should not open the dropdown on focus when options are empty', async () => {
+    const wrapper = mount(FormControlTag, {
+      global: { plugins },
+      props: { modelValue: [], options: [] }
+    })
+
+    await wrapper.vm.onFocus(new Event('focus'))
+    expect(wrapper.vm.showDropdown).toBe(false)
+  })
+
+  it('should reject a duplicate tag regardless of case', () => {
+    const wrapper = mount(FormControlTag, {
+      global: { plugins },
+      props: { modelValue: ['TAG1'], options: [], noDuplicates: true }
+    })
+
+    expect(wrapper.vm.tagDuplicatesValidator('tag1')).toBe(false)
+    expect(wrapper.vm.tagDuplicatesValidator('Tag1')).toBe(false)
+    expect(wrapper.vm.tagDuplicatesValidator('tag2')).toBe(true)
   })
 })

--- a/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControltag.spec.js
+++ b/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControltag.spec.js
@@ -151,4 +151,25 @@ describe('FormControlTag', () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.classList).toEqual({ 'form-control-tag--show-dropdown': true })
   })
+
+  it('should open the dropdown on focus when options are available', async () => {
+    const wrapper = mount(FormControlTag, {
+      global: { plugins },
+      props: { modelValue: [], options: ['tag1', 'tag2'] }
+    })
+
+    await wrapper.vm.onFocus(new Event('focus'))
+    expect(wrapper.vm.showDropdown).toBe(true)
+  })
+
+  it('should open the dropdown when options arrive after focus', async () => {
+    const wrapper = mount(FormControlTag, {
+      global: { plugins },
+      props: { modelValue: [], options: [] }
+    })
+
+    wrapper.vm.hasFocus = true
+    await wrapper.setProps({ options: ['tag1', 'tag2'] })
+    expect(wrapper.vm.showDropdown).toBe(true)
+  })
 })

--- a/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControltag.spec.js
+++ b/tests/unit/specs/components/Form/FormControl/FormControlTag/FormControltag.spec.js
@@ -193,4 +193,15 @@ describe('FormControlTag', () => {
     expect(wrapper.vm.tagDuplicatesValidator('Tag1')).toBe(false)
     expect(wrapper.vm.tagDuplicatesValidator('tag2')).toBe(true)
   })
+
+  it('should accept a tag that matches an option regardless of case when noCreate is set', () => {
+    const wrapper = mount(FormControlTag, {
+      global: { plugins },
+      props: { modelValue: [], options: ['Tag1', 'tag2'], noCreate: true }
+    })
+
+    expect(wrapper.vm.tagCreateValidator('TAG1')).toBe(true)
+    expect(wrapper.vm.tagCreateValidator('TAG2')).toBe(true)
+    expect(wrapper.vm.tagCreateValidator('tag3')).toBe(false)
+  })
 })

--- a/tests/unit/specs/views/Document/DocumentView/DocumentViewUserActions.spec.js
+++ b/tests/unit/specs/views/Document/DocumentView/DocumentViewUserActions.spec.js
@@ -61,4 +61,27 @@ describe('DocumentViewUserActions', () => {
 
     expect(fetchAllTagsByIndex).not.toHaveBeenCalled()
   })
+
+  it('calls fetchAllTagsByIndex immediately on mount when document is set', async () => {
+    shallowMount(DocumentViewUserActions, {
+      global: { plugins }
+    })
+
+    await flushPromises()
+
+    expect(fetchAllTagsByIndex).toHaveBeenCalledWith('test-index')
+  })
+
+  it('does not add labels to allTags when the store call fails', async () => {
+    vi.spyOn(documentStore, 'addTags').mockRejectedValue(new Error('network error'))
+
+    const wrapper = shallowMount(DocumentViewUserActions, {
+      global: { plugins }
+    })
+
+    await wrapper.vm.addTags(['failed-tag'])
+    await flushPromises()
+
+    expect(wrapper.vm.allTags.some(t => t.label === 'failed-tag')).toBe(false)
+  })
 })

--- a/tests/unit/specs/views/Document/DocumentView/DocumentViewUserActions.spec.js
+++ b/tests/unit/specs/views/Document/DocumentView/DocumentViewUserActions.spec.js
@@ -1,0 +1,64 @@
+import { shallowMount, flushPromises } from '@vue/test-utils'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import DocumentViewUserActions from '@/views/Document/DocumentView/DocumentViewUserActions'
+import { useDocumentStore } from '@/store/modules'
+
+const fetchAllTagsByIndex = vi.fn().mockResolvedValue([])
+
+vi.mock('@/composables/useElasticSearchQuery', () => ({
+  useElasticSearchQuery: () => ({ fetchAllTagsByIndex })
+}))
+
+vi.mock('@/composables/useElementObserver', () => ({
+  useElementObserver: () => ({ waitForElementCreated: vi.fn().mockResolvedValue(null) })
+}))
+
+describe('DocumentViewUserActions', () => {
+  let plugins, documentStore
+
+  beforeEach(() => {
+    fetchAllTagsByIndex.mockClear()
+    const core = CoreSetup.init().useAll()
+    plugins = core.plugins
+    documentStore = useDocumentStore()
+    vi.spyOn(documentStore, 'addTags').mockResolvedValue()
+    vi.spyOn(documentStore, 'deleteTag').mockResolvedValue()
+    documentStore.setDocument({ _id: 'doc1', _index: 'test-index' })
+  })
+
+  it('adds new labels to allTags after the store call completes', async () => {
+    const wrapper = shallowMount(DocumentViewUserActions, {
+      global: { plugins }
+    })
+
+    await wrapper.vm.addTags(['brand-new-tag'])
+    await flushPromises()
+
+    expect(wrapper.vm.allTags.some(t => t.label === 'brand-new-tag')).toBe(true)
+  })
+
+  it('does not add duplicate labels to allTags', async () => {
+    const wrapper = shallowMount(DocumentViewUserActions, {
+      global: { plugins }
+    })
+
+    wrapper.vm.allTags = [{ label: 'existing-tag' }]
+    await wrapper.vm.addTags(['existing-tag'])
+    await flushPromises()
+
+    expect(wrapper.vm.allTags.filter(t => t.label === 'existing-tag').length).toBe(1)
+  })
+
+  it('does not refresh allTags after deleting a tag', async () => {
+    const wrapper = shallowMount(DocumentViewUserActions, {
+      global: { plugins }
+    })
+
+    fetchAllTagsByIndex.mockClear()
+    await wrapper.vm.deleteTag('old-tag')
+    await flushPromises()
+
+    expect(fetchAllTagsByIndex).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/specs/views/Document/DocumentView/DocumentViewUserActions.spec.js
+++ b/tests/unit/specs/views/Document/DocumentView/DocumentViewUserActions.spec.js
@@ -50,6 +50,18 @@ describe('DocumentViewUserActions', () => {
     expect(wrapper.vm.allTags.filter(t => t.label === 'existing-tag').length).toBe(1)
   })
 
+  it('does not add a label to allTags when it already exists with different casing', async () => {
+    const wrapper = shallowMount(DocumentViewUserActions, {
+      global: { plugins }
+    })
+
+    wrapper.vm.allTags = [{ label: 'existing-tag' }]
+    await wrapper.vm.addTags(['EXISTING-TAG'])
+    await flushPromises()
+
+    expect(wrapper.vm.allTags.length).toBe(1)
+  })
+
   it('does not refresh allTags after deleting a tag', async () => {
     const wrapper = shallowMount(DocumentViewUserActions, {
       global: { plugins }


### PR DESCRIPTION
## Summary

This PR improves tag handling across document user tags and the tag form control, with a focus on case-insensitive behavior, dropdown reliability, and safer user-tag actions. It fixes ICIJ/datashare#2137

## Changes

- Make tag matching, creation, deletion, and duplicate detection consistently **case-insensitive**.
- Scope document tag actions to the current user’s own tags to avoid deleting or updating tags owned by other users.
- Prevent duplicate tags from being added when labels differ only by casing.
- Batch new tag additions into a single emit instead of emitting once per tag.
- Update local `allTags` only after successful store updates, and show an error toast when adding tags fails.
- Improve dropdown behavior:
  - Open when async options arrive after the input is focused.
  - Reopen when the input is cleared.
  - Avoid suppressing the dropdown while options are still loading.
  - Close the dropdown when options are cleared while it is open.
- Add an indeterminate hover state on checked tag items to better indicate “click to remove”.
- Add and update unit tests covering duplicate handling, invalid props, case-insensitive behavior, dropdown interactions, and failure scenarios.
- Add comments documenting styling/class coupling where relevant.

## Testing

Unit test coverage was added or updated for:

- `DocumentUserTags`
- `FormControlTag`
- `FormControlTagDropdown`
- `DocumentViewUserActions`

These tests cover case-insensitive deduplication, invalid tag handling, dropdown state changes, scoped user tag updates, and store failure behavior.

[Screencast from 2026-04-30 15-30-44.webm](https://github.com/user-attachments/assets/13dd2334-2734-4aaa-b81d-fdfca9ce707f)
