### PR TITLE
fix(recommendations): gate server-only fetches by mode

### DIFF
--- a/src/components/Project/ProjectDeletionModal.vue
+++ b/src/components/Project/ProjectDeletionModal.vue
@@ -9,7 +9,6 @@ import AppModal from '@/components/AppModal/AppModal'
 import DisplayNumber from '@/components/Display/DisplayNumber'
 import ProjectLabel from '@/components/Project/ProjectLabel'
 import { useProjectMetrics } from '@/composables/useProjectMetrics'
-import { useMode } from '@/composables/useMode'
 import { useWait } from '@/composables/useWait'
 import { useCore } from '@/composables/useCore'
 import { useToast } from '@/composables/useToast'
@@ -30,7 +29,6 @@ const recommendationsCount = ref(0)
 
 const { waitFor, loaderId } = useWait()
 const core = useCore()
-const { isServer } = useMode(core)
 const { toast } = useToast()
 const { fetchDocumentsCount, fetchTagsCount, fetchRecommendationsCount } = useProjectMetrics(toRef(props, 'project'))
 
@@ -54,10 +52,7 @@ onBeforeMount(
   waitFor(async () => {
     documentsCount.value = await fetchDocumentsCount()
     tagsCount.value = await fetchTagsCount()
-    // Recommendations are a server-mode-only feature
-    if (isServer.value) {
-      recommendationsCount.value = await fetchRecommendationsCount()
-    }
+    recommendationsCount.value = await fetchRecommendationsCount()
   })
 )
 </script>

--- a/src/components/Project/ProjectDeletionModal.vue
+++ b/src/components/Project/ProjectDeletionModal.vue
@@ -9,6 +9,7 @@ import AppModal from '@/components/AppModal/AppModal'
 import DisplayNumber from '@/components/Display/DisplayNumber'
 import ProjectLabel from '@/components/Project/ProjectLabel'
 import { useProjectMetrics } from '@/composables/useProjectMetrics'
+import { useMode } from '@/composables/useMode'
 import { useWait } from '@/composables/useWait'
 import { useCore } from '@/composables/useCore'
 import { useToast } from '@/composables/useToast'
@@ -29,6 +30,7 @@ const recommendationsCount = ref(0)
 
 const { waitFor, loaderId } = useWait()
 const core = useCore()
+const { isServer } = useMode(core)
 const { toast } = useToast()
 const { fetchDocumentsCount, fetchTagsCount, fetchRecommendationsCount } = useProjectMetrics(toRef(props, 'project'))
 
@@ -52,7 +54,10 @@ onBeforeMount(
   waitFor(async () => {
     documentsCount.value = await fetchDocumentsCount()
     tagsCount.value = await fetchTagsCount()
-    recommendationsCount.value = await fetchRecommendationsCount()
+    // Recommendations are a server-mode-only feature
+    if (isServer.value) {
+      recommendationsCount.value = await fetchRecommendationsCount()
+    }
   })
 )
 </script>

--- a/src/composables/useDocument.js
+++ b/src/composables/useDocument.js
@@ -24,9 +24,7 @@ export const useDocument = function (element) {
     await documentStore.getParentDocument()
     await documentStore.getRootDocument()
     await documentStore.getTags()
-    // Recommendations are a server-mode-only feature (see widget
-    // registration's `modes: [MODE_NAME.SERVER]` in store/widgets/index.js
-    // and the same guard in useSearchFilter.js's refreshRecommendedBy).
+    // Recommendations are a server-mode-only feature
     if (isServer.value) {
       await documentStore.getRecommendationsByDocuments(await core.auth.getUsername())
     }

--- a/src/composables/useDocument.js
+++ b/src/composables/useDocument.js
@@ -4,6 +4,7 @@ import { find, matches, overSome } from 'lodash'
 import { useModal } from 'bootstrap-vue-next'
 
 import { useCore } from '@/composables/useCore'
+import { useMode } from '@/composables/useMode'
 import { useWait } from '@/composables/useWait'
 import DocumentViewerModal from '@/components/Document/DocumentViewerModal/DocumentViewerModal'
 import { useDocumentStore } from '@/store/modules'
@@ -15,6 +16,7 @@ export const useDocument = function (element) {
   const route = useRoute()
   const router = useRouter()
   const core = useCore()
+  const { isServer } = useMode(core)
   const { waitFor, loaderId } = useWait()
 
   const fetchDocument = waitFor(async function ({ index, id, routing } = {}) {
@@ -22,7 +24,12 @@ export const useDocument = function (element) {
     await documentStore.getParentDocument()
     await documentStore.getRootDocument()
     await documentStore.getTags()
-    await documentStore.getRecommendationsByDocuments(await core.auth.getUsername())
+    // Recommendations are a server-mode-only feature (see widget
+    // registration's `modes: [MODE_NAME.SERVER]` in store/widgets/index.js
+    // and the same guard in useSearchFilter.js's refreshRecommendedBy).
+    if (isServer.value) {
+      await documentStore.getRecommendationsByDocuments(await core.auth.getUsername())
+    }
 
     if (document.value) {
       const { route, slicedNameToString } = document.value

--- a/src/composables/useProjectMetrics.js
+++ b/src/composables/useProjectMetrics.js
@@ -1,9 +1,11 @@
 import { toValue } from 'vue'
 
 import { useCore } from '@/composables/useCore'
+import { useMode } from '@/composables/useMode'
 
 export function useProjectMetrics(project) {
   const core = useCore()
+  const { isServer } = useMode(core)
   const { name: index } = toValue(project)
 
   async function fetchDocumentsCount() {
@@ -15,6 +17,8 @@ export function useProjectMetrics(project) {
   }
 
   async function fetchRecommendationsCount() {
+    // Recommendations are a server-mode-only feature
+    if (!isServer.value) return 0
     const recommendations = await core.api.getRecommendationsByProject(index)
     return recommendations?.totalCount || 0
   }

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -345,11 +345,7 @@ export function useSearchFilter() {
   }
 
   function refreshRecommendedBy() {
-    // Recommendations are a server-mode-only feature (see widget
-    // registration's `modes: [MODE_NAME.SERVER]` in store/widgets/index.js).
-    // Skip the fetch entirely in local/embedded mode instead of relying on
-    // getDocumentsRecommendedBy's incidental `indices.length + users.length
-    // > 1` guard, which doesn't actually check mode.
+    // Recommendations are a server-mode-only feature
     if (!isServer.value) return
     const users = getFilterValues({ name: 'recommendedBy' })
     return recommendedStore.getDocumentsRecommendedBy(indices.value, users)

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -6,6 +6,7 @@ import { useI18n } from 'vue-i18n'
 import settings from '@/utils/settings'
 import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 import { useCore } from '@/composables/useCore'
+import { useMode } from '@/composables/useMode'
 import { useContentTypeCategoryAvailability } from '@/composables/useContentTypeCategoryAvailability'
 import { onAfterRouteUpdate } from '@/composables/onAfterRouteUpdate'
 import FilterType from '@/components/Filter/FilterType/FilterType'
@@ -28,6 +29,7 @@ export function useSearchFilter() {
   const router = useRouter()
   const { t, te } = useI18n()
   const core = useCore()
+  const { isServer } = useMode(core)
   // Drives the read-layer degradation in getFilterPairedDimensions: when the
   // contentTypeCategory field is missing from the selected indices' mapping,
   // the contentType filter falls back to single-dimension behavior so paired
@@ -343,6 +345,12 @@ export function useSearchFilter() {
   }
 
   function refreshRecommendedBy() {
+    // Recommendations are a server-mode-only feature (see widget
+    // registration's `modes: [MODE_NAME.SERVER]` in store/widgets/index.js).
+    // Skip the fetch entirely in local/embedded mode instead of relying on
+    // getDocumentsRecommendedBy's incidental `indices.length + users.length
+    // > 1` guard, which doesn't actually check mode.
+    if (!isServer.value) return
     const users = getFilterValues({ name: 'recommendedBy' })
     return recommendedStore.getDocumentsRecommendedBy(indices.value, users)
   }

--- a/tests/unit/specs/components/Project/ProjectDeletionModal.spec.js
+++ b/tests/unit/specs/components/Project/ProjectDeletionModal.spec.js
@@ -1,9 +1,10 @@
-import { shallowMount } from '@vue/test-utils'
+import { shallowMount, flushPromises } from '@vue/test-utils'
 
 import CoreSetup from '~tests/unit/CoreSetup'
 import ProjectDeletionModal from '@/components/Project/ProjectDeletionModal'
 import esConnectionHelper from '~tests/unit/specs/utils/esConnectionHelper'
 import { apiInstance as api } from '@/api/apiInstance'
+import { MODE_NAME } from '@/mode'
 
 vi.mock('@/api/apiInstance', () => {
   return {
@@ -19,17 +20,21 @@ vi.mock('@/api/apiInstance', () => {
 })
 
 describe('ProjectDeletionModal.vue', () => {
-  let plugins, project
+  let plugins, project, core
 
   beforeEach(() => {
     const { index: name } = esConnectionHelper.build()
     // The modal uses the router to redirect to the project list so the route must exist
     const routes = [{ name: 'project.list', path: '/project' }]
-    const core = CoreSetup.init().useAll().useRouter(routes)
+    core = CoreSetup.init().useAll().useRouter(routes)
     // Ensure the local-datashare project can be found
     core.config.set('projects', [{ name, label: 'Default', sourcePath: '/' }])
     plugins = core.plugins
     project = { name }
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
   })
 
   afterAll(() => {
@@ -43,5 +48,24 @@ describe('ProjectDeletionModal.vue', () => {
     await wrapper.trigger('ok')
     expect(api.removeProject).toBeCalledWith(project.name)
     expect(wrapper.vm.$core.projects).toHaveLength(0)
+  })
+
+  it('should call the API to retrieve project recommendations count in server mode', async () => {
+    core.config.set('mode', MODE_NAME.SERVER)
+    api.getRecommendationsByProject.mockResolvedValue({ totalCount: 3 })
+
+    shallowMount(ProjectDeletionModal, { global: { plugins }, props: { project } })
+    await flushPromises()
+
+    expect(api.getRecommendationsByProject).toBeCalledWith(project.name)
+  })
+
+  it('should not call the API to retrieve project recommendations count in local mode', async () => {
+    core.config.set('mode', MODE_NAME.LOCAL)
+
+    shallowMount(ProjectDeletionModal, { global: { plugins }, props: { project } })
+    await flushPromises()
+
+    expect(api.getRecommendationsByProject).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/specs/composables/useSearchFilter.spec.js
+++ b/tests/unit/specs/composables/useSearchFilter.spec.js
@@ -198,7 +198,7 @@ describe('useSearchFilter', () => {
 })
 
 describe('useSearchFilter composable', () => {
-  let plugins, searchStore
+  let plugins, searchStore, core
 
   beforeEach(() => {
     // Default to "modern index" so paired-dimension tests behave as before;
@@ -209,7 +209,7 @@ describe('useSearchFilter composable', () => {
       error: ref(null)
     })
 
-    const core = CoreSetup.init().useAll().useRouterWithoutGuards()
+    core = CoreSetup.init().useAll().useRouterWithoutGuards()
     plugins = core.plugins
     searchStore = useSearchStore()
     searchStore.reset()
@@ -849,68 +849,41 @@ describe('useSearchFilter composable', () => {
       })
     })
   })
-})
 
-describe('useSearchFilter refreshSearch with recommendations gated to server mode', () => {
-  let plugins, core, searchStore, recommendedStore
+  describe('refreshSearch with recommendations gated to server mode', () => {
+    let recommendedStore
 
-  beforeEach(() => {
-    useContentTypeCategoryAvailability.mockReturnValue({
-      isAvailable: ref(true),
-      isLoading: ref(false),
-      error: ref(null)
+    beforeEach(() => {
+      recommendedStore = useRecommendedStore()
+      vi.spyOn(searchStore, 'query').mockResolvedValue()
+      vi.spyOn(recommendedStore, 'getDocumentsRecommendedBy').mockResolvedValue()
     })
 
-    core = CoreSetup.init().useAll().useRouterWithoutGuards()
-    plugins = core.plugins
-    searchStore = useSearchStore()
-    searchStore.reset()
-    recommendedStore = useRecommendedStore()
-    vi.spyOn(searchStore, 'query').mockResolvedValue()
-    vi.spyOn(recommendedStore, 'getDocumentsRecommendedBy').mockResolvedValue()
-  })
+    it('does not fetch recommendations in local mode', async () => {
+      core.config.set('mode', MODE_NAME.LOCAL)
+      const { refreshSearch } = mountComposable()
 
-  afterEach(() => {
-    vi.clearAllMocks()
-  })
+      await refreshSearch()
 
-  function mountComposable() {
-    let result
-    const TestComponent = {
-      setup() {
-        result = useSearchFilter()
-        return result
-      },
-      template: '<div></div>'
-    }
-    mount(TestComponent, { global: { plugins } })
-    return result
-  }
+      expect(recommendedStore.getDocumentsRecommendedBy).not.toHaveBeenCalled()
+    })
 
-  it('does not fetch recommendations in local mode', async () => {
-    core.config.set('mode', MODE_NAME.LOCAL)
-    const { refreshSearch } = mountComposable()
+    it('does not fetch recommendations in embedded mode', async () => {
+      core.config.set('mode', MODE_NAME.EMBEDDED)
+      const { refreshSearch } = mountComposable()
 
-    await refreshSearch()
+      await refreshSearch()
 
-    expect(recommendedStore.getDocumentsRecommendedBy).not.toHaveBeenCalled()
-  })
+      expect(recommendedStore.getDocumentsRecommendedBy).not.toHaveBeenCalled()
+    })
 
-  it('does not fetch recommendations in embedded mode', async () => {
-    core.config.set('mode', MODE_NAME.EMBEDDED)
-    const { refreshSearch } = mountComposable()
+    it('fetches recommendations in server mode', async () => {
+      core.config.set('mode', MODE_NAME.SERVER)
+      const { refreshSearch } = mountComposable()
 
-    await refreshSearch()
+      await refreshSearch()
 
-    expect(recommendedStore.getDocumentsRecommendedBy).not.toHaveBeenCalled()
-  })
-
-  it('fetches recommendations in server mode', async () => {
-    core.config.set('mode', MODE_NAME.SERVER)
-    const { refreshSearch } = mountComposable()
-
-    await refreshSearch()
-
-    expect(recommendedStore.getDocumentsRecommendedBy).toHaveBeenCalledOnce()
+      expect(recommendedStore.getDocumentsRecommendedBy).toHaveBeenCalledOnce()
+    })
   })
 })

--- a/tests/unit/specs/composables/useSearchFilter.spec.js
+++ b/tests/unit/specs/composables/useSearchFilter.spec.js
@@ -6,8 +6,9 @@ import { vi } from 'vitest'
 import CoreSetup from '~tests/unit/CoreSetup'
 import { useSearchFilter } from '@/composables/useSearchFilter'
 import { useContentTypeCategoryAvailability } from '@/composables/useContentTypeCategoryAvailability'
-import { useAppStore, useSearchStore } from '@/store/modules'
+import { useAppStore, useSearchStore, useRecommendedStore } from '@/store/modules'
 import { SEARCH_OPERATORS } from '@/enums/searchOperators'
+import { MODE_NAME } from '@/mode'
 
 vi.mock('@/views/App', () => ({ default: { template: '<router-view />' } }))
 vi.mock('@/views/Search/Search', () => ({ default: { template: '<div />' } }))
@@ -847,5 +848,69 @@ describe('useSearchFilter composable', () => {
         expect(all.value).toBe(true)
       })
     })
+  })
+})
+
+describe('useSearchFilter refreshSearch with recommendations gated to server mode', () => {
+  let plugins, core, searchStore, recommendedStore
+
+  beforeEach(() => {
+    useContentTypeCategoryAvailability.mockReturnValue({
+      isAvailable: ref(true),
+      isLoading: ref(false),
+      error: ref(null)
+    })
+
+    core = CoreSetup.init().useAll().useRouterWithoutGuards()
+    plugins = core.plugins
+    searchStore = useSearchStore()
+    searchStore.reset()
+    recommendedStore = useRecommendedStore()
+    vi.spyOn(searchStore, 'query').mockResolvedValue()
+    vi.spyOn(recommendedStore, 'getDocumentsRecommendedBy').mockResolvedValue()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function mountComposable() {
+    let result
+    const TestComponent = {
+      setup() {
+        result = useSearchFilter()
+        return result
+      },
+      template: '<div></div>'
+    }
+    mount(TestComponent, { global: { plugins } })
+    return result
+  }
+
+  it('does not fetch recommendations in local mode', async () => {
+    core.config.set('mode', MODE_NAME.LOCAL)
+    const { refreshSearch } = mountComposable()
+
+    await refreshSearch()
+
+    expect(recommendedStore.getDocumentsRecommendedBy).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch recommendations in embedded mode', async () => {
+    core.config.set('mode', MODE_NAME.EMBEDDED)
+    const { refreshSearch } = mountComposable()
+
+    await refreshSearch()
+
+    expect(recommendedStore.getDocumentsRecommendedBy).not.toHaveBeenCalled()
+  })
+
+  it('fetches recommendations in server mode', async () => {
+    core.config.set('mode', MODE_NAME.SERVER)
+    const { refreshSearch } = mountComposable()
+
+    await refreshSearch()
+
+    expect(recommendedStore.getDocumentsRecommendedBy).toHaveBeenCalledOnce()
   })
 })

--- a/tests/unit/specs/views/Document/DocumentView/DocumentView.spec.js
+++ b/tests/unit/specs/views/Document/DocumentView/DocumentView.spec.js
@@ -6,6 +6,7 @@ import CoreSetup from '~tests/unit/CoreSetup'
 import esConnectionHelper from '~tests/unit/specs/utils/esConnectionHelper'
 import DocumentView from '@/views/Document/DocumentView/DocumentView'
 import { useDocumentStore } from '@/store/modules'
+import { MODE_NAME } from '@/mode'
 
 vi.mock('@/api/apiInstance', async (importOriginal) => {
   const { apiInstance } = await importOriginal()
@@ -106,7 +107,9 @@ describe('DocumentView.vue', () => {
     expect(api.getTags).toBeCalledWith(project, id)
   })
 
-  it('should call the API to retrieve document recommendations', async () => {
+  it('should call the API to retrieve document recommendations in server mode', async () => {
+    core.config.set('mode', MODE_NAME.SERVER)
+
     shallowMount(DocumentView, {
       global: {
         plugins: core.plugins,
@@ -118,6 +121,22 @@ describe('DocumentView.vue', () => {
     await flushPromises()
 
     expect(api.getRecommendationsByDocuments).toBeCalledWith(project, id)
+  })
+
+  it('should not call the API to retrieve document recommendations in local mode', async () => {
+    core.config.set('mode', MODE_NAME.LOCAL)
+
+    shallowMount(DocumentView, {
+      global: {
+        plugins: core.plugins,
+        renderStubDefaultSlot: true
+      },
+      props
+    })
+
+    await flushPromises()
+
+    expect(api.getRecommendationsByDocuments).not.toHaveBeenCalled()
   })
 
   it('should display a document', async () => {


### PR DESCRIPTION
## Summary
- `useSearchFilter.js`'s `refreshRecommendedBy()` ran on every `refreshSearch()` regardless of mode, only incidentally avoided a fetch via `getDocumentsRecommendedBy`'s `indices.length + users.length > 1` check. Gated behind `useMode(core).isServer`.
- `useDocument.js`'s `fetchDocument()` unconditionally called `documentStore.getRecommendationsByDocuments(...)`, hitting a server-only endpoint (404 in local mode). Same guard applied.
- `ProjectDeletionModal.vue`'s `onBeforeMount` unconditionally called `fetchRecommendationsCount()`, not mode-gated even though project deletion is a LOCAL/EMBEDDED feature too. Same guard applied.
- Confirmed `FilterTypeRecommendedBy.vue` is already safe: it fetches unconditionally in its own code, but only mounts when `SearchFilters.vue` has already filtered filters by `filter.modes.some(isMode)`, so it never mounts outside server mode.

## Test plan
- [x] `useSearchFilter.spec.js`: 3 new tests, no fetch in LOCAL/EMBEDDED mode, fetch in SERVER mode
- [x] `DocumentView.spec.js`: 2 new tests, server called / local not called
- [x] `ProjectDeletionModal.spec.js`: 2 new tests, same pattern