### PR TITLE
fix: add onConsumeNoRefresh to ensure noRefresh is a one shot flag

### DIFF
--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -495,7 +495,12 @@ export function useSearchFilter() {
     return onAfterRouteUpdate((to) => {
       if (to.name === 'search' && to.query?.noRefresh) {
         const { noRefresh: _noRefresh, ...query } = to.query
-        router.replace({ name: 'search', query })
+        // Stripping `noRefresh` here re-triggers `onAfterRouteQueryUpdate` (it is NOT
+        // gated on `from`), which is what runs the initial search when a shared
+        // `noRefresh=1` URL is loaded/reloaded directly — do not add a `from` guard there,
+        // or reloading such a URL would leave the results blank.
+        // `.catch` swallows the benign rejection from a concurrent navigation superseding this replace.
+        router.replace({ name: 'search', query }).catch(() => {})
       }
     }, options)
   }

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -482,6 +482,24 @@ export function useSearchFilter() {
     }, options)
   }
 
+  function onConsumeNoRefresh(options) {
+    // `noRefresh` is a one-shot flag set when returning to search from a
+    // document, telling the refresh guards to skip a reload. Once those guards
+    // have observed it for this navigation, strip it from the URL so it never
+    // persists into the next navigation (page/sort/perPage changes copy the
+    // current route query forward via batchQueryParamUpdate, which would
+    // otherwise keep re-applying the flag and suppress the refresh).
+    //
+    // This consumer MUST be registered after the refresh guards so its
+    // queued microtask runs last and the guards read `noRefresh` first.
+    return onAfterRouteUpdate((to) => {
+      if (to.name === 'search' && to.query?.noRefresh) {
+        const { noRefresh: _noRefresh, ...query } = to.query
+        router.replace({ name: 'search', query })
+      }
+    }, options)
+  }
+
   return {
     indices,
     allProjectsSelected,
@@ -533,6 +551,7 @@ export function useSearchFilter() {
     watchOperator,
     onAfterRouteQueryUpdate,
     onAfterRouteQueryFromUpdate,
+    onConsumeNoRefresh,
     watchValues,
     whenFilterContextualized,
     isCategoryAvailable,

--- a/src/views/Search/Search.vue
+++ b/src/views/Search/Search.vue
@@ -41,7 +41,8 @@ const {
   watchFilters,
   watchOperator,
   onAfterRouteQueryUpdate,
-  onAfterRouteQueryFromUpdate
+  onAfterRouteQueryFromUpdate,
+  onConsumeNoRefresh
 } = useSearchFilter()
 const { count: searchBreadcrumbCounter, anyFilters } = useSearchBreadcrumb()
 const { hasCarousel } = useSearchNav()
@@ -122,6 +123,10 @@ onAfterRouteQueryUpdate(refreshSearchFromRouteStart)
 // change the "from" query parameter to the first page. If the current route is the search route, it
 // will also trigger the search API call immediately.
 onAfterRouteQueryFromUpdate(refreshSearchFromRoute, { immediate: route.name === 'search' })
+// Consume the one-shot `noRefresh` flag. MUST be registered after the two
+// refresh guards above so it runs last and they observe the flag before it is
+// stripped from the URL.
+onConsumeNoRefresh({ immediate: route.name === 'search' })
 </script>
 
 <template>

--- a/tests/unit/specs/composables/useSearchFilter.spec.js
+++ b/tests/unit/specs/composables/useSearchFilter.spec.js
@@ -1,5 +1,5 @@
 import { createApp, nextTick, ref } from 'vue'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import bodybuilder from 'bodybuilder'
 import { vi } from 'vitest'
 
@@ -144,6 +144,54 @@ describe('useSearchFilter', () => {
       await refreshSearchFromRouteStart()
 
       expect(useAppStore().getSettings('search', 'searchOperator')).toBe(SEARCH_OPERATORS.OR)
+    })
+  })
+
+  describe('onConsumeNoRefresh', () => {
+    it('strips noRefresh from the search route while preserving other params', async () => {
+      const core = CoreSetup.init().useAll().useRouterWithoutGuards()
+      withSetup(() => {
+        const { onConsumeNoRefresh } = useSearchFilter()
+        onConsumeNoRefresh()
+      }, core.plugins)
+
+      await core.router.push({ name: 'search', query: { q: 'foo', noRefresh: 1 } })
+      await flushPromises()
+      await flushPromises()
+
+      const { query } = core.router.currentRoute.value
+      expect(query.noRefresh).toBeUndefined()
+      expect(query.q).toBe('foo')
+    })
+
+    it('leaves the query untouched when noRefresh is absent', async () => {
+      const core = CoreSetup.init().useAll().useRouterWithoutGuards()
+      withSetup(() => {
+        const { onConsumeNoRefresh } = useSearchFilter()
+        onConsumeNoRefresh()
+      }, core.plugins)
+
+      await core.router.push({ name: 'search', query: { q: 'foo' } })
+      await flushPromises()
+      await flushPromises()
+
+      const { query } = core.router.currentRoute.value
+      expect(query.q).toBe('foo')
+      expect(query.noRefresh).toBeUndefined()
+    })
+
+    it('does not strip noRefresh outside the search route', async () => {
+      const core = CoreSetup.init().useAll().useRouterWithoutGuards()
+      withSetup(() => {
+        const { onConsumeNoRefresh } = useSearchFilter()
+        onConsumeNoRefresh()
+      }, core.plugins)
+
+      await core.router.push({ name: 'document-standalone', params: { index: 'test', id: 'doc1' }, query: { noRefresh: 1 } })
+      await flushPromises()
+      await flushPromises()
+
+      expect(core.router.currentRoute.value.query.noRefresh).toBe('1')
     })
   })
 })

--- a/tests/unit/specs/views/Search/Search.spec.js
+++ b/tests/unit/specs/views/Search/Search.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils'
+import { shallowMount, flushPromises } from '@vue/test-utils'
 
 import CoreSetup from '~tests/unit/CoreSetup'
 import Search from '@/views/Search/Search'
@@ -41,5 +41,15 @@ describe('Search.vue', () => {
     wrapper.unmount()
 
     expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('strips the noRefresh flag from the URL after returning to search', async () => {
+    await core.router.push({ name: 'search', query: { q: 'foo', noRefresh: 1 } })
+    await flushPromises()
+    await flushPromises()
+
+    const { query } = core.router.currentRoute.value
+    expect(query.noRefresh).toBeUndefined()
+    expect(query.q).toBe('foo')
   })
 })

--- a/tests/unit/specs/views/Search/Search.spec.js
+++ b/tests/unit/specs/views/Search/Search.spec.js
@@ -52,4 +52,23 @@ describe('Search.vue', () => {
     expect(query.noRefresh).toBeUndefined()
     expect(query.q).toBe('foo')
   })
+
+  it('runs the initial search when a reloaded noRefresh URL is stripped', async () => {
+    // Same active pinia as the mounted component, so this is the same store instance.
+    const searchStore = useSearchStore()
+    const querySpy = vi.spyOn(searchStore, 'query').mockResolvedValue(undefined)
+    // Use a query value distinct from other specs in this file: `sameAppliedQuery`
+    // compares against whatever the shared store instance last applied, so reusing
+    // a `q` value another test already searched for would make this test pass
+    // vacuously (the guard would short-circuit on a false "nothing changed").
+    const query = { q: 'noRefreshReloadTest', noRefresh: 1 }
+
+    await core.router.push({ name: 'search', query })
+    // Flush twice: once for the `noRefresh` consumer's `router.replace`, and once
+    // more for the resulting route update to reach `onAfterRouteQueryUpdate`.
+    await flushPromises()
+    await flushPromises()
+
+    expect(querySpy).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
This PR ensure that the noRefresh flag created when closing a document in the search results (list layout) is not blocking other query update. This is detailed in https://github.com/ICIJ/datashare/issues/2243.