### PR TITLE
fix: teleport the PDF viewer dropdown menu to body

### DIFF
--- a/src/components/Document/DocumentViewer/DocumentViewerPdf/DocumentViewerPdfDropdown/DocumentViewerPdfDropdown.vue
+++ b/src/components/Document/DocumentViewer/DocumentViewerPdf/DocumentViewerPdfDropdown/DocumentViewerPdfDropdown.vue
@@ -14,7 +14,10 @@ const embed = defineModel('embed', { type: Boolean, default: false })
 </script>
 
 <template>
-  <app-dropdown>
+  <app-dropdown
+    teleport-to="body"
+    boundary="viewport"
+  >
     <document-viewer-pdf-dropdown-rotation-clockwise v-model="rotation" />
     <document-viewer-pdf-dropdown-rotation-counter-clockwise v-model="rotation" />
     <b-dropdown-divider />

--- a/tests/unit/specs/components/Document/DocumentViewer/DocumentViewerPdf/DocumentViewerPdfDropdown/DocumentViewerPdfDropdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentViewer/DocumentViewerPdf/DocumentViewerPdfDropdown/DocumentViewerPdfDropdown.spec.js
@@ -1,0 +1,26 @@
+import { mount } from '@vue/test-utils'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import DocumentViewerPdfDropdown from '@/components/Document/DocumentViewer/DocumentViewerPdf/DocumentViewerPdfDropdown/DocumentViewerPdfDropdown.vue'
+
+describe('DocumentViewerPdfDropdown.vue', () => {
+  const factory = () => {
+    const { plugins } = CoreSetup.init().useAll()
+
+    return mount(DocumentViewerPdfDropdown, {
+      global: { plugins }
+    })
+  }
+
+  it('teleports the dropdown menu to the body so it is not clipped by an ancestor stacking context', () => {
+    const wrapper = factory()
+    const dropdown = wrapper.findComponent({ name: 'BDropdown' })
+    expect(dropdown.props('teleportTo')).toBe('body')
+  })
+
+  it('constrains the dropdown menu to the viewport boundary', () => {
+    const wrapper = factory()
+    const dropdown = wrapper.findComponent({ name: 'BDropdown' })
+    expect(dropdown.props('boundary')).toBe('viewport')
+  })
+})


### PR DESCRIPTION
The dropdown menu was rendered inline inside the toolbox's sticky positioning context, so when it flipped upward on short viewports it got clipped behind other elements instead of rendering on top.

Fixes https://github.com/ICIJ/datashare/issues/2295
<img width="316" height="307" alt="image" src="https://github.com/user-attachments/assets/aac83e90-4ea1-40a6-8910-fbaa84a10a05" />
