### PR TITLE
fix: disable Download text button when document has no text content

### DIFF
--- a/src/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.vue
+++ b/src/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.vue
@@ -49,6 +49,7 @@ const {
   hasCleanableContentType,
   isRootTooBig,
   downloadTextContent,
+  hasTextContent,
   hasTranslations,
   downloadTranslatedContent,
   fetchStatuses
@@ -114,6 +115,7 @@ defineExpose({
         :label="t('documentDownloadPopover.downloadExtractText')"
         variant="outline-action"
         class="document-download-popover__body__button"
+        :disabled="!hasTextContent"
         @click="downloadTextContent"
       />
       <button-icon

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -84,11 +84,15 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     }
   }
 
+  const hasTextContent = computed(() => {
+    return documentRef.value.contentTextLength > 0
+  })
+
   async function downloadTextContent() {
+    if (!hasTextContent.value) return
     if (!documentRef.value.content) {
       await documentStore.getContent()
     }
-
     const { content, title } = documentRef.value
     const a = window.document.createElement('a')
     a.href = URL.createObjectURL(new Blob([content], { type: 'text/plain;charset=UTF-8' }))
@@ -155,6 +159,7 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     rootContentLength,
     maxRootContentLength,
     downloadTextContent,
+    hasTextContent,
     hasTranslations,
     downloadTranslatedContent
   }


### PR DESCRIPTION
This PR disables "Download Text" button when there is no content text in the document