### PR TITLE
fix: enforce user management controls in the project Users tab

### DIFF
--- a/src/components/ProjectUsers/ProjectUsersList.vue
+++ b/src/components/ProjectUsers/ProjectUsersList.vue
@@ -139,12 +139,16 @@ function onUserDeleted({ uid }) {
   emit('user:deleted', { uid })
 }
 const { username, isUsernameResolved, isAuthWithUsersProvider } = useAuth()
-const { isInstanceAdmin } = usePolicies()
+const { isInstanceAdmin, getRoleByProject, hasRole } = usePolicies()
 // Deleting a user account removes it from every project (see the delete modal's warning) and the
 // backend requires INSTANCE_ADMIN, so hide the action from project admins who are not instance admins.
 const canDeleteUsers = computed(() => isAuthWithUsersProvider.value && isInstanceAdmin())
+const viewerRole = computed(() => getRoleByProject(props.project))
 function isCurrentUser(uid) {
   return !isUsernameResolved.value || username.value === uid
+}
+function outranksViewer(role) {
+  return !hasRole(viewerRole.value, role)
 }
 
 defineExpose({ pendingChanges, saving, showAdminModal, saveRoles, cancelChanges, onSaveClicked })
@@ -170,7 +174,7 @@ defineExpose({ pendingChanges, saving, showAdminModal, saveRoles, cancelChanges,
       </template>
       <template #cell(role)="{ item }">
         <project-users-role-dropdown
-          :disabled="isCurrentUser(item.uid)"
+          :disabled="isCurrentUser(item.uid) || outranksViewer(item.role)"
           :model-value="pendingChanges[item.uid] ?? item.role"
           :dirty="!!pendingChanges[item.uid]"
           :project="project"

--- a/src/components/ProjectUsers/ProjectUsersList.vue
+++ b/src/components/ProjectUsers/ProjectUsersList.vue
@@ -174,6 +174,7 @@ defineExpose({ pendingChanges, saving, showAdminModal, saveRoles, cancelChanges,
           :model-value="pendingChanges[item.uid] ?? item.role"
           :dirty="!!pendingChanges[item.uid]"
           :project="project"
+          :disabled-roles="[ROLE.DOMAIN_ADMIN, ROLE.INSTANCE_ADMIN]"
           @update:model-value="onRoleChanged(item.uid, $event)"
         />
       </template>

--- a/src/components/ProjectUsers/ProjectUsersList.vue
+++ b/src/components/ProjectUsers/ProjectUsersList.vue
@@ -10,6 +10,7 @@ import ProjectUsersAdminPromotionModal from '@/components/ProjectUsers/ProjectUs
 import ProjectUsersRoleDropdown from '@/components/ProjectUsers/ProjectUsersRoleDropdown.vue'
 
 import { useCore } from '@/composables/useCore.js'
+import { usePolicies } from '@/composables/usePolicies.js'
 import { useToast } from '@/composables/useToast.js'
 import { NO_ROLE, ROLE, ROLE_BIT, ROLE_LOWERCASE } from '@/enums/roles.js'
 import ButtonReset from '@/components/Button/ButtonReset'
@@ -138,6 +139,10 @@ function onUserDeleted({ uid }) {
   emit('user:deleted', { uid })
 }
 const { username, isUsernameResolved, isAuthWithUsersProvider } = useAuth()
+const { isInstanceAdmin } = usePolicies()
+// Deleting a user account removes it from every project (see the delete modal's warning) and the
+// backend requires INSTANCE_ADMIN, so hide the action from project admins who are not instance admins.
+const canDeleteUsers = computed(() => isAuthWithUsersProvider.value && isInstanceAdmin())
 function isCurrentUser(uid) {
   return !isUsernameResolved.value || username.value === uid
 }
@@ -177,7 +182,7 @@ defineExpose({ pendingChanges, saving, showAdminModal, saveRoles, cancelChanges,
           :user="item"
           :project="project"
           :disable-delete="isCurrentUser(item.uid)"
-          :hide-delete="!isAuthWithUsersProvider"
+          :hide-delete="!canDeleteUsers"
           @user:deleted="onUserDeleted"
         />
       </template>

--- a/src/components/ProjectUsers/ProjectUsersRoleDropdown.vue
+++ b/src/components/ProjectUsers/ProjectUsersRoleDropdown.vue
@@ -29,6 +29,14 @@ const props = defineProps({
   noRole: {
     type: Boolean,
     default: false
+  },
+  disabledRoles: {
+    type: Array,
+    default: () => []
+  },
+  hiddenRoles: {
+    type: Array,
+    default: () => []
   }
 })
 
@@ -42,9 +50,10 @@ const currentUserRole = computed(() => getRoleByProject(props.project))
 const availableRoles = computed(() => [
   ...Object.values(ROLE)
     .filter(role => (ROLE_HIERARCHY[currentUserRole.value] & ROLE_BIT[role]) !== 0)
+    .filter(role => !props.hiddenRoles.includes(role))
     .sort((a, b) => ROLE_BIT[b] - ROLE_BIT[a])
-    .map(role => ({ value: role, text: formatRole(t, role) })),
-  ...(props.noRole ? [{ value: NO_ROLE, text: formatRole(t, NO_ROLE) }] : [])
+    .map(role => ({ value: role, text: formatRole(t, role), disabled: props.disabledRoles.includes(role) })),
+  ...(props.noRole ? [{ value: NO_ROLE, text: formatRole(t, NO_ROLE), disabled: props.disabledRoles.includes(NO_ROLE) }] : [])
 ])
 
 defineExpose({ availableRoles })
@@ -86,7 +95,8 @@ defineExpose({ availableRoles })
         v-for="role in availableRoles"
         :key="role.value"
         :active="role.value === modelValue"
-        @click="emit('update:modelValue', role.value)"
+        :disabled="role.disabled"
+        @click="role.disabled || emit('update:modelValue', role.value)"
       >
         <display-role :value="role.value" />
       </b-dropdown-item>
@@ -97,7 +107,7 @@ defineExpose({ availableRoles })
 <style scoped lang="scss">
 .project-users-role-dropdown {
   :deep(.project-users-role-dropdown__content) {
-    width: 8rem;
+    width: 10rem;
   }
 }
 

--- a/src/composables/usePolicies.js
+++ b/src/composables/usePolicies.js
@@ -49,9 +49,13 @@ export function usePolicies() {
     return hasRole(getRoleByProject(projectName), ROLE.PROJECT_ADMIN)
   }
 
+  function isInstanceAdmin() {
+    return hasRole(getHighestRoleFromList(policies.value), ROLE.INSTANCE_ADMIN)
+  }
+
   function formatRole(t, role) {
     return upperFirst(t(ROLE_KEY[role] ?? ROLE_KEY[NO_ROLE]))
   }
 
-  return { getRoleByProject, getHighestRoleFromList, getHighestRoleFromListForDomain, getHighestRoleFromListForProject, formatRole, isProjectAdmin, hasRole }
+  return { getRoleByProject, getHighestRoleFromList, getHighestRoleFromListForDomain, getHighestRoleFromListForProject, formatRole, isProjectAdmin, isInstanceAdmin, hasRole }
 }

--- a/src/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsers.vue
+++ b/src/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsers.vue
@@ -13,7 +13,7 @@ import { useUrlParamsWithStore } from '@/composables/useUrlParamsWithStore.js'
 import { useUrlParam } from '@/composables/useUrlParam.js'
 import { useUrlPageParam } from '@/composables/useUrlPageParam.js'
 import { useAppStore } from '@/store/modules'
-import { NO_ROLE } from '@/enums/roles.js'
+import { NO_ROLE, ROLE_BIT } from '@/enums/roles.js'
 import FormControlSearch from '@/components/Form/FormControl/FormControlSearch.vue'
 import ProjectViewEditUsersCreateModal from '@/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsersCreateModal.vue'
 import IPhUserPlus from '~icons/ph/user-plus'
@@ -75,8 +75,9 @@ function roleForCurrentProject(permissions) {
     const [domain, project] = String(v2).split('::')
     return (domain === DEFAULT_DOMAIN || domain === '*') && (project === props.name || project === '*')
   })
-  if (!matching.length) return NO_ROLE
-  return getHighestRoleFromList(matching.map(({ v1 }) => ({ role: v1 })))
+  const recognized = matching.filter(({ v1 }) => v1 in ROLE_BIT)
+  if (!recognized.length) return NO_ROLE
+  return getHighestRoleFromList(recognized.map(({ v1 }) => ({ role: v1 })))
 }
 const createUserButtonText = computed(() => t('projectViewEdit.users.create.button'))
 const errorMessage = computed(() => t('projectViewEdit.users.fetchError'))

--- a/src/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsers.vue
+++ b/src/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsers.vue
@@ -30,7 +30,7 @@ const props = defineProps({
 const { toastedPromise } = useToast()
 const { t } = useI18n()
 const { isAuthWithUsersProvider } = useAuth()
-const { isInstanceAdmin } = usePolicies()
+const { isInstanceAdmin, getHighestRoleFromList } = usePolicies()
 // Creating a user account is an instance-wide operation (the backend requires INSTANCE_ADMIN),
 // so only expose the control to instance admins.
 const canManageUsers = computed(() => isAuthWithUsersProvider.value && isInstanceAdmin())
@@ -69,8 +69,14 @@ watch(query, (value) => {
 const page = useUrlPageParam()
 
 function roleForCurrentProject(permissions) {
-  const permission = (permissions ?? []).find(({ v2 }) => v2 === `${DEFAULT_DOMAIN}::${props.name}`)
-  return permission?.v1 ?? NO_ROLE
+  // Permissions are "<domain>::<project>" pairs where either side can be the "*" wildcard
+  // (e.g. "*::*" for instance admins, "default::*" for domain admins).
+  const matching = (permissions ?? []).filter(({ v2 }) => {
+    const [domain, project] = String(v2).split('::')
+    return (domain === DEFAULT_DOMAIN || domain === '*') && (project === props.name || project === '*')
+  })
+  if (!matching.length) return NO_ROLE
+  return getHighestRoleFromList(matching.map(({ v1 }) => ({ role: v1 })))
 }
 const createUserButtonText = computed(() => t('projectViewEdit.users.create.button'))
 const errorMessage = computed(() => t('projectViewEdit.users.fetchError'))

--- a/src/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsers.vue
+++ b/src/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsers.vue
@@ -6,6 +6,7 @@ import { debounce, isEqual } from 'lodash'
 import ProjectUsersList from '@/components/ProjectUsers/ProjectUsersList.vue'
 import RowPaginationUsers from '@/components/RowPagination/RowPaginationUsers.vue'
 import { useAuth } from '@/composables/useAuth.js'
+import { usePolicies } from '@/composables/usePolicies.js'
 import { useToast } from '@/composables/useToast.js'
 import { useUrlParamWithStore } from '@/composables/useUrlParamWithStore.js'
 import { useUrlParamsWithStore } from '@/composables/useUrlParamsWithStore.js'
@@ -29,6 +30,10 @@ const props = defineProps({
 const { toastedPromise } = useToast()
 const { t } = useI18n()
 const { isAuthWithUsersProvider } = useAuth()
+const { isInstanceAdmin } = usePolicies()
+// Creating a user account is an instance-wide operation (the backend requires INSTANCE_ADMIN),
+// so only expose the control to instance admins.
+const canManageUsers = computed(() => isAuthWithUsersProvider.value && isInstanceAdmin())
 const appStore = useAppStore()
 const { waitFor, isLoading, start, loaderId } = useWait()
 
@@ -155,7 +160,7 @@ onMounted(fetchUsers)
   <div class="project-view-edit-users p-4">
     <div class="d-flex flex-column gap-2 mb-3">
       <div
-        v-if="isAuthWithUsersProvider"
+        v-if="canManageUsers"
         class="d-flex justify-content-end"
       >
         <button-icon

--- a/src/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsersCreateModal.vue
+++ b/src/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsersCreateModal.vue
@@ -14,7 +14,7 @@ import ProjectUsersRoleDropdown from '@/components/ProjectUsers/ProjectUsersRole
 
 import { useCore } from '@/composables/useCore.js'
 import { useToast } from '@/composables/useToast.js'
-import { DEFAULT_ROLE, ROLE_ICON_DEFAULT, ROLE_LOWERCASE } from '@/enums/roles.js'
+import { DEFAULT_ROLE, ROLE, ROLE_ICON_DEFAULT, ROLE_LOWERCASE } from '@/enums/roles.js'
 import FormFieldsetI18n from '@/components/Form/FormFieldset/FormFieldsetI18n.vue'
 import { BFormInput } from 'bootstrap-vue-next'
 import ProjectLabel from '@/components/Project/ProjectLabel.vue'
@@ -229,6 +229,7 @@ defineExpose({ username, email, name, password, confirmPassword, selectedRole, i
           <project-users-role-dropdown
             v-model="selectedRole"
             :project="project"
+            :hidden-roles="[ROLE.DOMAIN_ADMIN, ROLE.INSTANCE_ADMIN]"
           />
           <i18n-t keypath="projectViewEdit.users.create.fields.role.inProject">
             <template #project>

--- a/tests/unit/composables/usePolicies.spec.js
+++ b/tests/unit/composables/usePolicies.spec.js
@@ -46,6 +46,22 @@ describe('usePolicies', () => {
     expect(isProjectAdmin('unknown')).toBe(false)
   })
 
+  it('isInstanceAdmin returns false when the user is only a project admin', () => {
+    const { isInstanceAdmin } = usePolicies()
+    expect(isInstanceAdmin()).toBe(false)
+  })
+
+  it('isInstanceAdmin returns true when the user holds an INSTANCE_ADMIN policy', () => {
+    configGet = vi.fn((key, fallback) =>
+      key === 'policies'
+        ? [{ projectId: '*', domainId: '*', role: 'INSTANCE_ADMIN' }]
+        : fallback
+    )
+    vi.spyOn(useConfigModule, 'useConfig').mockReturnValue({ get: configGet })
+    const { isInstanceAdmin } = usePolicies()
+    expect(isInstanceAdmin()).toBe(true)
+  })
+
   it('check role hierarchy with bit to see if a role has at least PROJECT_EDITOR capability', () => {
     const { hasRole } = usePolicies()
     expect(hasRole(ROLE.PROJECT_ADMIN, ROLE.PROJECT_EDITOR)).toBe(true)// true

--- a/tests/unit/specs/components/ProjectUsers/ProjectUsersList.spec.js
+++ b/tests/unit/specs/components/ProjectUsers/ProjectUsersList.spec.js
@@ -76,6 +76,29 @@ describe('ProjectUsersList.vue', () => {
     expect(wrapper.emitted('user:deleted')).toEqual([[{ uid: 'alice@icij.org' }]])
   })
 
+  describe('Delete action visibility (hide-delete)', () => {
+    it('shows the delete action for an instance admin using a users-provider auth', () => {
+      core.config.set('auth', 'form')
+      core.config.set('policies', [{ projectId: '*', domainId: '*', role: 'INSTANCE_ADMIN' }])
+      const wrapper = mountComponent()
+      expect(wrapper.findAllComponents(ProjectUsersActions)[0].props('hideDelete')).toBe(false)
+    })
+
+    it('hides the delete action from a project admin who is not an instance admin', () => {
+      core.config.set('auth', 'form')
+      core.config.set('policies', [{ projectId: project, domainId: 'default', role: 'PROJECT_ADMIN' }])
+      const wrapper = mountComponent()
+      expect(wrapper.findAllComponents(ProjectUsersActions)[0].props('hideDelete')).toBe(true)
+    })
+
+    it('hides the delete action when auth is not a users-provider even for an instance admin', () => {
+      core.config.set('auth', 'oauth')
+      core.config.set('policies', [{ projectId: '*', domainId: '*', role: 'INSTANCE_ADMIN' }])
+      const wrapper = mountComponent()
+      expect(wrapper.findAllComponents(ProjectUsersActions)[0].props('hideDelete')).toBe(true)
+    })
+  })
+
   it('renders ProjectUsersAdminPromotionModal', () => {
     const wrapper = mountComponent()
     expect(wrapper.findComponent(ProjectUsersAdminPromotionModal).exists()).toBe(true)

--- a/tests/unit/specs/components/ProjectUsers/ProjectUsersList.spec.js
+++ b/tests/unit/specs/components/ProjectUsers/ProjectUsersList.spec.js
@@ -65,6 +65,13 @@ describe('ProjectUsersList.vue', () => {
     expect(wrapper.findAllComponents(ProjectUsersRoleDropdown)).toHaveLength(2)
   })
 
+  it('disables the domain admin and instance admin options in each role dropdown', () => {
+    const wrapper = mountComponent()
+    for (const dropdown of wrapper.findAllComponents(ProjectUsersRoleDropdown)) {
+      expect(dropdown.props('disabledRoles')).toEqual(['DOMAIN_ADMIN', 'INSTANCE_ADMIN'])
+    }
+  })
+
   it('renders a ProjectUsersActions in each row', () => {
     const wrapper = mountComponent()
     expect(wrapper.findAllComponents(ProjectUsersActions)).toHaveLength(2)

--- a/tests/unit/specs/components/ProjectUsers/ProjectUsersList.spec.js
+++ b/tests/unit/specs/components/ProjectUsers/ProjectUsersList.spec.js
@@ -307,6 +307,35 @@ describe('ProjectUsersList.vue', () => {
     })
   })
 
+  describe('Locking the dropdown for rows that outrank the viewer', () => {
+    it('disables the whole dropdown for a row whose current role outranks what a project admin viewer may assign', async () => {
+      core.config.set('auth', 'form')
+      core.config.set('policies', [{ projectId: project, domainId: 'default', role: 'PROJECT_ADMIN' }])
+      const wrapper = mountComponent({
+        users: [
+          { uid: 'alice@example.org', role: 'PROJECT_EDITOR' },
+          { uid: 'bob@example.org', role: 'DOMAIN_ADMIN' },
+          { uid: 'carole@example.org', role: 'INSTANCE_ADMIN' }
+        ]
+      })
+      await flushPromises()
+      const dropdowns = wrapper.findAllComponents(ProjectUsersRoleDropdown)
+      expect(dropdowns[0].props('disabled')).toBe(false)
+      expect(dropdowns[1].props('disabled')).toBe(true)
+      expect(dropdowns[2].props('disabled')).toBe(true)
+    })
+
+    it('does not disable the dropdown for a row whose current role is within the viewer own hierarchy', async () => {
+      core.config.set('auth', 'form')
+      core.config.set('policies', [{ projectId: '*', domainId: '*', role: 'INSTANCE_ADMIN' }])
+      const wrapper = mountComponent({
+        users: [{ uid: 'bob@example.org', role: 'DOMAIN_ADMIN' }]
+      })
+      await flushPromises()
+      expect(wrapper.findAllComponents(ProjectUsersRoleDropdown)[0].props('disabled')).toBe(false)
+    })
+  })
+
   describe('Admin promotion modal', () => {
     it('onSaveClicked opens admin modal when a pending change promotes to an admin role', async () => {
       // users[0] is PROJECT_EDITOR; promoting to PROJECT_ADMIN triggers the modal

--- a/tests/unit/specs/components/ProjectUsers/ProjectUsersRoleDropdown.spec.js
+++ b/tests/unit/specs/components/ProjectUsers/ProjectUsersRoleDropdown.spec.js
@@ -101,6 +101,36 @@ describe('ProjectUsersRoleDropdown.vue', () => {
     expect(roleValues).not.toContain('NO_ROLE')
   })
 
+  it('excludes roles listed in hiddenRoles from available roles', () => {
+    const wrapper = mountComponent({ hiddenRoles: ['DOMAIN_ADMIN', 'INSTANCE_ADMIN'] })
+    const roleValues = wrapper.vm.availableRoles.map(r => r.value)
+    expect(roleValues).not.toContain('DOMAIN_ADMIN')
+    expect(roleValues).not.toContain('INSTANCE_ADMIN')
+    expect(roleValues).toContain('PROJECT_ADMIN')
+  })
+
+  it('keeps roles listed in disabledRoles visible but flags them as disabled', () => {
+    const wrapper = mountComponent({ disabledRoles: ['DOMAIN_ADMIN', 'INSTANCE_ADMIN'] })
+    const byValue = Object.fromEntries(wrapper.vm.availableRoles.map(r => [r.value, r.disabled]))
+    expect(byValue.DOMAIN_ADMIN).toBe(true)
+    expect(byValue.INSTANCE_ADMIN).toBe(true)
+    expect(byValue.PROJECT_ADMIN).toBe(false)
+  })
+
+  it('marks the dropdown items of disabledRoles as disabled', () => {
+    const wrapper = mountComponent({ disabledRoles: ['INSTANCE_ADMIN'] })
+    const index = wrapper.vm.availableRoles.findIndex(r => r.value === 'INSTANCE_ADMIN')
+    const item = wrapper.findAll('b-dropdown-item-stub')[index]
+    expect(item.attributes('disabled')).toBe('true')
+  })
+
+  it('does not emit update:modelValue when a disabled role is clicked', async () => {
+    const wrapper = mountComponent({ disabledRoles: ['INSTANCE_ADMIN'] })
+    const index = wrapper.vm.availableRoles.findIndex(r => r.value === 'INSTANCE_ADMIN')
+    await wrapper.findAll('b-dropdown-item-stub')[index].trigger('click')
+    expect(wrapper.emitted('update:modelValue')).toBeFalsy()
+  })
+
   it('defaults noRole to false', () => {
     const wrapper = shallowMount(ProjectUsersRoleDropdown, {
       global,

--- a/tests/unit/specs/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsers.spec.js
+++ b/tests/unit/specs/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsers.spec.js
@@ -141,6 +141,59 @@ describe('ProjectViewEditUsers.vue', () => {
     ])
   })
 
+  it.each([
+    ['INSTANCE_ADMIN', [{ v1: 'INSTANCE_ADMIN', v2: '*::*' }]],
+    ['DOMAIN_ADMIN', [{ v1: 'DOMAIN_ADMIN', v2: 'default::*' }]]
+  ])('maps a wildcard-scoped %s permission to that role', async (role, permissions) => {
+    api.getUsers.mockResolvedValue({
+      items: [{ uid: 'jdoe', name: 'Jane D', email: 'jdoe@example.org', permissions }],
+      pagination: { count: 1, from: 0, size: 10, total: 1 }
+    })
+    const wrapper = shallowMountComponent()
+    await flushPromises()
+    const list = wrapper.findComponent(ProjectUsersList)
+    expect(list.props('users')).toEqual([{ uid: 'jdoe', name: 'Jane D', email: 'jdoe@example.org', role }])
+  })
+
+  it('keeps the highest role when several permissions match the current project', async () => {
+    api.getUsers.mockResolvedValue({
+      items: [
+        {
+          uid: 'jdoe',
+          name: 'Jane D',
+          email: 'jdoe@example.org',
+          permissions: [
+            { v1: 'PROJECT_MEMBER', v2: 'default::local-datashare' },
+            { v1: 'INSTANCE_ADMIN', v2: '*::*' }
+          ]
+        }
+      ],
+      pagination: { count: 1, from: 0, size: 10, total: 1 }
+    })
+    const wrapper = shallowMountComponent()
+    await flushPromises()
+    const list = wrapper.findComponent(ProjectUsersList)
+    expect(list.props('users')[0].role).toBe('INSTANCE_ADMIN')
+  })
+
+  it('ignores a wildcard permission scoped to another domain', async () => {
+    api.getUsers.mockResolvedValue({
+      items: [
+        {
+          uid: 'jdoe',
+          name: 'Jane D',
+          email: 'jdoe@example.org',
+          permissions: [{ v1: 'DOMAIN_ADMIN', v2: 'other-domain::*' }]
+        }
+      ],
+      pagination: { count: 1, from: 0, size: 10, total: 1 }
+    })
+    const wrapper = shallowMountComponent()
+    await flushPromises()
+    const list = wrapper.findComponent(ProjectUsersList)
+    expect(list.props('users')[0].role).toBe('NO_ROLE')
+  })
+
   it('passes an empty users array before the API resolves', () => {
     const wrapper = shallowMountComponent()
     const list = wrapper.findComponent(ProjectUsersList)

--- a/tests/unit/specs/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsers.spec.js
+++ b/tests/unit/specs/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsers.spec.js
@@ -77,6 +77,39 @@ describe('ProjectViewEditUsers.vue', () => {
     expect(wrapper.findComponent(ProjectUsersList).exists()).toBe(true)
   })
 
+  describe('Create user control visibility', () => {
+    const INSTANCE_ADMIN_POLICIES = [{ projectId: '*', domainId: '*', role: 'INSTANCE_ADMIN' }]
+    const PROJECT_ADMIN_POLICIES = [{ projectId: 'local-datashare', domainId: 'default', role: 'PROJECT_ADMIN' }]
+
+    function mountWithSlots() {
+      return shallowMount(ProjectViewEditUsers, {
+        global: { plugins: core.plugins, renderStubDefaultSlot: true },
+        props
+      })
+    }
+
+    it('shows the create button for an instance admin using a users-provider auth', () => {
+      core.config.set('auth', 'form')
+      core.config.set('policies', INSTANCE_ADMIN_POLICIES)
+      const wrapper = mountWithSlots()
+      expect(wrapper.text()).toContain(core.i18n.global.t('projectViewEdit.users.create.button'))
+    })
+
+    it('hides the create button from a project admin who is not an instance admin', () => {
+      core.config.set('auth', 'form')
+      core.config.set('policies', PROJECT_ADMIN_POLICIES)
+      const wrapper = mountWithSlots()
+      expect(wrapper.text()).not.toContain(core.i18n.global.t('projectViewEdit.users.create.button'))
+    })
+
+    it('hides the create button when auth is not a users-provider even for an instance admin', () => {
+      core.config.set('auth', 'oauth')
+      core.config.set('policies', INSTANCE_ADMIN_POLICIES)
+      const wrapper = mountWithSlots()
+      expect(wrapper.text()).not.toContain(core.i18n.global.t('projectViewEdit.users.create.button'))
+    })
+  })
+
   it('maps getUsers items to { uid, name, email } and extracts role from permissions', async () => {
     api.getUsers.mockResolvedValue(usersResponse)
     const wrapper = shallowMountComponent()

--- a/tests/unit/specs/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsers.spec.js
+++ b/tests/unit/specs/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsers.spec.js
@@ -176,6 +176,24 @@ describe('ProjectViewEditUsers.vue', () => {
     expect(list.props('users')[0].role).toBe('INSTANCE_ADMIN')
   })
 
+  it('maps an unrecognized role value on a matching permission to NO_ROLE instead of defaulting to PROJECT_MEMBER', async () => {
+    api.getUsers.mockResolvedValue({
+      items: [
+        {
+          uid: 'jdoe',
+          name: 'Jane D',
+          email: 'jdoe@example.org',
+          permissions: [{ v1: '', v2: 'default::local-datashare' }]
+        }
+      ],
+      pagination: { count: 1, from: 0, size: 10, total: 1 }
+    })
+    const wrapper = shallowMountComponent()
+    await flushPromises()
+    const list = wrapper.findComponent(ProjectUsersList)
+    expect(list.props('users')[0].role).toBe('NO_ROLE')
+  })
+
   it('ignores a wildcard permission scoped to another domain', async () => {
     api.getUsers.mockResolvedValue({
       items: [

--- a/tests/unit/specs/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsersCreateModal.spec.js
+++ b/tests/unit/specs/views/Project/ProjectView/ProjectViewEdit/ProjectViewEditUsersCreateModal.spec.js
@@ -59,6 +59,12 @@ describe('ProjectViewEditUsersCreateModal.vue', () => {
     expect(dropdown.attributes('project')).toBe(project)
   })
 
+  it('hides the domain admin and instance admin options in the role dropdown', () => {
+    const wrapper = mountComponent()
+    const dropdown = wrapper.findComponent({ name: 'ProjectUsersRoleDropdown' })
+    expect(dropdown.props('hiddenRoles')).toEqual(['DOMAIN_ADMIN', 'INSTANCE_ADMIN'])
+  })
+
   it('isValid is false when username is empty', () => {
     const wrapper = mountComponent()
     expect(wrapper.vm.isValid).toBe(false)


### PR DESCRIPTION
## Enforce user management controls in the project Users tab
:warning: merge before https://github.com/ICIJ/datashare/pull/2271
This PR tightens the user CRUD flows added in #443:

- **Restrict user create/delete to instance admins** - both actions are instance-wide on the backend, so the controls are now hidden from project admins (and from non users-provider auth setups).
- **Gate domain/instance admin grants** - `grantUserRole` has no domain/wildcard support yet, so granting those roles would create wrong project-scoped policies. The role dropdown gains `disabledRoles`/`hiddenRoles` props: both options are shown disabled in the users list and hidden in the create-user modal.
- **Fix role display for wildcard policies** - permissions like `*::*` (instance admin) or `default::*` (domain admin) showed as "No role"; the mapping now resolves wildcards and keeps the highest matching role.
- Misc fixes: guard delete/role actions until the current username resolves, await create/grant calls before closing the create modal, remove a dead OAuth branch in the delete modal.

<img width="944" height="423" alt="image" src="https://github.com/user-attachments/assets/4dae9bda-aae6-4916-943e-353ec4e7005f" />
