### PR TITLE
perf(recommendations): fetch translation status only when the download popover opens

### DIFF
--- a/src/components/Document/DocumentActionsGroup/DocumentActionsGroupEntryDownload.vue
+++ b/src/components/Document/DocumentActionsGroup/DocumentActionsGroupEntryDownload.vue
@@ -40,13 +40,13 @@ const { t } = useI18n()
 
 const element = useTemplateRef('element')
 const isVisible = useElementVisibilityOnce(element)
-const { isDownloadAllowed, documentFullUrl, fetchStatuses } = useDocumentDownload(() => document, { immediate: false })
+const { isDownloadAllowed, documentFullUrl, fetchDownloadStatus } = useDocumentDownload(() => document, { immediate: false })
 // Probe once the row scrolls into view, and again whenever a recycled row is
 // handed a different document while it stays mounted. The store memoizes per
 // document, so re-probing a document already seen costs nothing.
 watch([isVisible, () => document?.id], ([visible]) => {
   if (visible) {
-    fetchStatuses()
+    fetchDownloadStatus()
   }
 })
 const href = computed(() => (isDownloadAllowed.value ? documentFullUrl.value : null))

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -1,14 +1,12 @@
 import { computed, ref, toRef, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { useCore } from '@/composables/useCore'
 import { useDocumentDownloadStore, useDocumentStore } from '@/store/modules'
 import settings from '@/utils/settings'
 
 export function useDocumentDownload(document, { immediate = true } = {}) {
   const documentStore = useDocumentStore()
   const documentDownloadStore = useDocumentDownloadStore()
-  const core = useCore()
   const { locale, t } = useI18n()
 
   const documentRef = toRef(document)

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -91,14 +91,7 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
   async function fetchTranslationStatus() {
     const { index, id, routing } = documentRef.value
     if (!index || !id) return
-    try {
-      const _source = 'content_translated.target_language'
-      const data = await core.api.elasticsearch.getSource({ index, id, routing, _source })
-      availableTranslations.value = (data.content_translated || []).filter(t => t.target_language)
-    }
-    catch {
-      availableTranslations.value = []
-    }
+    availableTranslations.value = await documentDownloadStore.fetchTranslationStatus({ index, id, routing })
   }
 
   async function downloadTranslatedContent() {
@@ -126,6 +119,8 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
 
   return {
     fetchStatuses,
+    fetchDownloadStatus,
+    fetchTranslationStatus,
     extensionWarning,
     description,
     showExtensionWarning,

--- a/src/store/modules/documentDownload.js
+++ b/src/store/modules/documentDownload.js
@@ -70,15 +70,21 @@ export const useDocumentDownloadStore = defineStore('documentDownload', () => {
   const fetchTranslationStatus = async ({ index, id, routing }) => {
     const key = translationCacheKey({ index, id })
     if (key in translationsFor) return translationsFor[key]
-    try {
-      const _source = 'content_translated.target_language'
-      const data = await api.elasticsearch.getSource({ index, id, routing, _source })
-      translationsFor[key] = extractTranslations(data)
+    fetchPromises[key] ??= (async () => {
+      try {
+        const _source = 'content_translated.target_language'
+        const data = await api.elasticsearch.getSource({ index, id, routing, _source })
+        translationsFor[key] = extractTranslations(data)
+      }
+      catch {
+        return []
+      }
+      finally {
+        delete fetchPromises[key]
+      }
       return translationsFor[key]
-    }
-    catch {
-      return []
-    }
+    })()
+    return fetchPromises[key]
   }
 
   return {

--- a/src/store/modules/documentDownload.js
+++ b/src/store/modules/documentDownload.js
@@ -3,9 +3,18 @@ import { defineStore } from 'pinia'
 
 import { apiInstance as api } from '@/api/apiInstance'
 
+function extractTranslations(source = {}) {
+  return (source.content_translated || []).filter(translation => translation.target_language)
+}
+
+function translationCacheKey({ index, id }) {
+  return `${index}:${id}`
+}
+
 export const useDocumentDownloadStore = defineStore('documentDownload', () => {
   const downloadableFor = reactive({})
   const fetchPromises = {} // this doesnt need to be reactive
+  const translationsFor = reactive({})
 
   /**
    * Build the memoization key of a document
@@ -49,5 +58,32 @@ export const useDocumentDownloadStore = defineStore('documentDownload', () => {
     }
   })
 
-  return { fetchDocumentStatus, isDownloadable }
+  /**
+   * Fetch the translation status for a single document.
+   *
+   * @param {Object} options
+   * @param {string} options.index - The document's index
+   * @param {string} options.id - The document's id
+   * @param {string} options.routing - The document's routing
+   * @returns {Promise<Array>} The document's available translations
+   */
+  const fetchTranslationStatus = async ({ index, id, routing }) => {
+    const key = translationCacheKey({ index, id })
+    if (key in translationsFor) return translationsFor[key]
+    try {
+      const _source = 'content_translated.target_language'
+      const data = await api.elasticsearch.getSource({ index, id, routing, _source })
+      translationsFor[key] = extractTranslations(data)
+    }
+    catch {
+      translationsFor[key] = []
+    }
+    return translationsFor[key]
+  }
+
+  return {
+    fetchDocumentStatus,
+    isDownloadable,
+    fetchTranslationStatus
+  }
 })

--- a/src/store/modules/documentDownload.js
+++ b/src/store/modules/documentDownload.js
@@ -74,11 +74,11 @@ export const useDocumentDownloadStore = defineStore('documentDownload', () => {
       const _source = 'content_translated.target_language'
       const data = await api.elasticsearch.getSource({ index, id, routing, _source })
       translationsFor[key] = extractTranslations(data)
+      return translationsFor[key]
     }
     catch {
-      translationsFor[key] = []
+      return []
     }
-    return translationsFor[key]
   }
 
   return {

--- a/tests/unit/specs/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.spec.js
+++ b/tests/unit/specs/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.spec.js
@@ -19,9 +19,9 @@ describe('DocumentDownloadPopover.vue', () => {
     vi.restoreAllMocks()
   })
 
-  function createDocument(overrides = {}) {
+  function createDocument(overrides = {}, id = 'test-doc-id') {
     return new Document({
-      _id: 'test-doc-id',
+      _id: id,
       _index: 'test-index',
       _source: {
         title: 'test-doc',
@@ -55,7 +55,7 @@ describe('DocumentDownloadPopover.vue', () => {
       content_translated: [{ target_language: 'ENGLISH' }]
     })
     apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
-    const doc = createDocument()
+    const doc = createDocument({}, 'test-doc-id-with-translations')
     const wrapper = mountPopover(doc)
     await flushPromises()
     const buttons = wrapper.findAll('.document-download-popover__body__button')
@@ -68,7 +68,7 @@ describe('DocumentDownloadPopover.vue', () => {
       content_translated: []
     })
     apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
-    const doc = createDocument()
+    const doc = createDocument({}, 'test-doc-id-without-translations')
     const wrapper = mountPopover(doc)
     await flushPromises()
     const buttons = wrapper.findAll('.document-download-popover__body__button')
@@ -81,9 +81,10 @@ describe('DocumentDownloadPopover.vue', () => {
       content_translated: [{ target_language: 'ENGLISH' }]
     })
     apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
-    const doc = createDocument({
-      content_translated: [{ content: 'translated text', target_language: 'ENGLISH' }]
-    })
+    const doc = createDocument(
+      { content_translated: [{ content: 'translated text', target_language: 'ENGLISH' }] },
+      'test-doc-id-translation-click'
+    )
 
     const fakeAnchor = { href: '', download: '', click: vi.fn() }
     const originalCreateElement = window.document.createElement.bind(window.document)

--- a/tests/unit/specs/composables/useDocumentDownload.spec.js
+++ b/tests/unit/specs/composables/useDocumentDownload.spec.js
@@ -129,7 +129,7 @@ describe('useDocumentDownload composable', () => {
     it('should be true when API returns translations', async () => {
       mockGetSource({ content_translated: [{ target_language: 'ENGLISH' }] })
       const doc = new Document({
-        _id: 'doc1',
+        _id: 'doc-with-translations',
         _index: 'test-index',
         _source: { title: 'test' }
       })

--- a/tests/unit/specs/store/modules/documentDownload.spec.js
+++ b/tests/unit/specs/store/modules/documentDownload.spec.js
@@ -126,5 +126,25 @@ describe('DocumentDownloadStore', () => {
       expect(api.elasticsearch.getSource).toBeCalledTimes(2)
       expect(translations).toEqual([{ target_language: 'fr' }])
     })
+
+    it('should not send two requests for two concurrent probes of the same document', async () => {
+      api.elasticsearch.getSource.mockResolvedValue({ content_translated: [{ target_language: 'fr' }] })
+      const [first, second] = await Promise.all([
+        documentDownloadStore.fetchTranslationStatus(document),
+        documentDownloadStore.fetchTranslationStatus(document)
+      ])
+      expect(api.elasticsearch.getSource).toBeCalledTimes(1)
+      expect(first).toEqual([{ target_language: 'fr' }])
+      expect(second).toEqual([{ target_language: 'fr' }])
+    })
+
+    it('should send two requests for two concurrent probes of different documents', async () => {
+      api.elasticsearch.getSource.mockResolvedValue({ content_translated: [] })
+      await Promise.all([
+        documentDownloadStore.fetchTranslationStatus(document),
+        documentDownloadStore.fetchTranslationStatus(anotherDocument)
+      ])
+      expect(api.elasticsearch.getSource).toBeCalledTimes(2)
+    })
   })
 })

--- a/tests/unit/specs/store/modules/documentDownload.spec.js
+++ b/tests/unit/specs/store/modules/documentDownload.spec.js
@@ -7,7 +7,10 @@ import { apiInstance as api } from '@/api/apiInstance'
 vi.mock('@/api/apiInstance', () => {
   return {
     apiInstance: {
-      isDocumentDownloadable: vi.fn().mockResolvedValue(true)
+      isDocumentDownloadable: vi.fn().mockResolvedValue(true),
+      elasticsearch: {
+        getSource: vi.fn()
+      }
     }
   }
 })
@@ -92,6 +95,36 @@ describe('DocumentDownloadStore', () => {
       documentDownloadStore.fetchDocumentStatus(sameIdOtherIndex)
       await flushPromises()
       expect(api.isDocumentDownloadable).toBeCalledTimes(2)
+    })
+  })
+
+  describe('fetchTranslationStatus', () => {
+    it('should return the available translations', async () => {
+      api.elasticsearch.getSource.mockResolvedValue({ content_translated: [{ target_language: 'fr' }] })
+      const translations = await documentDownloadStore.fetchTranslationStatus(document)
+      expect(translations).toEqual([{ target_language: 'fr' }])
+    })
+
+    it('should memoize a successful probe', async () => {
+      api.elasticsearch.getSource.mockResolvedValue({ content_translated: [] })
+      await documentDownloadStore.fetchTranslationStatus(document)
+      await documentDownloadStore.fetchTranslationStatus(document)
+      expect(api.elasticsearch.getSource).toBeCalledTimes(1)
+    })
+
+    it('should return an empty array when the probe fails', async () => {
+      api.elasticsearch.getSource.mockRejectedValue(new Error('network error'))
+      const translations = await documentDownloadStore.fetchTranslationStatus(document)
+      expect(translations).toEqual([])
+    })
+
+    it('should not memoize a failed probe, retrying it on the next call', async () => {
+      api.elasticsearch.getSource.mockRejectedValueOnce(new Error('network error'))
+      api.elasticsearch.getSource.mockResolvedValueOnce({ content_translated: [{ target_language: 'fr' }] })
+      await documentDownloadStore.fetchTranslationStatus(document)
+      const translations = await documentDownloadStore.fetchTranslationStatus(document)
+      expect(api.elasticsearch.getSource).toBeCalledTimes(2)
+      expect(translations).toEqual([{ target_language: 'fr' }])
     })
   })
 })


### PR DESCRIPTION
## Summary
- Translation status was fetched eagerly on visibility for every document's download button, even though only the download popover (opened on click) actually reads it.
- Split `useDocumentDownload`'s combined `fetchStatuses` so `DocumentActionsGroupEntryDownload` (the button) fetches only `fetchDownloadStatus` on scroll-into-view, leaving `fetchTranslationStatus` to the popover's own on-open fetch (`whenever(activated, fetchStatuses, { once: true })`).
- `documentDownloadStore` memoizes `fetchTranslationStatus` per `index:id` key, so re-opening an already-fetched document's popover costs nothing.

## Test plan
- [x] `DocumentDownloadPopover.spec.js`, `useDocumentDownload.spec.js`, `DocumentActionsGroupEntryDownload.spec.js` — 22 tests passing