### PR TITLE
feat(document): get the download state per document from HEAD /documents/src/:id

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -7,7 +7,8 @@ const Method = Object.freeze({
   PUT: 'PUT',
   UPDATE: 'UPDATE',
   DELETE: 'DELETE',
-  GET: 'GET'
+  GET: 'GET',
+  HEAD: 'HEAD'
 })
 
 export class Api {
@@ -322,6 +323,32 @@ export class Api {
 
   isDownloadAllowed(project) {
     return this.sendActionAsText(`/api/project/isDownloadAllowed/${project}`)
+  }
+
+  /**
+   * Probe whether a document's source can be downloaded.
+   *
+   * This deliberately bypasses `sendAction`: 403, 413 and 404 are expected
+   * answers from this endpoint, and `sendAction` would emit an `http::error`
+   * on the event bus for each one, spraying error notifications across a
+   * results page. Any non-200 status, and any transport failure, means the
+   * document cannot be downloaded.
+   *
+   * @param {string} index - The project index of the document
+   * @param {string} id - The document id
+   * @param {string} routing - The routing (the root document id)
+   * @returns {Promise<boolean>} True when the backend answers 200
+   */
+  async isDocumentDownloadable(index, id, routing) {
+    const url = Api.getFullUrl(`/api/${index}/documents/src/${id}`)
+    const validateStatus = () => true
+    try {
+      const { status } = await this.axios.request({ url, method: Method.HEAD, params: { routing }, validateStatus })
+      return status === 200
+    }
+    catch {
+      return false
+    }
   }
 
   login(username, password) {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -321,10 +321,6 @@ export class Api {
     return url.href
   }
 
-  isDownloadAllowed(project) {
-    return this.sendActionAsText(`/api/project/isDownloadAllowed/${project}`)
-  }
-
   /**
    * Probe whether a document's source can be downloaded.
    *

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -11,6 +11,10 @@ const Method = Object.freeze({
   HEAD: 'HEAD'
 })
 
+// The only statuses that mean "this document's source will not be served".
+// See Api#isDocumentDownloadable.
+const DOWNLOAD_REFUSED_STATUSES = [403, 404, 413]
+
 export class Api {
   constructor(_axios, _EventBus, _elasticsearch) {
     this.axios = _axios
@@ -324,26 +328,38 @@ export class Api {
   /**
    * Probe whether a document's source can be downloaded.
    *
-   * This deliberately bypasses `sendAction`: 403, 413 and 404 are expected
+   * This deliberately bypasses `sendAction`: 403, 404 and 413 are expected
    * answers from this endpoint, and `sendAction` would emit an `http::error`
    * on the event bus for each one, spraying error notifications across a
-   * results page. Any non-200 status, and any transport failure, means the
-   * document cannot be downloaded.
+   * results page.
+   *
+   * Only those three statuses count as a refusal. Anything else the probe
+   * cannot interpret — a server or proxy that doesn't route HEAD, a 5xx, a
+   * transport failure — leaves the document downloadable, so a probe we
+   * cannot read never hides a download that would in fact work.
    *
    * @param {string} index - The project index of the document
    * @param {string} id - The document id
    * @param {string} routing - The routing (the root document id)
-   * @returns {Promise<boolean>} True when the backend answers 200
+   * @returns {Promise<boolean>} False only when the backend explicitly refuses
    */
   async isDocumentDownloadable(index, id, routing) {
     const url = Api.getFullUrl(`/api/${index}/documents/src/${id}`)
     const validateStatus = () => true
     try {
-      const { status } = await this.axios.request({ url, method: Method.HEAD, params: { routing }, validateStatus })
-      return status === 200
+      const response = await this.axios.request({ url, method: Method.HEAD, params: { routing }, validateStatus })
+      const { status } = response
+      // An expired session says nothing about the document. Report it like any
+      // other request so the app can offer to log back in, and leave the
+      // document downloadable rather than greying out the whole page.
+      if (status === 401) {
+        this.eventBus?.emit('http::error', { response })
+        return true
+      }
+      return !DOWNLOAD_REFUSED_STATUSES.includes(status)
     }
     catch {
-      return false
+      return true
     }
   }
 

--- a/src/components/Document/DocumentActionsGroup/DocumentActionsGroupEntryDownload.vue
+++ b/src/components/Document/DocumentActionsGroup/DocumentActionsGroupEntryDownload.vue
@@ -41,10 +41,9 @@ const { t } = useI18n()
 
 const element = useTemplateRef('element')
 const isVisible = useElementVisibilityOnce(element)
-const { isDownloadAllowed, isRootTooBig, documentFullUrl, fetchStatuses } = useDocumentDownload(document, { immediate: false })
+const { isDownloadAllowed, documentFullUrl, fetchStatuses } = useDocumentDownload(document, { immediate: false })
 whenever(isVisible, fetchStatuses, { once: true })
-const hasDownload = computed(() => isDownloadAllowed.value && !isRootTooBig.value)
-const href = computed(() => (hasDownload.value ? documentFullUrl.value : null))
+const href = computed(() => (isDownloadAllowed.value ? documentFullUrl.value : null))
 const blur = () => nextTick(() => window.document?.activeElement.blur())
 </script>
 

--- a/src/components/Document/DocumentActionsGroup/DocumentActionsGroupEntryDownload.vue
+++ b/src/components/Document/DocumentActionsGroup/DocumentActionsGroupEntryDownload.vue
@@ -1,6 +1,5 @@
 <script setup>
-import { computed, nextTick, useTemplateRef } from 'vue'
-import { whenever } from '@vueuse/core'
+import { computed, nextTick, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import IPhDownloadSimple from '~icons/ph/download-simple'
@@ -41,8 +40,15 @@ const { t } = useI18n()
 
 const element = useTemplateRef('element')
 const isVisible = useElementVisibilityOnce(element)
-const { isDownloadAllowed, documentFullUrl, fetchStatuses } = useDocumentDownload(document, { immediate: false })
-whenever(isVisible, fetchStatuses, { once: true })
+const { isDownloadAllowed, documentFullUrl, fetchStatuses } = useDocumentDownload(() => document, { immediate: false })
+// Probe once the row scrolls into view, and again whenever a recycled row is
+// handed a different document while it stays mounted. The store memoizes per
+// document, so re-probing a document already seen costs nothing.
+watch([isVisible, () => document?.id], ([visible]) => {
+  if (visible) {
+    fetchStatuses()
+  }
+})
 const href = computed(() => (isDownloadAllowed.value ? documentFullUrl.value : null))
 const blur = () => nextTick(() => window.document?.activeElement.blur())
 </script>
@@ -57,6 +63,12 @@ const blur = () => nextTick(() => window.document?.activeElement.blur())
     :placement="tooltipPlacement"
   >
     <template #target>
+      <!--
+        Never disabled: this button opens the download popover, which still
+        offers the extracted text, the translations and the root document even
+        when the source itself cannot be served. Only the direct-download href
+        is withheld.
+      -->
       <document-actions-group-entry
         ref="element"
         class="document-actions-group-entry-download"
@@ -65,7 +77,6 @@ const blur = () => nextTick(() => window.document?.activeElement.blur())
         hide-tooltip
         :size="size"
         :label="t('documentActionsGroup.download')"
-        :disabled="!isDownloadAllowed"
         :href="href"
         @click.exact.prevent
         @focus="blur"

--- a/src/components/Document/DocumentCard/DocumentCard.vue
+++ b/src/components/Document/DocumentCard/DocumentCard.vue
@@ -32,9 +32,6 @@ const props = defineProps({
   selected: {
     type: Boolean
   },
-  isDownloadAllowed: {
-    type: Boolean
-  },
   routeName: {
     type: String,
     default: 'document'
@@ -132,7 +129,6 @@ const showTitle = computed(() => props.properties?.includes('title'))
           :document="document"
           vertical
           no-close
-          :is-download-allowed="isDownloadAllowed"
         />
       </slot>
     </div>

--- a/src/components/Document/DocumentCard/DocumentCardGrid.vue
+++ b/src/components/Document/DocumentCard/DocumentCardGrid.vue
@@ -29,9 +29,6 @@ const props = defineProps({
   selectMode: {
     type: Boolean
   },
-  isDownloadAllowed: {
-    type: Boolean
-  },
   routeName: {
     type: String,
     default: 'document'
@@ -111,7 +108,6 @@ const showTitle = computed(() => props.properties?.includes('title'))
     <document-actions-group
       v-model:selected="selected"
       :document="document"
-      :is-download-allowed="isDownloadAllowed"
       :select-mode="selectMode"
       name="checkbox"
       class="ms-auto flex-shrink-0 p-3 above-stretched-link"

--- a/src/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.vue
+++ b/src/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.vue
@@ -53,7 +53,7 @@ const {
   hasTranslations,
   downloadTranslatedContent,
   fetchStatuses
-} = useDocumentDownload(props.document, { immediate: !props.lazy })
+} = useDocumentDownload(() => props.document, { immediate: !props.lazy })
 const mounted = computed(() => !props.lazy || activated.value)
 
 // Activate when modelValue becomes true
@@ -103,6 +103,7 @@ defineExpose({
       />
       <button-icon
         v-if="hasCleanableContentType"
+        :disabled="!isDownloadAllowed"
         :icon-left="IPhDownloadSimple"
         :href="documentFullUrlWithoutMetadata"
         :label="t('documentDownloadPopover.downloadWithoutMetadata')"

--- a/src/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.vue
+++ b/src/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.vue
@@ -47,7 +47,7 @@ const {
   rootDocumentFullUrl,
   hasRoot,
   hasCleanableContentType,
-  isRootTooBig,
+  isDownloadAllowed,
   downloadTextContent,
   hasTextContent,
   hasTranslations,
@@ -94,7 +94,7 @@ defineExpose({
     </template>
     <div class="document-download-popover__body">
       <button-icon
-        :disabled="isRootTooBig"
+        :disabled="!isDownloadAllowed"
         :href="documentFullUrl"
         :label="t('documentDownloadPopover.download')"
         :icon-left="IPhDownloadSimple"

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -4,7 +4,6 @@ import { useI18n } from 'vue-i18n'
 import { useCore } from '@/composables/useCore'
 import { useDocumentDownloadStore, useDocumentStore } from '@/store/modules'
 import settings from '@/utils/settings'
-import byteSize from '@/utils/byteSize'
 
 export function useDocumentDownload(document, { immediate = true } = {}) {
   const documentStore = useDocumentStore()
@@ -54,33 +53,16 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     return settings.cleanableContentTypes.includes(documentRef.value.contentType)
   })
 
-  const embeddedDocumentDownloadMaxSize = computed(() => {
-    return core?.config?.get('embeddedDocumentDownloadMaxSize')
-  })
-
-  const isRootTooBig = computed(() => {
-    return hasRoot.value && rootContentLength.value > maxRootContentLength.value
-  })
-
   const isDownloadAllowed = computed(() => {
-    // Use nullish coalescing operator to allow download if the store/getter is undefined
-    return documentDownloadStore.isAllowed(documentRef.value.index) ?? true
-  })
-
-  const rootContentLength = computed(() => {
-    return documentRef.value?.root?.contentLength
-  })
-
-  const maxRootContentLength = computed(() => {
-    return byteSize(embeddedDocumentDownloadMaxSize.value)
+    return documentDownloadStore.isDownloadable(documentRef.value)
   })
 
   async function fetchDownloadStatus() {
-    const { index = null } = documentRef.value
-    // If the index is null, this means the document is not loaded yet
-    // and therefore, we should not fetch the status
-    if (index) {
-      await documentDownloadStore.fetchIndexStatus(index)
+    const { index = null, id = null } = documentRef.value
+    // If the index or the id is null, this means the document is not loaded
+    // yet and therefore, we should not probe its download status
+    if (index && id) {
+      await documentDownloadStore.fetchDocumentStatus(documentRef.value)
     }
   }
 
@@ -153,11 +135,7 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     rootDocumentFullUrl,
     hasRoot,
     hasCleanableContentType,
-    embeddedDocumentDownloadMaxSize,
-    isRootTooBig,
     isDownloadAllowed,
-    rootContentLength,
-    maxRootContentLength,
     downloadTextContent,
     hasTextContent,
     hasTranslations,

--- a/src/store/modules/documentDownload.js
+++ b/src/store/modules/documentDownload.js
@@ -1,59 +1,53 @@
-import { flatten } from 'lodash'
 import { reactive, computed } from 'vue'
 import { defineStore } from 'pinia'
 
 import { apiInstance as api } from '@/api/apiInstance'
 
 export const useDocumentDownloadStore = defineStore('documentDownload', () => {
-  const allowedFor = reactive({})
+  const downloadableFor = reactive({})
   const fetchPromises = {} // this doesnt need to be reactive
 
   /**
-   * Allow download for a given index
+   * Build the memoization key of a document
    *
-   * @param {Object} options
-   * @param {number} options.index - The index to allow
-   * @param {boolean} options.allowed - The allowed status
+   * @param {Object} document - The document to key
+   * @returns {string} The memoization key
    */
-  const allow = ({ index, allowed }) => {
-    allowedFor[index] = !!allowed
+  const documentKey = ({ index, id, routing }) => {
+    return `${index}/${id}/${routing}`
   }
 
   /**
-   * Fetch the download status for a given index
+   * Fetch the download status of a given document.
    *
-   * @param {number} index - The index to fetch
-   * @returns {void}
+   * The in-flight promise is memoized so several components probing the same
+   * document produce a single request.
+   *
+   * @param {Object} document - The document to probe
+   * @returns {Promise<void>}
    */
-  const fetchIndexStatus = async (index) => {
-    fetchPromises[index] ??= api.isDownloadAllowed(index)
-    const castTrue = () => true
-    const castFalse = () => false
-    const allowed = await fetchPromises[index].then(castTrue, castFalse)
-    allow({ index, allowed })
+  const fetchDocumentStatus = async (document) => {
+    const { index, id, routing } = document
+    const key = documentKey(document)
+    fetchPromises[key] ??= api.isDocumentDownloadable(index, id, routing)
+    downloadableFor[key] = await fetchPromises[key]
   }
 
   /**
-   * Fetch the download status for all indices
-   * @param {Array<number>} indices - The indices to fetch
-   * @returns {void}
+   * Check if a given document can be downloaded.
+   *
+   * Optimistic: a document whose status is not known yet is considered
+   * downloadable, so a results page doesn't render with every download
+   * button greyed out while the probes are in flight.
+   *
+   * @returns {Function<boolean>} The function to check if a document is downloadable
    */
-  const fetchIndicesStatus = async (...indices) => {
-    for (const index of flatten(indices)) {
-      await fetchIndexStatus(index)
+  const isDownloadable = computed(() => {
+    return (document) => {
+      const key = documentKey(document)
+      return !(key in downloadableFor) || downloadableFor[key]
     }
-  }
-
-  /**
-   * Check if download is allowed for a given index
-   *
-   * @returns {Function<boolean>} The function to check if download is allowed
-   */
-  const isAllowed = computed(() => {
-    // Stricktly equal to true so download is not allowed by default
-    // even if the index' status is not loaded.
-    return index => !(index in allowedFor) || allowedFor[index] === true
   })
 
-  return { allow, fetchIndexStatus, fetchIndicesStatus, isAllowed }
+  return { fetchDocumentStatus, isDownloadable }
 })

--- a/src/stories/components/Document/DocumentCard/DocumentCard.stories.js
+++ b/src/stories/components/Document/DocumentCard/DocumentCard.stories.js
@@ -49,7 +49,6 @@ export default {
     active: false,
     selected: false,
     selectMode: false,
-    isDownloadAllowed: true,
     to: { name: 'document' },
     properties: [
       'title',

--- a/src/stories/components/Document/DocumentCard/DocumentCardGrid.stories.js
+++ b/src/stories/components/Document/DocumentCard/DocumentCardGrid.stories.js
@@ -54,7 +54,6 @@ export default {
     active: false,
     selected: false,
     selectMode: false,
-    isDownloadAllowed: true,
     to: { name: 'document' },
     properties: ['title', 'thumbnail', 'path', 'creationDate', 'project'],
     document: {

--- a/src/stories/components/Document/DocumentRow/DocumentRow.stories.js
+++ b/src/stories/components/Document/DocumentRow/DocumentRow.stories.js
@@ -59,7 +59,6 @@ export default {
   args: {
     selected: false,
     selectMode: false,
-    isDownloadAllowed: true,
     to: { name: 'document' },
     properties: ['title', 'contentLength', 'contentType', 'project'],
     document: {

--- a/tests/unit/specs/api/index.spec.js
+++ b/tests/unit/specs/api/index.spec.js
@@ -602,9 +602,34 @@ describe('Datashare backend client', () => {
       expect(await api.isDocumentDownloadable('foo', 'doc-id', 'root-id')).toBe(false)
     })
 
-    it('should not be downloadable when the request fails', async () => {
+    it('should stay downloadable when the request fails', async () => {
       axios.request.mockRejectedValue(new Error('Network Error'))
-      expect(await api.isDocumentDownloadable('foo', 'doc-id', 'root-id')).toBe(false)
+      expect(await api.isDocumentDownloadable('foo', 'doc-id', 'root-id')).toBe(true)
+    })
+
+    it('should stay downloadable when the server does not route HEAD', async () => {
+      axios.request.mockResolvedValue({ status: 405 })
+      expect(await api.isDocumentDownloadable('foo', 'doc-id', 'root-id')).toBe(true)
+    })
+
+    it('should stay downloadable when the backend answers 500', async () => {
+      axios.request.mockResolvedValue({ status: 500 })
+      expect(await api.isDocumentDownloadable('foo', 'doc-id', 'root-id')).toBe(true)
+    })
+
+    it('should stay downloadable when the session expired', async () => {
+      axios.request.mockResolvedValue({ status: 401 })
+      expect(await api.isDocumentDownloadable('foo', 'doc-id', 'root-id')).toBe(true)
+    })
+
+    it('should emit an http error when the session expired', async () => {
+      axios.request.mockResolvedValue({ status: 401 })
+      const mockCallback = vi.fn()
+      EventBus.on('http::error', mockCallback)
+      await api.isDocumentDownloadable('foo', 'doc-id', 'root-id')
+      EventBus.off('http::error', mockCallback)
+      expect(mockCallback).toBeCalledTimes(1)
+      expect(mockCallback.mock.calls[0][0]).toEqual({ response: { status: 401 } })
     })
 
     it('should not emit an http error when the document is not downloadable', async () => {

--- a/tests/unit/specs/api/index.spec.js
+++ b/tests/unit/specs/api/index.spec.js
@@ -567,4 +567,53 @@ describe('Datashare backend client', () => {
       })
     )
   })
+
+  describe('isDocumentDownloadable', () => {
+    it('should send a HEAD request on the document source url', async () => {
+      axios.request.mockResolvedValue({ status: 200 })
+      await api.isDocumentDownloadable('foo', 'doc-id', 'root-id')
+      expect(axios.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl('/api/foo/documents/src/doc-id'),
+          method: 'HEAD',
+          params: { routing: 'root-id' },
+          validateStatus: expect.any(Function)
+        })
+      )
+    })
+
+    it('should be downloadable when the backend answers 200', async () => {
+      axios.request.mockResolvedValue({ status: 200 })
+      expect(await api.isDocumentDownloadable('foo', 'doc-id', 'root-id')).toBe(true)
+    })
+
+    it('should not be downloadable when the backend answers 403', async () => {
+      axios.request.mockResolvedValue({ status: 403 })
+      expect(await api.isDocumentDownloadable('foo', 'doc-id', 'root-id')).toBe(false)
+    })
+
+    it('should not be downloadable when the backend answers 413', async () => {
+      axios.request.mockResolvedValue({ status: 413 })
+      expect(await api.isDocumentDownloadable('foo', 'doc-id', 'root-id')).toBe(false)
+    })
+
+    it('should not be downloadable when the backend answers 404', async () => {
+      axios.request.mockResolvedValue({ status: 404 })
+      expect(await api.isDocumentDownloadable('foo', 'doc-id', 'root-id')).toBe(false)
+    })
+
+    it('should not be downloadable when the request fails', async () => {
+      axios.request.mockRejectedValue(new Error('Network Error'))
+      expect(await api.isDocumentDownloadable('foo', 'doc-id', 'root-id')).toBe(false)
+    })
+
+    it('should not emit an http error when the document is not downloadable', async () => {
+      axios.request.mockResolvedValue({ status: 403 })
+      const mockCallback = vi.fn()
+      EventBus.on('http::error', mockCallback)
+      await api.isDocumentDownloadable('foo', 'doc-id', 'root-id')
+      EventBus.off('http::error', mockCallback)
+      expect(mockCallback).not.toBeCalled()
+    })
+  })
 })

--- a/tests/unit/specs/components/Document/DocumentActionsGroup/DocumentActionsGroupEntryDownload.spec.js
+++ b/tests/unit/specs/components/Document/DocumentActionsGroup/DocumentActionsGroupEntryDownload.spec.js
@@ -1,0 +1,88 @@
+import { shallowMount } from '@vue/test-utils'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import Document from '@/api/resources/Document'
+import DocumentActionsGroupEntryDownload from '@/components/Document/DocumentActionsGroup/DocumentActionsGroupEntryDownload'
+import { apiInstance } from '@/api/apiInstance'
+import { useDocumentDownloadStore } from '@/store/modules'
+
+describe('DocumentActionsGroupEntryDownload.vue', () => {
+  let core, plugins
+
+  beforeEach(() => {
+    core = CoreSetup.init().useAll()
+    core.createPinia()
+    plugins = core.plugins
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function createDocument(overrides = {}) {
+    return new Document({
+      _id: 'test-doc-id',
+      _index: 'test-index',
+      _source: {
+        title: 'test-doc',
+        path: '/path/to/test-doc.pdf',
+        contentType: 'application/pdf',
+        content: 'some content',
+        ...overrides
+      }
+    })
+  }
+
+  // The real popover isn't relevant here: it's stubbed with a template that
+  // renders its "target" slot so the download button (rendered inside it)
+  // shows up in the shallow-mounted tree, mirroring DocumentDownloadPopover.spec.js
+  const DocumentDownloadPopoverStub = {
+    name: 'DocumentDownloadPopover',
+    template: '<div><slot name="target" /></div>'
+  }
+
+  function mountDownload(document) {
+    return shallowMount(DocumentActionsGroupEntryDownload, {
+      global: {
+        plugins,
+        stubs: {
+          DocumentDownloadPopover: DocumentDownloadPopoverStub
+        }
+      },
+      props: { document }
+    })
+  }
+
+  function findButton(wrapper) {
+    return wrapper.find('.document-actions-group-entry-download')
+  }
+
+  it('should enable the download button and set its href while the HEAD probe is still in flight', () => {
+    apiInstance.isDocumentDownloadable = vi.fn(() => new Promise(() => {}))
+    const doc = createDocument()
+    const wrapper = mountDownload(doc)
+    const button = findButton(wrapper)
+    expect(button.attributes('disabled')).toBe('false')
+    expect(button.attributes('href')).toBe(doc.fullUrl)
+  })
+
+  it('should disable the download button and clear its href when the backend refuses the download', async () => {
+    apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(false)
+    const doc = createDocument()
+    await useDocumentDownloadStore().fetchDocumentStatus(doc)
+    const wrapper = mountDownload(doc)
+    const button = findButton(wrapper)
+    expect(button.attributes('disabled')).toBe('true')
+    expect(button.attributes('href')).toBeFalsy()
+  })
+
+  it('should enable the download button and set its href when the backend allows the download', async () => {
+    apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
+    const doc = createDocument()
+    await useDocumentDownloadStore().fetchDocumentStatus(doc)
+    const wrapper = mountDownload(doc)
+    const button = findButton(wrapper)
+    expect(button.attributes('disabled')).toBe('false')
+    expect(button.attributes('href')).toBe(doc.fullUrl)
+  })
+})

--- a/tests/unit/specs/components/Document/DocumentActionsGroup/DocumentActionsGroupEntryDownload.spec.js
+++ b/tests/unit/specs/components/Document/DocumentActionsGroup/DocumentActionsGroupEntryDownload.spec.js
@@ -57,32 +57,50 @@ describe('DocumentActionsGroupEntryDownload.vue', () => {
     return wrapper.find('.document-actions-group-entry-download')
   }
 
-  it('should enable the download button and set its href while the HEAD probe is still in flight', () => {
+  it('should set the download href while the HEAD probe is still in flight', () => {
     apiInstance.isDocumentDownloadable = vi.fn(() => new Promise(() => {}))
     const doc = createDocument()
     const wrapper = mountDownload(doc)
-    const button = findButton(wrapper)
-    expect(button.attributes('disabled')).toBe('false')
-    expect(button.attributes('href')).toBe(doc.fullUrl)
+    expect(findButton(wrapper).attributes('href')).toBe(doc.fullUrl)
   })
 
-  it('should disable the download button and clear its href when the backend refuses the download', async () => {
+  it('should clear the download href when the backend refuses the download', async () => {
     apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(false)
     const doc = createDocument()
     await useDocumentDownloadStore().fetchDocumentStatus(doc)
     const wrapper = mountDownload(doc)
-    const button = findButton(wrapper)
-    expect(button.attributes('disabled')).toBe('true')
-    expect(button.attributes('href')).toBeFalsy()
+    expect(findButton(wrapper).attributes('href')).toBeFalsy()
   })
 
-  it('should enable the download button and set its href when the backend allows the download', async () => {
+  it('should set the download href when the backend allows the download', async () => {
     apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
     const doc = createDocument()
     await useDocumentDownloadStore().fetchDocumentStatus(doc)
     const wrapper = mountDownload(doc)
-    const button = findButton(wrapper)
-    expect(button.attributes('disabled')).toBe('false')
-    expect(button.attributes('href')).toBe(doc.fullUrl)
+    expect(findButton(wrapper).attributes('href')).toBe(doc.fullUrl)
+  })
+
+  // The button is the popover's trigger: the popover still offers the extracted
+  // text, the translations and the root document when the source is refused, so
+  // disabling the trigger would put those out of reach.
+  it('should never disable the download button, even when the backend refuses the download', async () => {
+    apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(false)
+    const doc = createDocument()
+    await useDocumentDownloadStore().fetchDocumentStatus(doc)
+    const wrapper = mountDownload(doc)
+    expect(findButton(wrapper).attributes('disabled')).toBe('false')
+  })
+
+  it('should follow the document when a recycled row is handed another one', async () => {
+    apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
+    const doc = createDocument()
+    const otherDoc = new Document({
+      _id: 'other-doc-id',
+      _index: 'test-index',
+      _source: { title: 'other-doc', contentType: 'application/pdf' }
+    })
+    const wrapper = mountDownload(doc)
+    await wrapper.setProps({ document: otherDoc })
+    expect(findButton(wrapper).attributes('href')).toBe(otherDoc.fullUrl)
   })
 })

--- a/tests/unit/specs/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.spec.js
+++ b/tests/unit/specs/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.spec.js
@@ -10,6 +10,7 @@ describe('DocumentDownloadPopover.vue', () => {
 
   beforeEach(() => {
     core = CoreSetup.init().useAll()
+    core.createPinia()
     plugins = core.plugins
     URL.createObjectURL = vi.fn().mockReturnValue('blob:fake-url')
   })
@@ -53,6 +54,7 @@ describe('DocumentDownloadPopover.vue', () => {
     apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue({
       content_translated: [{ target_language: 'ENGLISH' }]
     })
+    apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
     const doc = createDocument()
     const wrapper = mountPopover(doc)
     await flushPromises()
@@ -65,6 +67,7 @@ describe('DocumentDownloadPopover.vue', () => {
     apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue({
       content_translated: []
     })
+    apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
     const doc = createDocument()
     const wrapper = mountPopover(doc)
     await flushPromises()
@@ -77,6 +80,7 @@ describe('DocumentDownloadPopover.vue', () => {
     apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue({
       content_translated: [{ target_language: 'ENGLISH' }]
     })
+    apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
     const doc = createDocument({
       content_translated: [{ content: 'translated text', target_language: 'ENGLISH' }]
     })
@@ -95,5 +99,34 @@ describe('DocumentDownloadPopover.vue', () => {
     expect(translationButton.exists()).toBe(true)
     await translationButton.trigger('click')
     expect(fakeAnchor.click).toHaveBeenCalled()
+  })
+
+  it('should enable the download button while the download status is unknown', async () => {
+    apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue({ content_translated: [] })
+    apiInstance.isDocumentDownloadable = vi.fn(() => new Promise(() => {}))
+    const wrapper = mountPopover(createDocument())
+    const buttons = wrapper.findAll('.document-download-popover__body__button')
+    const downloadButton = buttons.find(btn => btn.attributes('label') === 'Download')
+    expect(downloadButton.attributes('disabled')).toBe('false')
+  })
+
+  it('should disable the download button when the backend refuses the download', async () => {
+    apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue({ content_translated: [] })
+    apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(false)
+    const wrapper = mountPopover(createDocument())
+    await flushPromises()
+    const buttons = wrapper.findAll('.document-download-popover__body__button')
+    const downloadButton = buttons.find(btn => btn.attributes('label') === 'Download')
+    expect(downloadButton.attributes('disabled')).toBe('true')
+  })
+
+  it('should keep the download button enabled when the backend allows the download', async () => {
+    apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue({ content_translated: [] })
+    apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
+    const wrapper = mountPopover(createDocument())
+    await flushPromises()
+    const buttons = wrapper.findAll('.document-download-popover__body__button')
+    const downloadButton = buttons.find(btn => btn.attributes('label') === 'Download')
+    expect(downloadButton.attributes('disabled')).toBe('false')
   })
 })

--- a/tests/unit/specs/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.spec.js
+++ b/tests/unit/specs/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.spec.js
@@ -120,6 +120,20 @@ describe('DocumentDownloadPopover.vue', () => {
     expect(downloadButton.attributes('disabled')).toBe('true')
   })
 
+  // It targets the same source endpoint as the main download button, only with
+  // filter_metadata=true, so the backend refuses it for the same reasons.
+  it('should disable the download-without-metadata button when the backend refuses the download', async () => {
+    apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue({ content_translated: [] })
+    apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(false)
+    const wrapper = mountPopover(createDocument())
+    await flushPromises()
+    const buttons = wrapper.findAll('.document-download-popover__body__button')
+    const label = 'Download without metadata'
+    const withoutMetadataButton = buttons.find(btn => btn.attributes('label') === label)
+    expect(withoutMetadataButton.exists()).toBe(true)
+    expect(withoutMetadataButton.attributes('disabled')).toBe('true')
+  })
+
   it('should keep the download button enabled when the backend allows the download', async () => {
     apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue({ content_translated: [] })
     apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)

--- a/tests/unit/specs/composables/useDocumentDownload.spec.js
+++ b/tests/unit/specs/composables/useDocumentDownload.spec.js
@@ -11,6 +11,9 @@ describe('useDocumentDownload composable', () => {
 
   beforeEach(() => {
     core = CoreSetup.init().useAll()
+    // Force a fresh Pinia so the document download store isn't memoized
+    // across tests sharing the same document index/id/routing
+    core.createPinia()
     plugins = core.plugins
     URL.createObjectURL = vi.fn().mockReturnValue('blob:fake-url')
   })
@@ -38,7 +41,7 @@ describe('useDocumentDownload composable', () => {
 
   describe('fetchStatuses', () => {
     it('should not fetch download status when immediate is false', async () => {
-      apiInstance.isDownloadAllowed = vi.fn().mockResolvedValue()
+      apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
       mockGetSource({ content_translated: [] })
       const doc = new Document({
         _id: 'doc1',
@@ -47,11 +50,11 @@ describe('useDocumentDownload composable', () => {
       })
       mountComposable(doc, { immediate: false })
       await flushPromises()
-      expect(apiInstance.isDownloadAllowed).not.toHaveBeenCalled()
+      expect(apiInstance.isDocumentDownloadable).not.toHaveBeenCalled()
     })
 
     it('should fetch download status and translations when fetchStatuses is called', async () => {
-      apiInstance.isDownloadAllowed = vi.fn().mockResolvedValue()
+      apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
       mockGetSource({ content_translated: [{ target_language: 'ENGLISH' }] })
       const doc = new Document({
         _id: 'doc1',
@@ -60,13 +63,65 @@ describe('useDocumentDownload composable', () => {
       })
       const { fetchStatuses, hasTranslations } = mountComposable(doc, { immediate: false })
       await flushPromises()
-      expect(apiInstance.isDownloadAllowed).not.toHaveBeenCalled()
+      expect(apiInstance.isDocumentDownloadable).not.toHaveBeenCalled()
       expect(hasTranslations.value).toBe(false)
 
       await fetchStatuses()
       await flushPromises()
-      expect(apiInstance.isDownloadAllowed).toHaveBeenCalledWith('test-index')
+      expect(apiInstance.isDocumentDownloadable).toHaveBeenCalledWith('test-index', 'doc1', 'doc1')
       expect(hasTranslations.value).toBe(true)
+    })
+
+    it('should not fetch download status when the document has no id', async () => {
+      apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
+      mockGetSource({ content_translated: [] })
+      const doc = new Document({ _index: 'test-index', _source: { title: 'test' } })
+      const { fetchStatuses } = mountComposable(doc, { immediate: false })
+      await fetchStatuses()
+      await flushPromises()
+      expect(apiInstance.isDocumentDownloadable).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('isDownloadAllowed', () => {
+    it('should be true before the status is fetched', async () => {
+      apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(false)
+      mockGetSource({ content_translated: [] })
+      const doc = new Document({
+        _id: 'doc1',
+        _index: 'test-index',
+        _source: { title: 'test' }
+      })
+      const { isDownloadAllowed } = mountComposable(doc, { immediate: false })
+      expect(isDownloadAllowed.value).toBe(true)
+    })
+
+    it('should be false once the backend refuses the download', async () => {
+      apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(false)
+      mockGetSource({ content_translated: [] })
+      const doc = new Document({
+        _id: 'doc1',
+        _index: 'test-index',
+        _source: { title: 'test' }
+      })
+      const { isDownloadAllowed, fetchStatuses } = mountComposable(doc, { immediate: false })
+      await fetchStatuses()
+      await flushPromises()
+      expect(isDownloadAllowed.value).toBe(false)
+    })
+
+    it('should stay true when the backend allows the download', async () => {
+      apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
+      mockGetSource({ content_translated: [] })
+      const doc = new Document({
+        _id: 'doc1',
+        _index: 'test-index',
+        _source: { title: 'test' }
+      })
+      const { isDownloadAllowed, fetchStatuses } = mountComposable(doc, { immediate: false })
+      await fetchStatuses()
+      await flushPromises()
+      expect(isDownloadAllowed.value).toBe(true)
     })
   })
 

--- a/tests/unit/specs/core/Core.spec.js
+++ b/tests/unit/specs/core/Core.spec.js
@@ -7,7 +7,7 @@ vi.mock('@/api/apiInstance', () => {
   return {
     apiInstance: {
       createProject: vi.fn(),
-      isDownloadAllowed: vi.fn(),
+      isDocumentDownloadable: vi.fn().mockResolvedValue(true),
       getUser: vi.fn(),
       getUserPermissions: vi.fn(),
       getSettings: vi.fn(),

--- a/tests/unit/specs/core/FiltersMixin.spec.js
+++ b/tests/unit/specs/core/FiltersMixin.spec.js
@@ -5,7 +5,7 @@ vi.mock('@/api/apiInstance', () => {
   return {
     apiInstance: {
       createProject: vi.fn(),
-      isDownloadAllowed: vi.fn(),
+      isDocumentDownloadable: vi.fn().mockResolvedValue(true),
       getUser: vi.fn(),
       getSettings: vi.fn().mockResolvedValue({}),
       getProject: vi.fn().mockResolvedValue({})

--- a/tests/unit/specs/store/modules/documentDownload.spec.js
+++ b/tests/unit/specs/store/modules/documentDownload.spec.js
@@ -1,164 +1,97 @@
 import { setActivePinia, createPinia } from 'pinia'
 import { flushPromises } from '@vue/test-utils'
 
-import { useDocumentDownloadStore, useSearchStore } from '@/store/modules'
+import { useDocumentDownloadStore } from '@/store/modules'
 import { apiInstance as api } from '@/api/apiInstance'
 
 vi.mock('@/api/apiInstance', () => {
   return {
     apiInstance: {
-      isDownloadAllowed: vi.fn().mockResolvedValue()
+      isDocumentDownloadable: vi.fn().mockResolvedValue(true)
     }
   }
 })
 
 describe('DocumentDownloadStore', () => {
   const index = 'downloadStoreFoo'
-  const anotherIndex = 'downloadStoreBar'
-  let documentDownloadStore, searchStore
+  const document = { index, id: 'doc-one', routing: 'doc-one' }
+  const anotherDocument = { index, id: 'doc-two', routing: 'doc-one' }
+  let documentDownloadStore
 
   beforeEach(() => {
     vi.clearAllMocks()
     setActivePinia(createPinia())
     documentDownloadStore = useDocumentDownloadStore()
-    searchStore = useSearchStore()
-    searchStore = useSearchStore()
-    searchStore.setIndex(index)
-  })
-
-  afterAll(() => {
-    vi.resetAllMocks()
   })
 
   describe('initial state', () => {
-    beforeEach(() => {
-      api.isDownloadAllowed.mockResolvedValue()
+    it('should be downloadable by default, before the status is known', () => {
+      expect(documentDownloadStore.isDownloadable(document)).toBe(true)
     })
 
-    it('should be allowed by default', async () => {
-      expect(documentDownloadStore.isAllowed(index)).toBe(true)
-    })
-  })
-
-  describe('allowed download', () => {
-    beforeEach(() => {
-      api.isDownloadAllowed.mockResolvedValue()
-      documentDownloadStore.allow({ index, allowed: false })
-      documentDownloadStore.allow({ index: anotherIndex, allowed: false })
-    })
-
-    it('should set the download status for the given index', async () => {
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
-      documentDownloadStore.allow({ index, allowed: true })
-      expect(documentDownloadStore.isAllowed(index)).toBe(true)
-    })
-
-    it('should set the download statuses for the two given indices', async () => {
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
-      expect(documentDownloadStore.isAllowed(anotherIndex)).toBe(false)
-      documentDownloadStore.allow({ index, allowed: true })
-      documentDownloadStore.allow({ index: anotherIndex, allowed: true })
-      expect(documentDownloadStore.isAllowed(index)).toBe(true)
-      expect(documentDownloadStore.isAllowed(anotherIndex)).toBe(true)
-    })
-
-    it('should get the download status for the given index', async () => {
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
-      await documentDownloadStore.fetchIndicesStatus(index)
-      expect(documentDownloadStore.isAllowed(index)).toBe(true)
-    })
-
-    it('should get the download statuses for the two given indices', async () => {
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
-      expect(documentDownloadStore.isAllowed(anotherIndex)).toBe(false)
-      await documentDownloadStore.fetchIndicesStatus(index, anotherIndex)
-      expect(documentDownloadStore.isAllowed(index)).toBe(true)
-      expect(documentDownloadStore.isAllowed(anotherIndex)).toBe(true)
-    })
-
-    it('should get the download statuses for the two given indices in an array', async () => {
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
-      expect(documentDownloadStore.isAllowed(anotherIndex)).toBe(false)
-      await documentDownloadStore.fetchIndicesStatus([index, anotherIndex])
-      expect(documentDownloadStore.isAllowed(index)).toBe(true)
-      expect(documentDownloadStore.isAllowed(anotherIndex)).toBe(true)
-    })
-
-    it('should get the download statuses for the given index only once', async () => {
-      documentDownloadStore.fetchIndexStatus(index)
-      documentDownloadStore.fetchIndexStatus(index)
-      await flushPromises()
-      expect(documentDownloadStore.isAllowed(index)).toBe(true)
-      expect(api.isDownloadAllowed).toHaveBeenCalledTimes(1)
-    })
-
-    it('should get the download statuses for the two given indices only twice', async () => {
-      documentDownloadStore.fetchIndicesStatus([index, anotherIndex])
-      documentDownloadStore.fetchIndicesStatus([index, anotherIndex])
-      await flushPromises()
-      expect(documentDownloadStore.isAllowed(index)).toBe(true)
-      expect(api.isDownloadAllowed).toHaveBeenCalledTimes(2)
+    it('should not send any request until the status is fetched', () => {
+      documentDownloadStore.isDownloadable(document)
+      expect(api.isDocumentDownloadable).not.toBeCalled()
     })
   })
 
-  describe('not allowed download', () => {
+  describe('downloadable document', () => {
     beforeEach(() => {
-      api.isDownloadAllowed.mockRejectedValue()
-      documentDownloadStore.allow({ index, allowed: false })
-      documentDownloadStore.allow({ index: anotherIndex, allowed: false })
+      api.isDocumentDownloadable.mockResolvedValue(true)
     })
 
-    it('should set the download status for the given index', async () => {
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
-      documentDownloadStore.allow({ index, allowed: false })
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
+    it('should probe the document with its index, id and routing', async () => {
+      await documentDownloadStore.fetchDocumentStatus(document)
+      expect(api.isDocumentDownloadable).toBeCalledWith(index, 'doc-one', 'doc-one')
     })
 
-    it('should set the download statuses for the two given indices', async () => {
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
-      expect(documentDownloadStore.isAllowed(anotherIndex)).toBe(false)
-      documentDownloadStore.allow({ index, allowed: false })
-      documentDownloadStore.allow({ index: anotherIndex, allowed: false })
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
-      expect(documentDownloadStore.isAllowed(anotherIndex)).toBe(false)
+    it('should stay downloadable once the status is fetched', async () => {
+      await documentDownloadStore.fetchDocumentStatus(document)
+      expect(documentDownloadStore.isDownloadable(document)).toBe(true)
+    })
+  })
+
+  describe('not downloadable document', () => {
+    beforeEach(() => {
+      api.isDocumentDownloadable.mockResolvedValue(false)
     })
 
-    it('should get the download status for the given index', async () => {
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
-      await documentDownloadStore.fetchIndicesStatus(index)
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
+    it('should not be downloadable once the status is fetched', async () => {
+      await documentDownloadStore.fetchDocumentStatus(document)
+      expect(documentDownloadStore.isDownloadable(document)).toBe(false)
     })
 
-    it('should get the download statuses for the two given indices', async () => {
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
-      expect(documentDownloadStore.isAllowed(anotherIndex)).toBe(false)
-      await documentDownloadStore.fetchIndicesStatus(index, anotherIndex)
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
-      expect(documentDownloadStore.isAllowed(anotherIndex)).toBe(false)
+    it('should not affect another document of the same index', async () => {
+      await documentDownloadStore.fetchDocumentStatus(document)
+      expect(documentDownloadStore.isDownloadable(anotherDocument)).toBe(true)
+    })
+  })
+
+  describe('memoization', () => {
+    beforeEach(() => {
+      api.isDocumentDownloadable.mockResolvedValue(true)
     })
 
-    it('should get the download statuses for the two given indices in an array', async () => {
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
-      expect(documentDownloadStore.isAllowed(anotherIndex)).toBe(false)
-      await documentDownloadStore.fetchIndicesStatus([index, anotherIndex])
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
-      expect(documentDownloadStore.isAllowed(anotherIndex)).toBe(false)
-    })
-
-    it('should get the download statuses for the given index only once', async () => {
-      documentDownloadStore.fetchIndexStatus(index)
-      documentDownloadStore.fetchIndexStatus(index)
+    it('should probe the same document only once', async () => {
+      documentDownloadStore.fetchDocumentStatus(document)
+      documentDownloadStore.fetchDocumentStatus(document)
       await flushPromises()
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
-      expect(api.isDownloadAllowed).toHaveBeenCalledTimes(1)
+      expect(api.isDocumentDownloadable).toBeCalledTimes(1)
     })
 
-    it('should get the download statuses for the two given indices only twice', async () => {
-      documentDownloadStore.fetchIndicesStatus([index, anotherIndex])
-      documentDownloadStore.fetchIndicesStatus([index, anotherIndex])
+    it('should probe two different documents twice', async () => {
+      documentDownloadStore.fetchDocumentStatus(document)
+      documentDownloadStore.fetchDocumentStatus(anotherDocument)
       await flushPromises()
-      expect(documentDownloadStore.isAllowed(index)).toBe(false)
-      expect(api.isDownloadAllowed).toHaveBeenCalledTimes(2)
+      expect(api.isDocumentDownloadable).toBeCalledTimes(2)
+    })
+
+    it('should probe the same id in two different indices twice', async () => {
+      const sameIdOtherIndex = { index: 'downloadStoreBar', id: 'doc-one', routing: 'doc-one' }
+      documentDownloadStore.fetchDocumentStatus(document)
+      documentDownloadStore.fetchDocumentStatus(sameIdOtherIndex)
+      await flushPromises()
+      expect(api.isDocumentDownloadable).toBeCalledTimes(2)
     })
   })
 })

--- a/tests/unit/specs/views/Search/SearchHistory/SearchHistoryList/SearchHistoryList.spec.js
+++ b/tests/unit/specs/views/Search/SearchHistory/SearchHistoryList/SearchHistoryList.spec.js
@@ -13,7 +13,7 @@ vi.mock('@/api/apiInstance', () => {
       elasticsearch: {
         search: vi.fn()
       },
-      isDownloadAllowed: vi.fn().mockResolvedValue(),
+      isDocumentDownloadable: vi.fn().mockResolvedValue(true),
       removeHistoryEvent: vi.fn().mockResolvedValue({}),
       getStarredDocuments: vi.fn().mockResolvedValue([]),
       getPathBanners: vi.fn().mockResolvedValue([]),

--- a/tests/unit/specs/views/Task/TaskBatchDownload/TaskBatchDownloadList.spec.js
+++ b/tests/unit/specs/views/Task/TaskBatchDownload/TaskBatchDownloadList.spec.js
@@ -9,7 +9,7 @@ import BatchDownloadUnavailableAlert from '@/components/BatchDownload/BatchDownl
 
 vi.mock('@/api/apiInstance', {
   apiInstance: {
-    isDownloadAllowed: vi.fn().mockResolvedValue(),
+    isDocumentDownloadable: vi.fn().mockResolvedValue(true),
     getTasks: vi.fn().mockResolvedValue({ items: [] })
   }
 })

--- a/tests/unit/specs/views/Task/TaskBatchDownload/TaskBatchDownloadList.spec.js
+++ b/tests/unit/specs/views/Task/TaskBatchDownload/TaskBatchDownloadList.spec.js
@@ -7,10 +7,12 @@ import BatchDownloadActions from '@/components/BatchDownload/BatchDownloadAction
 import BatchDownloadTruncatedAlert from '@/components/BatchDownload/BatchDownloadTruncatedAlert'
 import BatchDownloadUnavailableAlert from '@/components/BatchDownload/BatchDownloadUnavailableAlert'
 
-vi.mock('@/api/apiInstance', {
-  apiInstance: {
-    isDocumentDownloadable: vi.fn().mockResolvedValue(true),
-    getTasks: vi.fn().mockResolvedValue({ items: [] })
+vi.mock('@/api/apiInstance', () => {
+  return {
+    apiInstance: {
+      isDocumentDownloadable: vi.fn().mockResolvedValue(true),
+      getTasks: vi.fn().mockResolvedValue({ items: [] })
+    }
   }
 })
 


### PR DESCRIPTION
Frontend half of ICIJ/datashare#2288. The client used to decide whether a document's source could be downloaded from two signals that are both wrong: a project-level flag, and a client-side reimplementation of the backend's root-size rule. Neither can see the artifact cache, so an embedded document with a cached `raw` payload was refused even though the backend would serve it.

Both are replaced by a single per-document `HEAD /api/:project/documents/src/:id` probe, fetched lazily when a row scrolls into view or a download popover opens, and memoized per document so repeated probes cost one request. Only 403, 404 and 413 count as a refusal: anything the probe cannot interpret leaves the document downloadable, so an unreadable answer never hides a download that works.

- feat: add `Api#isDocumentDownloadable`, sending the HEAD probe and reporting a 401 on the `http::error` bus so an expired session still raises the re-login toast
- refactor: rekey the `documentDownload` store from project index to document, memoizing the in-flight promise
- refactor: drop `isRootTooBig` and the `embeddedDocumentDownloadMaxSize` rule from `useDocumentDownload`
- fix: gate the popover's download buttons, including "Download without metadata", on the probe
- fix: keep the row download button enabled since it opens the popover, which still offers the extracted text, the translations and the root document when the source is refused
- fix: read the document through a getter so a recycled row re-probes instead of answering for the document it first rendered
- refactor: remove the `isDownloadAllowed` prop that document cards forwarded to a component that never declared it
- test: cover the probe contract, the store's memoization, and all three button states