### PR TITLE
feat: async search

### DIFF
--- a/src/api/asyncSearch.js
+++ b/src/api/asyncSearch.js
@@ -78,8 +78,26 @@ export async function runAsyncSearch(client, { index, body }, options = {}) {
     maxWait = cfg.maxWait
   } = options
 
+  // Runs an async-search request, converting an abort-triggered rejection (the
+  // forwarded signal cancels the in-flight HTTP request) into a clean AbortError
+  // and freeing any stored result, so the caller can treat it as a cancellation.
+  const requestOrAbort = async (request, id) => {
+    try {
+      return await request()
+    }
+    catch (error) {
+      if (signal?.aborted) {
+        cleanup(client, id)
+        throw createAbortError()
+      }
+      throw error
+    }
+  }
+
   const start = Date.now()
-  let envelope = await client.submitAsyncSearch({ index, body, waitForCompletionTimeout, keepAlive })
+  let envelope = await requestOrAbort(
+    () => client.submitAsyncSearch({ index, body, waitForCompletionTimeout, keepAlive, signal })
+  )
 
   while (envelope.is_running) {
     if (signal?.aborted) {
@@ -95,7 +113,11 @@ export async function runAsyncSearch(client, { index, body }, options = {}) {
       cleanup(client, envelope.id)
       throw createAbortError()
     }
-    envelope = await client.getAsyncSearch(envelope.id, { waitForCompletionTimeout })
+    const currentId = envelope.id
+    envelope = await requestOrAbort(
+      () => client.getAsyncSearch(currentId, { waitForCompletionTimeout, signal }),
+      currentId
+    )
   }
 
   cleanup(client, envelope.id)

--- a/src/api/asyncSearch.js
+++ b/src/api/asyncSearch.js
@@ -41,7 +41,7 @@ function abortableDelay(ms, signal) {
  * @param {Object} client
  * @param {string} [id]
  */
-function cleanup(client, id) {
+function deleteStoredSearch(client, id) {
   if (id) {
     client.deleteAsyncSearch(id).catch(() => {})
   }
@@ -69,25 +69,25 @@ function cleanup(client, id) {
  * @returns {Promise<Object>} The inner search response
  */
 export async function runAsyncSearch(client, { index, body }, options = {}) {
-  const cfg = settings.elasticsearch.asyncSearch
+  const asyncSearchSettings = settings.elasticsearch.asyncSearch
   const {
     signal,
-    waitForCompletionTimeout = cfg.waitForCompletionTimeout,
-    keepAlive = cfg.keepAlive,
-    pollInterval = cfg.pollInterval,
-    maxWait = cfg.maxWait
+    waitForCompletionTimeout = asyncSearchSettings.waitForCompletionTimeout,
+    keepAlive = asyncSearchSettings.keepAlive,
+    pollInterval = asyncSearchSettings.pollInterval,
+    maxWait = asyncSearchSettings.maxWait
   } = options
 
   // Runs an async-search request, converting an abort-triggered rejection (the
   // forwarded signal cancels the in-flight HTTP request) into a clean AbortError
   // and freeing any stored result, so the caller can treat it as a cancellation.
-  const requestOrAbort = async (request, id) => {
+  const requestOrAbort = async (performRequest, id) => {
     try {
-      return await request()
+      return await performRequest()
     }
     catch (error) {
       if (signal?.aborted) {
-        cleanup(client, id)
+        deleteStoredSearch(client, id)
         throw createAbortError()
       }
       throw error
@@ -101,16 +101,16 @@ export async function runAsyncSearch(client, { index, body }, options = {}) {
 
   while (envelope.is_running) {
     if (signal?.aborted) {
-      cleanup(client, envelope.id)
+      deleteStoredSearch(client, envelope.id)
       throw createAbortError()
     }
     if (Date.now() - start >= maxWait) {
-      cleanup(client, envelope.id)
+      deleteStoredSearch(client, envelope.id)
       throw new Error('Async search exceeded the maximum wait time')
     }
     await abortableDelay(pollInterval, signal)
     if (signal?.aborted) {
-      cleanup(client, envelope.id)
+      deleteStoredSearch(client, envelope.id)
       throw createAbortError()
     }
     const currentId = envelope.id
@@ -120,6 +120,6 @@ export async function runAsyncSearch(client, { index, body }, options = {}) {
     )
   }
 
-  cleanup(client, envelope.id)
+  deleteStoredSearch(client, envelope.id)
   return envelope.response
 }

--- a/src/api/asyncSearch.js
+++ b/src/api/asyncSearch.js
@@ -1,0 +1,103 @@
+import settings from '@/utils/settings'
+
+/**
+ * Creates an Error tagged as an abort so callers can distinguish intentional
+ * cancellation (supersede / unmount) from real failures.
+ * @returns {Error}
+ */
+function createAbortError() {
+  const error = new Error('Async search aborted')
+  error.name = 'AbortError'
+  return error
+}
+
+/**
+ * Resolves after `ms`, or early if the signal aborts. Never rejects; the
+ * caller re-checks `signal.aborted` after awaiting.
+ * @param {number} ms
+ * @param {AbortSignal} [signal]
+ * @returns {Promise<void>}
+ */
+function abortableDelay(ms, signal) {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      return resolve()
+    }
+    const onAbort = () => {
+      clearTimeout(timer)
+      resolve()
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener?.('abort', onAbort)
+      resolve()
+    }, ms)
+    signal?.addEventListener?.('abort', onAbort, { once: true })
+  })
+}
+
+/**
+ * Fire-and-forget deletion of a stored async search. Swallows errors: a failed
+ * cleanup must never surface to the user (the result expires via keep_alive).
+ * @param {Object} client
+ * @param {string} [id]
+ */
+function cleanup(client, id) {
+  if (id) {
+    client.deleteAsyncSearch(id).catch(() => {})
+  }
+}
+
+/**
+ * Runs a search via Elasticsearch's async search API: submit, then poll until
+ * the result is ready, then delete the stored result. Resolves the inner
+ * `response` object, which is byte-for-byte a normal `_search` response.
+ *
+ * Cancellation: pass an AbortSignal. When it aborts (a newer search supersedes
+ * this one, or the search view unmounts) the runner stops polling, deletes the
+ * stored result, and rejects with an AbortError the caller can ignore.
+ *
+ * @param {Object} client - The Elasticsearch client (with submit/get/deleteAsyncSearch)
+ * @param {Object} request
+ * @param {string} request.index - Comma-separated index list
+ * @param {Object} request.body - The search body
+ * @param {Object} [options]
+ * @param {AbortSignal} [options.signal]
+ * @param {string} [options.waitForCompletionTimeout]
+ * @param {string} [options.keepAlive]
+ * @param {number} [options.pollInterval]
+ * @param {number} [options.maxWait]
+ * @returns {Promise<Object>} The inner search response
+ */
+export async function runAsyncSearch(client, { index, body }, options = {}) {
+  const cfg = settings.elasticsearch.asyncSearch
+  const {
+    signal,
+    waitForCompletionTimeout = cfg.waitForCompletionTimeout,
+    keepAlive = cfg.keepAlive,
+    pollInterval = cfg.pollInterval,
+    maxWait = cfg.maxWait
+  } = options
+
+  const start = Date.now()
+  let envelope = await client.submitAsyncSearch({ index, body, waitForCompletionTimeout, keepAlive })
+
+  while (envelope.is_running) {
+    if (signal?.aborted) {
+      cleanup(client, envelope.id)
+      throw createAbortError()
+    }
+    if (Date.now() - start >= maxWait) {
+      cleanup(client, envelope.id)
+      throw new Error('Async search exceeded the maximum wait time')
+    }
+    await abortableDelay(pollInterval, signal)
+    if (signal?.aborted) {
+      cleanup(client, envelope.id)
+      throw createAbortError()
+    }
+    envelope = await client.getAsyncSearch(envelope.id, { waitForCompletionTimeout })
+  }
+
+  cleanup(client, envelope.id)
+  return envelope.response
+}

--- a/src/api/asyncSearch.js
+++ b/src/api/asyncSearch.js
@@ -12,8 +12,25 @@ function createAbortError() {
 }
 
 /**
- * Resolves after `ms`, or early if the signal aborts. Never rejects; the
- * caller re-checks `signal.aborted` after awaiting.
+ * Fills in the configured async-search defaults for any option the caller omits.
+ * Uses nullish coalescing so an explicit `0` (e.g. `maxWait: 0`) is honored.
+ * @param {Object} options
+ * @returns {Object} The resolved options.
+ */
+function resolveAsyncSearchOptions(options) {
+  const asyncSearchSettings = settings.elasticsearch.asyncSearch
+  return {
+    signal: options.signal,
+    waitForCompletionTimeout: options.waitForCompletionTimeout ?? asyncSearchSettings.waitForCompletionTimeout,
+    keepAlive: options.keepAlive ?? asyncSearchSettings.keepAlive,
+    pollInterval: options.pollInterval ?? asyncSearchSettings.pollInterval,
+    maxWait: options.maxWait ?? asyncSearchSettings.maxWait
+  }
+}
+
+/**
+ * Resolves after `ms`, or early if the signal aborts. Never rejects; the caller
+ * re-checks `signal.aborted` after awaiting.
  * @param {number} ms
  * @param {AbortSignal} [signal]
  * @returns {Promise<void>}
@@ -39,12 +56,79 @@ function abortableDelay(ms, signal) {
  * Fire-and-forget deletion of a stored async search. Swallows errors: a failed
  * cleanup must never surface to the user (the result expires via keep_alive).
  * @param {Object} client
- * @param {string} [id]
+ * @param {string} [storedSearchId]
  */
-function deleteStoredSearch(client, id) {
-  if (id) {
-    client.deleteAsyncSearch(id).catch(() => {})
+function deleteStoredSearch(client, storedSearchId) {
+  if (storedSearchId) {
+    client.deleteAsyncSearch(storedSearchId).catch(() => {})
   }
+}
+
+/**
+ * Stops the search when it has been superseded or cancelled: frees the stored
+ * result, then throws an AbortError the caller can ignore.
+ * @param {Object} client
+ * @param {AbortSignal} [signal]
+ * @param {string} [storedSearchId]
+ */
+function throwIfAborted(client, signal, storedSearchId) {
+  if (signal?.aborted) {
+    deleteStoredSearch(client, storedSearchId)
+    throw createAbortError()
+  }
+}
+
+/**
+ * Stops the search once the client-side ceiling has elapsed, freeing the stored
+ * result so it does not linger on the server beyond keep_alive.
+ * @param {Object} client
+ * @param {number} deadline - Epoch ms after which the search is abandoned.
+ * @param {string} [storedSearchId]
+ */
+function throwIfDeadlineExceeded(client, deadline, storedSearchId) {
+  if (Date.now() >= deadline) {
+    deleteStoredSearch(client, storedSearchId)
+    throw new Error('Async search exceeded the maximum wait time')
+  }
+}
+
+/**
+ * Awaits an async-search request, converting an abort-triggered rejection (the
+ * forwarded signal cancelled the in-flight request) into a clean AbortError and
+ * freeing any stored result. Genuine failures propagate unchanged.
+ * @param {Object} client
+ * @param {AbortSignal} [signal]
+ * @param {Function} performRequest - Issues the request and returns its promise.
+ * @param {string} [storedSearchId]
+ * @returns {Promise<Object>} The async search envelope.
+ */
+async function requestOrAbort(client, signal, performRequest, storedSearchId) {
+  try {
+    return await performRequest()
+  }
+  catch (error) {
+    throwIfAborted(client, signal, storedSearchId)
+    throw error
+  }
+}
+
+/**
+ * Submits the search and returns its first envelope: a completed result or a
+ * running handle to poll.
+ * @returns {Promise<Object>} The async search envelope.
+ */
+function submitSearch(client, { index, body }, { signal, waitForCompletionTimeout, keepAlive }) {
+  return requestOrAbort(client, signal, () =>
+    client.submitAsyncSearch({ index, body, waitForCompletionTimeout, keepAlive, signal }))
+}
+
+/**
+ * Polls a running search once for its latest envelope.
+ * @returns {Promise<Object>} The async search envelope.
+ */
+function pollSearch(client, storedSearchId, { signal, waitForCompletionTimeout }) {
+  return requestOrAbort(client, signal, () =>
+    client.getAsyncSearch(storedSearchId, { waitForCompletionTimeout, signal }), storedSearchId)
 }
 
 /**
@@ -69,55 +153,20 @@ function deleteStoredSearch(client, id) {
  * @returns {Promise<Object>} The inner search response
  */
 export async function runAsyncSearch(client, { index, body }, options = {}) {
-  const asyncSearchSettings = settings.elasticsearch.asyncSearch
-  const {
-    signal,
-    waitForCompletionTimeout = asyncSearchSettings.waitForCompletionTimeout,
-    keepAlive = asyncSearchSettings.keepAlive,
-    pollInterval = asyncSearchSettings.pollInterval,
-    maxWait = asyncSearchSettings.maxWait
-  } = options
+  const resolvedOptions = resolveAsyncSearchOptions(options)
+  const { signal, pollInterval, maxWait } = resolvedOptions
+  const deadline = Date.now() + maxWait
 
-  // Runs an async-search request, converting an abort-triggered rejection (the
-  // forwarded signal cancels the in-flight HTTP request) into a clean AbortError
-  // and freeing any stored result, so the caller can treat it as a cancellation.
-  const requestOrAbort = async (performRequest, id) => {
-    try {
-      return await performRequest()
-    }
-    catch (error) {
-      if (signal?.aborted) {
-        deleteStoredSearch(client, id)
-        throw createAbortError()
-      }
-      throw error
-    }
-  }
+  // Kick off the search; a fast query already comes back complete on this call.
+  let envelope = await submitSearch(client, { index, body }, resolvedOptions)
 
-  const start = Date.now()
-  let envelope = await requestOrAbort(
-    () => client.submitAsyncSearch({ index, body, waitForCompletionTimeout, keepAlive, signal })
-  )
-
+  // Otherwise poll until the result is ready, bailing out on cancel or ceiling.
   while (envelope.is_running) {
-    if (signal?.aborted) {
-      deleteStoredSearch(client, envelope.id)
-      throw createAbortError()
-    }
-    if (Date.now() - start >= maxWait) {
-      deleteStoredSearch(client, envelope.id)
-      throw new Error('Async search exceeded the maximum wait time')
-    }
+    throwIfAborted(client, signal, envelope.id)
+    throwIfDeadlineExceeded(client, deadline, envelope.id)
     await abortableDelay(pollInterval, signal)
-    if (signal?.aborted) {
-      deleteStoredSearch(client, envelope.id)
-      throw createAbortError()
-    }
-    const currentId = envelope.id
-    envelope = await requestOrAbort(
-      () => client.getAsyncSearch(currentId, { waitForCompletionTimeout, signal }),
-      currentId
-    )
+    throwIfAborted(client, signal, envelope.id)
+    envelope = await pollSearch(client, envelope.id, resolvedOptions)
   }
 
   deleteStoredSearch(client, envelope.id)

--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -83,7 +83,7 @@ function handleSearchError(error) {
  * @param {AbortSignal} [signal]
  * @returns {Promise<Object>} The response body.
  */
-function abortableSearchRequest(request, signal) {
+async function abortableSearchRequest(request, signal) {
   const onAbort = () => request.abort?.()
   if (signal) {
     if (signal.aborted) {
@@ -93,20 +93,20 @@ function abortableSearchRequest(request, signal) {
       signal.addEventListener('abort', onAbort)
     }
   }
-  const stopListening = () => signal?.removeEventListener('abort', onAbort)
-  return request.then(
-    (data) => {
-      stopListening()
-      return data
-    },
-    (error) => {
-      stopListening()
-      if (!signal?.aborted) {
-        EventBus.emit('http::error', error)
-      }
-      throw error
+  try {
+    return await request
+  }
+  catch (error) {
+    // A request the caller has already cancelled must not raise a user-facing
+    // error (e.g. the 401 "logged out" toast); only genuine failures surface.
+    if (!signal?.aborted) {
+      EventBus.emit('http::error', error)
     }
-  )
+    throw error
+  }
+  finally {
+    signal?.removeEventListener('abort', onAbort)
+  }
 }
 
 function isFilterIncludedWithValues(filter) {

--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -72,6 +72,43 @@ function handleSearchError(error) {
   throw error
 }
 
+/**
+ * Wraps an async-search transport request so cancellation behaves correctly:
+ * - forwards the AbortSignal to the in-flight HTTP request so a superseded or
+ *   cancelled search stops promptly instead of finishing its long-poll;
+ * - on failure, re-throws but only emits the global `http::error` when the
+ *   request was NOT aborted, so a search the caller has already discarded never
+ *   raises a user-facing error (e.g. the 401 "logged out" toast).
+ * @param {Promise} request - The transport request promise (exposes `.abort`).
+ * @param {AbortSignal} [signal]
+ * @returns {Promise<Object>} The response body.
+ */
+function abortableSearchRequest(request, signal) {
+  const onAbort = () => request.abort?.()
+  if (signal) {
+    if (signal.aborted) {
+      onAbort()
+    }
+    else {
+      signal.addEventListener('abort', onAbort)
+    }
+  }
+  const stopListening = () => signal?.removeEventListener('abort', onAbort)
+  return request.then(
+    (data) => {
+      stopListening()
+      return data
+    },
+    (error) => {
+      stopListening()
+      if (!signal?.aborted) {
+        EventBus.emit('http::error', error)
+      }
+      throw error
+    }
+  )
+}
+
 function isFilterIncludedWithValues(filter) {
   return filter.hasValues() && !filter.excluded && !filter.forceExclude
 }
@@ -201,17 +238,17 @@ export function datasharePlugin(Client) {
    * @param {Object} options.body - The search body (from buildSearchDocsBody)
    * @param {string} options.waitForCompletionTimeout - ES duration, e.g. '1s'
    * @param {string} options.keepAlive - ES duration, e.g. '5m'
+   * @param {AbortSignal} [options.signal] - Cancels the in-flight request.
    * @returns {Promise<Object>} The async search envelope
    */
-  Client.prototype.submitAsyncSearch = function ({ index, body, waitForCompletionTimeout, keepAlive }) {
-    return this.transport
-      .request({
-        method: 'POST',
-        path: `/${index}/_async_search`,
-        query: compactQuery({ wait_for_completion_timeout: waitForCompletionTimeout, keep_alive: keepAlive }),
-        body
-      })
-      .then(data => data, handleSearchError)
+  Client.prototype.submitAsyncSearch = function ({ index, body, waitForCompletionTimeout, keepAlive, signal }) {
+    const request = this.transport.request({
+      method: 'POST',
+      path: `/${index}/_async_search`,
+      query: compactQuery({ wait_for_completion_timeout: waitForCompletionTimeout, keep_alive: keepAlive }),
+      body
+    })
+    return abortableSearchRequest(request, signal)
   }
 
   /**
@@ -219,16 +256,16 @@ export function datasharePlugin(Client) {
    * @param {string} id - The async search id
    * @param {Object} [options]
    * @param {string} [options.waitForCompletionTimeout] - ES duration, e.g. '1s'
+   * @param {AbortSignal} [options.signal] - Cancels the in-flight request.
    * @returns {Promise<Object>} The async search envelope
    */
-  Client.prototype.getAsyncSearch = function (id, { waitForCompletionTimeout } = {}) {
-    return this.transport
-      .request({
-        method: 'GET',
-        path: `/_async_search/${encodeURIComponent(id)}`,
-        query: compactQuery({ wait_for_completion_timeout: waitForCompletionTimeout })
-      })
-      .then(data => data, handleSearchError)
+  Client.prototype.getAsyncSearch = function (id, { waitForCompletionTimeout, signal } = {}) {
+    const request = this.transport.request({
+      method: 'GET',
+      path: `/_async_search/${encodeURIComponent(id)}`,
+      query: compactQuery({ wait_for_completion_timeout: waitForCompletionTimeout })
+    })
+    return abortableSearchRequest(request, signal)
   }
 
   /**

--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -54,6 +54,16 @@ function normalizeQuery(query) {
 }
 
 /**
+ * Drops keys whose value is undefined so the query string omits them rather
+ * than serializing them as empty (the bundled client stringifies undefined as '').
+ * @param {Object} params
+ * @returns {Object}
+ */
+function compactQuery(params) {
+  return Object.fromEntries(Object.entries(params).filter(([, value]) => value !== undefined))
+}
+
+/**
  * Emits an error event and re-throws the error.
  * @param {Error} error - The error to handle
  */
@@ -198,7 +208,7 @@ export function datasharePlugin(Client) {
       .request({
         method: 'POST',
         path: `/${index}/_async_search`,
-        query: { wait_for_completion_timeout: waitForCompletionTimeout, keep_alive: keepAlive },
+        query: compactQuery({ wait_for_completion_timeout: waitForCompletionTimeout, keep_alive: keepAlive }),
         body
       })
       .then(data => data, handleSearchError)
@@ -216,7 +226,7 @@ export function datasharePlugin(Client) {
       .request({
         method: 'GET',
         path: `/_async_search/${encodeURIComponent(id)}`,
-        query: { wait_for_completion_timeout: waitForCompletionTimeout }
+        query: compactQuery({ wait_for_completion_timeout: waitForCompletionTimeout })
       })
       .then(data => data, handleSearchError)
   }

--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -141,6 +141,32 @@ export function datasharePlugin(Client) {
   }
 
   /**
+   * Builds the search body for a document search (filters, query, pagination,
+   * highlighting). Exposed so async search can reuse the exact same body.
+   * @param {Object} options - Same shape as searchDocs options.
+   * @returns {Object} The built Elasticsearch search body.
+   */
+  Client.prototype.buildSearchDocsBody = function ({
+    query = DEFAULT_QUERY,
+    filters = [],
+    from = 0,
+    perPage = 25,
+    sort = { _score: { order: 'desc' } },
+    fields = [],
+    operator = SEARCH_OPERATORS.OR
+  } = {}) {
+    return this._buildSearchBody({
+      query: normalizeQuery(query),
+      filters,
+      fields,
+      from,
+      size: perPage,
+      sort,
+      operator
+    })
+  }
+
+  /**
    * Searches for documents with filters, pagination, and highlighting.
    * @param {Object} options - Search options
    * @param {string} options.index - The index name
@@ -152,26 +178,61 @@ export function datasharePlugin(Client) {
    * @param {string[]} [options.fields=[]] - Fields to search in
    * @returns {Promise<Object>} Search results
    */
-  Client.prototype.searchDocs = function ({
-    index,
-    query = DEFAULT_QUERY,
-    filters = [],
-    from = 0,
-    perPage = 25,
-    sort = { _score: { order: 'desc' } },
-    fields = [],
-    operator = SEARCH_OPERATORS.OR
-  }) {
-    const body = this._buildSearchBody({
-      query: normalizeQuery(query),
-      filters,
-      fields,
-      from,
-      size: perPage,
-      sort,
-      operator
+  Client.prototype.searchDocs = function (options) {
+    const body = this.buildSearchDocsBody(options)
+    return this._search({ index: options.index, body })
+  }
+
+  /**
+   * Submits an async search. Returns the async envelope: either a completed
+   * result (is_running:false) or a running handle ({ id, is_running:true }).
+   * @param {Object} options
+   * @param {string} options.index - Comma-separated index list
+   * @param {Object} options.body - The search body (from buildSearchDocsBody)
+   * @param {string} options.waitForCompletionTimeout - ES duration, e.g. '1s'
+   * @param {string} options.keepAlive - ES duration, e.g. '5m'
+   * @returns {Promise<Object>} The async search envelope
+   */
+  Client.prototype.submitAsyncSearch = function ({ index, body, waitForCompletionTimeout, keepAlive }) {
+    return this.transport
+      .request({
+        method: 'POST',
+        path: `/${index}/_async_search`,
+        query: { wait_for_completion_timeout: waitForCompletionTimeout, keep_alive: keepAlive },
+        body
+      })
+      .then(data => data, handleSearchError)
+  }
+
+  /**
+   * Polls a running async search by id.
+   * @param {string} id - The async search id
+   * @param {Object} [options]
+   * @param {string} [options.waitForCompletionTimeout] - ES duration, e.g. '1s'
+   * @returns {Promise<Object>} The async search envelope
+   */
+  Client.prototype.getAsyncSearch = function (id, { waitForCompletionTimeout } = {}) {
+    return this.transport
+      .request({
+        method: 'GET',
+        path: `/_async_search/${encodeURIComponent(id)}`,
+        query: { wait_for_completion_timeout: waitForCompletionTimeout }
+      })
+      .then(data => data, handleSearchError)
+  }
+
+  /**
+   * Deletes a stored async search to free its server-side storage. Used for
+   * fire-and-forget cleanup, so it deliberately does NOT emit http::error;
+   * callers should swallow rejections.
+   * @param {string} id - The async search id
+   * @returns {Promise<Object>} The deletion acknowledgement
+   */
+  Client.prototype.deleteAsyncSearch = function (id) {
+    return this.transport.request({
+      method: 'DELETE',
+      path: `/_async_search/${encodeURIComponent(id)}`
     })
-    return this._search({ index, body })
   }
 
   /**

--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -73,39 +73,58 @@ function handleSearchError(error) {
 }
 
 /**
- * Wraps an async-search transport request so cancellation behaves correctly:
- * - forwards the AbortSignal to the in-flight HTTP request so a superseded or
- *   cancelled search stops promptly instead of finishing its long-poll;
- * - on failure, re-throws but only emits the global `http::error` when the
- *   request was NOT aborted, so a search the caller has already discarded never
- *   raises a user-facing error (e.g. the 401 "logged out" toast).
+ * Forwards an AbortSignal to an in-flight transport request so a superseded or
+ * cancelled search stops promptly instead of finishing its long-poll. Returns a
+ * teardown that detaches the listener once the request has settled.
+ * @param {Promise} request - The transport request promise (exposes `.abort`).
+ * @param {AbortSignal} [signal]
+ * @returns {Function} Detaches the abort listener.
+ */
+function forwardAbortSignal(request, signal) {
+  const abortRequest = () => request.abort?.()
+  if (!signal) {
+    return () => {}
+  }
+  // Already cancelled: abort immediately, nothing left to listen for.
+  if (signal.aborted) {
+    abortRequest()
+    return () => {}
+  }
+  signal.addEventListener('abort', abortRequest)
+  return () => signal.removeEventListener('abort', abortRequest)
+}
+
+/**
+ * Emits the global search error for genuine failures only. A request the caller
+ * has already cancelled must not raise a user-facing error (e.g. the 401
+ * "logged out" toast) for a result that will be discarded.
+ * @param {Error} error
+ * @param {AbortSignal} [signal]
+ */
+function emitSearchErrorUnlessAborted(error, signal) {
+  if (!signal?.aborted) {
+    EventBus.emit('http::error', error)
+  }
+}
+
+/**
+ * Awaits an async-search transport request with cancellation wired in: the
+ * signal aborts the in-flight request, and only genuine failures surface.
  * @param {Promise} request - The transport request promise (exposes `.abort`).
  * @param {AbortSignal} [signal]
  * @returns {Promise<Object>} The response body.
  */
 async function abortableSearchRequest(request, signal) {
-  const onAbort = () => request.abort?.()
-  if (signal) {
-    if (signal.aborted) {
-      onAbort()
-    }
-    else {
-      signal.addEventListener('abort', onAbort)
-    }
-  }
+  const stopForwardingAbort = forwardAbortSignal(request, signal)
   try {
     return await request
   }
   catch (error) {
-    // A request the caller has already cancelled must not raise a user-facing
-    // error (e.g. the 401 "logged out" toast); only genuine failures surface.
-    if (!signal?.aborted) {
-      EventBus.emit('http::error', error)
-    }
+    emitSearchErrorUnlessAborted(error, signal)
     throw error
   }
   finally {
-    signal?.removeEventListener('abort', onAbort)
+    stopForwardingAbort()
   }
 }
 

--- a/src/composables/useSearchExecution.js
+++ b/src/composables/useSearchExecution.js
@@ -1,0 +1,29 @@
+import { onUnmounted } from 'vue'
+
+import { useSearchStore } from '@/store/modules'
+
+/**
+ * Ties the search execution lifecycle to the component that drives the search.
+ * Cancelling the in-flight async search when that component unmounts (the user
+ * leaves the search view) lets the backend stop polling and free the stored
+ * result.
+ *
+ * The store instance follows the parent context through `inject()`, matching
+ * the other search composables. The AbortController itself stays in the store,
+ * which is the single choke point for every search and aborts the previous run
+ * when a new one supersedes it; this composable owns only the lifecycle binding.
+ *
+ * @returns {{ cancel: Function }} Handle to cancel the in-flight search on demand.
+ */
+export function useSearchExecution() {
+  const searchStore = useSearchStore.inject()
+
+  function cancel() {
+    searchStore.cancelActiveSearch()
+  }
+
+  // Stop the in-flight search when the driving component goes away.
+  onUnmounted(cancel)
+
+  return { cancel }
+}

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -20,6 +20,7 @@ import { ref, computed, toRaw } from 'vue'
 import { useRouter } from 'vue-router'
 
 import EsDocList from '@/api/resources/EsDocList'
+import { runAsyncSearch } from '@/api/asyncSearch'
 import filterDefs, * as filterTypes from '@/store/filters'
 import { getPairedDimensions } from '@/store/filters/pairedDimensions'
 import { useAppStore, useSearchBreadcrumbStore } from '@/store/modules'
@@ -662,6 +663,10 @@ export const useSearchStore = defineSuffixedStore('search', () => {
   // (e.g. when both onBeforeRouteUpdate and the fullPath watcher fire
   // for the same navigation).
   let refreshPromise = null
+  // Controls cancellation of the in-flight async search and guards against a
+  // superseded search clobbering newer state.
+  let activeController = null
+  let generation = 0
 
   /**
    * Refresh the search results based on the current search parameters.
@@ -704,25 +709,45 @@ export const useSearchStore = defineSuffixedStore('search', () => {
    * @returns {Promise<void>} - A promise that resolves when the search is complete.
    */
   async function doRefresh(save) {
+    // A new search supersedes any in-flight one: abort it so the runner stops
+    // polling and frees the stored async result.
+    activeController?.abort()
+    const controller = new AbortController()
+    activeController = controller
+    const gen = ++generation
+
     setIsReady(false)
     setError()
 
     try {
       saveAppliedQuery()
-      const raw = await searchDocuments()
+      const raw = await searchDocuments(toSearchParams.value, controller.signal)
+      if (gen !== generation) {
+        return
+      }
       const roots = await searchRootDocuments(raw)
+      if (gen !== generation) {
+        return
+      }
       if (save) {
         searchBreadcrumbStore.pushSearchQuery(toBaseRouteQuery.value)
       }
       setResponse({ raw, roots })
     }
     catch (error) {
+      // Aborts are intentional (supersede / unmount); a newer search or
+      // navigation is already in control, so leave the state untouched.
+      if (error?.name === 'AbortError') {
+        return
+      }
       setResponse()
       setError(error)
     }
     finally {
-      setIsReady(true)
-      refreshPromise = null
+      if (gen === generation) {
+        setIsReady(true)
+        refreshPromise = null
+      }
     }
   }
 
@@ -734,8 +759,17 @@ export const useSearchStore = defineSuffixedStore('search', () => {
    * @param {Object} searchParams - The search parameters to use for the query.
    * @returns {Promise<EsDocList>} - A promise that resolves to an instance of EsDocList containing the search results.
    */
-  function searchDocuments(searchParams = toSearchParams.value) {
-    return api.elasticsearch.searchDocs(searchParams)
+  function searchDocuments(searchParams = toSearchParams.value, signal) {
+    const body = api.elasticsearch.buildSearchDocsBody(searchParams)
+    return runAsyncSearch(api.elasticsearch, { index: searchParams.index, body }, { signal })
+  }
+
+  /**
+   * Cancels the in-flight async search (if any). Called when leaving the search
+   * view so the backend stops polling and frees the stored result.
+   */
+  function cancelActiveSearch() {
+    activeController?.abort()
   }
 
   /**
@@ -1091,6 +1125,7 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     refresh,
     refreshStamp,
     searchDocuments,
+    cancelActiveSearch,
     searchRootDocuments,
     updateFromRouteQuery,
     query,

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -735,6 +735,10 @@ export const useSearchStore = defineSuffixedStore('search', () => {
       setResponse({ raw, roots })
     }
     catch (error) {
+      // A superseded run must never touch shared state, even on a real error.
+      if (gen !== generation) {
+        return
+      }
       // Aborts are intentional (supersede / unmount); a newer search or
       // navigation is already in control, so leave the state untouched.
       if (error?.name === 'AbortError') {
@@ -752,12 +756,13 @@ export const useSearchStore = defineSuffixedStore('search', () => {
   }
 
   /**
-   * Search for documents in the Elasticsearch index based on the current search parameters.
+   * Search for documents using Elasticsearch async search.
    *
-   * This function uses the `api.elasticsearch.searchDocs` method to perform the search
-   * and returns a promise that resolves to the search results.
-   * @param {Object} searchParams - The search parameters to use for the query.
-   * @returns {Promise<EsDocList>} - A promise that resolves to an instance of EsDocList containing the search results.
+   * Builds the search body with `api.elasticsearch.buildSearchDocsBody` and runs it
+   * through `runAsyncSearch`, which submits, polls, and cleans up the async search.
+   * @param {Object} [searchParams=toSearchParams.value] - The search parameters to use for the query.
+   * @param {AbortSignal} [signal] - Aborts the in-flight async search (supersede / unmount).
+   * @returns {Promise<Object>} - A promise that resolves to the raw Elasticsearch search response.
    */
   function searchDocuments(searchParams = toSearchParams.value, signal) {
     const body = api.elasticsearch.buildSearchDocsBody(searchParams)

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -177,7 +177,13 @@ export default {
   },
   elasticsearch: {
     waitForAnswer: 700,
-    requestTimeout: 60000
+    requestTimeout: 60000,
+    asyncSearch: {
+      waitForCompletionTimeout: '1s', // long-poll window per request (ES duration string)
+      pollInterval: 1000, // ms paused between polls
+      keepAlive: '5m', // ES retention for the stored async result (keep_alive param)
+      maxWait: 300000 // ms client-side ceiling; kept equal to keepAlive
+    }
   },
   filter: {
     bucketSize: 25,

--- a/src/views/Search/Search.vue
+++ b/src/views/Search/Search.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref, toValue, onUnmounted } from 'vue'
+import { computed, ref, toValue } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 
@@ -23,6 +23,7 @@ import { useUrlPageFromWithStore } from '@/composables/useUrlPageFromWithStore'
 import { useSearchFilter } from '@/composables/useSearchFilter'
 import { useSearchBreadcrumb } from '@/composables/useSearchBreadcrumb'
 import { useSearchNav } from '@/composables/useSearchNav'
+import { useSearchExecution } from '@/composables/useSearchExecution'
 import { useViews } from '@/composables/useViews'
 import { LAYOUTS } from '@/enums/layouts'
 import { DISPLAY as ENTRIES_DISPLAY } from '@/enums/documentFloating'
@@ -48,8 +49,10 @@ const { hasCarousel } = useSearchNav()
 const { t } = useI18n()
 const appStore = useAppStore()
 const searchStore = useSearchStore()
-onUnmounted(() => searchStore.cancelActiveSearch())
 const route = useRoute()
+
+// Cancel the in-flight async search when leaving the search view.
+useSearchExecution()
 
 const entries = computed(() => searchStore.response.hits)
 const properties = computed(() => appStore.getSettings('search', 'properties'))

--- a/src/views/Search/Search.vue
+++ b/src/views/Search/Search.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref, toValue } from 'vue'
+import { computed, ref, toValue, onUnmounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 
@@ -48,6 +48,7 @@ const { hasCarousel } = useSearchNav()
 const { t } = useI18n()
 const appStore = useAppStore()
 const searchStore = useSearchStore()
+onUnmounted(() => searchStore.cancelActiveSearch())
 const route = useRoute()
 
 const entries = computed(() => searchStore.response.hits)

--- a/tests/unit/specs/api/asyncSearch.spec.js
+++ b/tests/unit/specs/api/asyncSearch.spec.js
@@ -65,6 +65,22 @@ describe('runAsyncSearch', () => {
     expect(client.deleteAsyncSearch).toHaveBeenCalledWith('abc')
   })
 
+  it('aborted in-flight poll: rejects with an AbortError and deletes the id', async () => {
+    const client = makeClient()
+    const controller = new AbortController()
+    client.submitAsyncSearch.mockResolvedValue({ is_running: true, id: 'abc' })
+    // The poll request rejects because the signal aborted while it was in flight.
+    client.getAsyncSearch.mockImplementation(() => {
+      controller.abort()
+      return Promise.reject(new Error('aborted transport'))
+    })
+
+    await expect(
+      runAsyncSearch(client, { index: 'idx', body: {} }, { ...opts, signal: controller.signal })
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(client.deleteAsyncSearch).toHaveBeenCalledWith('abc')
+  })
+
   it('ceiling: rejects when maxWait is exceeded and deletes the id', async () => {
     const client = makeClient()
     client.submitAsyncSearch.mockResolvedValue({ is_running: true, id: 'abc' })

--- a/tests/unit/specs/api/asyncSearch.spec.js
+++ b/tests/unit/specs/api/asyncSearch.spec.js
@@ -22,6 +22,18 @@ describe('runAsyncSearch', () => {
     expect(client.deleteAsyncSearch).not.toHaveBeenCalled()
   })
 
+  it('completed-with-id path: returns the response and deletes the id without polling', async () => {
+    const client = makeClient()
+    client.submitAsyncSearch.mockResolvedValue({ is_running: false, id: 'abc', response: { hits: {} } })
+
+    const res = await runAsyncSearch(client, { index: 'idx', body: {} }, opts)
+
+    expect(res).toEqual({ hits: {} })
+    expect(client.getAsyncSearch).not.toHaveBeenCalled()
+    expect(client.deleteAsyncSearch).toHaveBeenCalledTimes(1)
+    expect(client.deleteAsyncSearch).toHaveBeenCalledWith('abc')
+  })
+
   it('polled path: polls until done, returns response, deletes the id once', async () => {
     vi.useFakeTimers()
     const client = makeClient()

--- a/tests/unit/specs/api/asyncSearch.spec.js
+++ b/tests/unit/specs/api/asyncSearch.spec.js
@@ -1,0 +1,65 @@
+import { runAsyncSearch } from '@/api/asyncSearch'
+
+function makeClient() {
+  return {
+    submitAsyncSearch: vi.fn(),
+    getAsyncSearch: vi.fn(),
+    deleteAsyncSearch: vi.fn().mockResolvedValue({ acknowledged: true })
+  }
+}
+
+const opts = { pollInterval: 10, maxWait: 100000, waitForCompletionTimeout: '1s', keepAlive: '5m' }
+
+describe('runAsyncSearch', () => {
+  it('fast path: returns the response without polling or deleting', async () => {
+    const client = makeClient()
+    client.submitAsyncSearch.mockResolvedValue({ is_running: false, response: { hits: {} } })
+
+    const res = await runAsyncSearch(client, { index: 'idx', body: {} }, opts)
+
+    expect(res).toEqual({ hits: {} })
+    expect(client.getAsyncSearch).not.toHaveBeenCalled()
+    expect(client.deleteAsyncSearch).not.toHaveBeenCalled()
+  })
+
+  it('polled path: polls until done, returns response, deletes the id once', async () => {
+    vi.useFakeTimers()
+    const client = makeClient()
+    client.submitAsyncSearch.mockResolvedValue({ is_running: true, id: 'abc' })
+    client.getAsyncSearch
+      .mockResolvedValueOnce({ is_running: true, id: 'abc' })
+      .mockResolvedValueOnce({ is_running: false, id: 'abc', response: { hits: { total: { value: 1 } } } })
+
+    const promise = runAsyncSearch(client, { index: 'idx', body: {} }, opts)
+    await vi.runAllTimersAsync()
+    const res = await promise
+
+    expect(res).toEqual({ hits: { total: { value: 1 } } })
+    expect(client.getAsyncSearch).toHaveBeenCalledTimes(2)
+    expect(client.deleteAsyncSearch).toHaveBeenCalledTimes(1)
+    expect(client.deleteAsyncSearch).toHaveBeenCalledWith('abc')
+    vi.useRealTimers()
+  })
+
+  it('abort: rejects with an AbortError and deletes the id', async () => {
+    const client = makeClient()
+    client.submitAsyncSearch.mockResolvedValue({ is_running: true, id: 'abc' })
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      runAsyncSearch(client, { index: 'idx', body: {} }, { ...opts, signal: controller.signal })
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(client.deleteAsyncSearch).toHaveBeenCalledWith('abc')
+  })
+
+  it('ceiling: rejects when maxWait is exceeded and deletes the id', async () => {
+    const client = makeClient()
+    client.submitAsyncSearch.mockResolvedValue({ is_running: true, id: 'abc' })
+
+    await expect(
+      runAsyncSearch(client, { index: 'idx', body: {} }, { ...opts, maxWait: 0 })
+    ).rejects.toThrow(/maximum wait/i)
+    expect(client.deleteAsyncSearch).toHaveBeenCalledWith('abc')
+  })
+})

--- a/tests/unit/specs/api/elasticsearch.asyncSearch.spec.js
+++ b/tests/unit/specs/api/elasticsearch.asyncSearch.spec.js
@@ -1,0 +1,97 @@
+import { elasticsearch } from '@/api/elasticsearch'
+import { EventBus } from '@/utils/eventBus'
+
+describe('elasticsearch async search wrappers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('buildSearchDocsBody', () => {
+    it('builds a body with pagination, highlighting and track_total_hits', () => {
+      const body = elasticsearch.buildSearchDocsBody({ index: 'idx', query: 'foo', from: 25, perPage: 10 })
+      expect(body.from).toBe(25)
+      expect(body.size).toBe(10)
+      expect(body.track_total_hits).toBe(true)
+      expect(body.highlight).toBeDefined()
+    })
+
+    it('normalizes an empty query to the default', () => {
+      const body = elasticsearch.buildSearchDocsBody({ index: 'idx', query: '' })
+      const json = JSON.stringify(body)
+      expect(json).toContain('"query":"*"')
+    })
+  })
+
+  describe('submitAsyncSearch', () => {
+    it('POSTs to _async_search with the timeout and keep_alive query params', async () => {
+      const envelope = { id: 'abc', is_running: true }
+      const spy = vi.spyOn(elasticsearch.transport, 'request').mockResolvedValue(envelope)
+      const body = { query: { match_all: {} } }
+
+      const result = await elasticsearch.submitAsyncSearch({
+        index: 'a,b',
+        body,
+        waitForCompletionTimeout: '1s',
+        keepAlive: '5m'
+      })
+
+      expect(result).toEqual(envelope)
+      expect(spy).toHaveBeenCalledWith({
+        method: 'POST',
+        path: '/a,b/_async_search',
+        query: { wait_for_completion_timeout: '1s', keep_alive: '5m' },
+        body
+      })
+    })
+
+    it('routes failures through the http::error bus and rejects', async () => {
+      vi.spyOn(elasticsearch.transport, 'request').mockRejectedValue(new Error('boom'))
+      const onError = vi.fn()
+      EventBus.on('http::error', onError)
+
+      await expect(
+        elasticsearch.submitAsyncSearch({ index: 'a', body: {}, waitForCompletionTimeout: '1s', keepAlive: '5m' })
+      ).rejects.toThrow('boom')
+      expect(onError).toHaveBeenCalledTimes(1)
+
+      EventBus.off('http::error', onError)
+    })
+  })
+
+  describe('getAsyncSearch', () => {
+    it('GETs the URL-encoded id with the completion timeout', async () => {
+      const envelope = { id: 'a/b=', is_running: false, response: { hits: {} } }
+      const spy = vi.spyOn(elasticsearch.transport, 'request').mockResolvedValue(envelope)
+
+      const result = await elasticsearch.getAsyncSearch('a/b=', { waitForCompletionTimeout: '1s' })
+
+      expect(result).toEqual(envelope)
+      expect(spy).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/_async_search/a%2Fb%3D',
+        query: { wait_for_completion_timeout: '1s' }
+      })
+    })
+  })
+
+  describe('deleteAsyncSearch', () => {
+    it('DELETEs the URL-encoded id', async () => {
+      const spy = vi.spyOn(elasticsearch.transport, 'request').mockResolvedValue({ acknowledged: true })
+
+      await elasticsearch.deleteAsyncSearch('a/b=')
+
+      expect(spy).toHaveBeenCalledWith({ method: 'DELETE', path: '/_async_search/a%2Fb%3D' })
+    })
+
+    it('does not emit http::error when the delete fails', async () => {
+      vi.spyOn(elasticsearch.transport, 'request').mockRejectedValue(new Error('gone'))
+      const onError = vi.fn()
+      EventBus.on('http::error', onError)
+
+      await expect(elasticsearch.deleteAsyncSearch('abc')).rejects.toThrow('gone')
+      expect(onError).not.toHaveBeenCalled()
+
+      EventBus.off('http::error', onError)
+    })
+  })
+})

--- a/tests/unit/specs/api/elasticsearch.asyncSearch.spec.js
+++ b/tests/unit/specs/api/elasticsearch.asyncSearch.spec.js
@@ -16,9 +16,9 @@ describe('elasticsearch async search wrappers', () => {
     })
 
     it('normalizes an empty query to the default', () => {
-      const body = elasticsearch.buildSearchDocsBody({ index: 'idx', query: '' })
-      const json = JSON.stringify(body)
-      expect(json).toContain('"query":"*"')
+      const emptyBody = elasticsearch.buildSearchDocsBody({ index: 'idx', query: '' })
+      const starBody = elasticsearch.buildSearchDocsBody({ index: 'idx', query: '*' })
+      expect(emptyBody).toEqual(starBody)
     })
   })
 
@@ -70,6 +70,18 @@ describe('elasticsearch async search wrappers', () => {
         method: 'GET',
         path: '/_async_search/a%2Fb%3D',
         query: { wait_for_completion_timeout: '1s' }
+      })
+    })
+
+    it('omits the completion timeout from the query when not provided', async () => {
+      const spy = vi.spyOn(elasticsearch.transport, 'request').mockResolvedValue({ is_running: false })
+
+      await elasticsearch.getAsyncSearch('abc')
+
+      expect(spy).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/_async_search/abc',
+        query: {}
       })
     })
   })

--- a/tests/unit/specs/api/elasticsearch.asyncSearch.spec.js
+++ b/tests/unit/specs/api/elasticsearch.asyncSearch.spec.js
@@ -86,6 +86,40 @@ describe('elasticsearch async search wrappers', () => {
     })
   })
 
+  describe('abort handling', () => {
+    it('does not emit http::error when the request fails after the signal aborted', async () => {
+      vi.spyOn(elasticsearch.transport, 'request').mockRejectedValue(new Error('boom'))
+      const onError = vi.fn()
+      EventBus.on('http::error', onError)
+      const controller = new AbortController()
+      controller.abort()
+
+      await expect(
+        elasticsearch.getAsyncSearch('abc', { waitForCompletionTimeout: '1s', signal: controller.signal })
+      ).rejects.toThrow('boom')
+      expect(onError).not.toHaveBeenCalled()
+
+      EventBus.off('http::error', onError)
+    })
+
+    it('aborts the in-flight transport request when the signal fires', async () => {
+      const abort = vi.fn()
+      const request = Promise.resolve({ is_running: true, id: 'abc' })
+      request.abort = abort
+      vi.spyOn(elasticsearch.transport, 'request').mockReturnValue(request)
+      const controller = new AbortController()
+
+      const promise = elasticsearch.getAsyncSearch('abc', {
+        waitForCompletionTimeout: '1s',
+        signal: controller.signal
+      })
+      controller.abort()
+      await promise
+
+      expect(abort).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('deleteAsyncSearch', () => {
     it('DELETEs the URL-encoded id', async () => {
       const spy = vi.spyOn(elasticsearch.transport, 'request').mockResolvedValue({ acknowledged: true })

--- a/tests/unit/specs/composables/useSearchExecution.spec.js
+++ b/tests/unit/specs/composables/useSearchExecution.spec.js
@@ -1,0 +1,48 @@
+import { mount } from '@vue/test-utils'
+
+import { useSearchExecution } from '@/composables/useSearchExecution'
+import { useSearchStore } from '@/store/modules'
+import CoreSetup from '~tests/unit/CoreSetup'
+
+describe('useSearchExecution', () => {
+  let plugins
+
+  beforeEach(() => {
+    plugins = CoreSetup.init().useAll().plugins
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function mountComposable() {
+    let result
+    const TestComponent = {
+      setup() {
+        result = useSearchExecution()
+        return result
+      },
+      template: '<div></div>'
+    }
+    const wrapper = mount(TestComponent, { global: { plugins } })
+    return { wrapper, result }
+  }
+
+  it('cancels the active search when the component unmounts', () => {
+    const { wrapper } = mountComposable()
+    const spy = vi.spyOn(useSearchStore(), 'cancelActiveSearch')
+
+    expect(spy).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes a cancel handle that delegates to the store', () => {
+    const { result } = mountComposable()
+    const spy = vi.spyOn(useSearchStore(), 'cancelActiveSearch')
+
+    result.cancel()
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/specs/store/modules/search.asyncSearch.spec.js
+++ b/tests/unit/specs/store/modules/search.asyncSearch.spec.js
@@ -131,4 +131,12 @@ describe('SearchStore async search wiring', () => {
     expect(searchStore.error).toBeInstanceOf(Error)
     expect(searchStore.error.message).toBe('boom')
   })
+
+  it('runs the search only once for concurrent identical queries', async () => {
+    runAsyncSearchMock.mockResolvedValue({ hits: { hits: [], total: { value: 0 } } })
+
+    await Promise.all([searchStore.query('bar'), searchStore.query('bar')])
+
+    expect(runAsyncSearchMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tests/unit/specs/store/modules/search.asyncSearch.spec.js
+++ b/tests/unit/specs/store/modules/search.asyncSearch.spec.js
@@ -1,0 +1,110 @@
+import { setActivePinia, createPinia } from 'pinia'
+
+import { useAppStore, useSearchStore } from '@/store/modules'
+
+const runAsyncSearchMock = vi.fn()
+vi.mock('@/api/asyncSearch', () => ({
+  runAsyncSearch: (...args) => runAsyncSearchMock(...args)
+}))
+
+function deferred() {
+  let resolve, reject
+  const promise = new Promise((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('SearchStore async search wiring', () => {
+  let searchStore, appStore
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    appStore = useAppStore()
+    searchStore = useSearchStore()
+    searchStore.setIndex('local-index')
+    appStore.setSettings('search', { perPage: 25, orderBy: ['_score', 'desc'] })
+    runAsyncSearchMock.mockReset()
+  })
+
+  it('passes an abort signal to the runner', async () => {
+    const d = deferred()
+    runAsyncSearchMock.mockReturnValue(d.promise)
+
+    searchStore.setQuery('alpha')
+    searchStore.refresh()
+
+    const [, , options] = runAsyncSearchMock.mock.calls[0]
+    expect(options.signal).toBeInstanceOf(AbortSignal)
+    expect(options.signal.aborted).toBe(false)
+
+    d.resolve({ hits: { hits: [], total: { value: 0 } } })
+  })
+
+  it('aborts the previous search when a new one supersedes it', async () => {
+    const first = deferred()
+    const second = deferred()
+    runAsyncSearchMock.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+
+    searchStore.setQuery('alpha')
+    searchStore.refresh()
+    const firstSignal = runAsyncSearchMock.mock.calls[0][2].signal
+
+    searchStore.setQuery('beta')
+    searchStore.refresh()
+
+    expect(firstSignal.aborted).toBe(true)
+
+    second.resolve({ hits: { hits: [], total: { value: 0 } } })
+    first.resolve({ hits: { hits: [], total: { value: 0 } } })
+  })
+
+  it('does not clobber the current response with a superseded result', async () => {
+    const first = deferred()
+    const second = deferred()
+    runAsyncSearchMock.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+
+    searchStore.setQuery('alpha')
+    const p1 = searchStore.refresh()
+    searchStore.setQuery('beta')
+    const p2 = searchStore.refresh()
+
+    // beta (the current search) resolves first, then the superseded alpha.
+    second.resolve({ hits: { hits: [], total: { value: 2 } } })
+    await p2
+    first.resolve({ hits: { hits: [], total: { value: 9 } } })
+    await p1
+
+    expect(searchStore.total).toBe(2)
+  })
+
+  it('ignores an AbortError without setting the error state', async () => {
+    const d = deferred()
+    runAsyncSearchMock.mockReturnValue(d.promise)
+
+    searchStore.setQuery('alpha')
+    const p = searchStore.refresh()
+    searchStore.cancelActiveSearch()
+
+    const abortError = new Error('Async search aborted')
+    abortError.name = 'AbortError'
+    d.reject(abortError)
+    await p
+
+    expect(searchStore.error).toBeNull()
+  })
+
+  it('sets the error state on a real failure', async () => {
+    const d = deferred()
+    runAsyncSearchMock.mockReturnValue(d.promise)
+
+    searchStore.setQuery('alpha')
+    const p = searchStore.refresh()
+    d.reject(new Error('boom'))
+    await p
+
+    expect(searchStore.error).toBeInstanceOf(Error)
+    expect(searchStore.error.message).toBe('boom')
+  })
+})

--- a/tests/unit/specs/store/modules/search.asyncSearch.spec.js
+++ b/tests/unit/specs/store/modules/search.asyncSearch.spec.js
@@ -81,6 +81,26 @@ describe('SearchStore async search wiring', () => {
     expect(searchStore.total).toBe(2)
   })
 
+  it('does not clobber or error the current response when a superseded run fails', async () => {
+    const first = deferred()
+    const second = deferred()
+    runAsyncSearchMock.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+
+    searchStore.setQuery('alpha')
+    const p1 = searchStore.refresh()
+    searchStore.setQuery('beta')
+    const p2 = searchStore.refresh()
+
+    // beta (current) succeeds; the superseded alpha then fails with a real error.
+    second.resolve({ hits: { hits: [], total: { value: 2 } } })
+    await p2
+    first.reject(new Error('boom'))
+    await p1
+
+    expect(searchStore.total).toBe(2)
+    expect(searchStore.error).toBeNull()
+  })
+
   it('ignores an AbortError without setting the error state', async () => {
     const d = deferred()
     runAsyncSearchMock.mockReturnValue(d.promise)

--- a/tests/unit/specs/store/modules/search.asyncSearch.spec.js
+++ b/tests/unit/specs/store/modules/search.asyncSearch.spec.js
@@ -33,13 +33,14 @@ describe('SearchStore async search wiring', () => {
     runAsyncSearchMock.mockReturnValue(d.promise)
 
     searchStore.setQuery('alpha')
-    searchStore.refresh()
+    const p = searchStore.refresh()
 
     const [, , options] = runAsyncSearchMock.mock.calls[0]
     expect(options.signal).toBeInstanceOf(AbortSignal)
     expect(options.signal.aborted).toBe(false)
 
     d.resolve({ hits: { hits: [], total: { value: 0 } } })
+    await p
   })
 
   it('aborts the previous search when a new one supersedes it', async () => {
@@ -48,16 +49,17 @@ describe('SearchStore async search wiring', () => {
     runAsyncSearchMock.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
 
     searchStore.setQuery('alpha')
-    searchStore.refresh()
+    const p1 = searchStore.refresh()
     const firstSignal = runAsyncSearchMock.mock.calls[0][2].signal
 
     searchStore.setQuery('beta')
-    searchStore.refresh()
+    const p2 = searchStore.refresh()
 
     expect(firstSignal.aborted).toBe(true)
 
     second.resolve({ hits: { hits: [], total: { value: 0 } } })
     first.resolve({ hits: { hits: [], total: { value: 0 } } })
+    await Promise.all([p1, p2])
   })
 
   it('does not clobber the current response with a superseded result', async () => {
@@ -93,6 +95,7 @@ describe('SearchStore async search wiring', () => {
     await p
 
     expect(searchStore.error).toBeNull()
+    expect(searchStore.isReady).toBe(true)
   })
 
   it('sets the error state on a real failure', async () => {

--- a/tests/unit/specs/store/modules/search.asyncSearch.spec.js
+++ b/tests/unit/specs/store/modules/search.asyncSearch.spec.js
@@ -8,12 +8,13 @@ vi.mock('@/api/asyncSearch', () => ({
 }))
 
 function deferred() {
-  let resolve, reject
-  const promise = new Promise((res, rej) => {
-    resolve = res
-    reject = rej
+  let resolveFn
+  let rejectFn
+  const promise = new Promise((resolve, reject) => {
+    resolveFn = resolve
+    rejectFn = reject
   })
-  return { promise, resolve, reject }
+  return { promise, resolve: resolveFn, reject: rejectFn }
 }
 
 describe('SearchStore async search wiring', () => {

--- a/tests/unit/specs/store/modules/search.spec.js
+++ b/tests/unit/specs/store/modules/search.spec.js
@@ -135,7 +135,9 @@ describe('SearchStore', () => {
 
     it('should only search once when query is called concurrently with the same parameters', async () => {
       await letData(es).have(new IndexedDocument('document', index).withContent('bar')).commit()
-      const spy = vi.spyOn(api.elasticsearch, 'searchDocs')
+      // The main search now goes through async search, so submitAsyncSearch is
+      // the request that must fire exactly once for a deduplicated query burst.
+      const spy = vi.spyOn(api.elasticsearch, 'submitAsyncSearch')
 
       await Promise.all([searchStore.query('bar'), searchStore.query('bar')])
 

--- a/tests/unit/specs/utils/settings.spec.js
+++ b/tests/unit/specs/utils/settings.spec.js
@@ -1,0 +1,12 @@
+import settings from '@/utils/settings'
+
+describe('settings.elasticsearch.asyncSearch', () => {
+  it('exposes the async search timing knobs', () => {
+    expect(settings.elasticsearch.asyncSearch).toEqual({
+      waitForCompletionTimeout: '1s',
+      pollInterval: 1000,
+      keepAlive: '5m',
+      maxWait: 300000
+    })
+  })
+})

--- a/tests/unit/specs/views/Search/Search.spec.js
+++ b/tests/unit/specs/views/Search/Search.spec.js
@@ -2,6 +2,7 @@ import { shallowMount } from '@vue/test-utils'
 
 import CoreSetup from '~tests/unit/CoreSetup'
 import Search from '@/views/Search/Search'
+import { useSearchStore } from '@/store/modules'
 
 vi.mock('@/api/apiInstance', {
   apiInstance: {
@@ -30,5 +31,15 @@ describe('Search.vue', () => {
 
   it('is a Vue instance', () => {
     expect(wrapper.vm).toBeTruthy()
+  })
+
+  it('cancels the active search when the view unmounts', () => {
+    // Same active pinia as the mounted component, so this is the same store instance.
+    const searchStore = useSearchStore()
+    const spy = vi.spyOn(searchStore, 'cancelActiveSearch')
+
+    wrapper.unmount()
+
+    expect(spy).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Heavy searches that fan out across many projects can take long enough that the proxy returns an "upstream request timeout" before Elasticsearch answers. This PR moves the main document search onto Elasticsearch's async search API: submit the search, then poll until it is ready so those searches no longer hit that timeout. This is part of icij/datashare#2153.

From the user's point of view nothing changes: the same loading state, then the full results all at once. In-flight searches are now cancelled automatically when a new search supersedes them or when the user leaves the search view.

## Changes:

- feat: run the main document search through async search, with auto cancel (new search or view is left)
- feat: add the async-search client methods and their timing configuration
- fix: stay quiet and correct on cancellation
- test: cover the runner, client methods, store wiring and view cancellation