### PR TITLE
fix: project selector must not be empty

### DIFF
--- a/src/components/DropdownSelector/DropdownSelector.vue
+++ b/src/components/DropdownSelector/DropdownSelector.vue
@@ -149,8 +149,17 @@ const multiple = computed(() => props.multiple || isArray(modelValue.value))
 /**
  * Selection
  */
-const { keyOf, selectedValues, selectedKeys, isSelected, toggleValue, toggleUniqueValue, selectAll, unselectAll }
-  = useDropdownSelection(modelValue, toRef(props, 'options'), { multiple, optionKey: props.optionKey })
+const {
+  keyOf,
+  selectedValues,
+  selectedKeys,
+  isSelected,
+  isRequiredSelection,
+  toggleValue,
+  toggleUniqueValue,
+  selectAll,
+  unselectAll
+} = useDropdownSelection(modelValue, toRef(props, 'options'), { multiple, optionKey: props.optionKey })
 
 /**
  * Filtering
@@ -342,6 +351,7 @@ defineExpose({ hide, focus })
           option,
           index,
           selected: isSelected(option),
+          selectionRequired: isRequiredSelection(option),
           focused: focusIndex === index,
           toggle: (event) => toggleValue(event, option),
           toggleUnique: (event) => toggleUniqueValue(event, option)

--- a/src/components/Project/ProjectDropdownSelector/ProjectDropdownSelector.vue
+++ b/src/components/Project/ProjectDropdownSelector/ProjectDropdownSelector.vue
@@ -121,11 +121,12 @@ function filterProject(project, query) {
         :projects="projects"
       />
     </template>
-    <template #item="{ option: project, selected, focused, toggle, toggleUnique }">
+    <template #item="{ option: project, selected, selectionRequired, focused, toggle, toggleUnique }">
       <project-dropdown-selector-entry
         :project="project"
         :focus="focused"
         :selected="selected"
+        :selection-required="selectionRequired"
         :no-checkbox="!multiple"
         @toggle-value="toggle($event)"
         @toggle-unique-value="toggleUnique($event)"

--- a/src/components/Project/ProjectDropdownSelector/ProjectDropdownSelectorEntry.vue
+++ b/src/components/Project/ProjectDropdownSelector/ProjectDropdownSelectorEntry.vue
@@ -15,6 +15,9 @@ const props = defineProps({
   selected: {
     type: Boolean
   },
+  selectionRequired: {
+    type: Boolean
+  },
   noCheckbox: {
     type: Boolean
   }
@@ -45,6 +48,7 @@ const emit = defineEmits(['toggleValue', 'toggleUniqueValue'])
     <project-dropdown-selector-checkbox
       v-if="!noCheckbox"
       :model-value="selected"
+      :disabled="selectionRequired"
     />
     <project-label
       class="pe-1 py-2"

--- a/src/composables/useDropdownSelection.js
+++ b/src/composables/useDropdownSelection.js
@@ -40,6 +40,11 @@ export function useDropdownSelection(modelValue, allOptions, { multiple, optionK
     return selectedKeys.value.some(selectedKey => isEqual(selectedKey, key))
   }
 
+  // A selected option in multiple mode can't be unselected if it's the last one.
+  const isRequiredSelection = (option) => {
+    return multiple.value && isSelected(option) && selectedValues.value.length <= 1
+  }
+
   // Replace the whole model value, honouring single vs multiple mode.
   const setSelection = (values) => {
     modelValue.value = multiple.value ? values : (values[0] ?? null)
@@ -99,6 +104,7 @@ export function useDropdownSelection(modelValue, allOptions, { multiple, optionK
     selectedValues,
     selectedKeys,
     isSelected,
+    isRequiredSelection,
     selectValue,
     unselectValue,
     toggleValue,

--- a/tests/unit/specs/components/Project/ProjectDropdownSelector/ProjectDropdownSelector.spec.js
+++ b/tests/unit/specs/components/Project/ProjectDropdownSelector/ProjectDropdownSelector.spec.js
@@ -97,4 +97,21 @@ describe('ProjectDropdownSelector.vue', function () {
     await wrapper.vm.$nextTick()
     expect(wrapper.findAll('.dropdown-item').at(0).text().trim()).toBe('Foo')
   })
+
+  it('disables the checkbox of the only selected project', () => {
+    const props = { modelValue: [{ name: 'foo' }], projects, teleportDisabled: true }
+    const wrapper = mount(ProjectDropdownSelector, { props, global: { plugins } })
+    const activeInput = wrapper.find('.dropdown-item.active input[type=checkbox]')
+    expect(activeInput.attributes('disabled')).toBeDefined()
+  })
+
+  it('does not disable checkboxes when two projects are selected', () => {
+    const props = { modelValue: [{ name: 'foo' }, { name: 'bar' }], projects, teleportDisabled: true }
+    const wrapper = mount(ProjectDropdownSelector, { props, global: { plugins } })
+    const activeInputs = wrapper.findAll('.dropdown-item.active input[type=checkbox]')
+    expect(activeInputs).toHaveLength(2)
+    activeInputs.forEach((input) => {
+      expect(input.attributes('disabled')).toBeUndefined()
+    })
+  })
 })

--- a/tests/unit/specs/composables/useDropdownSelection.spec.js
+++ b/tests/unit/specs/composables/useDropdownSelection.spec.js
@@ -58,4 +58,25 @@ describe('useDropdownSelection', () => {
     api.unselectAll()
     expect(modelValue.value.map(v => v.name)).toEqual(['a'])
   })
+
+  it('isRequiredSelection is true for the only selected option in multiple mode', () => {
+    const { api } = setup([{ name: 'a' }], true)
+    expect(api.isRequiredSelection({ name: 'a' })).toBe(true)
+  })
+
+  it('isRequiredSelection is false when more than one option is selected', () => {
+    const { api } = setup([{ name: 'a' }, { name: 'b' }], true)
+    expect(api.isRequiredSelection({ name: 'a' })).toBe(false)
+    expect(api.isRequiredSelection({ name: 'b' })).toBe(false)
+  })
+
+  it('isRequiredSelection is false for an unselected option', () => {
+    const { api } = setup([{ name: 'a' }], true)
+    expect(api.isRequiredSelection({ name: 'b' })).toBe(false)
+  })
+
+  it('isRequiredSelection is false in single-select mode', () => {
+    const { api } = setup({ name: 'a' }, false)
+    expect(api.isRequiredSelection({ name: 'a' })).toBe(false)
+  })
 })


### PR DESCRIPTION
Fix https://github.com/ICIJ/datashare/issues/2239 by disabling the project's checkbox in the selector when there is only one selected.