### PR TITLE
refactor: use murmur tree shaking

### DIFF
--- a/src/api/resources/Document.js
+++ b/src/api/resources/Document.js
@@ -1,6 +1,6 @@
 import { compact, endsWith, filter, find, get, keys, last, pick, startsWith, trim } from 'lodash'
 import { markRaw } from 'vue'
-import Murmur from '@icij/murmur'
+import { config } from '@icij/murmur'
 import dayjs from 'dayjs'
 import { extname } from 'path'
 
@@ -122,7 +122,7 @@ export default class Document extends EsDoc {
 
   get folder() {
     // Extract location parts
-    const pathSeparator = Murmur.config.get('pathSeparator', _separator)
+    const pathSeparator = config.get('pathSeparator', _separator)
     const parts = this.path.split(pathSeparator)
     // Remove the file name
     parts.splice(-1, 1)
@@ -131,11 +131,11 @@ export default class Document extends EsDoc {
   }
 
   get location() {
-    return this.folder.split(Murmur.config.get('dataDir', import.meta.env.VITE_DATA_PREFIX)).pop()
+    return this.folder.split(config.get('dataDir', import.meta.env.VITE_DATA_PREFIX)).pop()
   }
 
   get basename() {
-    return last(this.path.split(Murmur.config.get('pathSeparator', _separator)))
+    return last(this.path.split(config.get('pathSeparator', _separator)))
   }
 
   get extension() {

--- a/src/components/BatchSearch/BatchSeachCard/BatchSearchCardDetails.vue
+++ b/src/components/BatchSearch/BatchSeachCard/BatchSearchCardDetails.vue
@@ -44,7 +44,6 @@ const {
   nbQueries,
   nbQueriesWithoutResults,
   phraseMatches,
-  proximity,
   fuzziness,
   date,
   user,
@@ -85,7 +84,7 @@ const phraseMatchOff = computed(() => t('batchSearchCardDetails.phraseMatchOff')
 const phraseMatchValue = phraseMatches ? phraseMatchOn : phraseMatchOff
 
 const fuzzinessValue = computed(() => t('batchSearchCardDetails.fuzzinessValue', { n: fuzziness }))
-const proximityValue = computed(() => t('batchSearchCardDetails.proximityValue', { n: proximity }))
+const proximityValue = computed(() => t('batchSearchCardDetails.proximityValue', { n: fuzziness }))
 
 const { parseFiltersEntries } = useSearchBreadcrumb()
 
@@ -228,7 +227,7 @@ const showError = () => showBatchSearchErrorModal(batchSearch)
           :value="phraseMatchValue"
         />
       </li>
-      <li v-if="phraseMatch">
+      <li v-if="phraseMatches">
         <batch-search-card-details-entry
           :label="t('batchSearchCardDetails.proximity')"
           :icon="IPhArrowsOutLineHorizontal"

--- a/src/components/ColumnChartPicker.vue
+++ b/src/components/ColumnChartPicker.vue
@@ -1,12 +1,17 @@
 <script>
 import { cloneDeep, defaultTo, iteratee, isNumber, last, throttle } from 'lodash'
 import * as d3 from 'd3'
+import { ColumnChart, RangePicker } from '@icij/murmur'
 
 /**
  * Widget to display the number of file by creation date on the insights page.
  */
 export default {
   name: 'ColumnChartPicker',
+  components: {
+    ColumnChart,
+    RangePicker
+  },
   props: {
     /**
      * Initial values of the range bounds. Should contain two timestamps.

--- a/src/components/Document/DocumentContent.vue
+++ b/src/components/Document/DocumentContent.vue
@@ -2,6 +2,7 @@
 import { computed, nextTick, onMounted, reactive, ref, toRef, useTemplateRef, watch } from 'vue'
 import { clamp, entries, findLastIndex, get, isEmpty, iteratee, minBy, range, throttle } from 'lodash'
 import { useI18n } from 'vue-i18n'
+import { PaginationTiny } from '@icij/murmur'
 
 import { addLocalSearchMarksClassByOffsets } from '@/utils/strings'
 import { useCompact } from '@/composables/useCompact'
@@ -394,7 +395,7 @@ async function loadContentSliceAround(desiredOffset) {
           v-if="showPagination"
           class="document-content__toolbox__pagination"
         >
-          <tiny-pagination
+          <pagination-tiny
             v-model="page"
             :per-page="1"
             :total-rows="nbPages"

--- a/src/components/Document/DocumentViewer/DocumentViewerPdf/DocumentViewerPdfPagination.vue
+++ b/src/components/Document/DocumentViewer/DocumentViewerPdf/DocumentViewerPdfPagination.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { PaginationTiny } from '@icij/murmur'
+
 const page = defineModel('page', { type: Number, default: 1 })
 
 defineProps({
@@ -11,7 +13,7 @@ defineProps({
 </script>
 
 <template>
-  <tiny-pagination
+  <pagination-tiny
     :key="totalRows"
     v-model="page"
     :per-page="1"

--- a/src/components/Filter/FilterType/FilterTypeDateRange.vue
+++ b/src/components/Filter/FilterType/FilterTypeDateRange.vue
@@ -51,7 +51,7 @@ const selected = computed({
     <template #default="{ entries }">
       <form-control-date-range
         v-model="selected"
-        size="1em"
+        size="sm"
       />
       <column-chart-picker
         v-if="entries.length > 1"

--- a/src/components/Search/SearchBar/SearchBar.vue
+++ b/src/components/Search/SearchBar/SearchBar.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch, nextTick, useTemplateRef } from 'vue'
 import { isEqual, iteratee, sortBy, uniqueId } from 'lodash'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
+import { SelectableDropdown } from '@icij/murmur'
 
 import SearchBarInput from '@/components/Search/SearchBar/SearchBarInput'
 import FieldDropdownSelector from '@/components/FieldDropdownSelector/FieldDropdownSelector'

--- a/src/components/Task/TaskBoard/TaskBoardListEntry.vue
+++ b/src/components/Task/TaskBoard/TaskBoardListEntry.vue
@@ -8,7 +8,7 @@ import { SIZE } from '@/enums/sizes'
 
 defineProps({
   title: { type: String, default: '' },
-  icon: { type: String },
+  icon: { type: [String, Object, Function] },
   description: { type: String, default: '' },
   listLink: { type: [String, Object] },
   actionLink: { type: [String, Object] },

--- a/src/components/VersionNumber.vue
+++ b/src/components/VersionNumber.vue
@@ -51,7 +51,7 @@
 
 <script setup>
 import { onMounted, ref } from 'vue'
-import { AppIcon } from '@icij/murmur'
+import { AppIcon, HapticCopy } from '@icij/murmur'
 import { useI18n } from 'vue-i18n'
 
 import { apiInstance as api } from '@/api/apiInstance'

--- a/src/components/Widget/WidgetDocumentsByCreationDate.vue
+++ b/src/components/Widget/WidgetDocumentsByCreationDate.vue
@@ -97,6 +97,7 @@ import { computed, nextTick, ref, useTemplateRef, watch, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { whenever } from '@vueuse/core'
+import { ColumnChart } from '@icij/murmur'
 
 import IPhMagnifyingGlassBold from '~icons/ph/magnifying-glass-bold'
 

--- a/src/composables/useConfig.js
+++ b/src/composables/useConfig.js
@@ -1,5 +1,5 @@
-import Murmur from '@icij/murmur'
+import { config } from '@icij/murmur'
 
 export function useConfig() {
-  return Murmur.config
+  return config
 }

--- a/src/core/ComponentsMixin.js
+++ b/src/core/ComponentsMixin.js
@@ -1,7 +1,5 @@
 import { compact, find, keys, kebabCase, iteratee, uniq } from 'lodash'
 
-import Murmur from '@icij/murmur'
-
 import { slugger } from '@/utils/strings'
 
 /**
@@ -32,26 +30,31 @@ const ComponentMixin = superclass =>
     /**
      * Get a component from Murmur by its name.
      * Searches in Murmur.components, Murmur.datavisualisations, and Murmur.maps.
+     * Murmur is imported dynamically so its full component barrel is only
+     * loaded (as a separate chunk) if this lookup is actually used.
+     * @async
      * @function
      * @param {string} name - The name of the Murmur component to retrieve.
-     * @returns {Object} - The found component object, or null if not found.
+     * @returns {Promise.<Object>} - The found component object, or null if not found.
      */
-    getMurmurComponent(name) {
-      return Murmur.components[name] ?? Murmur.datavisualisations[name] ?? Murmur.maps[name] ?? null
+    async getMurmurComponent(name) {
+      const { components, datavisualisations, maps } = (await import('@icij/murmur')).default
+      return components[name] ?? datavisualisations[name] ?? maps[name] ?? null
     }
 
     /**
      * Check if name has "Murmur/" prefix and return the component from @icij/murmur.
+     * @async
      * @function
      * @param {string} name - The name of the component to retrieve, potentially with "Murmur/" prefix.
      * @returns {Promise.<Object>} - The found Murmur component, or null if not a Murmur component or not found.
      */
-    findMurmurComponentByPrefix(name) {
+    async findMurmurComponentByPrefix(name) {
       if (name.toLowerCase().startsWith(MURMUR_PREFIX)) {
         const murmurName = name.slice(MURMUR_PREFIX.length)
-        return Promise.resolve(this.getMurmurComponent(murmurName))
+        return this.getMurmurComponent(murmurName)
       }
-      return Promise.resolve(null)
+      return null
     }
 
     /**

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -212,6 +212,7 @@ class Core extends Behaviors {
     return class VueCore {
       static install(app) {
         app.config.globalProperties.$core = core
+        app.config.globalProperties.$config = core.config
         app.config.compilerOptions.whitespace = 'preserve'
         // inject a globally available $toast object
         app.config.globalProperties.$toast = {

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -2,7 +2,7 @@
 import 'mutationobserver-shim'
 
 import compose from 'lodash/fp/compose'
-import Murmur from '@icij/murmur'
+import { config } from '@icij/murmur'
 import VCalendar from 'v-calendar'
 import VueScrollTo from 'vue-scrollto'
 import Vue3Toastify, { toast } from 'vue3-toastify'
@@ -180,9 +180,6 @@ class Core extends Behaviors {
     // dynamic chunk import with third party modules.
     // @see https://github.com/nathanreyes/v-calendar/issues/413#issuecomment-530633437
     this.use(VCalendar, { componentPrefix: 'vc' })
-    // Murmur is loaded without installing Vue i18n and Bootstrap Vue
-    // to avoid adding them twice to the Vue instance.
-    this.use(Murmur, { useI18n: false, useBootstrap: false })
     // Vue Toastify uses as separated vue instance so we must install vue-i18n
     // separately to ensure vue-i18n's methods and components are available in the toastify plugin.
     this.use(Vue3Toastify, {
@@ -570,7 +567,7 @@ class Core extends Behaviors {
    * @type {Object}
    */
   get config() {
-    return Murmur.config
+    return config
   }
 
   /**

--- a/src/core/I18nMixin.js
+++ b/src/core/I18nMixin.js
@@ -1,5 +1,5 @@
 import { isEmpty } from 'lodash'
-import Murmur from '@icij/murmur'
+import { i18n as murmurI18n } from '@icij/murmur'
 
 import settings from '@/utils/settings'
 /**
@@ -54,7 +54,7 @@ const I18nMixin = superclass =>
         const messages = await import(`../lang/${locale}.json`).then(m => m.default)
         this.i18n.global.setLocaleMessage(locale, messages)
       }
-      const murmurMessages = Murmur.i18n.global.getLocaleMessage(locale)
+      const murmurMessages = murmurI18n.global.getLocaleMessage(locale)
       this.i18n.global.mergeLocaleMessage(locale, murmurMessages)
       return this.setI18nLocale(locale)
     }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -155,7 +155,8 @@ export const routes = [
             path: 'entities',
             meta: {
               title: 'task.entities.title',
-              icon: markRaw(IPhUsersThree)
+              icon: markRaw(IPhUsersThree),
+              allowedModes: [MODE_NAME.LOCAL, MODE_NAME.EMBEDDED]
             },
             children: [
               {

--- a/src/views/Search/SearchHistory/SearchHistoryList/SearchHistoryList.vue
+++ b/src/views/Search/SearchHistory/SearchHistoryList/SearchHistoryList.vue
@@ -100,13 +100,19 @@ watch(toRef(route, 'query'), fetch, { deep: true, immediate: true })
       :total-rows="pagination.total"
     >
       <template #breadcrumb>
-        <parent-overflow-entries-item>
+        <parent-overflow-entries-item
+          label="search"
+          :context="searchRoute"
+        >
           <navigation-breadcrumb-link
             :to="searchRoute"
             :title="t('appSidebar.search')"
           />
         </parent-overflow-entries-item>
-        <parent-overflow-entries-item>
+        <parent-overflow-entries-item
+          label="search.history.list"
+          :context="{ name: 'search.history.list' }"
+        >
           <navigation-breadcrumb-link
             :to="{ name: 'search.history.list' }"
             no-caret

--- a/src/views/Search/SearchSaved/SearchSavedList/SearchSavedList.vue
+++ b/src/views/Search/SearchSaved/SearchSavedList/SearchSavedList.vue
@@ -101,13 +101,19 @@ watch(toRef(route, 'query'), fetch, { deep: true, immediate: true })
       :total-rows="pagination?.total ?? 0"
     >
       <template #breadcrumb>
-        <parent-overflow-entries-item>
+        <parent-overflow-entries-item
+          label="search"
+          :context="searchRoute"
+        >
           <navigation-breadcrumb-link
             :to="searchRoute"
             :title="t('appSidebar.search')"
           />
         </parent-overflow-entries-item>
-        <parent-overflow-entries-item>
+        <parent-overflow-entries-item
+          label="search.saved.list"
+          :context="{ name: 'search.saved.list' }"
+        >
           <navigation-breadcrumb-link
             :to="{ name: 'search.saved.list' }"
             no-caret

--- a/tests/unit/CoreSetup.js
+++ b/tests/unit/CoreSetup.js
@@ -1,4 +1,3 @@
-import Murmur from '@icij/murmur'
 import VCalendar from 'v-calendar'
 import VueScrollTo from 'vue-scrollto'
 import { createWebHashHistory, createRouter } from 'vue-router'
@@ -15,16 +14,11 @@ class CoreSetup extends Core {
       this.plugin,
       this.bootstrapVue,
       this.i18n,
-      [this.murmur, { useI18n: false, useBootstrap: false }],
       this.pinia,
       this.vueScrollTo,
       this.vCalendar,
       this.router
     ]
-  }
-
-  get murmur() {
-    return Murmur
   }
 
   get vueScrollTo() {

--- a/tests/unit/specs/api/resources/Document.spec.js
+++ b/tests/unit/specs/api/resources/Document.spec.js
@@ -1,4 +1,4 @@
-import Murmur from '@icij/murmur'
+import { config } from '@icij/murmur'
 
 import Document from '@/api/resources/Document'
 
@@ -224,7 +224,7 @@ describe('Document', () => {
   })
 
   it('should return the correct basename on Windows', () => {
-    Murmur.config.set('pathSeparator', '\\')
+    config.set('pathSeparator', '\\')
     const doc = new Document({ _source: { path: 'C:\\this\\is\\a\\specific.file' } })
 
     expect(doc.basename).toBe('specific.file')

--- a/tests/unit/specs/components/BatchSearch/BatchSearchCard/BatchSearchCardDetails.spec.js
+++ b/tests/unit/specs/components/BatchSearch/BatchSearchCard/BatchSearchCardDetails.spec.js
@@ -1,9 +1,60 @@
 import { shallowMount } from '@vue/test-utils'
 
 import BatchSearchCardDetails from '@/components/BatchSearch/BatchSeachCard/BatchSearchCardDetails'
+import BatchSearchCardDetailsEntry from '@/components/BatchSearch/BatchSeachCard/BatchSearchCardDetailsEntry'
 import CoreSetup from '~tests/unit/CoreSetup'
 
-describe.skip('BatchSearchCardDetails', () => {
+describe('BatchSearchCardDetails', () => {
+  const batchSearch = {
+    uuid: 'uuid',
+    nbResults: 2,
+    nbQueries: 3,
+    nbQueriesWithoutResults: 1,
+    phraseMatches: true,
+    proximity: 2,
+    fuzziness: 1,
+    date: '2020-01-01',
+    user: { id: 'user' },
+    projects: ['local-datashare'],
+    state: 'DONE',
+    published: true,
+    uri: '/#/search?q=foo'
+  }
+
+  function mountWith(overrides = {}) {
+    const { plugins } = CoreSetup.init().useAll().useRouterWithoutGuards()
+    return shallowMount(BatchSearchCardDetails, {
+      props: { batchSearch: { ...batchSearch, ...overrides } },
+      global: { plugins }
+    })
+  }
+
+  it('displays the proximity entry when phraseMatches is true', () => {
+    const wrapper = mountWith({ phraseMatches: true })
+    const labels = wrapper.findAllComponents(BatchSearchCardDetailsEntry).map(entry => entry.props('label'))
+    expect(labels).toContain('Proximity - Sentence changes')
+    expect(labels).not.toContain('Fuzziness - Spelling changes')
+  })
+
+  it('displays the fuzziness entry when phraseMatches is false', () => {
+    const wrapper = mountWith({ phraseMatches: false })
+    const labels = wrapper.findAllComponents(BatchSearchCardDetailsEntry).map(entry => entry.props('label'))
+    expect(labels).toContain('Fuzziness - Spelling changes')
+    expect(labels).not.toContain('Proximity - Sentence changes')
+  })
+
+  it('does not warn about an undefined "phraseMatch" property', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mountWith()
+    const undefinedPropertyWarning = warnSpy.mock.calls.find(([message]) => {
+      return typeof message === 'string' && message.includes('phraseMatch') && !message.includes('phraseMatches')
+    })
+    expect(undefinedPropertyWarning).toBeUndefined()
+    warnSpy.mockRestore()
+  })
+})
+
+describe.skip('BatchSearchCardDetails (legacy)', () => {
   let plugins
   beforeAll(() => {
     const core = CoreSetup.init().useAll().useRouterWithoutGuards()

--- a/tests/unit/specs/components/Filter/FilterType/FilterTypeDateRange.spec.js
+++ b/tests/unit/specs/components/Filter/FilterType/FilterTypeDateRange.spec.js
@@ -52,4 +52,20 @@ describe('FilterTypeDateRange.vue', () => {
     const endAttr = elementEnd.attributes()
     expect(endAttr.placeholder).toBe('MM/DD/YYYY')
   })
+
+  it('passes a valid size value to the underlying inputs without a Vue warning', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const inputs = wrapper.findAll('input[type=text]')
+    inputs.forEach((input) => {
+      expect(input.classes()).toContain('form-control-sm')
+    })
+
+    const invalidSizeWarning = warnSpy.mock.calls.find(([message]) => {
+      return typeof message === 'string' && message.includes('Invalid prop') && message.includes('size')
+    })
+    expect(invalidSizeWarning).toBeUndefined()
+
+    warnSpy.mockRestore()
+  })
 })

--- a/tests/unit/specs/components/Project/ProjectCard/ProjectCardFooter.spec.js
+++ b/tests/unit/specs/components/Project/ProjectCard/ProjectCardFooter.spec.js
@@ -1,5 +1,5 @@
 import { shallowMount } from '@vue/test-utils'
-import Murmur from '@icij/murmur'
+import { config } from '@icij/murmur'
 
 import CoreSetup from '~tests/unit/CoreSetup'
 import ProjectCardFooter from '@/components/Project/ProjectCard/ProjectCardFooter'
@@ -13,8 +13,8 @@ describe('ProjectCardFooter.vue', () => {
   })
 
   afterEach(() => {
-    Murmur.config.set('mode', null)
-    Murmur.config.set('policies', [])
+    config.set('mode', null)
+    config.set('policies', [])
   })
 
   it('should render without errors', () => {
@@ -27,11 +27,11 @@ describe('ProjectCardFooter.vue', () => {
     const project = { name: 'banana-papers' }
 
     beforeEach(() => {
-      Murmur.config.set('mode', 'SERVER')
+      config.set('mode', 'SERVER')
     })
 
     it('shows default role when no policy exists for the project', () => {
-      Murmur.config.set('policies', [{ projectId: 'other-project', role: 'PROJECT_ADMIN' }])
+      config.set('policies', [{ projectId: 'other-project', role: 'PROJECT_ADMIN' }])
       const wrapper = shallowMount(ProjectCardFooter, {
         global: {
           plugins,
@@ -43,7 +43,7 @@ describe('ProjectCardFooter.vue', () => {
     })
 
     it('shows PROJECT_EDITOR role when policy has PROJECT_EDITOR', () => {
-      Murmur.config.set('policies', [{ projectId: 'banana-papers', role: 'PROJECT_EDITOR' }])
+      config.set('policies', [{ projectId: 'banana-papers', role: 'PROJECT_EDITOR' }])
       const wrapper = shallowMount(ProjectCardFooter, {
         global: {
           plugins,

--- a/tests/unit/specs/components/Project/ProjectJumbotron/ProjectJumbotron.spec.js
+++ b/tests/unit/specs/components/Project/ProjectJumbotron/ProjectJumbotron.spec.js
@@ -1,5 +1,5 @@
 import { shallowMount } from '@vue/test-utils'
-import Murmur from '@icij/murmur'
+import { config } from '@icij/murmur'
 
 import CoreSetup from '~tests/unit/CoreSetup'
 import ProjectJumbotron from '@/components/Project/ProjectJumbotron/ProjectJumbotron'
@@ -13,8 +13,8 @@ describe('ProjectJumbotron.vue', () => {
   })
 
   afterEach(() => {
-    Murmur.config.set('mode', null)
-    Murmur.config.set('policies', [])
+    config.set('mode', null)
+    config.set('policies', [])
   })
 
   it('should render without errors', () => {
@@ -27,11 +27,11 @@ describe('ProjectJumbotron.vue', () => {
     const project = { name: 'citrus-confidential' }
 
     beforeEach(() => {
-      Murmur.config.set('mode', 'SERVER')
+      config.set('mode', 'SERVER')
     })
 
     it('shows the role from policies for the current project', () => {
-      Murmur.config.set('policies', [{ projectId: 'citrus-confidential', role: 'PROJECT_ADMIN' }])
+      config.set('policies', [{ projectId: 'citrus-confidential', role: 'PROJECT_ADMIN' }])
       const wrapper = shallowMount(ProjectJumbotron, {
         global: {
           plugins,
@@ -43,7 +43,7 @@ describe('ProjectJumbotron.vue', () => {
     })
 
     it('shows default role when no policy exists for the project', () => {
-      Murmur.config.set('policies', [{ projectId: 'other-project', role: 'PROJECT_ADMIN' }])
+      config.set('policies', [{ projectId: 'other-project', role: 'PROJECT_ADMIN' }])
       const wrapper = shallowMount(ProjectJumbotron, {
         global: {
           plugins,
@@ -55,7 +55,7 @@ describe('ProjectJumbotron.vue', () => {
     })
 
     it('shows PROJECT_EDITOR role when policy has PROJECT_EDITOR', () => {
-      Murmur.config.set('policies', [{ projectId: 'citrus-confidential', role: 'PROJECT_EDITOR' }])
+      config.set('policies', [{ projectId: 'citrus-confidential', role: 'PROJECT_EDITOR' }])
       const wrapper = shallowMount(ProjectJumbotron, {
         global: {
           plugins,

--- a/tests/unit/specs/components/Task/TaskBoard/TaskBoardListEntry.spec.js
+++ b/tests/unit/specs/components/Task/TaskBoard/TaskBoardListEntry.spec.js
@@ -1,0 +1,46 @@
+import { mount } from '@vue/test-utils'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import TaskBoardListEntry from '@/components/Task/TaskBoard/TaskBoardListEntry'
+import IPhListMagnifyingGlass from '~icons/ph/list-magnifying-glass'
+
+describe('TaskBoardListEntry.vue', () => {
+  let core, warnSpy
+
+  beforeEach(() => {
+    core = CoreSetup.init().useAll().useRouterWithoutGuards()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('accepts an icon component (as produced by unplugin-icons) without a prop-type warning', () => {
+    const props = {
+      icon: IPhListMagnifyingGlass,
+      title: 'Batch search',
+      listLink: { name: 'task.batch-search.list' }
+    }
+    mount(TaskBoardListEntry, { props, global: { plugins: core.plugins } })
+
+    const invalidPropWarning = warnSpy.mock.calls.find(([message]) => {
+      return typeof message === 'string' && message.includes('Invalid prop') && message.includes('icon')
+    })
+    expect(invalidPropWarning).toBeUndefined()
+  })
+
+  it('still accepts a string icon name without a prop-type warning', () => {
+    const props = {
+      icon: 'list-magnifying-glass',
+      title: 'Batch search',
+      listLink: { name: 'task.batch-search.list' }
+    }
+    mount(TaskBoardListEntry, { props, global: { plugins: core.plugins } })
+
+    const invalidPropWarning = warnSpy.mock.calls.find(([message]) => {
+      return typeof message === 'string' && message.includes('Invalid prop') && message.includes('icon')
+    })
+    expect(invalidPropWarning).toBeUndefined()
+  })
+})

--- a/tests/unit/specs/components/VersionNumber.spec.js
+++ b/tests/unit/specs/components/VersionNumber.spec.js
@@ -23,8 +23,11 @@ describe('VersionNumber.vue', () => {
     return container
   }
 
-  beforeAll(() => {
+  beforeAll(async () => {
     core = Core.init().useAll()
+    // Merge Murmur's locale messages, as the real app does in initializeI18n(),
+    // so components like HapticCopy can resolve their translated label.
+    await core.loadI18Locale('en')
   })
 
   beforeEach(() => {
@@ -58,7 +61,8 @@ describe('VersionNumber.vue', () => {
   it('should display git sha1 in a tooltip', async () => {
     await wrapper.vm.setVersion()
     const body = attachTo.closest('body')
-    const abbrev = body.querySelector('.version-number__tooltip__server__value')?.textContent?.trim()
+    // Only the leading text node holds the hash; the rest is the HapticCopy button (with its a11y label).
+    const abbrev = body.querySelector('.version-number__tooltip__server__value')?.firstChild?.textContent?.trim()
     expect(abbrev).toBe('sha1_abbrev')
   })
 })

--- a/tests/unit/specs/components/Widget/WidgetDocumentsByCreationDate.spec.js
+++ b/tests/unit/specs/components/Widget/WidgetDocumentsByCreationDate.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils'
+import { mount, shallowMount } from '@vue/test-utils'
 
 import esConnectionHelper from '../../utils/esConnectionHelper.js'
 
@@ -23,6 +23,20 @@ describe('WidgetDocumentsByCreationDate.vue', () => {
 
     it('should be a Vue instance', () => {
       expect(wrapper).toBeTruthy()
+    })
+
+    it('should resolve the column-chart component without a Vue warning', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const { plugins } = CoreSetup.init().useAll()
+      const global = { plugins, renderStubDefaultSlot: true }
+      mount(WidgetDocumentsByCreationDate, { props, global })
+      await new Promise(resolve => setTimeout(resolve))
+
+      const resolveWarning = warnSpy.mock.calls.find(([message]) => {
+        return typeof message === 'string' && message.includes('Failed to resolve component: column-chart')
+      })
+      expect(resolveWarning).toBeUndefined()
+      warnSpy.mockRestore()
     })
 
     it('should display no message if no data are missing', async () => {

--- a/tests/unit/specs/core/ComponentsMixin.spec.js
+++ b/tests/unit/specs/core/ComponentsMixin.spec.js
@@ -86,14 +86,14 @@ describe('ComponentsMixin', () => {
       }
     })
 
-    it('should get Murmur component directly with getMurmurComponent', () => {
-      const ButtonIcon = core.getMurmurComponent('ButtonIcon')
+    it('should get Murmur component directly with getMurmurComponent', async () => {
+      const ButtonIcon = await core.getMurmurComponent('ButtonIcon')
       expect(ButtonIcon).not.toBeNull()
       expect(ButtonIcon.name).toBe('ButtonIcon')
     })
 
-    it('should return null for unknown component with getMurmurComponent', () => {
-      expect(core.getMurmurComponent('NonExistentComponent')).toBeNull()
+    it('should return null for unknown component with getMurmurComponent', async () => {
+      expect(await core.getMurmurComponent('NonExistentComponent')).toBeNull()
     })
   })
 })

--- a/tests/unit/specs/core/Core.spec.js
+++ b/tests/unit/specs/core/Core.spec.js
@@ -1,4 +1,4 @@
-import Murmur from '@icij/murmur'
+import { config } from '@icij/murmur'
 
 import { Core } from '@/core'
 import { apiInstance as api } from '@/api/apiInstance'
@@ -69,7 +69,7 @@ describe('Core', () => {
     })
 
     it('should expose the config from Murmur', () => {
-      expect(core.config).toBe(Murmur.config)
+      expect(core.config).toBe(config)
     })
 
     it('should mount the app on a specific element', () => {

--- a/tests/unit/specs/router/guards.spec.js
+++ b/tests/unit/specs/router/guards.spec.js
@@ -161,6 +161,24 @@ describe('guards', () => {
       expect(router.currentRoute.value.name).not.toBe('error')
     })
 
+    it('should redirect task.entities.list to error in SERVER mode', async () => {
+      config.set('mode', 'SERVER')
+      await router.push({ name: 'task.entities.list' })
+      expect(router.currentRoute.value.name).toBe('error')
+    })
+
+    it('should redirect task.entities.new to error in SERVER mode', async () => {
+      config.set('mode', 'SERVER')
+      await router.push({ name: 'task.entities.new' })
+      expect(router.currentRoute.value.name).toBe('error')
+    })
+
+    it('should not redirect task.entities.list to error in LOCAL mode', async () => {
+      config.set('mode', 'LOCAL')
+      await router.push({ name: 'task.entities.list' })
+      expect(router.currentRoute.value.name).not.toBe('error')
+    })
+
     it('should redirect project.new to error in SERVER mode', async () => {
       config.set('mode', 'SERVER')
       await router.push({ name: 'project.new' })

--- a/tests/unit/specs/views/Search/SearchHistory/SearchHistoryList/SearchHistoryList.spec.js
+++ b/tests/unit/specs/views/Search/SearchHistory/SearchHistoryList/SearchHistoryList.spec.js
@@ -3,6 +3,7 @@ import { mount, flushPromises } from '@vue/test-utils'
 import CoreSetup from '~tests/unit/CoreSetup'
 import ButtonToggleDay from '@/components/Button/ButtonToggleDay'
 import DocumentCard from '@/components/Document/DocumentCard/DocumentCard'
+import ParentOverflowEntriesItem from '@/components/ParentOverflow/ParentOverflowEntriesItem'
 import SearchHistoryList from '@/views/Search/SearchHistory/SearchHistoryList/SearchHistoryList'
 import { apiInstance as api } from '@/api/apiInstance'
 
@@ -116,5 +117,16 @@ describe('SearchHistoryList.vue', () => {
     await flushPromises()
     const cards = wrapper.findAllComponents(ButtonToggleDay)
     expect(cards).toHaveLength(2)
+  })
+
+  it('should give each breadcrumb entry a label and a route context so it can be shown in the overflow dropdown', async () => {
+    const wrapper = mount(SearchHistoryList, { global: { plugins: core.plugins } })
+    await flushPromises()
+    const entries = wrapper.findAllComponents(ParentOverflowEntriesItem)
+    expect(entries.length).toBeGreaterThan(0)
+    entries.forEach((entry) => {
+      expect(entry.props('label')).toBeTruthy()
+      expect(entry.props('context')).not.toBeNull()
+    })
   })
 })

--- a/tests/unit/specs/views/Search/SearchSaved/SearchSavedList/SearchSavedList.spec.js
+++ b/tests/unit/specs/views/Search/SearchSaved/SearchSavedList/SearchSavedList.spec.js
@@ -1,6 +1,7 @@
 import { flushPromises, mount } from '@vue/test-utils'
 
 import CoreSetup from '~tests/unit/CoreSetup'
+import ParentOverflowEntriesItem from '@/components/ParentOverflow/ParentOverflowEntriesItem'
 import SearchSavedEntries from '@/components/Search/SearchSavedEntries/SearchSavedEntries'
 import SearchSavedList from '@/views/Search/SearchSaved/SearchSavedList/SearchSavedList'
 import { apiInstance as api } from '@/api/apiInstance'
@@ -80,5 +81,14 @@ describe('Search/SearchSaved/SearchSavedList.vue', () => {
     expect(api.getHistoryEvents).toBeCalledTimes(1)
     await router.push({ name: 'search.saved.list', query: { page: '2' } })
     expect(api.getHistoryEvents).toBeCalledTimes(2)
+  })
+
+  it('should give each breadcrumb entry a label and a route context so it can be shown in the overflow dropdown', () => {
+    const entries = wrapper.findAllComponents(ParentOverflowEntriesItem)
+    expect(entries.length).toBeGreaterThan(0)
+    entries.forEach((entry) => {
+      expect(entry.props('label')).toBeTruthy()
+      expect(entry.props('context')).not.toBeNull()
+    })
   })
 })


### PR DESCRIPTION
Refactor `@icij/murmur` usage to enable tree-shaking: 
* named imports for `config/i18n` instead of the default export, 
* direct component imports in SFCs instead of global plugin registration, 
* and lazy-load of the rarely-used Murmur components in `getMurmurComponent` 

**🍪 Girl Scout side quest** - while testing the refactor, found and fixed console warnings, each with a regression test:
- `TaskBoardListEntry`: `icon` prop still typed as `String` after `TASK_NAME_ICON` moved to `unplugin-icons` component objects
- `SearchHistoryList`/`SearchSavedList`: custom breadcrumb slots omitted `label`/`context` on overflow entries, so overflowed items resolved to a `null` route
- `FilterTypeDateRange`: stray `size="1em"` (an icon-sized value) accidentally landed on `FormControlDateRange`'s `size` prop, which only accepts `sm`/`md`/`lg`
- `BatchSearchCardDetails`: typo (`phraseMatch` vs `phraseMatches`) picked the wrong proximity/fuzziness entry
- add guards to prevent access to `task.entities` routes in server mode