### PR TITLE
perf(build): add manualChunks vendor-chunking strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "msw": "^2.14.6",
     "msw-storybook-addon": "^2.0.7",
     "playwright": "^1.60.0",
+    "rollup-plugin-visualizer": "5.14.0",
     "sass": "^1.97.2",
     "storybook": "^10.1.11",
     "storybook-addon-pseudo-states": "^10.1.11",

--- a/vite.config.js
+++ b/vite.config.js
@@ -128,33 +128,44 @@ export default ({ mode }) => {
           /**
            * No vendor-chunking strategy existed before this: heavy,
            * rarely-changing dependencies got bundled into whichever route
-           * chunk first imported them (see log.md 2026-07-24/27 bundle
-           * analysis). Grouping them into their own chunks lets the browser
-           * cache them independently of app-code deploys and keeps them out
-           * of the search route's critical path.
+           * chunk first imported them. Grouping the ones that are eagerly
+           * reachable anyway into their own chunks lets the browser cache
+           * them independently of app-code deploys.
+           *
+           * This does not defer anything: a group is downloaded on first
+           * paint as soon as one member is statically reachable from the
+           * entry. Deferring needs a dynamic import at the call site, not a
+           * chunk name here.
            */
           manualChunks(id) {
             if (!id.includes('node_modules')) return
 
-            const match = id.match(/node_modules\/((?:@[^/]+\/)?[^/]+)/)
+            const scope = id.slice(id.lastIndexOf('node_modules/') + 'node_modules/'.length)
+            const match = scope.match(/^((?:@[^/]+\/)?[^/]+)/)
             const pkg = match?.[1]
             if (!pkg) return
 
-            // Search/ES client stack — single biggest dependency (log.md:
-            // elasticsearch-browser alone is ~1.6MB raw).
+            // Search/ES client stack — elasticsearch-browser alone is
+            // ~1.6 MB raw, the single biggest dependency in the app.
             if (['elasticsearch-browser', 'bodybuilder', 'lucene'].includes(pkg)) {
               return 'vendor-search'
             }
 
-            // Charting/geo/calendar — mostly project-overview widgets, not
-            // needed on the search route itself.
+            // Charting/geo/calendar. Despite the name, this is not deferred
+            // to project-overview: ColumnChartPicker.vue imports d3 directly
+            // and is statically reachable from the search route itself (via
+            // FilterTypeDateRange.vue -> FilterDateRange.js ->
+            // store/filters/index.js -> search.js), which the eager store
+            // barrel in Core.js pulls in on every page..
+            // Isolating it here still lets it cache independently of
+            // app-code deploys; actually deferring it needs breaking that
+            // eager import chain, not a chunk name.
             if (pkg === 'd3' || pkg.startsWith('d3-') || pkg === 'v-calendar' || pkg.startsWith('topojson')) {
               return 'vendor-charts'
             }
 
             // UI kit — bootstrap-vue-next and @icij/murmur share a large
-            // amount of code (see log.md 2026-07-27) and are used across
-            // nearly every view.
+            // amount of code and are used across nearly every view.
             if (['bootstrap-vue-next', '@icij/murmur', 'bootstrap'].includes(pkg) || pkg.startsWith('@floating-ui')) {
               return 'vendor-ui'
             }
@@ -165,35 +176,31 @@ export default ({ mode }) => {
             }
 
             // NOTE: pdfjs-dist/@tato30/vue-pdf/image-js/tiff/jpeg-js were
-            // tried as their own "vendor-viewer" chunk (log.md 2026-07-24
-            // bundle analysis flagged them as document-viewer-only, not
-            // needed on generic app load) but that grouping produced a
-            // "Cannot access '<var>' before initialization" runtime error —
-            // a circular chunk dependency between that group and other
-            // chunks. Verified in a real browser via claude-in-chrome (build
-            // succeeds either way; only runtime testing catches this).
-            // Left in the catch-all `vendor` chunk below; revisit only with
-            // careful cycle analysis, not a blind re-split.
+            // tried as their own "vendor-viewer" chunk (document-viewer-only,
+            // not needed on generic app load) but that grouping produced a
+            // "Cannot access '<var>' before initialization" runtime error, a
+            // circular chunk dependency between that group and other chunks.
+            // Verified in a real browser (build succeeds either way; only
+            // runtime testing catches this). Left ungrouped below so Rollup
+            // keeps them in their existing lazy route chunks; revisit only
+            // with careful cycle analysis, not a blind re-split.
 
             // Spreadsheet export — feature-specific, not needed app-wide.
             if (pkg === 'xlsx') {
               return 'vendor-export'
             }
 
-            // Markdown rendering stack (micromark/mdast/unified/hast) — used
-            // for rendering release-notes/help content, not core navigation.
-            if (['micromark', 'unified', 'vfile', 'property-information'].includes(pkg) || pkg.startsWith('micromark-') || pkg.startsWith('mdast-') || pkg.startsWith('hast-') || pkg.startsWith('unist-') || pkg.startsWith('remark-')) {
-              return 'vendor-markdown'
-            }
-
-            // lodash + the standalone lodash.* packages (log.md: 885 kB raw,
+            // lodash + the standalone lodash.* packages (885 kB raw,
             // duplicated logic across lodash and lodash.merge/clonedeep/unset)
             // — isolate so it caches independently of unrelated vendor code.
             if (pkg === 'lodash' || pkg.startsWith('lodash.')) {
               return 'vendor-lodash'
             }
 
-            return 'vendor'
+            // Anything else keeps Rollup's default placement: lazily
+            // imported deps (e.g. the markdown stack, PDF/TIFF viewers) stay
+            // in their route-specific async chunks instead of being pulled
+            // into a preloaded catch-all.
           }
         }
       }

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,7 @@ import Icons from 'unplugin-icons/vite'
 import IconsResolver from 'unplugin-icons/resolver'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
+import { visualizer } from 'rollup-plugin-visualizer'
 
 import { BootstrapVueNextResolver } from 'unplugin-vue-components/resolvers'
 
@@ -30,6 +31,12 @@ export default ({ mode }) => {
     plugins: [
       vue(),
       !isStorybook && vueDevTools(),
+      process.env.VITE_ANALYZE && visualizer({
+        filename: 'dist/stats.html',
+        gzipSize: true,
+        brotliSize: true,
+        template: 'treemap'
+      }),
       /**
        * The "Icons" plugin generates icon components from Iconify collections.
        * Icons are used via <i-{collection}-{icon}> syntax (e.g., <i-ph-user />).
@@ -112,6 +119,82 @@ export default ({ mode }) => {
           target: process.env.VITE_DEV_PROXY,
           changeOrigin: true,
           secure: false
+        }
+      }
+    },
+    build: {
+      rollupOptions: {
+        output: {
+          /**
+           * No vendor-chunking strategy existed before this: heavy,
+           * rarely-changing dependencies got bundled into whichever route
+           * chunk first imported them (see log.md 2026-07-24/27 bundle
+           * analysis). Grouping them into their own chunks lets the browser
+           * cache them independently of app-code deploys and keeps them out
+           * of the search route's critical path.
+           */
+          manualChunks(id) {
+            if (!id.includes('node_modules')) return
+
+            const match = id.match(/node_modules\/((?:@[^/]+\/)?[^/]+)/)
+            const pkg = match?.[1]
+            if (!pkg) return
+
+            // Search/ES client stack — single biggest dependency (log.md:
+            // elasticsearch-browser alone is ~1.6MB raw).
+            if (['elasticsearch-browser', 'bodybuilder', 'lucene'].includes(pkg)) {
+              return 'vendor-search'
+            }
+
+            // Charting/geo/calendar — mostly project-overview widgets, not
+            // needed on the search route itself.
+            if (pkg === 'd3' || pkg.startsWith('d3-') || pkg === 'v-calendar' || pkg.startsWith('topojson')) {
+              return 'vendor-charts'
+            }
+
+            // UI kit — bootstrap-vue-next and @icij/murmur share a large
+            // amount of code (see log.md 2026-07-27) and are used across
+            // nearly every view.
+            if (['bootstrap-vue-next', '@icij/murmur', 'bootstrap'].includes(pkg) || pkg.startsWith('@floating-ui')) {
+              return 'vendor-ui'
+            }
+
+            // Core framework — changes rarely, needed on every route.
+            if (pkg === 'vue' || pkg.startsWith('@vue/') || pkg === 'vue-router' || pkg === 'pinia' || pkg === 'vue-i18n' || pkg.startsWith('@intlify')) {
+              return 'vendor-framework'
+            }
+
+            // NOTE: pdfjs-dist/@tato30/vue-pdf/image-js/tiff/jpeg-js were
+            // tried as their own "vendor-viewer" chunk (log.md 2026-07-24
+            // bundle analysis flagged them as document-viewer-only, not
+            // needed on generic app load) but that grouping produced a
+            // "Cannot access '<var>' before initialization" runtime error —
+            // a circular chunk dependency between that group and other
+            // chunks. Verified in a real browser via claude-in-chrome (build
+            // succeeds either way; only runtime testing catches this).
+            // Left in the catch-all `vendor` chunk below; revisit only with
+            // careful cycle analysis, not a blind re-split.
+
+            // Spreadsheet export — feature-specific, not needed app-wide.
+            if (pkg === 'xlsx') {
+              return 'vendor-export'
+            }
+
+            // Markdown rendering stack (micromark/mdast/unified/hast) — used
+            // for rendering release-notes/help content, not core navigation.
+            if (['micromark', 'unified', 'vfile', 'property-information'].includes(pkg) || pkg.startsWith('micromark-') || pkg.startsWith('mdast-') || pkg.startsWith('hast-') || pkg.startsWith('unist-') || pkg.startsWith('remark-')) {
+              return 'vendor-markdown'
+            }
+
+            // lodash + the standalone lodash.* packages (log.md: 885 kB raw,
+            // duplicated logic across lodash and lodash.merge/clonedeep/unset)
+            // — isolate so it caches independently of unrelated vendor code.
+            if (pkg === 'lodash' || pkg.startsWith('lodash.')) {
+              return 'vendor-lodash'
+            }
+
+            return 'vendor'
+          }
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3178,6 +3178,11 @@ default-browser@^5.2.1:
     bundle-name "^4.1.0"
     default-browser-id "^5.0.0"
 
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
 define-lazy-prop@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
@@ -4197,6 +4202,11 @@ is-core-module@^2.16.0:
   dependencies:
     hasown "^2.0.2"
 
+is-docker@^2.0.0, is-docker@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-docker@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
@@ -4273,6 +4283,13 @@ is-what@^4.1.8:
   version "4.1.16"
   resolved "https://registry.yarnpkg.com/is-what/-/is-what-4.1.16.tgz#1ad860a19da8b4895ad5495da3182ce2acdd7a6f"
   integrity sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==
+
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 is-wsl@^3.1.0:
   version "3.1.0"
@@ -5482,6 +5499,15 @@ open@^10.2.0:
     is-inside-container "^1.0.0"
     wsl-utils "^0.1.0"
 
+open@^8.4.0:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
+  integrity sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
+
 optionator@^0.9.3:
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.4.tgz#7ea1c1a5d91d764fb282139c88fe11e182a3a734"
@@ -6106,6 +6132,16 @@ robust-sum@^1.0.0:
   resolved "https://registry.yarnpkg.com/robust-sum/-/robust-sum-1.0.0.tgz#16646e525292b4d25d82757a286955e0bbfa53d9"
   integrity sha512-AvLExwpaqUqD1uwLU6MwzzfRdaI6VEZsyvQ3IAQ0ZJ08v1H+DTyqskrf2ZJyh0BDduFVLN7H04Zmc+qTiahhAw==
 
+rollup-plugin-visualizer@5.14.0:
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.14.0.tgz#be82d43fb3c644e396e2d50ac8a53d354022d57c"
+  integrity sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==
+  dependencies:
+    open "^8.4.0"
+    picomatch "^4.0.2"
+    source-map "^0.7.4"
+    yargs "^17.5.1"
+
 rollup@^4.43.0:
   version "4.53.5"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.53.5.tgz#820f46d435c207fd640256f34a0deadf8e95b118"
@@ -6298,6 +6334,11 @@ source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.7.4:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.6.tgz#a3658ab87e5b6429c8a1f3ba0083d4c61ca3ef02"
+  integrity sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==
 
 space-separated-tokens@^2.0.0:
   version "2.0.2"
@@ -7481,6 +7522,19 @@ yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^17.5.1:
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yargs@^17.7.2:
   version "17.7.2"


### PR DESCRIPTION
## Summary
- Adds `build.rollupOptions.manualChunks` in `vite.config.js`, grouping heavy, eagerly-reachable vendor deps (search/ES client, charts/calendar, UI kit, core framework, lodash) into their own cache-friendly chunks instead of bundling with whatever route imported them first.
- `xlsx` (spreadsheet export) also gets its own chunk since it's feature-specific.
- No catch-all chunk and no markdown grouping: anything not explicitly matched keeps Rollup's default placement, so already-lazy code (the markdown stack, PDF/TIFF/image viewers) stays lazy instead of being pulled into the eager preload set.

## Review history
An earlier version of this PR had a catch-all `vendor` chunk and a `vendor-markdown` group. Both were eagerly reachable from the entry, so they defeated the point: `pdfjs-dist`/`tiff`/`image-js` and the markdown stack got preloaded on first paint instead of staying in their lazy document-viewer chunks, a real first-load regression (measured 1,160 kB gzip vs. 791 kB on `main`). Fixed per review by dropping both groups, correcting the header comment's claim that grouping "keeps things out of the critical path" (`manualChunks` only affects caching, not reachability), and fixing the package-name regex to scope from the last `node_modules` segment.

## Measured impact (real browser, real backend, `performance.getEntriesByType('resource')`, hard-reload to bypass stale cache)

**Initial page load, total JS transferred:**
| | `main` (no manualChunks) | this branch |
|---|---|---|
| Total JS transferred | 867,489 B (~847 kB) | 840,856 B (~821 kB) |
| Largest chunk | one 745,366 B monolith | `index.js` 241,451 B + `vendor-ui` 159 kB + `vendor-charts` 144 kB + `vendor-search` 103 kB + `vendor-framework` 95 kB + `vendor-lodash` 65 kB |

First-load bytes are roughly flat (~3% smaller), not a regression, confirming the fixed version behaves as the reviewer expected: `manualChunks` doesn't meaningfully shrink first load since these deps are eagerly reachable either way.

**The actual benefit is repeat-deploy caching**, not first load: with `main`'s single monolith, any app-code change forces a full 745 kB re-download for every user. With this branch, app code lives in `index.js` (241 kB) while 567 kB of vendor code sits in independently-hashed chunks that stay cached across app-only deploys, roughly a 68% smaller re-download for that common case.

## Test plan
- [x] Verified via `vite preview` + real browser against the live local backend: project list, search, and document viewer (spreadsheet + image) all load cleanly, zero console exceptions, all requests 200
- [x] Confirmed lazy chunks (e.g. `DocumentViewerLegacySpreadsheet`) only fetch on demand, not on initial page load
- [x] Confirmed no circular-chunk-dependency runtime errors (an initial `vendor-viewer` grouping for pdfjs-dist/image-js/tiff threw at runtime; reverted that specific grouping)
- [x] Measured initial-load JS transfer bytes against `main` baseline (see above)