### PR TITLE
fix: show error modal on batch search failure status click 

### DIFF
--- a/src/composables/useBatchSearchErrorModal.js
+++ b/src/composables/useBatchSearchErrorModal.js
@@ -9,12 +9,14 @@ export function useBatchSearchErrorModal() {
   function show({ errorMessage, errorQuery } = {}) {
     return new Promise((resolve) => {
       const component = h(BatchSearchErrorModal, {
+        errorMessage,
+        errorQuery,
         onOk: resolve,
         onClose: resolve,
         onCancel: resolve
       })
 
-      create({ component, errorMessage, errorQuery }).show()
+      create({ component, modelValue: true }).show()
     })
   }
 

--- a/src/views/Task/TaskBatchSearch/TaskBatchSearchList.vue
+++ b/src/views/Task/TaskBatchSearch/TaskBatchSearchList.vue
@@ -16,6 +16,7 @@ import RouterLinkBatchSearch from '@/components/RouterLink/RouterLinkBatchSearch
 import RowPaginationBatchSearches from '@/components/RowPagination/RowPaginationBatchSearches'
 import { useTaskSettings } from '@/composables/useTaskSettings'
 import { useAuth } from '@/composables/useAuth'
+import { useBatchSearchErrorModal } from '@/composables/useBatchSearchErrorModal.js'
 import { TASK_NAME } from '@/enums/taskNames'
 import TaskPage from '@/views/Task/TaskPage'
 import TaskStatus from '@/views/Task/TaskStatus.vue'
@@ -23,9 +24,16 @@ import TaskStatus from '@/views/Task/TaskStatus.vue'
 const { t } = useI18n()
 const { propertiesModelValueOptions } = useTaskSettings('batch-search')
 const { username } = useAuth()
+const { show: showBatchSearchErrorModal } = useBatchSearchErrorModal()
 
 function getBatchSearchRecord(item, key, defaultValue = null) {
   return get(item, ['args', 'batchRecord', key].join('.'), defaultValue)
+}
+
+function showError(item) {
+  const errorMessage = getBatchSearchRecord(item, 'errorMessage') ?? item.error?.message ?? null
+  const errorQuery = getBatchSearchRecord(item, 'errorQuery') ?? null
+  showBatchSearchErrorModal({ errorMessage, errorQuery })
 }
 
 function getBatchSearchResult(item, defaultValue = 0) {
@@ -85,7 +93,11 @@ function canManageBatchSearch(item) {
           </p>
         </template>
         <template #cell(state)="{ item }">
-          <task-status :status="item.state" />
+          <task-status
+            :status="item.state"
+            with-click
+            @error="showError(item)"
+          />
         </template>
         <template #cell(privacy)="{ item }">
           <display-visibility :value="getBatchSearchRecord(item, 'published')" />

--- a/tests/unit/specs/composables/useBatchSearchErrorModal.spec.js
+++ b/tests/unit/specs/composables/useBatchSearchErrorModal.spec.js
@@ -1,0 +1,43 @@
+import { mount } from '@vue/test-utils'
+
+import BatchSearchErrorModal from '@/components/BatchSearch/BatchSearchErrorModal'
+import { useBatchSearchErrorModal } from '@/composables/useBatchSearchErrorModal'
+
+const showMock = vi.fn()
+const createMock = vi.fn(() => ({ show: showMock }))
+
+vi.mock('bootstrap-vue-next', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, useModal: () => ({ create: createMock, hide: vi.fn() }) }
+})
+
+describe('useBatchSearchErrorModal', () => {
+  beforeEach(() => {
+    createMock.mockClear()
+    showMock.mockClear()
+  })
+
+  function mountComposable() {
+    let composable
+    mount({ setup() {
+      composable = useBatchSearchErrorModal()
+      return {}
+    },
+    template: '<div />' })
+    return composable
+  }
+
+  it('calls create() with modelValue: true so the modal is visible on open', () => {
+    const { show } = mountComposable()
+    show({ errorMessage: 'oops', errorQuery: 'bad query' })
+    expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ modelValue: true }))
+  })
+
+  it('passes errorMessage and errorQuery as props to BatchSearchErrorModal', () => {
+    const { show } = mountComposable()
+    show({ errorMessage: 'oops', errorQuery: 'bad query' })
+    const { component } = createMock.mock.calls[0][0]
+    expect(component.type).toBe(BatchSearchErrorModal)
+    expect(component.props).toMatchObject({ errorMessage: 'oops', errorQuery: 'bad query' })
+  })
+})

--- a/tests/unit/specs/views/Task/TaskBatchSearch/TaskBatchSearchList.spec.js
+++ b/tests/unit/specs/views/Task/TaskBatchSearch/TaskBatchSearchList.spec.js
@@ -4,6 +4,11 @@ import { flushPromises, mount } from '@vue/test-utils'
 import CoreSetup from '~tests/unit/CoreSetup'
 import TaskBatchSearchList from '@/views/Task/TaskBatchSearch/TaskBatchSearchList'
 
+const showBatchSearchErrorModalMock = vi.fn()
+vi.mock('@/composables/useBatchSearchErrorModal.js', () => ({
+  useBatchSearchErrorModal: () => ({ show: showBatchSearchErrorModalMock, hide: vi.fn() })
+}))
+
 vi.mock('@/api/apiInstance', () => {
   return {
     apiInstance: {
@@ -98,6 +103,7 @@ describe('TaskBatchSearchList', () => {
   beforeEach(async () => {
     const core = CoreSetup.init().useAll().useRouterWithoutGuards()
     plugins = core.plugins
+    showBatchSearchErrorModalMock.mockReset()
   })
 
   afterAll(() => {
@@ -118,5 +124,47 @@ describe('TaskBatchSearchList', () => {
     const rows = wrapper.findAll('.page-table-generic__row')
     expect(rows.at(0).find('.batch-search-actions').exists()).toBe(true)
     expect(rows.at(1).find('.batch-search-actions').exists()).toBe(false)
+  })
+
+  it('should open the error modal with errorMessage and errorQuery when clicking a failure status', async () => {
+    const { apiInstance } = await import('@/api/apiInstance')
+    vi.mocked(apiInstance.getTasks).mockResolvedValueOnce({
+      items: [
+        {
+          id: 'failure-id',
+          name: 'org.icij.datashare.tasks.BatchSearchRunner',
+          state: 'FAILURE',
+          progress: 0,
+          createdAt: '2025-03-06T06:47:19.857+00:00',
+          args: {
+            batchRecord: {
+              uuid: 'failure-id',
+              projects: ['local-datashare'],
+              name: 'failed batch',
+              description: '',
+              nbQueries: 1,
+              date: '2025-03-06T06:47:19.820+00:00',
+              state: 'FAILURE',
+              user: { id: 'local', name: null, email: null, provider: 'local' },
+              nbResults: 0,
+              published: false,
+              errorMessage: 'Something went wrong',
+              errorQuery: 'bad query'
+            },
+            user: { id: 'local' }
+          }
+        }
+      ]
+    })
+
+    const wrapper = mount(TaskBatchSearchList, { global: { plugins } })
+    await flushPromises()
+
+    await wrapper.find('.page-table-generic__row button').trigger('click')
+
+    expect(showBatchSearchErrorModalMock).toHaveBeenCalledWith({
+      errorMessage: 'Something went wrong',
+      errorQuery: 'bad query'
+    })
   })
 })


### PR DESCRIPTION
related to https://github.com/ICIJ/datashare/issues/2154

Fix batch search error modal not displaying when clicking a failed status in the list.

- `TaskBatchSearchList`: add `with-click` + `@error` handler on the status cell, wired to `useBatchSearchErrorModal` - the click was silently swallowed before
- `useBatchSearchErrorModal`: pass `errorMessage`/`errorQuery` as VNode props (via `h()`) and `modelValue: true` to `create()`, matching the pattern used by every other modal composable in the codebase

[Screencast from 2026-05-27 11-30-25.webm](https://github.com/user-attachments/assets/11fc478d-ed52-4477-973a-bd575ba8d736)
