### PR TITLE
fix: reset document selection when exiting selection mode

### DIFF
--- a/src/views/Search/Search.vue
+++ b/src/views/Search/Search.vue
@@ -68,6 +68,8 @@ const selection = ref([])
 const toggleSearchBreadcrumb = ref(false)
 const selectMode = ref(false)
 
+// Clear selected documents when leaving selection mode so stale
+// selections don't persist across separate selection sessions.
 watch(selectMode, (value) => {
   if (!value) selection.value = []
 })

--- a/src/views/Search/Search.vue
+++ b/src/views/Search/Search.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref, toValue } from 'vue'
+import { computed, ref, toValue, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 
@@ -67,6 +67,10 @@ const isEmpty = computed(() => isSearchRoute.value && !isLoading.value && !total
 const selection = ref([])
 const toggleSearchBreadcrumb = ref(false)
 const selectMode = ref(false)
+
+watch(selectMode, (value) => {
+  if (!value) selection.value = []
+})
 
 // The this value is used to know if the floating document view has enough space to be displayed
 // next to the search results. It is updated by the DocumentEntries component which itself gets it


### PR DESCRIPTION
While demonstrating this https://github.com/ICIJ/datashare/issues/2235 we noticed that exiting selection mode does not reinitialize the selected items. As a result, switching in selection mode again (on the same page or on another page) still have the previously selected items.