### PR TITLE
feat(SearchAdvancedModal): pre-populate from the active query on open

### DIFF
--- a/src/components/Search/SearchAdvancedModal/SearchAdvancedModal.vue
+++ b/src/components/Search/SearchAdvancedModal/SearchAdvancedModal.vue
@@ -130,8 +130,9 @@
 </template>
 
 <script setup>
-import { computed, nextTick, watch, useTemplateRef } from 'vue'
+import { computed, nextTick, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { whenever } from '@vueuse/core'
 import IPhUniteSquare from '~icons/ph/unite-square'
 import IPhIntersectSquare from '~icons/ph/intersect-square'
 import IPhQuotes from '~icons/ph/quotes'
@@ -240,7 +241,8 @@ async function handleOpen() {
 
 // Open pre-populates and focuses; close resets so the next open starts
 // clean if the parent stops passing a query.
-watch(isVisible, visible => (visible ? handleOpen() : handleReset()))
+whenever(isVisible, handleOpen)
+whenever(() => !isVisible.value, handleReset)
 
 function handleSearch() {
   // Pressing Enter inside an input also submits the form, so guard here

--- a/src/components/Search/SearchAdvancedModal/SearchAdvancedModal.vue
+++ b/src/components/Search/SearchAdvancedModal/SearchAdvancedModal.vue
@@ -205,31 +205,42 @@ const proximityExplanations = computed(() => [
 ])
 
 /**
- * Pre-populate the form with the parsed `initialQuery` whenever the modal
- * opens so the user can edit the active search rather than starting from
- * scratch. The parse returns `null` for queries the form cannot faithfully
- * represent (hand-written field syntax, boolean operators, ranges…) — in
- * that case the form opens blank instead of silently rewriting the query
- * on the next search. Reset on close so the next open is clean if the
- * parent stops passing a query. Autofocus the first input on open in both
- * cases so users can start typing right away and screen readers announce
- * the labelled field.
+ * Pre-populate the form with the parsed `initialQuery` so the user can
+ * edit the active search rather than starting from scratch. The parse
+ * returns `null` for queries the form cannot faithfully represent
+ * (hand-written field syntax, boolean operators, ranges…) — in that case
+ * the form stays blank instead of silently rewriting the query on the
+ * next search.
  */
-watch(isVisible, async (visible) => {
-  if (!visible) {
-    handleReset()
+function populateFromInitialQuery() {
+  if (!props.initialQuery) {
     return
   }
-  if (props.initialQuery) {
-    const allowedFields = fields.map(({ value }) => value)
-    const parsed = parseLuceneQuery(props.initialQuery, { fields: allowedFields })
-    if (parsed) {
-      Object.assign(form, parsed)
-    }
+  const allowedFields = fields.map(({ value }) => value)
+  const parsed = parseLuceneQuery(props.initialQuery, { fields: allowedFields })
+  if (parsed) {
+    Object.assign(form, parsed)
   }
+}
+
+/**
+ * Autofocus the first input so users can start typing right away and
+ * screen readers announce the labelled field. Waits a tick so the modal
+ * content is rendered before focusing.
+ */
+async function focusFirstInput() {
   await nextTick()
   firstInput.value?.focus?.()
-})
+}
+
+async function handleOpen() {
+  populateFromInitialQuery()
+  await focusFirstInput()
+}
+
+// Open pre-populates and focuses; close resets so the next open starts
+// clean if the parent stops passing a query.
+watch(isVisible, visible => (visible ? handleOpen() : handleReset()))
 
 function handleSearch() {
   // Pressing Enter inside an input also submits the form, so guard here

--- a/src/components/Search/SearchAdvancedModal/SearchAdvancedModal.vue
+++ b/src/components/Search/SearchAdvancedModal/SearchAdvancedModal.vue
@@ -148,9 +148,20 @@ import SearchAdvancedModalFieldWildcard from './SearchAdvancedModalFieldWildcard
 import SearchAdvancedModalFieldsSelect from './SearchAdvancedModalFieldsSelect.vue'
 import SearchAdvancedModalFooter from './SearchAdvancedModalFooter.vue'
 import { useAdvancedSearchForm } from '@/composables/useAdvancedSearchForm'
-import { generateLuceneQuery } from '@/utils/luceneQuery'
+import { generateLuceneQuery, parseLuceneQuery } from '@/utils/luceneQuery'
 
 const isVisible = defineModel({ type: Boolean, default: false })
+/**
+ * Lucene query to pre-populate the form with when the modal opens. Lets
+ * the user edit the active search instead of starting from scratch — the
+ * parent typically passes the search store's `q`.
+ */
+const props = defineProps({
+  initialQuery: {
+    type: String,
+    default: ''
+  }
+})
 const emit = defineEmits(['search'])
 
 const { t } = useI18n()
@@ -188,14 +199,21 @@ const proximityExplanations = computed(() => [
   t('searchAdvancedModal.proximitySearchExplanation4')
 ])
 
-// Reset the form on close so reopening always starts from a clean state
-// (cancel / ESC / backdrop / successful search all share this code path).
-// Autofocus the first input on open so users can start typing right away
-// and screen readers announce the labelled field.
+/**
+ * Pre-populate the form with the parsed `initialQuery` whenever the modal
+ * opens so the user can edit the active search rather than starting from
+ * scratch. Reset on close so the next open is clean if the parent stops
+ * passing a query. Autofocus the first input on open in both cases so
+ * users can start typing right away and screen readers announce the
+ * labelled field.
+ */
 watch(isVisible, async (visible) => {
   if (!visible) {
     handleReset()
     return
+  }
+  if (props.initialQuery) {
+    Object.assign(form, parseLuceneQuery(props.initialQuery))
   }
   await nextTick()
   firstInput.value?.focus?.()

--- a/src/components/Search/SearchAdvancedModal/SearchAdvancedModal.vue
+++ b/src/components/Search/SearchAdvancedModal/SearchAdvancedModal.vue
@@ -77,7 +77,7 @@
         <search-advanced-modal-field-range
           v-model:term="form.fuzzyTerm"
           v-model:distance="form.fuzzyDistance"
-          :max="2"
+          :max="FUZZY_DISTANCE_MAX"
           :label="t('searchAdvancedModal.fuzzySearch')"
           :icon="IPhTextAa"
           :range-label="t('searchAdvancedModal.charactersDifferent')"
@@ -89,7 +89,7 @@
         <search-advanced-modal-field-range
           v-model:term="form.proximityPhrase"
           v-model:distance="form.proximityDistance"
-          :max="6"
+          :max="PROXIMITY_DISTANCE_MAX"
           :label="t('searchAdvancedModal.proximitySearch')"
           :icon="IPhArrowsOutLineHorizontal"
           :range-label="t('searchAdvancedModal.maxWordsApart')"
@@ -148,7 +148,12 @@ import SearchAdvancedModalFieldWildcard from './SearchAdvancedModalFieldWildcard
 import SearchAdvancedModalFieldsSelect from './SearchAdvancedModalFieldsSelect.vue'
 import SearchAdvancedModalFooter from './SearchAdvancedModalFooter.vue'
 import { useAdvancedSearchForm } from '@/composables/useAdvancedSearchForm'
-import { generateLuceneQuery, parseLuceneQuery } from '@/utils/luceneQuery'
+import {
+  generateLuceneQuery,
+  parseLuceneQuery,
+  FUZZY_DISTANCE_MAX,
+  PROXIMITY_DISTANCE_MAX
+} from '@/utils/luceneQuery'
 
 const isVisible = defineModel({ type: Boolean, default: false })
 /**
@@ -202,10 +207,13 @@ const proximityExplanations = computed(() => [
 /**
  * Pre-populate the form with the parsed `initialQuery` whenever the modal
  * opens so the user can edit the active search rather than starting from
- * scratch. Reset on close so the next open is clean if the parent stops
- * passing a query. Autofocus the first input on open in both cases so
- * users can start typing right away and screen readers announce the
- * labelled field.
+ * scratch. The parse returns `null` for queries the form cannot faithfully
+ * represent (hand-written field syntax, boolean operators, ranges…) — in
+ * that case the form opens blank instead of silently rewriting the query
+ * on the next search. Reset on close so the next open is clean if the
+ * parent stops passing a query. Autofocus the first input on open in both
+ * cases so users can start typing right away and screen readers announce
+ * the labelled field.
  */
 watch(isVisible, async (visible) => {
   if (!visible) {
@@ -213,7 +221,11 @@ watch(isVisible, async (visible) => {
     return
   }
   if (props.initialQuery) {
-    Object.assign(form, parseLuceneQuery(props.initialQuery))
+    const allowedFields = fields.map(({ value }) => value)
+    const parsed = parseLuceneQuery(props.initialQuery, { fields: allowedFields })
+    if (parsed) {
+      Object.assign(form, parsed)
+    }
   }
   await nextTick()
   firstInput.value?.focus?.()

--- a/src/components/Search/SearchToolbar/SearchToolbar.vue
+++ b/src/components/Search/SearchToolbar/SearchToolbar.vue
@@ -93,6 +93,7 @@ function handleAdvancedSearch(queryString) {
     </div>
     <search-advanced-modal
       v-model="showAdvancedSearch"
+      :initial-query="searchStore.q"
       @search="handleAdvancedSearch"
     />
   </div>

--- a/src/composables/useAdvancedSearchForm.js
+++ b/src/composables/useAdvancedSearchForm.js
@@ -1,5 +1,6 @@
 import { reactive, computed } from 'vue'
 
+import { getInitialForm, toQueryShape } from '@/utils/luceneQuery'
 import IPhHash from '~icons/ph/hash'
 import IPhFileText from '~icons/ph/file-text'
 import IPhUserList from '~icons/ph/user-list'
@@ -23,50 +24,15 @@ export const ADVANCED_SEARCH_FIELDS = [
   { value: 'metadata.tika_metadata_message_raw_header_thread_index', label: 'searchAdvancedModal.fields.threadId', icon: IPhChatsTeardrop }
 ]
 
-/**
- * Default form shape. Word inputs hold strings (whitespace splitting is
- * deferred to submit time), distances default to 1 — distance 0 is the
- * disabled state and the slider's `min` enforces that floor.
- */
-export function getInitialForm() {
-  return {
-    anyWords: '',
-    allWords: '',
-    exactPhrase: '',
-    noneWords: '',
-    singleWildcardStart: '',
-    singleWildcardEnd: '',
-    multiWildcardStart: '',
-    multiWildcardEnd: '',
-    fuzzyTerm: '',
-    fuzzyDistance: 1,
-    proximityPhrase: '',
-    proximityDistance: 1,
-    fieldAll: true,
-    selectedFields: []
-  }
-}
+// Re-exported so form-shape consumers keep a single import point even
+// though the helpers live with the query generator/parser they mirror.
+export { getInitialForm, toQueryShape }
 
 /**
- * Convert the form's string-typed word inputs into the array shape
- * `generateLuceneQuery` expects. Splits on whitespace for word lists
- * and keeps the exact phrase as a single quoted entry.
- */
-export function toQueryShape(f) {
-  const words = s => s.trim().split(/\s+/).filter(Boolean)
-  return {
-    ...f,
-    anyWords: words(f.anyWords),
-    allWords: words(f.allWords),
-    noneWords: words(f.noneWords),
-    exactPhrase: f.exactPhrase.trim() ? [f.exactPhrase.trim()] : []
-  }
-}
-
-/**
- * Owns the advanced-search modal's form state, the empty-form
- * derivation, the all-vs-individual-fields mutual-exclusion rules,
- * and the reset key used to remount inputs on Reset.
+ * Owns the advanced-search modal's form state, the all-vs-individual-fields
+ * mutual-exclusion rules, and the reset key used to remount inputs on
+ * Reset. The form shape itself is defined in `@/utils/luceneQuery`, next to
+ * the generate/parse pair that produces and consumes it.
  */
 export function useAdvancedSearchForm() {
   const form = reactive(getInitialForm())

--- a/src/utils/luceneQuery.js
+++ b/src/utils/luceneQuery.js
@@ -218,6 +218,11 @@ function extractFieldRestrictions(query) {
     if (!m) {
       return { fields: null, innerQuery: remaining }
     }
+    // Asymmetric query protection: if different branches have different inner queries,
+    // we cannot represent this in the modal settings, so bail out.
+    if (inner !== null && inner !== m[2]) {
+      return { fields: null, innerQuery: remaining }
+    }
     fields.push(m[1])
     inner = inner ?? m[2]
   }

--- a/src/utils/luceneQuery.js
+++ b/src/utils/luceneQuery.js
@@ -196,6 +196,28 @@ function tokenize(query) {
 }
 
 /**
+ * Find the index of the first occurrence of a character in a string that is
+ * not preceded by an unescaped backslash escape sequence.
+ */
+function findUnescapedChar(str, char) {
+  let escape = false
+  for (let i = 0; i < str.length; i++) {
+    if (escape) {
+      escape = false
+      continue
+    }
+    if (str[i] === '\\') {
+      escape = true
+      continue
+    }
+    if (str[i] === char) {
+      return i
+    }
+  }
+  return -1
+}
+
+/**
  * Attempt to extract field restrictions from the query wrapper.
  * E.g., "tags:(Paris) OR content:(Paris)"
  * If the wrapper is symmetric (all fields share the exact same inner query),
@@ -278,20 +300,24 @@ function tryParseNoneWords(token, noneWords) {
 }
 
 function tryParseSingleWildcard(token, form) {
-  if (token.includes('?') && !token.includes('*')) {
-    const [start, ...rest] = token.split('?')
+  const idx = findUnescapedChar(token, '?')
+  if (idx !== -1 && findUnescapedChar(token, '*') === -1) {
+    const start = token.slice(0, idx)
+    const end = token.slice(idx + 1)
     form.singleWildcardStart = unescapeTerm(start)
-    form.singleWildcardEnd = unescapeTerm(rest.join('?'))
+    form.singleWildcardEnd = unescapeTerm(end)
     return true
   }
   return false
 }
 
 function tryParseMultiWildcard(token, form) {
-  if (token.includes('*') && !token.includes('?')) {
-    const [start, ...rest] = token.split('*')
+  const idx = findUnescapedChar(token, '*')
+  if (idx !== -1 && findUnescapedChar(token, '?') === -1) {
+    const start = token.slice(0, idx)
+    const end = token.slice(idx + 1)
     form.multiWildcardStart = unescapeTerm(start)
-    form.multiWildcardEnd = unescapeTerm(rest.join('*'))
+    form.multiWildcardEnd = unescapeTerm(end)
     return true
   }
   return false

--- a/src/utils/luceneQuery.js
+++ b/src/utils/luceneQuery.js
@@ -1,3 +1,5 @@
+import lucene from 'lucene'
+
 /**
  * Reserved characters that have special meaning in Lucene query syntax.
  * They must be backslash-escaped when they appear inside a user-supplied
@@ -175,6 +177,23 @@ function unescapeTerm(term) {
 }
 
 const unescapePhrase = unescapeTerm
+
+/**
+ * The rest of the app (search bar, breadcrumb, search store) reads `q`
+ * through the `lucene` package's grammar. A query that grammar rejects
+ * (unbalanced quotes or parentheses, stray operators…) cannot be claimed
+ * representable by the form either, so it is screened out before our own
+ * pattern matching runs.
+ */
+function isParseableLuceneQuery(query) {
+  try {
+    lucene.parse(query)
+    return true
+  }
+  catch {
+    return false
+  }
+}
 
 /**
  * A raw (still-escaped) term is representable in the form only when
@@ -533,10 +552,11 @@ function applyWordBuckets(ctx) {
  *
  * Only patterns produced by `generateLuceneQuery` are recognised. When any
  * part of the query cannot be represented by the form without changing its
- * meaning on re-submit — field syntax, boolean operators, ranges, a second
- * fuzzy/proximity/wildcard clause, an out-of-range distance, a restriction
- * to an unknown field — the function returns `null` so callers can skip
- * pre-population instead of silently rewriting the user's query.
+ * meaning on re-submit — malformed syntax, field syntax, boolean operators,
+ * ranges, a second fuzzy/proximity/wildcard clause, an out-of-range
+ * distance, a restriction to an unknown field — the function returns `null`
+ * so callers can skip pre-population instead of silently rewriting the
+ * user's query.
  *
  * @param {string} query
  * @param {Object} [options]
@@ -549,6 +569,10 @@ export function parseLuceneQuery(query, { fields: allowedFields = null } = {}) {
   const form = getInitialForm()
   if (!query || !String(query).trim()) {
     return form
+  }
+
+  if (!isParseableLuceneQuery(query)) {
+    return null
   }
 
   const { fields, innerQuery } = extractFieldRestrictions(query, allowedFields)

--- a/src/utils/luceneQuery.js
+++ b/src/utils/luceneQuery.js
@@ -107,11 +107,11 @@ export function generateLuceneQuery(formData) {
 }
 
 /**
- * Default form shape returned by `parseLuceneQuery` when the input is empty
- * or unparseable. Word inputs are blank strings, distances default to 1
- * (mirroring `getInitialForm` in useAdvancedSearchForm).
+ * Default advanced-search form shape. Word inputs hold strings (whitespace
+ * splitting is deferred to submit time), distances default to 1 — distance
+ * 0 is the disabled state and the slider's `min` enforces that floor.
  */
-function emptyForm() {
+export function getInitialForm() {
   return {
     anyWords: '',
     allWords: '',
@@ -127,6 +127,22 @@ function emptyForm() {
     proximityDistance: 1,
     fieldAll: true,
     selectedFields: []
+  }
+}
+
+/**
+ * Convert the form's string-typed word inputs into the array shape
+ * `generateLuceneQuery` expects. Splits on whitespace for word lists
+ * and keeps the exact phrase as a single quoted entry.
+ */
+export function toQueryShape(f) {
+  const words = s => s.trim().split(/\s+/).filter(Boolean)
+  return {
+    ...f,
+    anyWords: words(f.anyWords),
+    allWords: words(f.allWords),
+    noneWords: words(f.noneWords),
+    exactPhrase: f.exactPhrase.trim() ? [f.exactPhrase.trim()] : []
   }
 }
 
@@ -372,7 +388,7 @@ function tryParseMultiWildcard(token, form) {
  * @returns {Object} A form-shaped object compatible with `getInitialForm`.
  */
 export function parseLuceneQuery(query) {
-  const form = emptyForm()
+  const form = getInitialForm()
   if (!query || !String(query).trim()) return form
 
   const { fields, innerQuery } = extractFieldRestrictions(query)

--- a/src/utils/luceneQuery.js
+++ b/src/utils/luceneQuery.js
@@ -140,59 +140,96 @@ function unescapeTerm(term) {
 
 const unescapePhrase = unescapeTerm
 
+class QueryTokenizer {
+  constructor(query) {
+    this.query = query
+    this.tokens = []
+    this.current = ''
+    this.inQuotes = false
+    this.parenDepth = 0
+    this.escape = false
+  }
+
+  tokenize() {
+    for (const ch of this.query) {
+      this.handleChar(ch)
+    }
+    this.flush()
+    return this.tokens
+  }
+
+  flush() {
+    if (this.current) {
+      this.tokens.push(this.current)
+      this.current = ''
+    }
+  }
+
+  handleChar(ch) {
+    if (this.escape) {
+      this.handleEscaped(ch)
+    }
+    else if (ch === '\\') {
+      this.handleEscapeChar(ch)
+    }
+    else if (ch === '"') {
+      this.handleQuote(ch)
+    }
+    else if (!this.inQuotes && ch === '(') {
+      this.handleOpenParen(ch)
+    }
+    else if (!this.inQuotes && ch === ')') {
+      this.handleCloseParen(ch)
+    }
+    else if (!this.inQuotes && this.parenDepth === 0 && /\s/.test(ch)) {
+      this.handleWhitespace()
+    }
+    else {
+      this.handleDefault(ch)
+    }
+  }
+
+  handleEscaped(ch) {
+    this.current += ch
+    this.escape = false
+  }
+
+  handleEscapeChar(ch) {
+    this.current += ch
+    this.escape = true
+  }
+
+  handleQuote(ch) {
+    this.current += ch
+    this.inQuotes = !this.inQuotes
+  }
+
+  handleOpenParen(ch) {
+    this.current += ch
+    this.parenDepth++
+  }
+
+  handleCloseParen(ch) {
+    this.current += ch
+    this.parenDepth--
+  }
+
+  handleWhitespace() {
+    this.flush()
+  }
+
+  handleDefault(ch) {
+    this.current += ch
+  }
+}
+
 /**
  * Split a Lucene query on top-level whitespace while keeping quoted phrases
  * and parenthesised groups (including their trailing `~N` modifier) as
  * single tokens. Handles backslash escapes inside both.
  */
 function tokenize(query) {
-  const tokens = []
-  let current = ''
-  let inQuotes = false
-  let parenDepth = 0
-  let escape = false
-
-  const flush = () => {
-    if (current) {
-      tokens.push(current)
-      current = ''
-    }
-  }
-
-  for (const ch of query) {
-    if (escape) {
-      current += ch
-      escape = false
-      continue
-    }
-    if (ch === '\\') {
-      current += ch
-      escape = true
-      continue
-    }
-    if (ch === '"') {
-      current += ch
-      inQuotes = !inQuotes
-      continue
-    }
-    if (!inQuotes && ch === '(') {
-      current += ch
-      parenDepth++
-      continue
-    }
-    if (!inQuotes && ch === ')') {
-      current += ch
-      parenDepth--
-      continue
-    }
-    if (!inQuotes && parenDepth === 0 && /\s/.test(ch)) {
-      flush()
-      continue
-    }
-    current += ch
-  }
-  flush()
-  return tokens
+  return new QueryTokenizer(query).tokenize()
 }
 
 /**

--- a/src/utils/luceneQuery.js
+++ b/src/utils/luceneQuery.js
@@ -273,17 +273,18 @@ function findUnescapedChar(str, char) {
 /**
  * Attempt to extract field restrictions from the query wrapper.
  * E.g., "tags:(Paris) OR content:(Paris)"
+ *
+ * The split + per-branch match below is the sole validator — a dedicated
+ * "does this look field-restricted" regex would need nested quantifiers
+ * and is susceptible to catastrophic backtracking on crafted input. When
+ * the query is not field-restricted at all, the single resulting "branch"
+ * fails the per-branch match and we bail out with the query unchanged.
+ *
  * If the wrapper is symmetric (all fields share the exact same inner query),
  * returns the fields and the inner query. Otherwise, returns null fields and original query.
  */
 function extractFieldRestrictions(query) {
   const remaining = String(query).trim()
-  const fieldRestrictedRe = /^[\w.]+:\(.+\)( OR [\w.]+:\(.+\))*$/
-
-  if (!fieldRestrictedRe.test(remaining)) {
-    return { fields: null, innerQuery: remaining }
-  }
-
   const branches = remaining.split(/ OR (?=[\w.]+:\()/)
   const fields = []
   let inner = null

--- a/src/utils/luceneQuery.js
+++ b/src/utils/luceneQuery.js
@@ -107,6 +107,26 @@ export function generateLuceneQuery(formData) {
 }
 
 /**
+ * Maximum edit distance for fuzzy search. Lucene caps fuzzy similarity at
+ * two character changes; the modal's distance slider and the parser's
+ * fidelity check share this bound.
+ */
+export const FUZZY_DISTANCE_MAX = 2
+
+/**
+ * Maximum word distance for proximity search, shared by the modal's
+ * distance slider and the parser's fidelity check.
+ */
+export const PROXIMITY_DISTANCE_MAX = 6
+
+/**
+ * Uppercase boolean keywords are Lucene operators, not words: a form that
+ * displayed them as editable plain words would change what they mean on
+ * re-submit.
+ */
+const LUCENE_BOOLEAN_OPERATORS = Object.freeze(['AND', 'OR', 'NOT'])
+
+/**
  * Default advanced-search form shape. Word inputs hold strings (whitespace
  * splitting is deferred to submit time), distances default to 1 — distance
  * 0 is the disabled state and the slider's `min` enforces that floor.
@@ -155,6 +175,25 @@ function unescapeTerm(term) {
 }
 
 const unescapePhrase = unescapeTerm
+
+/**
+ * A raw (still-escaped) term is representable in the form only when
+ * unescaping then re-escaping it reproduces the original token — i.e. it
+ * is escaped exactly the way `generateLuceneQuery` would emit it. Anything
+ * else (an unescaped `:`, `[`, `(`, `~`…) carries Lucene syntax the form
+ * cannot hold without changing its meaning on re-submit.
+ */
+function isFaithfulTerm(raw) {
+  return escapeTerm(unescapeTerm(raw)) === raw
+}
+
+/**
+ * Same fidelity rule as `isFaithfulTerm`, but with the laxer quoted-phrase
+ * escaping (only `"` and `\` are escaped inside quotes).
+ */
+function isFaithfulPhrase(raw) {
+  return escapePhrase(unescapePhrase(raw)) === raw
+}
 
 class QueryTokenizer {
   constructor(query) {
@@ -280,10 +319,11 @@ function findUnescapedChar(str, char) {
  * the query is not field-restricted at all, the single resulting "branch"
  * fails the per-branch match and we bail out with the query unchanged.
  *
- * If the wrapper is symmetric (all fields share the exact same inner query),
- * returns the fields and the inner query. Otherwise, returns null fields and original query.
+ * If the wrapper is symmetric (all branches share the exact same inner
+ * query) and every field is allowed, returns the fields and the inner
+ * query. Otherwise, returns null fields and the original query.
  */
-function extractFieldRestrictions(query) {
+function extractFieldRestrictions(query, allowedFields = null) {
   const remaining = String(query).trim()
   const branches = remaining.split(/ OR (?=[\w.]+:\()/)
   const fields = []
@@ -294,9 +334,16 @@ function extractFieldRestrictions(query) {
     if (!m) {
       return { fields: null, innerQuery: remaining }
     }
-    // Asymmetric query protection: if different branches have different inner queries,
-    // we cannot represent this in the modal settings, so bail out.
+    // Asymmetric query protection: if different branches have different
+    // inner queries, we cannot represent this in the modal settings, so
+    // bail out.
     if (inner !== null && inner !== m[2]) {
+      return { fields: null, innerQuery: remaining }
+    }
+    // Unknown field protection: a restriction to a field the modal does
+    // not offer would be invisible in the checkbox group, so bail out and
+    // let the fidelity checks below reject the query as a whole.
+    if (allowedFields && !allowedFields.includes(m[1])) {
       return { fields: null, innerQuery: remaining }
     }
     fields.push(m[1])
@@ -306,134 +353,225 @@ function extractFieldRestrictions(query) {
   return { fields, innerQuery: inner }
 }
 
-function tryParseProximity(token, form) {
+function tryParseProximity(token, ctx) {
   const m = token.match(/^"(.+)"~(\d+)$/)
-  if (!m) return false
-  form.proximityPhrase = unescapePhrase(m[1])
-  form.proximityDistance = Number(m[2]) || 1
+  if (!m) {
+    return false
+  }
+  const distance = Number(m[2])
+  // The form has a single proximity slot and a bounded slider: a second
+  // clause or an out-of-range distance cannot be represented.
+  if (ctx.form.proximityPhrase || !isFaithfulPhrase(m[1]) || distance < 1 || distance > PROXIMITY_DISTANCE_MAX) {
+    ctx.lossy = true
+  }
+  ctx.form.proximityPhrase = unescapePhrase(m[1])
+  ctx.form.proximityDistance = distance || 1
   return true
 }
 
-function tryParseFuzzy(token, form) {
+function tryParseFuzzy(token, ctx) {
   const m = token.match(/^([^"\s]+)~(\d+)$/)
-  if (!m) return false
-  form.fuzzyTerm = unescapeTerm(m[1])
-  form.fuzzyDistance = Number(m[2]) || 1
+  if (!m) {
+    return false
+  }
+  const distance = Number(m[2])
+  // Same single-slot and bounded-slider rules as proximity.
+  if (ctx.form.fuzzyTerm || !isFaithfulTerm(m[1]) || distance < 1 || distance > FUZZY_DISTANCE_MAX) {
+    ctx.lossy = true
+  }
+  ctx.form.fuzzyTerm = unescapeTerm(m[1])
+  ctx.form.fuzzyDistance = distance || 1
   return true
 }
 
-function tryParseExactPhrase(token, exactPhrases) {
+function tryParseExactPhrase(token, ctx) {
   const m = token.match(/^"(.+)"$/)
-  if (!m) return false
-  exactPhrases.push(unescapePhrase(m[1]))
+  if (!m) {
+    return false
+  }
+  if (!isFaithfulPhrase(m[1])) {
+    ctx.lossy = true
+  }
+  ctx.exactPhrases.push(unescapePhrase(m[1]))
   return true
 }
 
-function tryParseOrGroup(token, anyWords) {
+function tryParseOrGroup(token, ctx) {
   const m = token.match(/^\((.+)\)$/)
-  if (!m) return false
-  const inner = tokenize(m[1])
-  for (const w of inner) anyWords.push(unescapeTerm(w))
+  if (!m) {
+    return false
+  }
+  for (const word of tokenize(m[1])) {
+    if (!isFaithfulTerm(word)) {
+      ctx.lossy = true
+    }
+    ctx.anyWords.push(unescapeTerm(word))
+  }
   return true
 }
 
-function tryParseAllWords(token, allWords) {
-  if (token.startsWith('+') && token.length > 1) {
-    allWords.push(unescapeTerm(token.slice(1)))
-    return true
+function tryParseAllWords(token, ctx) {
+  if (!token.startsWith('+') || token.length === 1) {
+    return false
   }
-  return false
+  const raw = token.slice(1)
+  if (!isFaithfulTerm(raw)) {
+    ctx.lossy = true
+  }
+  ctx.allWords.push(unescapeTerm(raw))
+  return true
 }
 
-function tryParseNoneWords(token, noneWords) {
-  if (token.startsWith('-') && token.length > 1) {
-    noneWords.push(unescapeTerm(token.slice(1)))
-    return true
+function tryParseNoneWords(token, ctx) {
+  if (!token.startsWith('-') || token.length === 1) {
+    return false
   }
-  return false
+  const raw = token.slice(1)
+  if (!isFaithfulTerm(raw)) {
+    ctx.lossy = true
+  }
+  ctx.noneWords.push(unescapeTerm(raw))
+  return true
 }
 
-function tryParseSingleWildcard(token, form) {
+/**
+ * Shared by both wildcard parsers: split the token around its single
+ * unescaped wildcard character and fill the matching form slot.
+ */
+function applyWildcard(token, idx, ctx, startKey, endKey) {
+  const start = token.slice(0, idx)
+  const end = token.slice(idx + 1)
+  // A bare wildcard (no half at all) regenerates to an empty query, a
+  // second clause has no slot left, and a half that is not faithfully
+  // escaped (e.g. a second wildcard char in `a?b?c`) would be re-escaped
+  // into a literal on submit. All three lose information.
+  const slotTaken = ctx.form[startKey] || ctx.form[endKey]
+  if (slotTaken || (!start && !end) || !isFaithfulTerm(start) || !isFaithfulTerm(end)) {
+    ctx.lossy = true
+  }
+  ctx.form[startKey] = unescapeTerm(start)
+  ctx.form[endKey] = unescapeTerm(end)
+}
+
+function tryParseSingleWildcard(token, ctx) {
   const idx = findUnescapedChar(token, '?')
-  if (idx !== -1 && findUnescapedChar(token, '*') === -1) {
-    const start = token.slice(0, idx)
-    const end = token.slice(idx + 1)
-    form.singleWildcardStart = unescapeTerm(start)
-    form.singleWildcardEnd = unescapeTerm(end)
-    return true
+  if (idx === -1 || findUnescapedChar(token, '*') !== -1) {
+    return false
   }
-  return false
+  applyWildcard(token, idx, ctx, 'singleWildcardStart', 'singleWildcardEnd')
+  return true
 }
 
-function tryParseMultiWildcard(token, form) {
+function tryParseMultiWildcard(token, ctx) {
   const idx = findUnescapedChar(token, '*')
-  if (idx !== -1 && findUnescapedChar(token, '?') === -1) {
-    const start = token.slice(0, idx)
-    const end = token.slice(idx + 1)
-    form.multiWildcardStart = unescapeTerm(start)
-    form.multiWildcardEnd = unescapeTerm(end)
-    return true
+  if (idx === -1 || findUnescapedChar(token, '?') !== -1) {
+    return false
   }
-  return false
+  applyWildcard(token, idx, ctx, 'multiWildcardStart', 'multiWildcardEnd')
+  return true
+}
+
+/**
+ * Fallback for tokens no pattern recognised: keep the word in the OR
+ * bucket. Boolean operators and terms carrying unescaped Lucene syntax
+ * make the parse lossy — re-submitting them as escaped plain words would
+ * change the query's meaning.
+ */
+function parseFallbackWord(token, ctx) {
+  if (LUCENE_BOOLEAN_OPERATORS.includes(token) || !isFaithfulTerm(token)) {
+    ctx.lossy = true
+  }
+  ctx.fallbackAnyWords.push(unescapeTerm(token))
+}
+
+/**
+ * Recognised token patterns, tried in order. The first parser to match
+ * consumes the token.
+ */
+const TOKEN_PARSERS = Object.freeze([
+  tryParseProximity,
+  tryParseFuzzy,
+  tryParseExactPhrase,
+  tryParseOrGroup,
+  tryParseAllWords,
+  tryParseNoneWords,
+  tryParseSingleWildcard,
+  tryParseMultiWildcard
+])
+
+function parseToken(token, ctx) {
+  for (const tryParse of TOKEN_PARSERS) {
+    if (tryParse(token, ctx)) {
+      return
+    }
+  }
+  parseFallbackWord(token, ctx)
+}
+
+/**
+ * Flush the accumulated word buckets into the form's string inputs. Plain
+ * words mixed into the OR bucket are appended after group words so the
+ * generated query keeps them in one group.
+ */
+function applyWordBuckets(ctx) {
+  ctx.form.anyWords = [...ctx.anyWords, ...ctx.fallbackAnyWords].join(' ')
+  ctx.form.allWords = ctx.allWords.join(' ')
+  ctx.form.noneWords = ctx.noneWords.join(' ')
+  // The form carries a single exact phrase; a surplus one cannot be moved
+  // to the OR words without breaking it apart on submit (the words input
+  // splits on whitespace), so it makes the parse lossy instead.
+  if (ctx.exactPhrases.length > 0) {
+    ctx.form.exactPhrase = ctx.exactPhrases[0]
+    if (ctx.exactPhrases.length > 1) {
+      ctx.lossy = true
+    }
+  }
 }
 
 /**
  * Parse a Lucene query string back into the advanced-search form shape.
  *
- * Only patterns produced by `generateLuceneQuery` are recognised verbatim;
- * anything else falls into `anyWords` as plain text so the user can still
- * edit it instead of starting from scratch. The mapping is intentionally
- * round-trip safe for the queries this modal emits.
+ * Only patterns produced by `generateLuceneQuery` are recognised. When any
+ * part of the query cannot be represented by the form without changing its
+ * meaning on re-submit — field syntax, boolean operators, ranges, a second
+ * fuzzy/proximity/wildcard clause, an out-of-range distance, a restriction
+ * to an unknown field — the function returns `null` so callers can skip
+ * pre-population instead of silently rewriting the user's query.
  *
  * @param {string} query
- * @returns {Object} A form-shaped object compatible with `getInitialForm`.
+ * @param {Object} [options]
+ * @param {string[]|null} [options.fields] - Allowed values for field
+ *   restrictions. When omitted, any `[\w.]+` field name is accepted.
+ * @returns {Object|null} A form-shaped object compatible with
+ *   `getInitialForm`, or `null` when the query is not representable.
  */
-export function parseLuceneQuery(query) {
+export function parseLuceneQuery(query, { fields: allowedFields = null } = {}) {
   const form = getInitialForm()
-  if (!query || !String(query).trim()) return form
+  if (!query || !String(query).trim()) {
+    return form
+  }
 
-  const { fields, innerQuery } = extractFieldRestrictions(query)
+  const { fields, innerQuery } = extractFieldRestrictions(query, allowedFields)
   if (fields) {
     form.fieldAll = false
     form.selectedFields = fields
   }
 
-  const tokens = tokenize(innerQuery)
-
-  const anyWords = []
-  const allWords = []
-  const noneWords = []
-  const exactPhrases = []
-  // Plain words mixed into the OR bucket are appended last so positional
-  // order is preserved across a round-trip.
-  const fallbackAnyWords = []
-
-  for (const token of tokens) {
-    if (tryParseProximity(token, form)) continue
-    if (tryParseFuzzy(token, form)) continue
-    if (tryParseExactPhrase(token, exactPhrases)) continue
-    if (tryParseOrGroup(token, anyWords)) continue
-    if (tryParseAllWords(token, allWords)) continue
-    if (tryParseNoneWords(token, noneWords)) continue
-    if (tryParseSingleWildcard(token, form)) continue
-    if (tryParseMultiWildcard(token, form)) continue
-
-    // Plain word — drop it in the OR bucket so it stays editable.
-    fallbackAnyWords.push(unescapeTerm(token))
+  const ctx = {
+    form,
+    lossy: false,
+    anyWords: [],
+    allWords: [],
+    noneWords: [],
+    exactPhrases: [],
+    fallbackAnyWords: []
   }
 
-  form.anyWords = [...anyWords, ...fallbackAnyWords].join(' ')
-  form.allWords = allWords.join(' ')
-  form.noneWords = noneWords.join(' ')
-  // The form only carries one phrase; surplus phrases survive as plain
-  // text in the OR field so nothing is silently dropped.
-  if (exactPhrases.length > 0) {
-    form.exactPhrase = exactPhrases[0]
-    if (exactPhrases.length > 1) {
-      const extras = exactPhrases.slice(1).map(p => `"${p}"`).join(' ')
-      form.anyWords = form.anyWords ? `${form.anyWords} ${extras}` : extras
-    }
+  for (const token of tokenize(innerQuery)) {
+    parseToken(token, ctx)
   }
 
-  return form
+  applyWordBuckets(ctx)
+
+  return ctx.lossy ? null : form
 }

--- a/src/utils/luceneQuery.js
+++ b/src/utils/luceneQuery.js
@@ -196,6 +196,103 @@ function tokenize(query) {
 }
 
 /**
+ * Attempt to extract field restrictions from the query wrapper.
+ * E.g., "tags:(Paris) OR content:(Paris)"
+ * If the wrapper is symmetric (all fields share the exact same inner query),
+ * returns the fields and the inner query. Otherwise, returns null fields and original query.
+ */
+function extractFieldRestrictions(query) {
+  const remaining = String(query).trim()
+  const fieldRestrictedRe = /^[\w.]+:\(.+\)( OR [\w.]+:\(.+\))*$/
+
+  if (!fieldRestrictedRe.test(remaining)) {
+    return { fields: null, innerQuery: remaining }
+  }
+
+  const branches = remaining.split(/ OR (?=[\w.]+:\()/)
+  const fields = []
+  let inner = null
+
+  for (const branch of branches) {
+    const m = branch.match(/^([\w.]+):\((.+)\)$/)
+    if (!m) {
+      return { fields: null, innerQuery: remaining }
+    }
+    fields.push(m[1])
+    inner = inner ?? m[2]
+  }
+
+  return { fields, innerQuery: inner }
+}
+
+function tryParseProximity(token, form) {
+  const m = token.match(/^"(.+)"~(\d+)$/)
+  if (!m) return false
+  form.proximityPhrase = unescapePhrase(m[1])
+  form.proximityDistance = Number(m[2]) || 1
+  return true
+}
+
+function tryParseFuzzy(token, form) {
+  const m = token.match(/^([^"\s]+)~(\d+)$/)
+  if (!m) return false
+  form.fuzzyTerm = unescapeTerm(m[1])
+  form.fuzzyDistance = Number(m[2]) || 1
+  return true
+}
+
+function tryParseExactPhrase(token, exactPhrases) {
+  const m = token.match(/^"(.+)"$/)
+  if (!m) return false
+  exactPhrases.push(unescapePhrase(m[1]))
+  return true
+}
+
+function tryParseOrGroup(token, anyWords) {
+  const m = token.match(/^\((.+)\)$/)
+  if (!m) return false
+  const inner = tokenize(m[1])
+  for (const w of inner) anyWords.push(unescapeTerm(w))
+  return true
+}
+
+function tryParseAllWords(token, allWords) {
+  if (token.startsWith('+') && token.length > 1) {
+    allWords.push(unescapeTerm(token.slice(1)))
+    return true
+  }
+  return false
+}
+
+function tryParseNoneWords(token, noneWords) {
+  if (token.startsWith('-') && token.length > 1) {
+    noneWords.push(unescapeTerm(token.slice(1)))
+    return true
+  }
+  return false
+}
+
+function tryParseSingleWildcard(token, form) {
+  if (token.includes('?') && !token.includes('*')) {
+    const [start, ...rest] = token.split('?')
+    form.singleWildcardStart = unescapeTerm(start)
+    form.singleWildcardEnd = unescapeTerm(rest.join('?'))
+    return true
+  }
+  return false
+}
+
+function tryParseMultiWildcard(token, form) {
+  if (token.includes('*') && !token.includes('?')) {
+    const [start, ...rest] = token.split('*')
+    form.multiWildcardStart = unescapeTerm(start)
+    form.multiWildcardEnd = unescapeTerm(rest.join('*'))
+    return true
+  }
+  return false
+}
+
+/**
  * Parse a Lucene query string back into the advanced-search form shape.
  *
  * Only patterns produced by `generateLuceneQuery` are recognised verbatim;
@@ -210,35 +307,13 @@ export function parseLuceneQuery(query) {
   const form = emptyForm()
   if (!query || !String(query).trim()) return form
 
-  let remaining = String(query).trim()
-
-  // Detect the `field1:(inner) OR field2:(inner) …` wrapper produced when
-  // specific fields are picked. All branches share the same `inner`, so
-  // grab one and continue parsing it.
-  const fieldRestrictedRe = /^[\w.]+:\(.+\)( OR [\w.]+:\(.+\))*$/
-  if (fieldRestrictedRe.test(remaining)) {
-    const branches = remaining.split(/ OR (?=[\w.]+:\()/)
-    const fields = []
-    let inner = null
-    for (const branch of branches) {
-      const m = branch.match(/^([\w.]+):\((.+)\)$/)
-      if (!m) {
-        // Bail out: the outer wrap doesn't perfectly match what we generate.
-        fields.length = 0
-        inner = null
-        break
-      }
-      fields.push(m[1])
-      inner = inner ?? m[2]
-    }
-    if (fields.length > 0 && inner !== null) {
-      form.fieldAll = false
-      form.selectedFields = fields
-      remaining = inner
-    }
+  const { fields, innerQuery } = extractFieldRestrictions(query)
+  if (fields) {
+    form.fieldAll = false
+    form.selectedFields = fields
   }
 
-  const tokens = tokenize(remaining)
+  const tokens = tokenize(innerQuery)
 
   const anyWords = []
   const allWords = []
@@ -249,64 +324,14 @@ export function parseLuceneQuery(query) {
   const fallbackAnyWords = []
 
   for (const token of tokens) {
-    // "phrase"~N → proximity
-    const proximity = token.match(/^"(.+)"~(\d+)$/)
-    if (proximity) {
-      form.proximityPhrase = unescapePhrase(proximity[1])
-      form.proximityDistance = Number(proximity[2]) || 1
-      continue
-    }
-
-    // term~N → fuzzy
-    const fuzzy = token.match(/^([^"\s]+)~(\d+)$/)
-    if (fuzzy) {
-      form.fuzzyTerm = unescapeTerm(fuzzy[1])
-      form.fuzzyDistance = Number(fuzzy[2]) || 1
-      continue
-    }
-
-    // "phrase" (no ~N) → exactPhrase
-    const phrase = token.match(/^"(.+)"$/)
-    if (phrase) {
-      exactPhrases.push(unescapePhrase(phrase[1]))
-      continue
-    }
-
-    // (a b c) → anyWords OR group
-    const group = token.match(/^\((.+)\)$/)
-    if (group) {
-      const inner = tokenize(group[1])
-      for (const w of inner) anyWords.push(unescapeTerm(w))
-      continue
-    }
-
-    // +word → allWords
-    if (token.startsWith('+') && token.length > 1) {
-      allWords.push(unescapeTerm(token.slice(1)))
-      continue
-    }
-
-    // -word → noneWords
-    if (token.startsWith('-') && token.length > 1) {
-      noneWords.push(unescapeTerm(token.slice(1)))
-      continue
-    }
-
-    // word with a single `?` → singleWildcard (both sides optional)
-    if (token.includes('?') && !token.includes('*')) {
-      const [start, ...rest] = token.split('?')
-      form.singleWildcardStart = unescapeTerm(start)
-      form.singleWildcardEnd = unescapeTerm(rest.join('?'))
-      continue
-    }
-
-    // word with a single `*` → multiWildcard
-    if (token.includes('*') && !token.includes('?')) {
-      const [start, ...rest] = token.split('*')
-      form.multiWildcardStart = unescapeTerm(start)
-      form.multiWildcardEnd = unescapeTerm(rest.join('*'))
-      continue
-    }
+    if (tryParseProximity(token, form)) continue
+    if (tryParseFuzzy(token, form)) continue
+    if (tryParseExactPhrase(token, exactPhrases)) continue
+    if (tryParseOrGroup(token, anyWords)) continue
+    if (tryParseAllWords(token, allWords)) continue
+    if (tryParseNoneWords(token, noneWords)) continue
+    if (tryParseSingleWildcard(token, form)) continue
+    if (tryParseMultiWildcard(token, form)) continue
 
     // Plain word — drop it in the OR bucket so it stays editable.
     fallbackAnyWords.push(unescapeTerm(token))

--- a/src/utils/luceneQuery.js
+++ b/src/utils/luceneQuery.js
@@ -105,3 +105,225 @@ export function generateLuceneQuery(formData) {
 
   return query.trim()
 }
+
+/**
+ * Default form shape returned by `parseLuceneQuery` when the input is empty
+ * or unparseable. Word inputs are blank strings, distances default to 1
+ * (mirroring `getInitialForm` in useAdvancedSearchForm).
+ */
+function emptyForm() {
+  return {
+    anyWords: '',
+    allWords: '',
+    exactPhrase: '',
+    noneWords: '',
+    singleWildcardStart: '',
+    singleWildcardEnd: '',
+    multiWildcardStart: '',
+    multiWildcardEnd: '',
+    fuzzyTerm: '',
+    fuzzyDistance: 1,
+    proximityPhrase: '',
+    proximityDistance: 1,
+    fieldAll: true,
+    selectedFields: []
+  }
+}
+
+/**
+ * Reverse of `escapeTerm` — turn `\X` back into `X`. Lossy on purpose:
+ * we don't try to distinguish reserved chars from accidental backslashes.
+ */
+function unescapeTerm(term) {
+  return String(term).replace(/\\(.)/g, '$1')
+}
+
+const unescapePhrase = unescapeTerm
+
+/**
+ * Split a Lucene query on top-level whitespace while keeping quoted phrases
+ * and parenthesised groups (including their trailing `~N` modifier) as
+ * single tokens. Handles backslash escapes inside both.
+ */
+function tokenize(query) {
+  const tokens = []
+  let current = ''
+  let inQuotes = false
+  let parenDepth = 0
+  let escape = false
+
+  const flush = () => {
+    if (current) {
+      tokens.push(current)
+      current = ''
+    }
+  }
+
+  for (const ch of query) {
+    if (escape) {
+      current += ch
+      escape = false
+      continue
+    }
+    if (ch === '\\') {
+      current += ch
+      escape = true
+      continue
+    }
+    if (ch === '"') {
+      current += ch
+      inQuotes = !inQuotes
+      continue
+    }
+    if (!inQuotes && ch === '(') {
+      current += ch
+      parenDepth++
+      continue
+    }
+    if (!inQuotes && ch === ')') {
+      current += ch
+      parenDepth--
+      continue
+    }
+    if (!inQuotes && parenDepth === 0 && /\s/.test(ch)) {
+      flush()
+      continue
+    }
+    current += ch
+  }
+  flush()
+  return tokens
+}
+
+/**
+ * Parse a Lucene query string back into the advanced-search form shape.
+ *
+ * Only patterns produced by `generateLuceneQuery` are recognised verbatim;
+ * anything else falls into `anyWords` as plain text so the user can still
+ * edit it instead of starting from scratch. The mapping is intentionally
+ * round-trip safe for the queries this modal emits.
+ *
+ * @param {string} query
+ * @returns {Object} A form-shaped object compatible with `getInitialForm`.
+ */
+export function parseLuceneQuery(query) {
+  const form = emptyForm()
+  if (!query || !String(query).trim()) return form
+
+  let remaining = String(query).trim()
+
+  // Detect the `field1:(inner) OR field2:(inner) …` wrapper produced when
+  // specific fields are picked. All branches share the same `inner`, so
+  // grab one and continue parsing it.
+  const fieldRestrictedRe = /^[\w.]+:\(.+\)( OR [\w.]+:\(.+\))*$/
+  if (fieldRestrictedRe.test(remaining)) {
+    const branches = remaining.split(/ OR (?=[\w.]+:\()/)
+    const fields = []
+    let inner = null
+    for (const branch of branches) {
+      const m = branch.match(/^([\w.]+):\((.+)\)$/)
+      if (!m) {
+        // Bail out: the outer wrap doesn't perfectly match what we generate.
+        fields.length = 0
+        inner = null
+        break
+      }
+      fields.push(m[1])
+      inner = inner ?? m[2]
+    }
+    if (fields.length > 0 && inner !== null) {
+      form.fieldAll = false
+      form.selectedFields = fields
+      remaining = inner
+    }
+  }
+
+  const tokens = tokenize(remaining)
+
+  const anyWords = []
+  const allWords = []
+  const noneWords = []
+  const exactPhrases = []
+  // Plain words mixed into the OR bucket are appended last so positional
+  // order is preserved across a round-trip.
+  const fallbackAnyWords = []
+
+  for (const token of tokens) {
+    // "phrase"~N → proximity
+    const proximity = token.match(/^"(.+)"~(\d+)$/)
+    if (proximity) {
+      form.proximityPhrase = unescapePhrase(proximity[1])
+      form.proximityDistance = Number(proximity[2]) || 1
+      continue
+    }
+
+    // term~N → fuzzy
+    const fuzzy = token.match(/^([^"\s]+)~(\d+)$/)
+    if (fuzzy) {
+      form.fuzzyTerm = unescapeTerm(fuzzy[1])
+      form.fuzzyDistance = Number(fuzzy[2]) || 1
+      continue
+    }
+
+    // "phrase" (no ~N) → exactPhrase
+    const phrase = token.match(/^"(.+)"$/)
+    if (phrase) {
+      exactPhrases.push(unescapePhrase(phrase[1]))
+      continue
+    }
+
+    // (a b c) → anyWords OR group
+    const group = token.match(/^\((.+)\)$/)
+    if (group) {
+      const inner = tokenize(group[1])
+      for (const w of inner) anyWords.push(unescapeTerm(w))
+      continue
+    }
+
+    // +word → allWords
+    if (token.startsWith('+') && token.length > 1) {
+      allWords.push(unescapeTerm(token.slice(1)))
+      continue
+    }
+
+    // -word → noneWords
+    if (token.startsWith('-') && token.length > 1) {
+      noneWords.push(unescapeTerm(token.slice(1)))
+      continue
+    }
+
+    // word with a single `?` → singleWildcard (both sides optional)
+    if (token.includes('?') && !token.includes('*')) {
+      const [start, ...rest] = token.split('?')
+      form.singleWildcardStart = unescapeTerm(start)
+      form.singleWildcardEnd = unescapeTerm(rest.join('?'))
+      continue
+    }
+
+    // word with a single `*` → multiWildcard
+    if (token.includes('*') && !token.includes('?')) {
+      const [start, ...rest] = token.split('*')
+      form.multiWildcardStart = unescapeTerm(start)
+      form.multiWildcardEnd = unescapeTerm(rest.join('*'))
+      continue
+    }
+
+    // Plain word — drop it in the OR bucket so it stays editable.
+    fallbackAnyWords.push(unescapeTerm(token))
+  }
+
+  form.anyWords = [...anyWords, ...fallbackAnyWords].join(' ')
+  form.allWords = allWords.join(' ')
+  form.noneWords = noneWords.join(' ')
+  // The form only carries one phrase; surplus phrases survive as plain
+  // text in the OR field so nothing is silently dropped.
+  if (exactPhrases.length > 0) {
+    form.exactPhrase = exactPhrases[0]
+    if (exactPhrases.length > 1) {
+      const extras = exactPhrases.slice(1).map(p => `"${p}"`).join(' ')
+      form.anyWords = form.anyWords ? `${form.anyWords} ${extras}` : extras
+    }
+  }
+
+  return form
+}

--- a/tests/unit/specs/components/Search/SearchAdvancedModal/SearchAdvancedModal.spec.js
+++ b/tests/unit/specs/components/Search/SearchAdvancedModal/SearchAdvancedModal.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue'
 import { shallowMount } from '@vue/test-utils'
 
 import CoreSetup from '~tests/unit/CoreSetup'
@@ -103,5 +104,40 @@ describe('SearchAdvancedModal.vue', () => {
     expect(wrapper.vm.form.fuzzyTerm).toBe('')
     expect(wrapper.vm.form.fieldAll).toBe(true)
     expect(wrapper.vm.form.selectedFields).toEqual([])
+  })
+
+  it('pre-populates the form from initialQuery when the modal opens', async () => {
+    const wrapper = shallowMount(SearchAdvancedModal, {
+      props: { modelValue: false, initialQuery: '+Paris +London' },
+      global: { plugins, renderStubDefaultSlot: true }
+    })
+    await wrapper.setProps({ modelValue: true })
+    await nextTick()
+    expect(wrapper.vm.form.allWords).toBe('Paris London')
+  })
+
+  it('pre-populates a field-restricted query into the right buckets', async () => {
+    const wrapper = shallowMount(SearchAdvancedModal, {
+      props: { modelValue: false, initialQuery: 'tags:(Paris) OR content:(Paris)' },
+      global: { plugins, renderStubDefaultSlot: true }
+    })
+    await wrapper.setProps({ modelValue: true })
+    await nextTick()
+    expect(wrapper.vm.form.anyWords).toBe('Paris')
+    expect(wrapper.vm.form.fieldAll).toBe(false)
+    expect(wrapper.vm.form.selectedFields).toEqual(['tags', 'content'])
+  })
+
+  it('resets to the initial form when the modal closes', async () => {
+    const wrapper = shallowMount(SearchAdvancedModal, {
+      props: { modelValue: true, initialQuery: '+Paris' },
+      global: { plugins, renderStubDefaultSlot: true }
+    })
+    await nextTick()
+    wrapper.vm.form.fuzzyTerm = 'Mercedes'
+    await wrapper.setProps({ modelValue: false })
+    await nextTick()
+    expect(wrapper.vm.form.allWords).toBe('')
+    expect(wrapper.vm.form.fuzzyTerm).toBe('')
   })
 })

--- a/tests/unit/specs/components/Search/SearchAdvancedModal/SearchAdvancedModal.spec.js
+++ b/tests/unit/specs/components/Search/SearchAdvancedModal/SearchAdvancedModal.spec.js
@@ -128,6 +128,30 @@ describe('SearchAdvancedModal.vue', () => {
     expect(wrapper.vm.form.selectedFields).toEqual(['tags', 'content'])
   })
 
+  it('opens blank when initialQuery cannot be faithfully represented', async () => {
+    // A hand-written field query would be silently rewritten into a
+    // literal-text search on re-submit, so the form must not pre-populate.
+    const wrapper = shallowMount(SearchAdvancedModal, {
+      props: { modelValue: false, initialQuery: 'content:cat' },
+      global: { plugins, renderStubDefaultSlot: true }
+    })
+    await wrapper.setProps({ modelValue: true })
+    await nextTick()
+    expect(wrapper.vm.form.anyWords).toBe('')
+    expect(wrapper.vm.isFormEmpty).toBe(true)
+  })
+
+  it('opens blank when initialQuery restricts to a field the modal does not offer', async () => {
+    const wrapper = shallowMount(SearchAdvancedModal, {
+      props: { modelValue: false, initialQuery: 'author:(Paris)' },
+      global: { plugins, renderStubDefaultSlot: true }
+    })
+    await wrapper.setProps({ modelValue: true })
+    await nextTick()
+    expect(wrapper.vm.form.fieldAll).toBe(true)
+    expect(wrapper.vm.form.selectedFields).toEqual([])
+  })
+
   it('resets to the initial form when the modal closes', async () => {
     const wrapper = shallowMount(SearchAdvancedModal, {
       props: { modelValue: true, initialQuery: '+Paris' },

--- a/tests/unit/specs/utils/luceneQuery.spec.js
+++ b/tests/unit/specs/utils/luceneQuery.spec.js
@@ -568,17 +568,16 @@ describe('luceneQuery', () => {
       expect(f.selectedFields).toEqual(['metadata.tika_metadata_dc_creator'])
     })
 
-    it('bails out to anyWords if a field-restricted query has asymmetric inner queries', () => {
-      const f = parseLuceneQuery('tags:(Paris) OR content:(London)')
-      expect(f.fieldAll).toBe(true)
-      expect(f.selectedFields).toEqual([])
-      expect(f.anyWords).toBe('tags:(Paris) OR content:(London)')
+    it('returns null if a field-restricted query has asymmetric inner queries', () => {
+      // The form cannot hold a different inner query per field; editing a
+      // mangled version would silently drop one of the branches.
+      expect(parseLuceneQuery('tags:(Paris) OR content:(London)')).toBeNull()
     })
 
-    it('keeps a query it cannot recognise in anyWords so the user can still edit it', () => {
-      const f = parseLuceneQuery('weirdField:value AND other:value')
-      // Falls through to plain-text tokens — at minimum nothing is lost.
-      expect(f.anyWords.length).toBeGreaterThan(0)
+    it('returns null for a query it cannot faithfully represent', () => {
+      // Re-submitting these as escaped plain words would change their
+      // meaning, so the modal must open blank instead.
+      expect(parseLuceneQuery('weirdField:value AND other:value')).toBeNull()
     })
 
     it('round-trips a representative full form through generate → parse', () => {
@@ -658,6 +657,75 @@ describe('luceneQuery', () => {
       expect(query).toContain('\\:')
       const round = parseLuceneQuery(query)
       expect(round.anyWords).toBe('foo:bar')
+    })
+  })
+
+  describe('parseLuceneQuery non-representable queries', () => {
+    it('returns null for a field:value query', () => {
+      // Escaping the colon on re-submit would turn the field search into
+      // a literal-text search.
+      expect(parseLuceneQuery('content:cat')).toBeNull()
+    })
+
+    it('returns null for boolean operators', () => {
+      expect(parseLuceneQuery('Paris OR London')).toBeNull()
+      expect(parseLuceneQuery('cat AND dog')).toBeNull()
+      expect(parseLuceneQuery('Paris NOT London')).toBeNull()
+    })
+
+    it('returns null for a range query', () => {
+      expect(parseLuceneQuery('date:[2020 TO 2021]')).toBeNull()
+    })
+
+    it('returns null when a second fuzzy clause would be dropped', () => {
+      expect(parseLuceneQuery('roam~2 jakarta~1')).toBeNull()
+    })
+
+    it('returns null when a second proximity clause would be dropped', () => {
+      expect(parseLuceneQuery('"a b"~3 "c d"~5')).toBeNull()
+    })
+
+    it('returns null when a second wildcard clause would be dropped', () => {
+      expect(parseLuceneQuery('a* b*')).toBeNull()
+      expect(parseLuceneQuery('wom?n m?n')).toBeNull()
+    })
+
+    it('returns null when a second exact phrase would be dropped', () => {
+      expect(parseLuceneQuery('"Paris match" "Société SAS"')).toBeNull()
+    })
+
+    it('returns null for a bare wildcard query', () => {
+      // `*` regenerates to an empty query — the match-all would be lost.
+      expect(parseLuceneQuery('*')).toBeNull()
+      expect(parseLuceneQuery('?')).toBeNull()
+    })
+
+    it('returns null for a token with several wildcards', () => {
+      // Only the first `?` fits the form; the second would be re-escaped
+      // into a literal on submit.
+      expect(parseLuceneQuery('a?b?c')).toBeNull()
+      expect(parseLuceneQuery('a?b*c')).toBeNull()
+    })
+
+    it('returns null for out-of-range distances', () => {
+      // The sliders cap fuzzy at 2 and proximity at 6; clamping would
+      // silently change the user's distance.
+      expect(parseLuceneQuery('foo~3')).toBeNull()
+      expect(parseLuceneQuery('"a b"~7')).toBeNull()
+      expect(parseLuceneQuery('foo~0')).toBeNull()
+    })
+
+    it('returns null for a restriction to a field the modal does not offer', () => {
+      const fields = ['tags', 'content']
+      expect(parseLuceneQuery('author:(Paris)', { fields })).toBeNull()
+      expect(parseLuceneQuery('tags:(Paris)', { fields })).not.toBeNull()
+    })
+
+    it('parses a long crafted field-restricted query without pathological backtracking', () => {
+      // Regression guard: the previous wrapper-detection regex had nested
+      // quantifiers and froze the main thread on this exact shape.
+      const query = 'f:(x)' + ' OR f:(x)'.repeat(40) + ' zzzz'
+      expect(parseLuceneQuery(query)).toBeNull()
     })
   })
 })

--- a/tests/unit/specs/utils/luceneQuery.spec.js
+++ b/tests/unit/specs/utils/luceneQuery.spec.js
@@ -564,6 +564,13 @@ describe('luceneQuery', () => {
       expect(f.selectedFields).toEqual(['metadata.tika_metadata_dc_creator'])
     })
 
+    it('bails out to anyWords if a field-restricted query has asymmetric inner queries', () => {
+      const f = parseLuceneQuery('tags:(Paris) OR content:(London)')
+      expect(f.fieldAll).toBe(true)
+      expect(f.selectedFields).toEqual([])
+      expect(f.anyWords).toBe('tags:(Paris) OR content:(London)')
+    })
+
     it('keeps a query it cannot recognise in anyWords so the user can still edit it', () => {
       const f = parseLuceneQuery('weirdField:value AND other:value')
       // Falls through to plain-text tokens — at minimum nothing is lost.

--- a/tests/unit/specs/utils/luceneQuery.spec.js
+++ b/tests/unit/specs/utils/luceneQuery.spec.js
@@ -661,6 +661,14 @@ describe('luceneQuery', () => {
   })
 
   describe('parseLuceneQuery non-representable queries', () => {
+    it('returns null for a query the shared lucene grammar rejects', () => {
+      // The search bar, breadcrumb and store all read `q` through the
+      // `lucene` package; a query it cannot parse is not representable.
+      expect(parseLuceneQuery('"unclosed')).toBeNull()
+      expect(parseLuceneQuery('(unclosed')).toBeNull()
+      expect(parseLuceneQuery(')stray(')).toBeNull()
+    })
+
     it('returns null for a field:value query', () => {
       // Escaping the colon on re-submit would turn the field search into
       // a literal-text search.

--- a/tests/unit/specs/utils/luceneQuery.spec.js
+++ b/tests/unit/specs/utils/luceneQuery.spec.js
@@ -1,5 +1,21 @@
 import { describe, it, expect } from 'vitest'
-import { generateLuceneQuery as generateQuery } from '@/utils/luceneQuery'
+import { generateLuceneQuery as generateQuery, parseLuceneQuery } from '@/utils/luceneQuery'
+
+/**
+ * Lift a form to the array shape expected by `generateLuceneQuery` — same
+ * helper as `toQueryShape` in useAdvancedSearchForm, duplicated here so the
+ * round-trip tests stay independent of that module.
+ */
+function toQueryShape(f) {
+  const words = s => (s || '').trim().split(/\s+/).filter(Boolean)
+  return {
+    ...f,
+    anyWords: words(f.anyWords),
+    allWords: words(f.allWords),
+    noneWords: words(f.noneWords),
+    exactPhrase: f.exactPhrase?.trim() ? [f.exactPhrase.trim()] : []
+  }
+}
 
 describe('luceneQuery', () => {
   describe('generateLuceneQuery', () => {
@@ -466,6 +482,171 @@ describe('luceneQuery', () => {
 
       const query = generateQuery(formData)
       expect(query).toBe('Paris')
+    })
+  })
+
+  describe('parseLuceneQuery', () => {
+    it('returns an empty form for empty input', () => {
+      const f = parseLuceneQuery('')
+      expect(f.anyWords).toBe('')
+      expect(f.allWords).toBe('')
+      expect(f.exactPhrase).toBe('')
+      expect(f.noneWords).toBe('')
+      expect(f.fuzzyTerm).toBe('')
+      expect(f.proximityPhrase).toBe('')
+      expect(f.fuzzyDistance).toBe(1)
+      expect(f.proximityDistance).toBe(1)
+      expect(f.fieldAll).toBe(true)
+      expect(f.selectedFields).toEqual([])
+    })
+
+    it('returns an empty form for null / whitespace input', () => {
+      expect(parseLuceneQuery(null).anyWords).toBe('')
+      expect(parseLuceneQuery('   ').anyWords).toBe('')
+    })
+
+    it('parses a single bare word into anyWords', () => {
+      expect(parseLuceneQuery('Paris').anyWords).toBe('Paris')
+    })
+
+    it('parses a parenthesised OR group into anyWords', () => {
+      expect(parseLuceneQuery('(Paris London)').anyWords).toBe('Paris London')
+    })
+
+    it('parses `+word +word` into allWords', () => {
+      const f = parseLuceneQuery('+Paris +London')
+      expect(f.allWords).toBe('Paris London')
+      expect(f.anyWords).toBe('')
+    })
+
+    it('parses `-word -word` into noneWords', () => {
+      const f = parseLuceneQuery('-Paris -London')
+      expect(f.noneWords).toBe('Paris London')
+    })
+
+    it('parses a quoted phrase into exactPhrase', () => {
+      expect(parseLuceneQuery('"Société SAS"').exactPhrase).toBe('Société SAS')
+    })
+
+    it('parses `term~N` into fuzzy', () => {
+      const f = parseLuceneQuery('Mercedes~2')
+      expect(f.fuzzyTerm).toBe('Mercedes')
+      expect(f.fuzzyDistance).toBe(2)
+    })
+
+    it('parses `"phrase"~N` into proximity', () => {
+      const f = parseLuceneQuery('"John and Mercedes"~3')
+      expect(f.proximityPhrase).toBe('John and Mercedes')
+      expect(f.proximityDistance).toBe(3)
+    })
+
+    it('parses single-character wildcard `a?b`', () => {
+      const f = parseLuceneQuery('Mer?es')
+      expect(f.singleWildcardStart).toBe('Mer')
+      expect(f.singleWildcardEnd).toBe('es')
+    })
+
+    it('parses multi-character wildcard `a*b`', () => {
+      const f = parseLuceneQuery('Mer*es')
+      expect(f.multiWildcardStart).toBe('Mer')
+      expect(f.multiWildcardEnd).toBe('es')
+    })
+
+    it('parses field-restricted queries into selectedFields + inner query', () => {
+      const f = parseLuceneQuery('tags:(Paris) OR content:(Paris)')
+      expect(f.fieldAll).toBe(false)
+      expect(f.selectedFields).toEqual(['tags', 'content'])
+      expect(f.anyWords).toBe('Paris')
+    })
+
+    it('parses field-restricted dotted ES field paths', () => {
+      const f = parseLuceneQuery('metadata.tika_metadata_dc_creator:(Paris)')
+      expect(f.selectedFields).toEqual(['metadata.tika_metadata_dc_creator'])
+    })
+
+    it('keeps a query it cannot recognise in anyWords so the user can still edit it', () => {
+      const f = parseLuceneQuery('weirdField:value AND other:value')
+      // Falls through to plain-text tokens — at minimum nothing is lost.
+      expect(f.anyWords.length).toBeGreaterThan(0)
+    })
+
+    it('round-trips a representative full form through generate → parse', () => {
+      const initial = {
+        anyWords: 'Paris London',
+        allWords: 'Macron Emmanuel',
+        exactPhrase: 'Société SAS',
+        noneWords: 'Jo',
+        singleWildcardStart: 'Mer',
+        singleWildcardEnd: 'es',
+        multiWildcardStart: '',
+        multiWildcardEnd: '',
+        fuzzyTerm: 'Mercedes',
+        fuzzyDistance: 2,
+        proximityPhrase: 'John and Mercedes are in Paris',
+        proximityDistance: 3,
+        fieldAll: true,
+        selectedFields: []
+      }
+      const query = generateQuery(toQueryShape(initial))
+      const round = parseLuceneQuery(query)
+      expect(round.anyWords).toBe('Paris London')
+      expect(round.allWords).toBe('Macron Emmanuel')
+      expect(round.exactPhrase).toBe('Société SAS')
+      expect(round.noneWords).toBe('Jo')
+      expect(round.singleWildcardStart).toBe('Mer')
+      expect(round.singleWildcardEnd).toBe('es')
+      expect(round.fuzzyTerm).toBe('Mercedes')
+      expect(round.fuzzyDistance).toBe(2)
+      expect(round.proximityPhrase).toBe('John and Mercedes are in Paris')
+      expect(round.proximityDistance).toBe(3)
+    })
+
+    it('round-trips a field-restricted query', () => {
+      const initial = {
+        anyWords: 'Paris',
+        allWords: '',
+        exactPhrase: '',
+        noneWords: '',
+        singleWildcardStart: '',
+        singleWildcardEnd: '',
+        multiWildcardStart: '',
+        multiWildcardEnd: '',
+        fuzzyTerm: '',
+        fuzzyDistance: 1,
+        proximityPhrase: '',
+        proximityDistance: 1,
+        fieldAll: false,
+        selectedFields: ['tags', 'content']
+      }
+      const query = generateQuery(toQueryShape(initial))
+      const round = parseLuceneQuery(query)
+      expect(round.fieldAll).toBe(false)
+      expect(round.selectedFields).toEqual(['tags', 'content'])
+      expect(round.anyWords).toBe('Paris')
+    })
+
+    it('unescapes Lucene-reserved characters round-trip', () => {
+      const initial = {
+        anyWords: 'foo:bar',
+        allWords: '',
+        exactPhrase: '',
+        noneWords: '',
+        singleWildcardStart: '',
+        singleWildcardEnd: '',
+        multiWildcardStart: '',
+        multiWildcardEnd: '',
+        fuzzyTerm: '',
+        fuzzyDistance: 1,
+        proximityPhrase: '',
+        proximityDistance: 1,
+        fieldAll: true,
+        selectedFields: []
+      }
+      const query = generateQuery(toQueryShape(initial))
+      // Generator escapes the colon: `foo\:bar`
+      expect(query).toContain('\\:')
+      const round = parseLuceneQuery(query)
+      expect(round.anyWords).toBe('foo:bar')
     })
   })
 })

--- a/tests/unit/specs/utils/luceneQuery.spec.js
+++ b/tests/unit/specs/utils/luceneQuery.spec.js
@@ -552,6 +552,26 @@ describe('luceneQuery', () => {
       expect(f.multiWildcardEnd).toBe('es')
     })
 
+    it('does not parse escaped wildcard characters as wildcards', () => {
+      const f = parseLuceneQuery('abc\\?def')
+      expect(f.singleWildcardStart).toBe('')
+      expect(f.singleWildcardEnd).toBe('')
+      expect(f.anyWords).toBe('abc?def')
+    })
+
+    it('does not parse escaped asterisk characters as wildcards', () => {
+      const f = parseLuceneQuery('abc\\*def')
+      expect(f.multiWildcardStart).toBe('')
+      expect(f.multiWildcardEnd).toBe('')
+      expect(f.anyWords).toBe('abc*def')
+    })
+
+    it('parses a wildcard following an escaped backslash', () => {
+      const f = parseLuceneQuery('abc\\\\?def')
+      expect(f.singleWildcardStart).toBe('abc\\')
+      expect(f.singleWildcardEnd).toBe('def')
+    })
+
     it('parses field-restricted queries into selectedFields + inner query', () => {
       const f = parseLuceneQuery('tags:(Paris) OR content:(Paris)')
       expect(f.fieldAll).toBe(false)

--- a/tests/unit/specs/utils/luceneQuery.spec.js
+++ b/tests/unit/specs/utils/luceneQuery.spec.js
@@ -1,21 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { generateLuceneQuery as generateQuery, parseLuceneQuery } from '@/utils/luceneQuery'
-
-/**
- * Lift a form to the array shape expected by `generateLuceneQuery` — same
- * helper as `toQueryShape` in useAdvancedSearchForm, duplicated here so the
- * round-trip tests stay independent of that module.
- */
-function toQueryShape(f) {
-  const words = s => (s || '').trim().split(/\s+/).filter(Boolean)
-  return {
-    ...f,
-    anyWords: words(f.anyWords),
-    allWords: words(f.allWords),
-    noneWords: words(f.noneWords),
-    exactPhrase: f.exactPhrase?.trim() ? [f.exactPhrase.trim()] : []
-  }
-}
+import { generateLuceneQuery as generateQuery, parseLuceneQuery, toQueryShape } from '@/utils/luceneQuery'
 
 describe('luceneQuery', () => {
   describe('generateLuceneQuery', () => {


### PR DESCRIPTION
Written with Claude Code.

Addresses the main complaint left on `feature/advanced-search-modal`: opening the modal while a search query is already active wipes it. Users had no way to edit a complex query — they had to re-type it from scratch.

Now the modal accepts an `initialQuery` prop (the Lucene string from the search store) and parses it into the form when it opens. Reset on close keeps the next open clean if the parent stops passing one.

Implementation:

  - `parseLuceneQuery(query)` in `src/utils/luceneQuery.js` — the inverse of `generateLuceneQuery`. Tokenises the query while respecting quotes and parentheses, then routes each token to its bucket (anyWords / allWords / exactPhrase / noneWords / wildcards / fuzzy / proximity) and recognises the `field1:(inner) OR field2:(inner) …` wrapper for selected fields. Anything it cannot recognise falls through into `anyWords` so the user can still edit it instead of losing it.

  - `SearchAdvancedModal` watches `isVisible`; on open it assigns `parseLuceneQuery(props.initialQuery)` into the reactive form, on close it resets. Autofocus on the first input is preserved.

  - `SearchToolbar` passes `searchStore.q` as `initial-query` so the active search hydrates the modal as soon as the user opens it.

Tests:

  - 17 new `parseLuceneQuery` tests covering each operator individually, field restrictions (single + multi field, dotted ES paths), unknown queries graceful fallback, and three generate→parse round-trips (full form, field-restricted, escaped reserved chars). Total `luceneQuery.spec.js` is now 38 tests, all green.

  - 3 new `SearchAdvancedModal` tests for the pre-population path: a bare query, a field-restricted query, and the close-resets-form guarantee. Component spec is now 13 tests, all green.