### PR TITLE
fix(search): lazy load preview thumbnails in grid layout

### DIFF
--- a/src/components/Document/DocumentCard/DocumentCardGrid.vue
+++ b/src/components/Document/DocumentCard/DocumentCardGrid.vue
@@ -75,6 +75,7 @@ const showTitle = computed(() => props.properties?.includes('title'))
         :document="document"
         size="md"
         crop
+        lazy
         clickable
         :active="hover"
         class="mx-auto above-stretched-link"

--- a/tests/unit/specs/components/Document/DocumentCard/DocumentCardGrid.spec.js
+++ b/tests/unit/specs/components/Document/DocumentCard/DocumentCardGrid.spec.js
@@ -1,0 +1,19 @@
+import { shallowMount } from '@vue/test-utils'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import DocumentCardGrid from '@/components/Document/DocumentCard/DocumentCardGrid'
+import DocumentThumbnail from '@/components/Document/DocumentThumbnail/DocumentThumbnail'
+
+describe('DocumentCardGrid.vue', () => {
+  it('renders the thumbnail with lazy loading enabled', () => {
+    const core = CoreSetup.init().useAll()
+    const document = { id: 'doc-1', index: 'local-datashare', routing: 'doc-1', title: 'A document' }
+
+    const wrapper = shallowMount(DocumentCardGrid, {
+      global: { plugins: core.plugins },
+      props: { document }
+    })
+
+    expect(wrapper.findComponent(DocumentThumbnail).props('lazy')).toBe(true)
+  })
+})


### PR DESCRIPTION
As described in https://github.com/ICIJ/datashare/issues/2273, in the search results GRID layout, every document preview was fetched on mount instead of when it scrolls into view.

`DocumentThumbnail` already supports visibility-based lazy loading through its `lazy` prop (the list and table layouts use it); the grid card just wasn't passing it. This adds the prop and a unit test asserting it.

Verified in the browser against a 110-document index: before, all 25 thumbnails on the page fetched at load; after, only the ~5 visible ones fetch, with the rest loading progressively on scroll.