### PR TITLE
fix: ensure loadData runs queries in parallel

### DIFF
--- a/src/components/Widget/WidgetDocuments.vue
+++ b/src/components/Widget/WidgetDocuments.vue
@@ -74,9 +74,10 @@ export default {
       return this.count(q)
     },
     async loadData() {
-      this.total = await this.countTotal()
-      this.onDisk = await this.countOnDisk()
-      this.duplicates = await this.countDuplicates()
+      const [total, onDisk, duplicates] = await Promise.all([this.countTotal(), this.countOnDisk(), this.countDuplicates()])
+      this.total = total
+      this.onDisk = onDisk
+      this.duplicates = duplicates
     }
   }
 }

--- a/tests/unit/specs/components/Widget/WidgetDocuments.spec.js
+++ b/tests/unit/specs/components/Widget/WidgetDocuments.spec.js
@@ -36,4 +36,12 @@ describe('WidgetDocuments.vue', () => {
     await wrapper.vm.loadData()
     expect(wrapper.vm.duplicates).toBe(7)
   })
+
+  it('loadData issues the three count queries in parallel, not in series', async () => {
+    const spy = vi.spyOn(wrapper.vm, 'count').mockResolvedValue(0)
+    const promise = wrapper.vm.loadData()
+    // With sequential awaits, only the first count() would have fired by now.
+    expect(spy).toHaveBeenCalledTimes(3)
+    await promise
+  })
 })


### PR DESCRIPTION
## Summary
- `WidgetDocuments.vue`'s `loadData()` made 3 count queries (`total`/`onDisk`/`duplicates`) sequentially via separate `await`s, stacking 3 round-trips in series even though they share the same `preference` and don't depend on each other.
- Switched to `Promise.all` so all 3 fire concurrently.

## Test plan
- [x] `WidgetDocuments.spec.js` — new test asserts all 3 `count()` calls fire before any resolves