### PR TITLE
fix: redirect users to their requested page after login in server mode

### DIFF
--- a/src/core/handleBootFailure.js
+++ b/src/core/handleBootFailure.js
@@ -7,6 +7,7 @@ import { useAppStore } from '@/store/modules'
  * error redirects to the error page.
  * @param {import('@/core/Core').default} core - The core instance whose `ready` promise rejected.
  * @param {Error} error - The boot error.
+ * @returns {Promise} Resolves once the redirect navigation has settled.
  */
 export function handleBootFailure(core, error) {
   const unauthorized = error?.response?.status === 401
@@ -17,9 +18,7 @@ export function handleBootFailure(core, error) {
   }
   core.useRouter().mount()
   if (unauthorized) {
-    core.router.push({ name: 'login' })
+    return core.router.push({ name: 'login' })
   }
-  else {
-    core.router.push({ name: 'error', state: { error } })
-  }
+  return core.router.push({ name: 'error', state: { error } })
 }

--- a/src/core/handleBootFailure.js
+++ b/src/core/handleBootFailure.js
@@ -1,0 +1,25 @@
+import { useAppStore } from '@/store/modules'
+
+/**
+ * Handles a failed core boot sequence. On a 401 (unauthenticated in server
+ * mode), stores the URL the user originally requested so the router guard
+ * can restore it after login, then redirects to the login page. Any other
+ * error redirects to the error page.
+ * @param {import('@/core/Core').default} core - The core instance whose `ready` promise rejected.
+ * @param {Error} error - The boot error.
+ */
+export function handleBootFailure(core, error) {
+  const unauthorized = error?.response?.status === 401
+  if (unauthorized) {
+    const { pathname, search, hash } = window.location
+    useAppStore(core.pinia).setRedirectAfterLogin(pathname + search + hash)
+    core.auth.reset()
+  }
+  core.useRouter().mount()
+  if (unauthorized) {
+    core.router.push({ name: 'login' })
+  }
+  else {
+    core.router.push({ name: 'error', state: { error } })
+  }
+}

--- a/src/core/handleBootFailure.js
+++ b/src/core/handleBootFailure.js
@@ -12,8 +12,12 @@ import { useAppStore } from '@/store/modules'
 export function handleBootFailure(core, error) {
   const unauthorized = error?.response?.status === 401
   if (unauthorized) {
-    const { pathname, search, hash } = window.location
-    useAppStore(core.pinia).setRedirectAfterLogin(pathname + search + hash)
+    // The router uses createWebHashHistory (see Core.js), so the requested
+    // route lives entirely in the URL hash (e.g. `#/settings?foo=bar`), not
+    // in pathname/search. Slicing off the leading `#` yields the route path
+    // the router guard expects (`/settings?foo=bar`).
+    const route = window.location.hash.slice(1) || '/'
+    useAppStore(core.pinia).setRedirectAfterLogin(route)
     core.auth.reset()
   }
   core.useRouter().mount()

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import '@/main.scss'
 import '@/utils/shared'
 import { createCore } from '@/core'
+import { handleBootFailure } from '@/core/handleBootFailure'
 
 if (import.meta.env.MODE !== 'test' && window) {
   const datashare = createCore()
@@ -8,19 +9,8 @@ if (import.meta.env.MODE !== 'test' && window) {
   datashare.ready
     // Everything is fine
     .then(() => datashare.useRouter().mount())
-    // Redirect to the error page
-    .catch((error) => {
-      datashare.useRouter().mount()
-      // Unauthenticated error during initialization:
-      // redirect the user to the login page
-      if (error?.response?.status === 401) {
-        datashare.auth.reset()
-        datashare.router.push('login')
-      }
-      else {
-        datashare.router.push({ name: 'error', state: { error } })
-      }
-    })
+    // Store the requested URL (on 401) and redirect to login or error
+    .catch(error => handleBootFailure(datashare, error))
   // Register the core globally (so plugins can use it)
   window.datashare = datashare
 }

--- a/src/router/guards/index.js
+++ b/src/router/guards/index.js
@@ -232,8 +232,8 @@ export default (core) => {
   }
 
   router.beforeEach(checkMode)
-  router.beforeEach(checkUserRole)
   router.beforeEach(checkUserAuthentication)
+  router.beforeEach(checkUserRole)
   router.beforeEach(checkUserProjects)
   router.beforeEach(preparePageContext)
   router.beforeEach(startProgress)

--- a/src/router/guards/index.js
+++ b/src/router/guards/index.js
@@ -38,8 +38,8 @@ export default (core) => {
   function proceedAuthenticated(to, next) {
     const appStore = useAppStore()
     const path = appStore.popRedirectAfterLogin()
-    if (to.path !== path && path !== null) {
-      next({ path })
+    if (path !== null && to.fullPath !== path) {
+      next(path)
     }
     else {
       next()
@@ -56,7 +56,7 @@ export default (core) => {
   function proceedUnauthenticated(to, from, next) {
     const appStore = useAppStore()
     if (from.name !== 'login' && to.name !== 'login') {
-      appStore.setRedirectAfterLogin(to.path)
+      appStore.setRedirectAfterLogin(to.fullPath)
       next({ name: 'login' })
     }
     else {

--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -188,6 +188,9 @@ export const useAppStore = defineStore(
       else if (path.startsWith('/') && !path.startsWith('//') && !path.startsWith('/\\') && !path.startsWith('/login')) {
         redirectAfterLogin.value = path
       }
+      else { 
+          redirectAfterLogin.value = null
+      }
     }
 
     /**

--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -175,12 +175,17 @@ export const useAppStore = defineStore(
     }
 
     /**
-     * Sets the redirect path to be used after login.
+     * Sets the redirect path to be used after login. Only relative paths
+     * (starting with `/`) are accepted, and never the login page itself.
+     * Passing a falsy value clears the stored path.
      *
      * @param {string|null} [path=null] - Redirect path.
      */
     const setRedirectAfterLogin = (path = null) => {
-      if (!path || !path.startsWith('/login')) {
+      if (!path) {
+        redirectAfterLogin.value = null
+      }
+      else if (path.startsWith('/') && !path.startsWith('/login')) {
         redirectAfterLogin.value = path
       }
     }

--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -175,9 +175,9 @@ export const useAppStore = defineStore(
     }
 
     /**
-     * Sets the redirect path to be used after login. Only relative paths
-     * (starting with `/`) are accepted, and never the login page itself.
-     * Passing a falsy value clears the stored path.
+     * Sets the redirect path to be used after login. Only same-origin relative paths
+     * (starting with `/`, but not `//` or `/\` which are protocol-relative) are accepted,
+     * and never the login page itself. Passing a falsy value clears the stored path.
      *
      * @param {string|null} [path=null] - Redirect path.
      */
@@ -185,7 +185,7 @@ export const useAppStore = defineStore(
       if (!path) {
         redirectAfterLogin.value = null
       }
-      else if (path.startsWith('/') && !path.startsWith('/login')) {
+      else if (path.startsWith('/') && !path.startsWith('//') && !path.startsWith('/\\') && !path.startsWith('/login')) {
         redirectAfterLogin.value = path
       }
     }

--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -177,7 +177,8 @@ export const useAppStore = defineStore(
     /**
      * Sets the redirect path to be used after login. Only same-origin relative paths
      * (starting with `/`, but not `//` or `/\` which are protocol-relative) are accepted,
-     * and never the login page itself. Passing a falsy value clears the stored path.
+     * and never the login page itself. Any other value (including a falsy one) clears
+     * the stored path rather than leaving a stale one behind.
      *
      * @param {string|null} [path=null] - Redirect path.
      */
@@ -188,8 +189,8 @@ export const useAppStore = defineStore(
       else if (path.startsWith('/') && !path.startsWith('//') && !path.startsWith('/\\') && !path.startsWith('/login')) {
         redirectAfterLogin.value = path
       }
-      else { 
-          redirectAfterLogin.value = null
+      else {
+        redirectAfterLogin.value = null
       }
     }
 

--- a/tests/unit/specs/core/handleBootFailure.spec.js
+++ b/tests/unit/specs/core/handleBootFailure.spec.js
@@ -34,7 +34,10 @@ describe('handleBootFailure', () => {
   })
 
   it('should store the requested URL and redirect to login on a 401', async () => {
-    window.history.replaceState({}, '', '/settings?foo=bar#appearance')
+    // The router uses createWebHashHistory, so a real deep link is shaped
+    // like `https://host/#/settings?foo=bar`: the route lives entirely in
+    // the hash, not in pathname/search.
+    window.history.replaceState({}, '', '/#/settings?foo=bar')
     // Await the redirect navigation itself (handleBootFailure returns the
     // router.push promise) rather than router.isReady(), which resolves as
     // soon as ANY pending navigation settles — including the automatic one
@@ -42,7 +45,20 @@ describe('handleBootFailure', () => {
     // false positive if a future change inserted an await before the push.
     await handleBootFailure(core, { response: { status: 401 } })
     const appStore = useAppStore(core.pinia)
-    expect(appStore.redirectAfterLogin).toBe('/settings?foo=bar#appearance')
+    expect(appStore.redirectAfterLogin).toBe('/settings?foo=bar')
+    expect(core.router.currentRoute.value.name).toBe('login')
+  })
+
+  it('should keep the stored redirect intact after the boot-failure flow settles', async () => {
+    window.history.replaceState({}, '', '/#/settings?foo=bar')
+    await handleBootFailure(core, { response: { status: 401 } })
+    // handleBootFailure's own push has resolved above, but this guards
+    // against the router guards (which run their own auth check and login
+    // push as part of mount()'s initial navigation) overwriting the value
+    // stored here with something else once everything has settled.
+    await core.router.isReady()
+    const appStore = useAppStore(core.pinia)
+    expect(appStore.redirectAfterLogin).toBe('/settings?foo=bar')
     expect(core.router.currentRoute.value.name).toBe('login')
   })
 

--- a/tests/unit/specs/core/handleBootFailure.spec.js
+++ b/tests/unit/specs/core/handleBootFailure.spec.js
@@ -35,20 +35,19 @@ describe('handleBootFailure', () => {
 
   it('should store the requested URL and redirect to login on a 401', async () => {
     window.history.replaceState({}, '', '/settings?foo=bar#appearance')
-    handleBootFailure(core, { response: { status: 401 } })
-    // Wait for the router's (only) pending navigation, triggered by
-    // handleBootFailure's push, to settle rather than relying on
-    // microtask-only flushPromises, since the route's async component
-    // import takes longer than a microtask flush.
-    await core.router.isReady()
+    // Await the redirect navigation itself (handleBootFailure returns the
+    // router.push promise) rather than router.isReady(), which resolves as
+    // soon as ANY pending navigation settles — including the automatic one
+    // vue-router kicks off when the router is installed — and would give a
+    // false positive if a future change inserted an await before the push.
+    await handleBootFailure(core, { response: { status: 401 } })
     const appStore = useAppStore(core.pinia)
     expect(appStore.redirectAfterLogin).toBe('/settings?foo=bar#appearance')
     expect(core.router.currentRoute.value.name).toBe('login')
   })
 
   it('should redirect to the error page on a non-401 failure', async () => {
-    handleBootFailure(core, new Error('boom'))
-    await core.router.isReady()
+    await handleBootFailure(core, new Error('boom'))
     expect(core.router.currentRoute.value.name).toBe('error')
   })
 })

--- a/tests/unit/specs/core/handleBootFailure.spec.js
+++ b/tests/unit/specs/core/handleBootFailure.spec.js
@@ -1,0 +1,54 @@
+import { createCore } from '@/core'
+import { handleBootFailure } from '@/core/handleBootFailure'
+import { useAppStore } from '@/store/modules'
+import { apiInstance as api } from '@/api/apiInstance'
+
+vi.mock('@/api/apiInstance', () => ({
+  apiInstance: {
+    getUser: vi.fn(),
+    getSettings: vi.fn().mockResolvedValue({}),
+    getProject: vi.fn().mockResolvedValue({}),
+    // Rendered by the navbar mounted with the login/error page.
+    getVersion: vi.fn().mockResolvedValue({})
+  }
+}))
+
+describe('handleBootFailure', () => {
+  let core
+
+  beforeEach(() => {
+    const app = document.createElement('div')
+    app.setAttribute('id', 'app')
+    document.body.appendChild(app)
+    api.getUser.mockRejectedValue({ response: { status: 401 } })
+    core = createCore()
+    // createCore's own boot sequence also rejects on the 401 above; that
+    // rejection is unrelated to handleBootFailure, which is called directly.
+    core.ready.catch(() => {})
+    window.history.replaceState({}, '', '/')
+  })
+
+  afterEach(() => {
+    document.querySelectorAll('#app').forEach(el => el.remove())
+    vi.clearAllMocks()
+  })
+
+  it('should store the requested URL and redirect to login on a 401', async () => {
+    window.history.replaceState({}, '', '/settings?foo=bar#appearance')
+    handleBootFailure(core, { response: { status: 401 } })
+    // Wait for the router's (only) pending navigation, triggered by
+    // handleBootFailure's push, to settle rather than relying on
+    // microtask-only flushPromises, since the route's async component
+    // import takes longer than a microtask flush.
+    await core.router.isReady()
+    const appStore = useAppStore(core.pinia)
+    expect(appStore.redirectAfterLogin).toBe('/settings?foo=bar#appearance')
+    expect(core.router.currentRoute.value.name).toBe('login')
+  })
+
+  it('should redirect to the error page on a non-401 failure', async () => {
+    handleBootFailure(core, new Error('boom'))
+    await core.router.isReady()
+    expect(core.router.currentRoute.value.name).toBe('error')
+  })
+})

--- a/tests/unit/specs/router/guards.spec.js
+++ b/tests/unit/specs/router/guards.spec.js
@@ -68,6 +68,14 @@ describe('guards', () => {
         await router.push({ name: 'project.list' })
         expect(router.currentRoute.value.path).toBe('/settings/appearance')
       })
+
+      it('should restore query and hash of the stored path after login', async () => {
+        setCookie(process.env.VITE_DS_COOKIE_NAME, { login: 'yolo' }, JSON.stringify)
+        const appStore = useAppStore()
+        appStore.setRedirectAfterLogin('/settings/appearance?search=test#overview')
+        await router.push({ name: 'project.list' })
+        expect(router.currentRoute.value.fullPath).toBe('/settings/appearance?search=test#overview')
+      })
     })
 
     describe('when the user is not authenticated', () => {
@@ -99,6 +107,15 @@ describe('guards', () => {
         await router.replace({ name: 'login' })
         await router.push({ name: 'login' })
         expect(router.currentRoute.value.name).toBe('login')
+      })
+
+      it('should store the full path including query and hash before redirecting to login', async () => {
+        removeCookie(process.env.VITE_DS_COOKIE_NAME)
+        const appStore = useAppStore()
+        appStore.setRedirectAfterLogin(null)
+        await router.push('/settings?search=test#overview')
+        expect(router.currentRoute.value.name).toBe('login')
+        expect(appStore.redirectAfterLogin).toBe('/settings/appearance?search=test#overview')
       })
     })
   })

--- a/tests/unit/specs/router/guards.spec.js
+++ b/tests/unit/specs/router/guards.spec.js
@@ -291,5 +291,17 @@ describe('guards', () => {
       await router.push({ name: 'project.view.overview', params: { name: 'local-datashare' } })
       expect(router.currentRoute.value.name).not.toBe('error')
     })
+
+    it('should redirect an unauthenticated user to login instead of error', async () => {
+      removeCookie(process.env.VITE_DS_COOKIE_NAME)
+      auth.reset()
+      api.getUser.mockRejectedValue()
+      config.set('policies', [])
+      const appStore = useAppStore()
+      appStore.setRedirectAfterLogin(null)
+      await router.push({ name: 'project.view.edit', params: { name: 'local-datashare' } })
+      expect(router.currentRoute.value.name).toBe('login')
+      expect(appStore.redirectAfterLogin).toContain('/local-datashare/')
+    })
   })
 })

--- a/tests/unit/specs/store/modules/app.spec.js
+++ b/tests/unit/specs/store/modules/app.spec.js
@@ -123,6 +123,18 @@ describe('AppStore', () => {
       expect(store.redirectAfterLogin).toBe('/settings')
     })
 
+    it('setRedirectAfterLogin should ignore protocol-relative paths', () => {
+      store.setRedirectAfterLogin('/settings')
+      store.setRedirectAfterLogin('//evil.example.com/')
+      expect(store.redirectAfterLogin).toBe('/settings')
+    })
+
+    it('setRedirectAfterLogin should ignore backslash-prefixed paths', () => {
+      store.setRedirectAfterLogin('/settings')
+      store.setRedirectAfterLogin('/\\evil.example.com/')
+      expect(store.redirectAfterLogin).toBe('/settings')
+    })
+
     it('setRedirectAfterLogin should clear the value when passed null', () => {
       store.setRedirectAfterLogin('/settings')
       store.setRedirectAfterLogin(null)

--- a/tests/unit/specs/store/modules/app.spec.js
+++ b/tests/unit/specs/store/modules/app.spec.js
@@ -95,4 +95,48 @@ describe('AppStore', () => {
   it('should default searchHistoryList order to modification_date desc', () => {
     expect(store.getSettings('searchHistoryList', 'orderBy')).toEqual(['modification_date', 'desc'])
   })
+
+  describe('redirectAfterLogin', () => {
+    it('should be null initially', () => {
+      expect(store.redirectAfterLogin).toBeNull()
+    })
+
+    it('setRedirectAfterLogin should store a path starting with a slash', () => {
+      store.setRedirectAfterLogin('/settings/appearance')
+      expect(store.redirectAfterLogin).toBe('/settings/appearance')
+    })
+
+    it('setRedirectAfterLogin should store a full path with query and hash', () => {
+      store.setRedirectAfterLogin('/settings?foo=bar#appearance')
+      expect(store.redirectAfterLogin).toBe('/settings?foo=bar#appearance')
+    })
+
+    it('setRedirectAfterLogin should ignore the login page', () => {
+      store.setRedirectAfterLogin('/settings')
+      store.setRedirectAfterLogin('/login')
+      expect(store.redirectAfterLogin).toBe('/settings')
+    })
+
+    it('setRedirectAfterLogin should ignore values not starting with a slash', () => {
+      store.setRedirectAfterLogin('/settings')
+      store.setRedirectAfterLogin('https://evil.example.com/')
+      expect(store.redirectAfterLogin).toBe('/settings')
+    })
+
+    it('setRedirectAfterLogin should clear the value when passed null', () => {
+      store.setRedirectAfterLogin('/settings')
+      store.setRedirectAfterLogin(null)
+      expect(store.redirectAfterLogin).toBeNull()
+    })
+
+    it('popRedirectAfterLogin should return the value and clear it', () => {
+      store.setRedirectAfterLogin('/settings?foo=bar')
+      expect(store.popRedirectAfterLogin()).toBe('/settings?foo=bar')
+      expect(store.redirectAfterLogin).toBeNull()
+    })
+
+    it('popRedirectAfterLogin should return null when nothing is stored', () => {
+      expect(store.popRedirectAfterLogin()).toBeNull()
+    })
+  })
 })

--- a/tests/unit/specs/store/modules/app.spec.js
+++ b/tests/unit/specs/store/modules/app.spec.js
@@ -111,28 +111,28 @@ describe('AppStore', () => {
       expect(store.redirectAfterLogin).toBe('/settings?foo=bar#appearance')
     })
 
-    it('setRedirectAfterLogin should ignore the login page', () => {
+    it('setRedirectAfterLogin should reject the login page', () => {
       store.setRedirectAfterLogin('/settings')
       store.setRedirectAfterLogin('/login')
-      expect(store.redirectAfterLogin).toBe('/settings')
+      expect(store.redirectAfterLogin).toBeNull()
     })
 
-    it('setRedirectAfterLogin should ignore values not starting with a slash', () => {
+    it('setRedirectAfterLogin should reject values not starting with a slash', () => {
       store.setRedirectAfterLogin('/settings')
       store.setRedirectAfterLogin('https://evil.example.com/')
-      expect(store.redirectAfterLogin).toBe('/settings')
+      expect(store.redirectAfterLogin).toBeNull()
     })
 
-    it('setRedirectAfterLogin should ignore protocol-relative paths', () => {
+    it('setRedirectAfterLogin should reject protocol-relative paths', () => {
       store.setRedirectAfterLogin('/settings')
       store.setRedirectAfterLogin('//evil.example.com/')
-      expect(store.redirectAfterLogin).toBe('/settings')
+      expect(store.redirectAfterLogin).toBeNull()
     })
 
-    it('setRedirectAfterLogin should ignore backslash-prefixed paths', () => {
+    it('setRedirectAfterLogin should reject backslash-prefixed paths', () => {
       store.setRedirectAfterLogin('/settings')
       store.setRedirectAfterLogin('/\\evil.example.com/')
-      expect(store.redirectAfterLogin).toBe('/settings')
+      expect(store.redirectAfterLogin).toBeNull()
     })
 
     it('setRedirectAfterLogin should clear the value when passed null', () => {


### PR DESCRIPTION
In server mode, an unauthenticated user opening a deep link (shared document, search URL) was redirected to login but landed on the default page after logging in, for both form auth and OAuth. The intended destination is now stored before redirecting to login (including from the boot 401 path) and restored, with query and hash, on the first authenticated navigation.

- fix(store): only accept relative paths as redirect after login
- fix(store): reject protocol-relative paths as redirect after login
- fix(router): preserve query and hash in redirect after login
- fix(router): check authentication before user role in guards
- fix(core): store requested url before redirecting to login on boot 401
- test(core): await boot failure navigation deterministically
- fix(core): capture hash route for redirect after boot 401