### PR TITLE
fix(SearchAdvancedModal): align value columns in multi-line examples

### DIFF
--- a/src/components/Search/SearchAdvancedModal/SearchAdvancedModal.vue
+++ b/src/components/Search/SearchAdvancedModal/SearchAdvancedModal.vue
@@ -258,13 +258,14 @@ defineExpose({ form, isFormEmpty, handleSearch, handleReset })
     margin: 0;
     font-size: $small-font-size;
     line-height: $line-height-sm;
+    // Both the "e.g." prefix and the example value share the same secondary
+    // gray; the markup is kept so future variants can re-tint either side.
+    color: var(--bs-secondary-color);
 
     &__prefix {
-      color: var(--bs-secondary-color);
-    }
-
-    &__value {
-      color: var(--bs-body-color);
+      // Reserve the width of the widest prefix ("e.g.") so the value column
+      // lines up across rows in multi-line examples (AND… stacked over +…).
+      min-width: 2.5em;
     }
 
     &__break {


### PR DESCRIPTION
This was written with Claude.

Two small visual fixes on the example lines under the "All these words" and "None of these words" fields:

  - merge the prefix and value `color` into a single secondary-gray declaration on `&__example` so "e.g." / "or" and the example values are visually the same shade;
  - reserve a min-width of 2.5em on `&__example__prefix` so the second row's value starts at the same x-offset as the first row's. Without it "or" (2 chars) was narrower than "e.g." (4 chars) and `+Paris…` drifted left of `AND Paris…`.

No behaviour change.