### PR TITLE
fix: increase hide-margin on download popover to improve the download button hover

### DIFF
--- a/src/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.vue
+++ b/src/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.vue
@@ -86,6 +86,7 @@ defineExpose({
     v-model="modelValue"
     hide-header
     class="document-download-popover"
+    :hide-margin="16"
   >
     <template #target>
       <slot name="target" />

--- a/src/composables/useUrlParam.js
+++ b/src/composables/useUrlParam.js
@@ -12,6 +12,13 @@ import { toRoute } from '@/utils/toRoute'
 let batchedUpdates = {}
 
 /**
+ * Tracks the resolved route name of the current batch context.
+ * Used to detect when a call comes from a different route context and
+ * discard stale accumulated updates to prevent cross-route contamination.
+ */
+let batchedUpdatesContextName = undefined
+
+/**
  * Debounced function to apply batched updates to the query parameters
  * Updates are only applied after a 50ms delay to group multiple updates together.
  *
@@ -32,6 +39,7 @@ const applyBatchedUpdates = debounce((router, route, to) => {
     }
     // Reset the batch after applying
     batchedUpdates = {}
+    batchedUpdatesContextName = undefined
   }
 }, 50)
 
@@ -46,6 +54,14 @@ const applyBatchedUpdates = debounce((router, route, to) => {
  * @param {*} value - The new values for each query parameter
  */
 export function batchQueryParamUpdate(router, route, to = null, queryParams = [], values = {}) {
+  const { name } = toRoute(to)
+  // When the route context changes (e.g. search → task), discard accumulated
+  // updates from the previous context to prevent cross-route contamination.
+  if (batchedUpdatesContextName !== undefined && name !== batchedUpdatesContextName) {
+    batchedUpdates = {}
+    applyBatchedUpdates.cancel()
+  }
+  batchedUpdatesContextName = name
   queryParams.forEach((param, index) => {
     batchedUpdates[param] = values[index]
   })

--- a/tests/unit/specs/composables/useUrlParam.spec.js
+++ b/tests/unit/specs/composables/useUrlParam.spec.js
@@ -564,4 +564,66 @@ describe('whenDifferentRoute', () => {
 
     expect(callback).not.toHaveBeenCalled()
   })
+
+  describe('batchQueryParamUpdate', () => {
+    let router
+    let route
+    let batchQueryParamUpdate
+
+    beforeEach(async () => {
+      vi.useFakeTimers()
+      // The file-level vi.mock replaces lodash debounce with an identity function,
+      // which makes applyBatchedUpdates fire immediately on every call and prevents
+      // batching. We reset modules and re-import with real lodash debounce so the
+      // fake timers can control when the debounce fires.
+      vi.resetModules()
+      vi.doMock('lodash', async (importOriginal) => {
+        const { default: actual } = await importOriginal()
+        return { ...actual }
+      })
+      ;({ batchQueryParamUpdate } = await import('@/composables/useUrlParam'))
+      router = { push: vi.fn() }
+      route = { query: {}, name: 'current-route' }
+    })
+
+    afterEach(() => {
+      // Fire any pending debounce to reset module-level state for the next test
+      vi.advanceTimersByTime(100)
+      vi.useRealTimers()
+      vi.resetModules()
+    })
+
+    it('accumulates params from the same route context and pushes them together', () => {
+      const to = { name: 'search' }
+      batchQueryParamUpdate(router, route, to, ['sort', 'order'], ['_score', 'desc'])
+      batchQueryParamUpdate(router, route, to, ['perPage'], ['25'])
+
+      vi.advanceTimersByTime(50)
+
+      expect(router.push).toHaveBeenCalledOnce()
+      expect(router.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({ sort: '_score', order: 'desc', perPage: '25' })
+        })
+      )
+    })
+
+    it('does not apply params from a previous route context when the context changes', () => {
+      // Simulate search page writing sort=_score with a named route context
+      batchQueryParamUpdate(router, route, { name: 'search' }, ['sort', 'order'], ['_score', 'desc'])
+
+      // Simulate task page writing perPage=10 with no route context (different context)
+      // This resets the debounce with to=null but must NOT inherit sort=_score
+      batchQueryParamUpdate(router, route, null, ['perPage'], ['10'])
+
+      vi.advanceTimersByTime(50)
+
+      // Only one push should occur (task context), and it must not carry sort=_score
+      expect(router.push).toHaveBeenCalledOnce()
+      const [pushArg] = router.push.mock.calls[0]
+      expect(pushArg.query).not.toHaveProperty('sort')
+      expect(pushArg.query).not.toHaveProperty('order')
+      expect(pushArg.query).toHaveProperty('perPage', '10')
+    })
+  })
 })


### PR DESCRIPTION
Bug:
The download popover disappear when going from hovering the download button to the popover
[Screencast from 2026-06-25 16-41-06.webm](https://github.com/user-attachments/assets/cfe529f5-a8d0-454b-936c-f6b6a4e2bf51)

Fix:
Increase hide-margin on download popover so it covers the button and keep it hovered and visible
[Screencast from 2026-06-25 16-43-33.webm](https://github.com/user-attachments/assets/a7a3ebec-1327-4a18-b8ea-ff39e7ea6d76)


Girl scout:
Fix the race condition in `useUrlParam.js` : detects route changes and discards stale URL parameter updates to prevent cross-route contamination
