### PR TITLE
fix: set modification_date as default for history settings

### DIFF
--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -10,7 +10,7 @@ import { SEARCH_OPERATORS } from '@/enums/searchOperators'
  * will require resetting user settings to defaults. This is useful if for instance you add new settings
  * or change the structure of existing settings and want to ensure users get the latest defaults.
  */
-const SETTINGS_VERSION = 1
+const SETTINGS_VERSION = 2
 
 /**
  * Defines the application-wide store for managing UI state and user preferences.
@@ -40,7 +40,7 @@ export const useAppStore = defineStore(
           perPage: '25'
         },
         searchHistoryList: {
-          orderBy: ['creation_date', 'desc'],
+          orderBy: ['modification_date', 'desc'],
           perPage: '25',
           properties: ['title', 'thumbnail', 'path', 'creationDate']
         },

--- a/tests/unit/specs/store/modules/app.spec.js
+++ b/tests/unit/specs/store/modules/app.spec.js
@@ -91,4 +91,8 @@ describe('AppStore', () => {
     store.resetSettings('search')
     expect(store.getSettings('search', 'searchOperator')).toBe(SEARCH_OPERATORS.OR)
   })
+
+  it('should default searchHistoryList order to modification_date desc', () => {
+    expect(store.getSettings('searchHistoryList', 'orderBy')).toEqual(['modification_date', 'desc'])
+  })
 })


### PR DESCRIPTION
The `searchHistoryList` default sort was set to `creation_date`, which is not a valid sort field accepted by `/api/users/me/history` - the API's own default is `modification_date`. This aligns the client default with the backend and ensures users see their most recently visited searches first out of the box.

Settings version is bumped to 2 so existing users with a stale `creation_date` value persisted in localStorage are migrated to the new default on next load.