### PR TITLE
feat: download a document's markdown

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -363,6 +363,58 @@ export class Api {
     }
   }
 
+  /**
+   * Probe the structure artifact manifest of a document.
+   *
+   * A document with no structure artifact is the common case, and the backend
+   * says so with a 404. That is not an error worth a toast, so this probe goes
+   * straight to axios with a permissive `validateStatus` instead of through
+   * `sendAction`, which would push every 404 onto the `http::error` bus.
+   *
+   * Unlike `isDocumentDownloadable`, a probe we cannot read fails closed: a
+   * button that 404s on click is worse than no button at all.
+   *
+   * @param {string} index - The project index of the document
+   * @param {string} id - The document id
+   * @param {string} routing - The routing (the root document id)
+   * @returns {Promise<Object|null>} The manifest, or null when there is none
+   */
+  async getStructureManifest(index, id, routing) {
+    const url = Api.getFullUrl(`/api/${index}/artifacts/structure/${id}`)
+    const validateStatus = () => true
+    try {
+      const response = await this.axios.request({ url, method: Method.GET, params: { routing }, validateStatus })
+      const { status, data } = response
+      // An expired session says nothing about the artifact. Report it so the
+      // app can offer to log back in, and hide the button either way.
+      if (status === 401) {
+        this.eventBus?.emit('http::error', { response })
+        return null
+      }
+      return status === 200 ? data : null
+    }
+    catch {
+      return null
+    }
+  }
+
+  /**
+   * Fetch one page of a document's structure artifact, as Markdown.
+   *
+   * The `format` parameter is omitted on purpose: `md` is the server-side
+   * default, and it is the only format this client asks for.
+   *
+   * @param {string} index - The project index of the document
+   * @param {string} id - The document id
+   * @param {number} page - The 1-based page number
+   * @param {string} routing - The routing (the root document id)
+   * @returns {Promise<string>} The page content
+   */
+  getStructurePage(index, id, page, routing) {
+    const url = `/api/${index}/artifacts/structure/${id}/${page}`
+    return this.sendAction(url, { method: Method.GET, params: { routing }, responseType: 'text' })
+  }
+
   login(username, password) {
     return this.sendAction('/auth/login', {
       method: Method.POST,

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -364,16 +364,14 @@ export class Api {
   }
 
   /**
-   * Probe the structure artifact manifest of a document.
+   * Probe the structure artifact manifest of a document, or null when there is
+   * none.
    *
-   * A document with no structure artifact is the common case, and the backend
-   * says so with a 404. That is not an error worth a toast, so this probe goes
-   * straight to axios with a permissive `validateStatus` instead of through
-   * `sendAction`, which would push every 404 onto the `http::error` bus.
-   *
-   * Unlike `isDocumentDownloadable`, a probe we cannot read fails closed: a
-   * button that 404s on click is worse than no button at all. Returns the
-   * manifest, or null when there is none.
+   * The structure endpoints bypass `sendAction`, which pushes every rejection
+   * onto the `http::error` bus: a document with no artifact answers 404, which
+   * is the common case and not an error worth a toast. Unlike
+   * `isDocumentDownloadable`, a probe we cannot read fails closed, because a
+   * button that 404s on click is worse than no button at all.
    */
   async getStructureManifest(index, id, routing) {
     const url = Api.getFullUrl(`/api/${index}/artifacts/structure/${id}`)
@@ -396,14 +394,10 @@ export class Api {
 
   /**
    * Fetch one page (1-based) of a document's structure artifact, as Markdown.
-   *
-   * The `format` parameter is omitted on purpose: `md` is the server-side
-   * default, and it is the only format this client asks for.
-   *
-   * Like the two probes above, this bypasses `sendAction`, which emits an
-   * `http::error` for every rejection: a download fans out one request per
-   * page, so a single expired session would stack one sticky notification per
-   * page. The caller reports the failed download once instead.
+   * Bypasses `sendAction` for the reason given on `getStructureManifest`, all
+   * the more so as a download fans out one request per page: the caller reports
+   * a failure once instead of once per page. The `format` parameter is omitted
+   * because `md` is the server-side default.
    */
   async getStructurePage(index, id, page, routing) {
     const url = Api.getFullUrl(`/api/${index}/artifacts/structure/${id}/${page}`)

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -404,15 +404,21 @@ export class Api {
    * The `format` parameter is omitted on purpose: `md` is the server-side
    * default, and it is the only format this client asks for.
    *
+   * Like the two probes above, this bypasses `sendAction`, which emits an
+   * `http::error` for every rejection: a download fans out one request per
+   * page, so a single expired session would stack one sticky notification per
+   * page. The caller reports the failed download once instead.
+   *
    * @param {string} index - The project index of the document
    * @param {string} id - The document id
    * @param {number} page - The 1-based page number
    * @param {string} routing - The routing (the root document id)
    * @returns {Promise<string>} The page content
    */
-  getStructurePage(index, id, page, routing) {
-    const url = `/api/${index}/artifacts/structure/${id}/${page}`
-    return this.sendAction(url, { method: Method.GET, params: { routing }, responseType: 'text' })
+  async getStructurePage(index, id, page, routing) {
+    const url = Api.getFullUrl(`/api/${index}/artifacts/structure/${id}/${page}`)
+    const { data } = await this.axios.request({ url, method: Method.GET, params: { routing }, responseType: 'text' })
+    return data
   }
 
   login(username, password) {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -372,12 +372,8 @@ export class Api {
    * `sendAction`, which would push every 404 onto the `http::error` bus.
    *
    * Unlike `isDocumentDownloadable`, a probe we cannot read fails closed: a
-   * button that 404s on click is worse than no button at all.
-   *
-   * @param {string} index - The project index of the document
-   * @param {string} id - The document id
-   * @param {string} routing - The routing (the root document id)
-   * @returns {Promise<Object|null>} The manifest, or null when there is none
+   * button that 404s on click is worse than no button at all. Returns the
+   * manifest, or null when there is none.
    */
   async getStructureManifest(index, id, routing) {
     const url = Api.getFullUrl(`/api/${index}/artifacts/structure/${id}`)
@@ -399,7 +395,7 @@ export class Api {
   }
 
   /**
-   * Fetch one page of a document's structure artifact, as Markdown.
+   * Fetch one page (1-based) of a document's structure artifact, as Markdown.
    *
    * The `format` parameter is omitted on purpose: `md` is the server-side
    * default, and it is the only format this client asks for.
@@ -408,12 +404,6 @@ export class Api {
    * `http::error` for every rejection: a download fans out one request per
    * page, so a single expired session would stack one sticky notification per
    * page. The caller reports the failed download once instead.
-   *
-   * @param {string} index - The project index of the document
-   * @param {string} id - The document id
-   * @param {number} page - The 1-based page number
-   * @param {string} routing - The routing (the root document id)
-   * @returns {Promise<string>} The page content
    */
   async getStructurePage(index, id, page, routing) {
     const url = Api.getFullUrl(`/api/${index}/artifacts/structure/${id}/${page}`)

--- a/src/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.vue
+++ b/src/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.vue
@@ -52,6 +52,8 @@ const {
   hasTextContent,
   hasTranslations,
   downloadTranslatedContent,
+  hasMarkdown,
+  downloadMarkdown,
   fetchStatuses
 } = useDocumentDownload(() => props.document, { immediate: !props.lazy })
 const mounted = computed(() => !props.lazy || activated.value)
@@ -118,6 +120,14 @@ defineExpose({
         class="document-download-popover__body__button"
         :disabled="!hasTextContent"
         @click="downloadTextContent"
+      />
+      <button-icon
+        v-if="hasMarkdown"
+        :icon-left="IPhDownloadSimple"
+        :label="t('documentDownloadPopover.downloadMarkdown')"
+        variant="outline-action"
+        class="document-download-popover__body__button"
+        @click="downloadMarkdown"
       />
       <button-icon
         v-if="hasTranslations"

--- a/src/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.vue
+++ b/src/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.vue
@@ -54,6 +54,7 @@ const {
   downloadTranslatedContent,
   hasMarkdown,
   downloadMarkdown,
+  isDownloadingMarkdown,
   fetchStatuses
 } = useDocumentDownload(() => props.document, { immediate: !props.lazy })
 const mounted = computed(() => !props.lazy || activated.value)
@@ -121,10 +122,17 @@ defineExpose({
         :disabled="!hasTextContent"
         @click="downloadTextContent"
       />
+      <!--
+        `loading` only swaps the icon for a spinner in murmur's ButtonIcon, so
+        `disabled` is what actually stops a second click starting a duplicate
+        download while the pages are still being fetched.
+      -->
       <button-icon
         v-if="hasMarkdown"
         :icon-left="IPhDownloadSimple"
         :label="t('documentDownloadPopover.downloadMarkdown')"
+        :loading="isDownloadingMarkdown"
+        :disabled="isDownloadingMarkdown"
         variant="outline-action"
         class="document-download-popover__body__button"
         @click="downloadMarkdown"

--- a/src/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.vue
+++ b/src/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.vue
@@ -122,17 +122,11 @@ defineExpose({
         :disabled="!hasTextContent"
         @click="downloadTextContent"
       />
-      <!--
-        `loading` only swaps the icon for a spinner in murmur's ButtonIcon, so
-        `disabled` is what actually stops a second click starting a duplicate
-        download while the pages are still being fetched.
-      -->
       <button-icon
         v-if="hasMarkdown"
         :icon-left="IPhDownloadSimple"
         :label="t('documentDownloadPopover.downloadMarkdown')"
         :loading="isDownloadingMarkdown"
-        :disabled="isDownloadingMarkdown"
         variant="outline-action"
         class="document-download-popover__body__button"
         @click="downloadMarkdown"

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -1,6 +1,7 @@
 import { computed, ref, toRef, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { apiInstance as api } from '@/api/apiInstance'
 import { useDocumentDownloadStore, useDocumentStore } from '@/store/modules'
 import settings from '@/utils/settings'
 
@@ -92,6 +93,19 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     availableTranslations.value = await documentDownloadStore.fetchTranslationStatus({ index, id, routing })
   }
 
+  const structureManifest = ref(null)
+
+  const hasMarkdown = computed(() => {
+    const { pages = 0, formats = [] } = structureManifest.value ?? {}
+    return pages > 0 && formats.includes('md')
+  })
+
+  async function fetchMarkdownStatus() {
+    const { index, id, routing } = documentRef.value
+    if (!index || !id) return
+    structureManifest.value = await api.getStructureManifest(index, id, routing)
+  }
+
   async function downloadTranslatedContent() {
     if (!documentRef.value.content) {
       await documentStore.getContent()
@@ -107,18 +121,20 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
   }
 
   async function fetchStatuses() {
-    await Promise.all([fetchDownloadStatus(), fetchTranslationStatus()])
+    await Promise.all([fetchDownloadStatus(), fetchTranslationStatus(), fetchMarkdownStatus()])
   }
 
   if (immediate) {
     watchEffect(fetchDownloadStatus)
     watchEffect(fetchTranslationStatus)
+    watchEffect(fetchMarkdownStatus)
   }
 
   return {
     fetchStatuses,
     fetchDownloadStatus,
     fetchTranslationStatus,
+    fetchMarkdownStatus,
     extensionWarning,
     description,
     showExtensionWarning,
@@ -132,6 +148,8 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     downloadTextContent,
     hasTextContent,
     hasTranslations,
-    downloadTranslatedContent
+    downloadTranslatedContent,
+    structureManifest,
+    hasMarkdown
   }
 }

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -96,46 +96,54 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     availableTranslations.value = await documentDownloadStore.fetchTranslationStatus({ index, id, routing })
   }
 
+  // The manifest carries the id of the document it describes: a component
+  // handed another document (a recycled row, a slow probe resolving after the
+  // user moved on) must not offer the page count of the previous one.
   const structureManifest = ref(null)
 
   const hasMarkdown = computed(() => {
-    const { pages = 0, formats = [] } = structureManifest.value ?? {}
-    return pages > 0 && formats.includes('md')
+    const { documentId, pages = 0, formats = [] } = structureManifest.value ?? {}
+    return documentId === documentRef.value.id && pages > 0 && formats.includes('md')
   })
 
   async function fetchMarkdownStatus() {
     const { index, id, routing } = documentRef.value
-    if (!index || !id) return
-    structureManifest.value = await api.getStructureManifest(index, id, routing)
+    if (!index || !id) {
+      return
+    }
+    const manifest = await api.getStructureManifest(index, id, routing)
+    structureManifest.value = { ...manifest, documentId: id }
   }
 
   const isDownloadingMarkdown = ref(false)
 
   async function downloadMarkdown() {
-    if (!hasMarkdown.value) return
+    if (!hasMarkdown.value || isDownloadingMarkdown.value) {
+      return
+    }
     const { index, id, routing, title } = documentRef.value
     const { pages } = structureManifest.value
-    // No hand-rolled concurrency limit: the browser's per-host connection cap
-    // already throttles these, and a document rarely has more than a few pages.
     const numbers = range(1, pages + 1)
     isDownloadingMarkdown.value = true
     const promise = Promise.all(numbers.map(page => api.getStructurePage(index, id, page, routing)))
+    let contents
     try {
-      const contents = await toastedPromise(promise, { errorMessage: t('documentDownloadPopover.downloadMarkdownError') })
-      const a = window.document.createElement('a')
-      // Blank lines on both sides of the rule: `---` directly under a text line
-      // is a setext heading underline, not a page break.
-      a.href = URL.createObjectURL(new Blob([contents.join('\n\n---\n\n')], { type: 'text/markdown;charset=UTF-8' }))
-      a.download = `${title}.md`
-      a.click()
+      contents = await toastedPromise(promise, { errorMessage: t('documentDownloadPopover.downloadMarkdownError') })
     }
     catch {
       // toastedPromise already reported the error; swallow the rejection so it
       // doesn't escape the template click handler.
+      return
     }
     finally {
       isDownloadingMarkdown.value = false
     }
+    const a = window.document.createElement('a')
+    // Blank lines on both sides of the rule: `---` directly under a text line
+    // is a setext heading underline, not a page break.
+    a.href = URL.createObjectURL(new Blob([contents.join('\n\n---\n\n')], { type: 'text/markdown;charset=UTF-8' }))
+    a.download = `${title}.md`
+    a.click()
   }
 
   async function downloadTranslatedContent() {
@@ -181,7 +189,6 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     hasTextContent,
     hasTranslations,
     downloadTranslatedContent,
-    structureManifest,
     hasMarkdown,
     downloadMarkdown,
     isDownloadingMarkdown

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -123,7 +123,9 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     try {
       const contents = await toastedPromise(promise, { errorMessage: t('documentDownloadPopover.downloadMarkdownError') })
       const a = window.document.createElement('a')
-      a.href = URL.createObjectURL(new Blob([contents.join('\n\n')], { type: 'text/markdown;charset=UTF-8' }))
+      // Blank lines on both sides of the rule: `---` directly under a text line
+      // is a setext heading underline, not a page break.
+      a.href = URL.createObjectURL(new Blob([contents.join('\n\n---\n\n')], { type: 'text/markdown;charset=UTF-8' }))
       a.download = `${title}.md`
       a.click()
     }

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -174,7 +174,6 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     fetchStatuses,
     fetchDownloadStatus,
     fetchTranslationStatus,
-    fetchMarkdownStatus,
     extensionWarning,
     description,
     showExtensionWarning,

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -1,3 +1,4 @@
+import { range } from 'lodash'
 import { computed, ref, toRef, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -106,6 +107,20 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     structureManifest.value = await api.getStructureManifest(index, id, routing)
   }
 
+  async function downloadMarkdown() {
+    if (!hasMarkdown.value) return
+    const { index, id, routing, title } = documentRef.value
+    const { pages } = structureManifest.value
+    // No hand-rolled concurrency limit: the browser's per-host connection cap
+    // already throttles these, and a document rarely has more than a few pages.
+    const numbers = range(1, pages + 1)
+    const contents = await Promise.all(numbers.map(page => api.getStructurePage(index, id, page, routing)))
+    const a = window.document.createElement('a')
+    a.href = URL.createObjectURL(new Blob([contents.join('\n\n')], { type: 'text/markdown;charset=UTF-8' }))
+    a.download = `${title}.md`
+    a.click()
+  }
+
   async function downloadTranslatedContent() {
     if (!documentRef.value.content) {
       await documentStore.getContent()
@@ -150,6 +165,7 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     hasTranslations,
     downloadTranslatedContent,
     structureManifest,
-    hasMarkdown
+    hasMarkdown,
+    downloadMarkdown
   }
 }

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -4,11 +4,13 @@ import { useI18n } from 'vue-i18n'
 
 import { apiInstance as api } from '@/api/apiInstance'
 import { useDocumentDownloadStore, useDocumentStore } from '@/store/modules'
+import { useToast } from '@/composables/useToast'
 import settings from '@/utils/settings'
 
 export function useDocumentDownload(document, { immediate = true } = {}) {
   const documentStore = useDocumentStore()
   const documentDownloadStore = useDocumentDownloadStore()
+  const { toastedPromise } = useToast()
   const { locale, t } = useI18n()
 
   const documentRef = toRef(document)
@@ -114,11 +116,18 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     // No hand-rolled concurrency limit: the browser's per-host connection cap
     // already throttles these, and a document rarely has more than a few pages.
     const numbers = range(1, pages + 1)
-    const contents = await Promise.all(numbers.map(page => api.getStructurePage(index, id, page, routing)))
-    const a = window.document.createElement('a')
-    a.href = URL.createObjectURL(new Blob([contents.join('\n\n')], { type: 'text/markdown;charset=UTF-8' }))
-    a.download = `${title}.md`
-    a.click()
+    const promise = Promise.all(numbers.map(page => api.getStructurePage(index, id, page, routing)))
+    try {
+      const contents = await toastedPromise(promise, { errorMessage: t('documentDownloadPopover.downloadMarkdownError') })
+      const a = window.document.createElement('a')
+      a.href = URL.createObjectURL(new Blob([contents.join('\n\n')], { type: 'text/markdown;charset=UTF-8' }))
+      a.download = `${title}.md`
+      a.click()
+    }
+    catch {
+      // toastedPromise already reported the error; swallow the rejection so it
+      // doesn't escape the template click handler.
+    }
   }
 
   async function downloadTranslatedContent() {

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -1,6 +1,6 @@
 import { computed, ref, toRef, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { range } from 'lodash'
+import range from 'lodash/range'
 
 import { apiInstance as api } from '@/api/apiInstance'
 import { useDocumentDownloadStore, useDocumentStore } from '@/store/modules'

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -1,11 +1,20 @@
-import { range } from 'lodash'
 import { computed, ref, toRef, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { range } from 'lodash'
 
 import { apiInstance as api } from '@/api/apiInstance'
 import { useDocumentDownloadStore, useDocumentStore } from '@/store/modules'
 import { useToast } from '@/composables/useToast'
+import { downloadBlob } from '@/utils/download'
 import settings from '@/utils/settings'
+
+const TEXT_MIME_TYPE = 'text/plain;charset=UTF-8'
+const MARKDOWN_MIME_TYPE = 'text/markdown;charset=UTF-8'
+const MARKDOWN_FORMAT = 'md'
+
+// Blank lines on both sides of the rule: `---` directly under a text line is a
+// setext heading underline, not a page break.
+const MARKDOWN_PAGE_SEPARATOR = '\n\n---\n\n'
 
 export function useDocumentDownload(document, { immediate = true } = {}) {
   const documentStore = useDocumentStore()
@@ -73,15 +82,14 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
   })
 
   async function downloadTextContent() {
-    if (!hasTextContent.value) return
+    if (!hasTextContent.value) {
+      return
+    }
     if (!documentRef.value.content) {
       await documentStore.getContent()
     }
     const { content, title } = documentRef.value
-    const a = window.document.createElement('a')
-    a.href = URL.createObjectURL(new Blob([content], { type: 'text/plain;charset=UTF-8' }))
-    a.download = `${title}.txt`
-    a.click()
+    downloadBlob(content, `${title}.txt`, TEXT_MIME_TYPE)
   }
 
   const availableTranslations = ref([])
@@ -92,7 +100,9 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
 
   async function fetchTranslationStatus() {
     const { index, id, routing } = documentRef.value
-    if (!index || !id) return
+    if (!index || !id) {
+      return
+    }
     availableTranslations.value = await documentDownloadStore.fetchTranslationStatus({ index, id, routing })
   }
 
@@ -103,7 +113,7 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
 
   const hasMarkdown = computed(() => {
     const { documentId, pages = 0, formats = [] } = structureManifest.value ?? {}
-    return documentId === documentRef.value.id && pages > 0 && formats.includes('md')
+    return documentId === documentRef.value.id && pages > 0 && formats.includes(MARKDOWN_FORMAT)
   })
 
   async function fetchMarkdownStatus() {
@@ -138,12 +148,7 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     finally {
       isDownloadingMarkdown.value = false
     }
-    const a = window.document.createElement('a')
-    // Blank lines on both sides of the rule: `---` directly under a text line
-    // is a setext heading underline, not a page break.
-    a.href = URL.createObjectURL(new Blob([contents.join('\n\n---\n\n')], { type: 'text/markdown;charset=UTF-8' }))
-    a.download = `${title}.md`
-    a.click()
+    downloadBlob(contents.join(MARKDOWN_PAGE_SEPARATOR), `${title}.md`, MARKDOWN_MIME_TYPE)
   }
 
   async function downloadTranslatedContent() {
@@ -154,10 +159,7 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     const { translations, title } = documentRef.value
     const targetLanguage = translations[0]?.target_language ?? availableTranslations.value[0]?.target_language
     const translatedContent = documentRef.value.translatedContentIn(targetLanguage)
-    const a = window.document.createElement('a')
-    a.href = URL.createObjectURL(new Blob([translatedContent], { type: 'text/plain;charset=UTF-8' }))
-    a.download = `${title}.txt`
-    a.click()
+    downloadBlob(translatedContent, `${title}.txt`, TEXT_MIME_TYPE)
   }
 
   async function fetchStatuses() {

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -127,28 +127,33 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
 
   const isDownloadingMarkdown = ref(false)
 
+  async function fetchMarkdownPages() {
+    const { index, id, routing } = documentRef.value
+    const { pages } = structureManifest.value
+    const requests = range(1, pages + 1).map(page => api.getStructurePage(index, id, page, routing))
+    const errorMessage = t('documentDownloadPopover.downloadMarkdownError')
+    return toastedPromise(Promise.all(requests), { errorMessage })
+  }
+
   async function downloadMarkdown() {
     if (!hasMarkdown.value || isDownloadingMarkdown.value) {
       return
     }
-    const { index, id, routing, title } = documentRef.value
-    const { pages } = structureManifest.value
-    const numbers = range(1, pages + 1)
+    // Captured before the fetch: the pages belong to the document that was
+    // clicked, so the filename must not follow a later document.
+    const { title } = documentRef.value
     isDownloadingMarkdown.value = true
-    const promise = Promise.all(numbers.map(page => api.getStructurePage(index, id, page, routing)))
-    let contents
     try {
-      contents = await toastedPromise(promise, { errorMessage: t('documentDownloadPopover.downloadMarkdownError') })
+      const pages = await fetchMarkdownPages()
+      downloadBlob(pages.join(MARKDOWN_PAGE_SEPARATOR), `${title}.md`, MARKDOWN_MIME_TYPE)
     }
     catch {
-      // toastedPromise already reported the error; swallow the rejection so it
-      // doesn't escape the template click handler.
-      return
+      // toastedPromise already reported the failure; swallow the rejection so
+      // it doesn't escape the template's click handler.
     }
     finally {
       isDownloadingMarkdown.value = false
     }
-    downloadBlob(contents.join(MARKDOWN_PAGE_SEPARATOR), `${title}.md`, MARKDOWN_MIME_TYPE)
   }
 
   async function downloadTranslatedContent() {

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -109,6 +109,8 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     structureManifest.value = await api.getStructureManifest(index, id, routing)
   }
 
+  const isDownloadingMarkdown = ref(false)
+
   async function downloadMarkdown() {
     if (!hasMarkdown.value) return
     const { index, id, routing, title } = documentRef.value
@@ -116,6 +118,7 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     // No hand-rolled concurrency limit: the browser's per-host connection cap
     // already throttles these, and a document rarely has more than a few pages.
     const numbers = range(1, pages + 1)
+    isDownloadingMarkdown.value = true
     const promise = Promise.all(numbers.map(page => api.getStructurePage(index, id, page, routing)))
     try {
       const contents = await toastedPromise(promise, { errorMessage: t('documentDownloadPopover.downloadMarkdownError') })
@@ -127,6 +130,9 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     catch {
       // toastedPromise already reported the error; swallow the rejection so it
       // doesn't escape the template click handler.
+    }
+    finally {
+      isDownloadingMarkdown.value = false
     }
   }
 
@@ -175,6 +181,7 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     downloadTranslatedContent,
     structureManifest,
     hasMarkdown,
-    downloadMarkdown
+    downloadMarkdown,
+    isDownloadingMarkdown
   }
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -173,6 +173,7 @@
     "downloadWithoutMetadata": "Download without metadata",
     "downloadExtractText": "Download text",
     "downloadMarkdown": "Download markdown",
+    "downloadMarkdownError": "The markdown could not be downloaded.",
     "downloadTranslatedText": "Download text translation",
     "downloadRoot": "Download root",
     "sectionTitle": "What's the document's title?",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -172,6 +172,7 @@
     "download": "Download",
     "downloadWithoutMetadata": "Download without metadata",
     "downloadExtractText": "Download text",
+    "downloadMarkdown": "Download markdown",
     "downloadTranslatedText": "Download text translation",
     "downloadRoot": "Download root",
     "sectionTitle": "What's the document's title?",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -172,6 +172,7 @@
     "download": "Télécharger",
     "downloadWithoutMetadata": "Télécharger sans les métadonnées",
     "downloadExtractText": "Télécharger le texte",
+    "downloadMarkdown": "Télécharger le markdown",
     "downloadTranslatedText": "Télécharger la traduction de texte",
     "downloadRoot": "Télécharger le document à la racine",
     "sectionTitle": "Quel est le titre du document ?",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -173,6 +173,7 @@
     "downloadWithoutMetadata": "Télécharger sans les métadonnées",
     "downloadExtractText": "Télécharger le texte",
     "downloadMarkdown": "Télécharger le markdown",
+    "downloadMarkdownError": "Le markdown n'a pas pu être téléchargé.",
     "downloadTranslatedText": "Télécharger la traduction de texte",
     "downloadRoot": "Télécharger le document à la racine",
     "sectionTitle": "Quel est le titre du document ?",

--- a/src/utils/download.js
+++ b/src/utils/download.js
@@ -1,0 +1,11 @@
+/**
+ * Trigger a browser download of in-memory content under `filename`, with no
+ * round-trip to the server: the content becomes a blob URL that a detached
+ * anchor clicks.
+ */
+export function downloadBlob(content, filename, type) {
+  const anchor = window.document.createElement('a')
+  anchor.href = URL.createObjectURL(new Blob([content], { type }))
+  anchor.download = filename
+  anchor.click()
+}

--- a/src/views/Document/DocumentView/DocumentViewTabs/DocumentViewTabsEntities.vue
+++ b/src/views/Document/DocumentView/DocumentViewTabs/DocumentViewTabsEntities.vue
@@ -9,6 +9,9 @@ import { useDocument } from '@/composables/useDocument'
 import { useWait } from '@/composables/useWait'
 import EntitySection from '@/components/Entity/EntitySection/EntitySection'
 import { useDocumentStore } from '@/store/modules'
+import { downloadBlob } from '@/utils/download'
+
+const CSV_MIME_TYPE = 'text/csv;charset=UTF-8'
 
 const { t } = useI18n()
 const { document } = useDocument()
@@ -43,10 +46,8 @@ const hitsAsCsv = (hits = []) => {
 
 const downloadHitsAsCsv = (hits = [], category) => {
   const content = hitsAsCsv(hits)
-  const a = window.document.createElement('a')
-  a.href = URL.createObjectURL(new Blob([content], { type: 'text/csv;charset=UTF-8' }))
-  a.download = `${documentStore.document.title} - ${category}.csv`
-  a.click()
+  const filename = `${documentStore.document.title} - ${category}.csv`
+  downloadBlob(content, filename, CSV_MIME_TYPE)
 }
 
 const copyHits = (hits = []) => {

--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -1,5 +1,19 @@
 import 'whatwg-fetch'
 
+// jsdom's Blob implementation only exposes `slice`, `size` and `type`; it is
+// missing the standard `text()` method used by tests asserting on blob
+// contents. Polyfill it with `FileReader`, which jsdom does support.
+if (!Blob.prototype.text) {
+  Blob.prototype.text = function () {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => resolve(reader.result)
+      reader.onerror = () => reject(reader.error)
+      reader.readAsText(this)
+    })
+  }
+}
+
 // Node 22+ ships a native `localStorage` that throws on access unless the
 // runtime is launched with `--localstorage-file`. Some sandboxed CI
 // environments hit this at the very first access made by `@vue/devtools-kit`

--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -1,19 +1,5 @@
 import 'whatwg-fetch'
 
-// jsdom's Blob implementation only exposes `slice`, `size` and `type`; it is
-// missing the standard `text()` method used by tests asserting on blob
-// contents. Polyfill it with `FileReader`, which jsdom does support.
-if (!Blob.prototype.text) {
-  Blob.prototype.text = function () {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = () => resolve(reader.result)
-      reader.onerror = () => reject(reader.error)
-      reader.readAsText(this)
-    })
-  }
-}
-
 // Node 22+ ships a native `localStorage` that throws on access unless the
 // runtime is launched with `--localstorage-file`. Some sandboxed CI
 // environments hit this at the very first access made by `@vue/devtools-kit`

--- a/tests/unit/specs/api/index.spec.js
+++ b/tests/unit/specs/api/index.spec.js
@@ -641,4 +641,84 @@ describe('Datashare backend client', () => {
       expect(mockCallback).not.toBeCalled()
     })
   })
+
+  describe('getStructureManifest', () => {
+    it('should send a GET request on the structure artifact url', async () => {
+      axios.request.mockResolvedValue({ status: 200, data: { pages: 2, formats: ['md'] } })
+      await api.getStructureManifest('foo', 'doc-id', 'root-id')
+      expect(axios.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl('/api/foo/artifacts/structure/doc-id'),
+          method: 'GET',
+          params: { routing: 'root-id' },
+          validateStatus: expect.any(Function)
+        })
+      )
+    })
+
+    it('should return the manifest when the backend answers 200', async () => {
+      axios.request.mockResolvedValue({ status: 200, data: { pages: 2, formats: ['md', 'xhtml'] } })
+      const manifest = await api.getStructureManifest('foo', 'doc-id', 'root-id')
+      expect(manifest).toEqual({ pages: 2, formats: ['md', 'xhtml'] })
+    })
+
+    it('should return null when the backend answers 404', async () => {
+      axios.request.mockResolvedValue({ status: 404, data: {} })
+      expect(await api.getStructureManifest('foo', 'doc-id', 'root-id')).toBeNull()
+    })
+
+    it('should return null when the backend answers 403', async () => {
+      axios.request.mockResolvedValue({ status: 403, data: {} })
+      expect(await api.getStructureManifest('foo', 'doc-id', 'root-id')).toBeNull()
+    })
+
+    it('should return null when the backend answers 500', async () => {
+      axios.request.mockResolvedValue({ status: 500, data: {} })
+      expect(await api.getStructureManifest('foo', 'doc-id', 'root-id')).toBeNull()
+    })
+
+    it('should return null when the request fails', async () => {
+      axios.request.mockRejectedValue(new Error('Network Error'))
+      expect(await api.getStructureManifest('foo', 'doc-id', 'root-id')).toBeNull()
+    })
+
+    it('should not emit an http error when the artifact is missing', async () => {
+      axios.request.mockResolvedValue({ status: 404, data: {} })
+      const mockCallback = vi.fn()
+      EventBus.on('http::error', mockCallback)
+      await api.getStructureManifest('foo', 'doc-id', 'root-id')
+      EventBus.off('http::error', mockCallback)
+      expect(mockCallback).not.toBeCalled()
+    })
+
+    it('should return null and emit an http error when the session expired', async () => {
+      axios.request.mockResolvedValue({ status: 401, data: {} })
+      const mockCallback = vi.fn()
+      EventBus.on('http::error', mockCallback)
+      const manifest = await api.getStructureManifest('foo', 'doc-id', 'root-id')
+      EventBus.off('http::error', mockCallback)
+      expect(manifest).toBeNull()
+      expect(mockCallback).toBeCalledTimes(1)
+    })
+  })
+
+  describe('getStructurePage', () => {
+    it('should request a single page as text', async () => {
+      axios.request.mockResolvedValue({ data: '# Page three' })
+      await api.getStructurePage('foo', 'doc-id', 3, 'root-id')
+      expect(axios.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl('/api/foo/artifacts/structure/doc-id/3'),
+          method: 'GET',
+          params: { routing: 'root-id' },
+          responseType: 'text'
+        })
+      )
+    })
+
+    it('should return the page content', async () => {
+      axios.request.mockResolvedValue({ data: '# Page three' })
+      expect(await api.getStructurePage('foo', 'doc-id', 3, 'root-id')).toBe('# Page three')
+    })
+  })
 })

--- a/tests/unit/specs/api/index.spec.js
+++ b/tests/unit/specs/api/index.spec.js
@@ -720,5 +720,16 @@ describe('Datashare backend client', () => {
       axios.request.mockResolvedValue({ data: '# Page three' })
       expect(await api.getStructurePage('foo', 'doc-id', 3, 'root-id')).toBe('# Page three')
     })
+
+    // A download fans out one request per page: pushing each failure onto the
+    // bus would stack one notification per page for a single failed download.
+    it('should not emit an http error when the page request fails', async () => {
+      axios.request.mockRejectedValue(new Error('Network Error'))
+      const mockCallback = vi.fn()
+      EventBus.on('http::error', mockCallback)
+      await expect(api.getStructurePage('foo', 'doc-id', 3, 'root-id')).rejects.toThrow('Network Error')
+      EventBus.off('http::error', mockCallback)
+      expect(mockCallback).not.toBeCalled()
+    })
   })
 })

--- a/tests/unit/specs/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.spec.js
+++ b/tests/unit/specs/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.spec.js
@@ -168,6 +168,24 @@ describe('DocumentDownloadPopover.vue', () => {
     expect(labels).not.toContain('Download markdown')
   })
 
+  it('should put the markdown button in a loading state while the pages are fetched', async () => {
+    apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue({ content_translated: [] })
+    apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
+    apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
+    apiInstance.getStructurePage = vi.fn(() => new Promise(() => {}))
+
+    const wrapper = mountPopover(createDocument({}, 'test-doc-id-markdown-loading'))
+    await flushPromises()
+    const markdownButton = () => wrapper
+      .findAll('.document-download-popover__body__button')
+      .find(btn => btn.attributes('label') === 'Download markdown')
+
+    expect(markdownButton().attributes('loading')).toBe('false')
+    await markdownButton().trigger('click')
+    expect(markdownButton().attributes('loading')).toBe('true')
+    expect(markdownButton().attributes('disabled')).toBe('true')
+  })
+
   it('should trigger a download when the markdown button is clicked', async () => {
     apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue({ content_translated: [] })
     apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)

--- a/tests/unit/specs/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.spec.js
+++ b/tests/unit/specs/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.spec.js
@@ -183,7 +183,6 @@ describe('DocumentDownloadPopover.vue', () => {
     expect(markdownButton().attributes('loading')).toBe('false')
     await markdownButton().trigger('click')
     expect(markdownButton().attributes('loading')).toBe('true')
-    expect(markdownButton().attributes('disabled')).toBe('true')
   })
 
   it('should trigger a download when the markdown button is clicked', async () => {

--- a/tests/unit/specs/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.spec.js
+++ b/tests/unit/specs/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.spec.js
@@ -195,7 +195,9 @@ describe('DocumentDownloadPopover.vue', () => {
     const fakeAnchor = { href: '', download: '', click: vi.fn() }
     const originalCreateElement = window.document.createElement.bind(window.document)
     vi.spyOn(window.document, 'createElement').mockImplementation((tag) => {
-      if (tag === 'a') return fakeAnchor
+      if (tag === 'a') {
+        return fakeAnchor
+      }
       return originalCreateElement(tag)
     })
 

--- a/tests/unit/specs/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.spec.js
+++ b/tests/unit/specs/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.spec.js
@@ -5,6 +5,8 @@ import Document from '@/api/resources/Document'
 import DocumentDownloadPopover from '@/components/Document/DocumentDownloadPopover/DocumentDownloadPopover'
 import { apiInstance } from '@/api/apiInstance'
 
+const MARKDOWN_MANIFEST = Object.freeze({ pages: 1, formats: ['md'] })
+
 describe('DocumentDownloadPopover.vue', () => {
   let core, plugins
 
@@ -149,7 +151,7 @@ describe('DocumentDownloadPopover.vue', () => {
   it('should show the markdown download button when the document has a markdown artifact', async () => {
     apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue({ content_translated: [] })
     apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
-    apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
+    apiInstance.getStructureManifest = vi.fn().mockResolvedValue(MARKDOWN_MANIFEST)
     const wrapper = mountPopover(createDocument({}, 'test-doc-id-with-markdown'))
     await flushPromises()
     const buttons = wrapper.findAll('.document-download-popover__body__button')
@@ -171,7 +173,7 @@ describe('DocumentDownloadPopover.vue', () => {
   it('should put the markdown button in a loading state while the pages are fetched', async () => {
     apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue({ content_translated: [] })
     apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
-    apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
+    apiInstance.getStructureManifest = vi.fn().mockResolvedValue(MARKDOWN_MANIFEST)
     apiInstance.getStructurePage = vi.fn(() => new Promise(() => {}))
 
     const wrapper = mountPopover(createDocument({}, 'test-doc-id-markdown-loading'))
@@ -188,7 +190,7 @@ describe('DocumentDownloadPopover.vue', () => {
   it('should trigger a download when the markdown button is clicked', async () => {
     apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue({ content_translated: [] })
     apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
-    apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
+    apiInstance.getStructureManifest = vi.fn().mockResolvedValue(MARKDOWN_MANIFEST)
     apiInstance.getStructurePage = vi.fn().mockResolvedValue('# Hello')
 
     const fakeAnchor = { href: '', download: '', click: vi.fn() }

--- a/tests/unit/specs/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.spec.js
+++ b/tests/unit/specs/components/Document/DocumentDownloadPopover/DocumentDownloadPopover.spec.js
@@ -13,6 +13,7 @@ describe('DocumentDownloadPopover.vue', () => {
     core.createPinia()
     plugins = core.plugins
     URL.createObjectURL = vi.fn().mockReturnValue('blob:fake-url')
+    apiInstance.getStructureManifest = vi.fn().mockResolvedValue(null)
   })
 
   afterEach(() => {
@@ -143,5 +144,50 @@ describe('DocumentDownloadPopover.vue', () => {
     const buttons = wrapper.findAll('.document-download-popover__body__button')
     const downloadButton = buttons.find(btn => btn.attributes('label') === 'Download')
     expect(downloadButton.attributes('disabled')).toBe('false')
+  })
+
+  it('should show the markdown download button when the document has a markdown artifact', async () => {
+    apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue({ content_translated: [] })
+    apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
+    apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
+    const wrapper = mountPopover(createDocument({}, 'test-doc-id-with-markdown'))
+    await flushPromises()
+    const buttons = wrapper.findAll('.document-download-popover__body__button')
+    const labels = buttons.map(btn => btn.attributes('label'))
+    expect(labels).toContain('Download markdown')
+  })
+
+  it('should not show the markdown download button when the document has no markdown artifact', async () => {
+    apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue({ content_translated: [] })
+    apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
+    apiInstance.getStructureManifest = vi.fn().mockResolvedValue(null)
+    const wrapper = mountPopover(createDocument({}, 'test-doc-id-without-markdown'))
+    await flushPromises()
+    const buttons = wrapper.findAll('.document-download-popover__body__button')
+    const labels = buttons.map(btn => btn.attributes('label'))
+    expect(labels).not.toContain('Download markdown')
+  })
+
+  it('should trigger a download when the markdown button is clicked', async () => {
+    apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue({ content_translated: [] })
+    apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
+    apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
+    apiInstance.getStructurePage = vi.fn().mockResolvedValue('# Hello')
+
+    const fakeAnchor = { href: '', download: '', click: vi.fn() }
+    const originalCreateElement = window.document.createElement.bind(window.document)
+    vi.spyOn(window.document, 'createElement').mockImplementation((tag) => {
+      if (tag === 'a') return fakeAnchor
+      return originalCreateElement(tag)
+    })
+
+    const wrapper = mountPopover(createDocument({}, 'test-doc-id-markdown-click'))
+    await flushPromises()
+    const buttons = wrapper.findAll('.document-download-popover__body__button')
+    const markdownButton = buttons.find(btn => btn.attributes('label') === 'Download markdown')
+    expect(markdownButton.exists()).toBe(true)
+    await markdownButton.trigger('click')
+    await flushPromises()
+    expect(fakeAnchor.click).toHaveBeenCalled()
   })
 })

--- a/tests/unit/specs/composables/useDocumentDownload.spec.js
+++ b/tests/unit/specs/composables/useDocumentDownload.spec.js
@@ -17,11 +17,13 @@ describe('useDocumentDownload composable', () => {
     core.createPinia()
     plugins = core.plugins
     URL.createObjectURL = vi.fn().mockReturnValue('blob:fake-url')
-    apiInstance.getStructureManifest = vi.fn().mockResolvedValue(null)
     // Plain property assignments on the api singleton survive
     // `vi.restoreAllMocks`, so every probe is stubbed here rather than relying
-    // on a stub set by an earlier test to leak into the next one
+    // on a stub set by an earlier test to leak into the next one. Tests that
+    // need another answer than "nothing to download" override their own.
+    apiInstance.getStructureManifest = vi.fn().mockResolvedValue(null)
     apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
+    mockGetSource({ content_translated: [] })
   })
 
   afterEach(() => {
@@ -30,6 +32,18 @@ describe('useDocumentDownload composable', () => {
 
   function mockGetSource(response) {
     apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue(response)
+  }
+
+  function stubAnchor() {
+    const anchor = { href: '', download: '', click: vi.fn() }
+    const originalCreateElement = window.document.createElement.bind(window.document)
+    vi.spyOn(window.document, 'createElement').mockImplementation((tag) => {
+      if (tag === 'a') {
+        return anchor
+      }
+      return originalCreateElement(tag)
+    })
+    return anchor
   }
 
   function mountComposable(document, options) {
@@ -47,8 +61,6 @@ describe('useDocumentDownload composable', () => {
 
   describe('fetchStatuses', () => {
     it('should not fetch download status when immediate is false', async () => {
-      apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
-      mockGetSource({ content_translated: [] })
       const doc = new Document({
         _id: 'doc1',
         _index: 'test-index',
@@ -60,7 +72,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should fetch download status and translations when fetchStatuses is called', async () => {
-      apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
       mockGetSource({ content_translated: [{ target_language: 'ENGLISH' }] })
       const doc = new Document({
         _id: 'doc1',
@@ -79,8 +90,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should not fetch download status when the document has no id', async () => {
-      apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
-      mockGetSource({ content_translated: [] })
       const doc = new Document({ _index: 'test-index', _source: { title: 'test' } })
       const { fetchStatuses } = mountComposable(doc, { immediate: false })
       await fetchStatuses()
@@ -92,7 +101,6 @@ describe('useDocumentDownload composable', () => {
   describe('isDownloadAllowed', () => {
     it('should be true before the status is fetched', async () => {
       apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(false)
-      mockGetSource({ content_translated: [] })
       const doc = new Document({
         _id: 'doc1',
         _index: 'test-index',
@@ -104,7 +112,6 @@ describe('useDocumentDownload composable', () => {
 
     it('should be false once the backend refuses the download', async () => {
       apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(false)
-      mockGetSource({ content_translated: [] })
       const doc = new Document({
         _id: 'doc1',
         _index: 'test-index',
@@ -117,8 +124,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should stay true when the backend allows the download', async () => {
-      apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
-      mockGetSource({ content_translated: [] })
       const doc = new Document({
         _id: 'doc1',
         _index: 'test-index',
@@ -145,7 +150,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should be false when API returns no translations', async () => {
-      mockGetSource({ content_translated: [] })
       const doc = new Document({
         _id: 'doc2',
         _index: 'test-index',
@@ -224,22 +228,18 @@ describe('useDocumentDownload composable', () => {
     }
 
     it('should be false before the manifest is fetched', () => {
-      mockGetSource({ content_translated: [] })
       apiInstance.getStructureManifest = vi.fn(() => new Promise(() => {}))
       const { hasMarkdown } = mountComposable(markdownDocument('md-pending'))
       expect(hasMarkdown.value).toBe(false)
     })
 
     it('should be false when the document has no structure artifact', async () => {
-      mockGetSource({ content_translated: [] })
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue(null)
       const { hasMarkdown } = mountComposable(markdownDocument('md-none'))
       await flushPromises()
       expect(hasMarkdown.value).toBe(false)
     })
 
     it('should be false when the manifest reports zero pages', async () => {
-      mockGetSource({ content_translated: [] })
       apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 0, formats: ['md'] })
       const { hasMarkdown } = mountComposable(markdownDocument('md-empty'))
       await flushPromises()
@@ -247,7 +247,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should be false when markdown is not among the available formats', async () => {
-      mockGetSource({ content_translated: [] })
       apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 3, formats: ['xhtml'] })
       const { hasMarkdown } = mountComposable(markdownDocument('md-xhtml-only'))
       await flushPromises()
@@ -255,7 +254,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should be true when the manifest reports markdown pages', async () => {
-      mockGetSource({ content_translated: [] })
       apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 3, formats: ['md', 'xhtml'] })
       const { hasMarkdown } = mountComposable(markdownDocument('md-available'))
       await flushPromises()
@@ -265,7 +263,6 @@ describe('useDocumentDownload composable', () => {
     // A recycled component keeps its manifest when it is handed another
     // document: the page count of the previous one must never be reused
     it('should be false again when the document changes', async () => {
-      mockGetSource({ content_translated: [] })
       apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 3, formats: ['md'] })
       const document = ref(markdownDocument('md-first'))
       const { hasMarkdown, fetchStatuses } = mountComposable(document, { immediate: false })
@@ -279,8 +276,6 @@ describe('useDocumentDownload composable', () => {
 
   describe('fetchMarkdownStatus', () => {
     it('should not probe the manifest when immediate is false', async () => {
-      mockGetSource({ content_translated: [] })
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue(null)
       const doc = new Document({ _id: 'md-lazy', _index: 'test-index', _source: { title: 'test' } })
       mountComposable(doc, { immediate: false })
       await flushPromises()
@@ -288,7 +283,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should probe the manifest when fetchStatuses is called', async () => {
-      mockGetSource({ content_translated: [] })
       apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
       apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
       const doc = new Document({ _id: 'md-explicit', _index: 'test-index', _source: { title: 'test' } })
@@ -300,8 +294,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should not probe the manifest when the document has no id', async () => {
-      mockGetSource({ content_translated: [] })
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue(null)
       const doc = new Document({ _index: 'test-index', _source: { title: 'test' } })
       const { fetchStatuses } = mountComposable(doc, { immediate: false })
       await fetchStatuses()
@@ -311,18 +303,6 @@ describe('useDocumentDownload composable', () => {
   })
 
   describe('downloadMarkdown', () => {
-    function stubAnchor() {
-      const anchor = { href: '', download: '', click: vi.fn() }
-      const originalCreateElement = window.document.createElement.bind(window.document)
-      vi.spyOn(window.document, 'createElement').mockImplementation((tag) => {
-        if (tag === 'a') {
-          return anchor
-        }
-        return originalCreateElement(tag)
-      })
-      return anchor
-    }
-
     // jsdom's Blob doesn't implement `text()`; read it via FileReader instead.
     function readBlob(blob) {
       return new Promise((resolve, reject) => {
@@ -334,7 +314,6 @@ describe('useDocumentDownload composable', () => {
     }
 
     it('should request every page of the artifact', async () => {
-      mockGetSource({ content_translated: [] })
       apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 3, formats: ['md'] })
       apiInstance.getStructurePage = vi.fn().mockResolvedValue('page')
       stubAnchor()
@@ -349,7 +328,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should join the pages with a horizontal rule', async () => {
-      mockGetSource({ content_translated: [] })
       apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 2, formats: ['md'] })
       apiInstance.getStructurePage = vi.fn((index, id, page) => Promise.resolve(`# Page ${page}`))
       stubAnchor()
@@ -363,7 +341,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should name the file after the document title', async () => {
-      mockGetSource({ content_translated: [] })
       apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
       apiInstance.getStructurePage = vi.fn().mockResolvedValue('# Only page')
       const anchor = stubAnchor()
@@ -376,8 +353,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should do nothing when the document has no markdown', async () => {
-      mockGetSource({ content_translated: [] })
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue(null)
       apiInstance.getStructurePage = vi.fn().mockResolvedValue('# Nope')
       const anchor = stubAnchor()
       const doc = new Document({ _id: 'md-absent', _index: 'test-index', _source: { title: 'test' } })
@@ -389,7 +364,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should resolve without downloading when a page fails to load', async () => {
-      mockGetSource({ content_translated: [] })
       apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 2, formats: ['md'] })
       apiInstance.getStructurePage = vi.fn((index, id, page) => {
         return page === 2 ? Promise.reject(new Error('boom')) : Promise.resolve('# Page 1')
@@ -404,7 +378,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should report an error toast when a page fails to load', async () => {
-      mockGetSource({ content_translated: [] })
       apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
       apiInstance.getStructurePage = vi.fn().mockRejectedValue(new Error('boom'))
       stubAnchor()
@@ -417,7 +390,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should ignore a second call while the pages are still being fetched', async () => {
-      mockGetSource({ content_translated: [] })
       apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
       const resolvers = []
       apiInstance.getStructurePage = vi.fn(() => new Promise(resolve => resolvers.push(resolve)))
@@ -435,20 +407,7 @@ describe('useDocumentDownload composable', () => {
   })
 
   describe('isDownloadingMarkdown', () => {
-    function stubAnchor() {
-      const anchor = { href: '', download: '', click: vi.fn() }
-      const originalCreateElement = window.document.createElement.bind(window.document)
-      vi.spyOn(window.document, 'createElement').mockImplementation((tag) => {
-        if (tag === 'a') {
-          return anchor
-        }
-        return originalCreateElement(tag)
-      })
-      return anchor
-    }
-
     it('should be false before any download starts', async () => {
-      mockGetSource({ content_translated: [] })
       apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
       const doc = new Document({ _id: 'md-idle', _index: 'test-index', _source: { title: 'test' } })
       const { isDownloadingMarkdown } = mountComposable(doc)
@@ -457,7 +416,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should be true while the pages are being fetched', async () => {
-      mockGetSource({ content_translated: [] })
       apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 2, formats: ['md'] })
       // Every page must be resolvable: Promise.all only settles once the last
       // one does, so keeping a single resolver would hang the download.
@@ -476,7 +434,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should be false again once a page fails', async () => {
-      mockGetSource({ content_translated: [] })
       apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
       apiInstance.getStructurePage = vi.fn().mockRejectedValue(new Error('boom'))
       stubAnchor()
@@ -488,8 +445,6 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should stay false when the document has no markdown', async () => {
-      mockGetSource({ content_translated: [] })
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue(null)
       const doc = new Document({ _id: 'md-no-artifact', _index: 'test-index', _source: { title: 'test' } })
       const { downloadMarkdown, isDownloadingMarkdown } = mountComposable(doc)
       await flushPromises()

--- a/tests/unit/specs/composables/useDocumentDownload.spec.js
+++ b/tests/unit/specs/composables/useDocumentDownload.spec.js
@@ -366,5 +366,20 @@ describe('useDocumentDownload composable', () => {
       expect(apiInstance.getStructurePage).not.toHaveBeenCalled()
       expect(anchor.click).not.toHaveBeenCalled()
     })
+
+    it('should resolve without downloading when a page fails to load', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 2, formats: ['md'] })
+      apiInstance.getStructurePage = vi.fn((index, id, page) => {
+        return page === 2 ? Promise.reject(new Error('boom')) : Promise.resolve('# Page 1')
+      })
+      const anchor = stubAnchor()
+      const doc = new Document({ _id: 'md-failing-page', _index: 'test-index', _source: { title: 'test' } })
+      const { downloadMarkdown } = mountComposable(doc)
+      await flushPromises()
+      await expect(downloadMarkdown()).resolves.toBeUndefined()
+      expect(anchor.click).not.toHaveBeenCalled()
+      expect(URL.createObjectURL).not.toHaveBeenCalled()
+    })
   })
 })

--- a/tests/unit/specs/composables/useDocumentDownload.spec.js
+++ b/tests/unit/specs/composables/useDocumentDownload.spec.js
@@ -16,6 +16,7 @@ describe('useDocumentDownload composable', () => {
     core.createPinia()
     plugins = core.plugins
     URL.createObjectURL = vi.fn().mockReturnValue('blob:fake-url')
+    apiInstance.getStructureManifest = vi.fn().mockResolvedValue(null)
   })
 
   afterEach(() => {
@@ -205,6 +206,88 @@ describe('useDocumentDownload composable', () => {
       await downloadTranslatedContent()
 
       expect(getContentSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('hasMarkdown', () => {
+    function markdownDocument(id) {
+      return new Document({
+        _id: id,
+        _index: 'test-index',
+        _source: { title: 'test' }
+      })
+    }
+
+    it('should be false before the manifest is fetched', () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn(() => new Promise(() => {}))
+      const { hasMarkdown } = mountComposable(markdownDocument('md-pending'))
+      expect(hasMarkdown.value).toBe(false)
+    })
+
+    it('should be false when the document has no structure artifact', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue(null)
+      const { hasMarkdown } = mountComposable(markdownDocument('md-none'))
+      await flushPromises()
+      expect(hasMarkdown.value).toBe(false)
+    })
+
+    it('should be false when the manifest reports zero pages', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 0, formats: ['md'] })
+      const { hasMarkdown } = mountComposable(markdownDocument('md-empty'))
+      await flushPromises()
+      expect(hasMarkdown.value).toBe(false)
+    })
+
+    it('should be false when markdown is not among the available formats', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 3, formats: ['xhtml'] })
+      const { hasMarkdown } = mountComposable(markdownDocument('md-xhtml-only'))
+      await flushPromises()
+      expect(hasMarkdown.value).toBe(false)
+    })
+
+    it('should be true when the manifest reports markdown pages', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 3, formats: ['md', 'xhtml'] })
+      const { hasMarkdown } = mountComposable(markdownDocument('md-available'))
+      await flushPromises()
+      expect(hasMarkdown.value).toBe(true)
+    })
+  })
+
+  describe('fetchMarkdownStatus', () => {
+    it('should not probe the manifest when immediate is false', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue(null)
+      const doc = new Document({ _id: 'md-lazy', _index: 'test-index', _source: { title: 'test' } })
+      mountComposable(doc, { immediate: false })
+      await flushPromises()
+      expect(apiInstance.getStructureManifest).not.toHaveBeenCalled()
+    })
+
+    it('should probe the manifest when fetchStatuses is called', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
+      const doc = new Document({ _id: 'md-explicit', _index: 'test-index', _source: { title: 'test' } })
+      const { fetchStatuses, hasMarkdown } = mountComposable(doc, { immediate: false })
+      await fetchStatuses()
+      await flushPromises()
+      expect(apiInstance.getStructureManifest).toHaveBeenCalledWith('test-index', 'md-explicit', 'md-explicit')
+      expect(hasMarkdown.value).toBe(true)
+    })
+
+    it('should not probe the manifest when the document has no id', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue(null)
+      const doc = new Document({ _index: 'test-index', _source: { title: 'test' } })
+      const { fetchStatuses } = mountComposable(doc, { immediate: false })
+      await fetchStatuses()
+      await flushPromises()
+      expect(apiInstance.getStructureManifest).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/unit/specs/composables/useDocumentDownload.spec.js
+++ b/tests/unit/specs/composables/useDocumentDownload.spec.js
@@ -290,4 +290,71 @@ describe('useDocumentDownload composable', () => {
       expect(apiInstance.getStructureManifest).not.toHaveBeenCalled()
     })
   })
+
+  describe('downloadMarkdown', () => {
+    function stubAnchor() {
+      const anchor = { href: '', download: '', click: vi.fn() }
+      const originalCreateElement = window.document.createElement.bind(window.document)
+      vi.spyOn(window.document, 'createElement').mockImplementation((tag) => {
+        if (tag === 'a') return anchor
+        return originalCreateElement(tag)
+      })
+      return anchor
+    }
+
+    it('should request every page of the artifact', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 3, formats: ['md'] })
+      apiInstance.getStructurePage = vi.fn().mockResolvedValue('page')
+      stubAnchor()
+      const doc = new Document({ _id: 'md-pages', _index: 'test-index', _source: { title: 'test' } })
+      const { downloadMarkdown } = mountComposable(doc)
+      await flushPromises()
+      await downloadMarkdown()
+      expect(apiInstance.getStructurePage).toHaveBeenCalledTimes(3)
+      expect(apiInstance.getStructurePage).toHaveBeenCalledWith('test-index', 'md-pages', 1, 'md-pages')
+      expect(apiInstance.getStructurePage).toHaveBeenCalledWith('test-index', 'md-pages', 2, 'md-pages')
+      expect(apiInstance.getStructurePage).toHaveBeenCalledWith('test-index', 'md-pages', 3, 'md-pages')
+    })
+
+    it('should join the pages with a blank line', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 2, formats: ['md'] })
+      apiInstance.getStructurePage = vi.fn((index, id, page) => Promise.resolve(`# Page ${page}`))
+      stubAnchor()
+      const doc = new Document({ _id: 'md-join', _index: 'test-index', _source: { title: 'test' } })
+      const { downloadMarkdown } = mountComposable(doc)
+      await flushPromises()
+      await downloadMarkdown()
+      const [blob] = URL.createObjectURL.mock.calls.at(-1)
+      expect(blob.type).toBe('text/markdown;charset=utf-8')
+      await expect(blob.text()).resolves.toBe('# Page 1\n\n# Page 2')
+    })
+
+    it('should name the file after the document title', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
+      apiInstance.getStructurePage = vi.fn().mockResolvedValue('# Only page')
+      const anchor = stubAnchor()
+      const doc = new Document({ _id: 'md-name', _index: 'test-index', _source: { title: 'my-doc' } })
+      const { downloadMarkdown } = mountComposable(doc)
+      await flushPromises()
+      await downloadMarkdown()
+      expect(anchor.download).toBe('my-doc.md')
+      expect(anchor.click).toHaveBeenCalled()
+    })
+
+    it('should do nothing when the document has no markdown', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue(null)
+      apiInstance.getStructurePage = vi.fn().mockResolvedValue('# Nope')
+      const anchor = stubAnchor()
+      const doc = new Document({ _id: 'md-absent', _index: 'test-index', _source: { title: 'test' } })
+      const { downloadMarkdown } = mountComposable(doc)
+      await flushPromises()
+      await downloadMarkdown()
+      expect(apiInstance.getStructurePage).not.toHaveBeenCalled()
+      expect(anchor.click).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/tests/unit/specs/composables/useDocumentDownload.spec.js
+++ b/tests/unit/specs/composables/useDocumentDownload.spec.js
@@ -302,6 +302,16 @@ describe('useDocumentDownload composable', () => {
       return anchor
     }
 
+    // jsdom's Blob doesn't implement `text()`; read it via FileReader instead.
+    function readBlob(blob) {
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader()
+        reader.onload = () => resolve(reader.result)
+        reader.onerror = () => reject(reader.error)
+        reader.readAsText(blob)
+      })
+    }
+
     it('should request every page of the artifact', async () => {
       mockGetSource({ content_translated: [] })
       apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 3, formats: ['md'] })
@@ -328,7 +338,7 @@ describe('useDocumentDownload composable', () => {
       await downloadMarkdown()
       const [blob] = URL.createObjectURL.mock.calls.at(-1)
       expect(blob.type).toBe('text/markdown;charset=utf-8')
-      await expect(blob.text()).resolves.toBe('# Page 1\n\n# Page 2')
+      await expect(readBlob(blob)).resolves.toBe('# Page 1\n\n# Page 2')
     })
 
     it('should name the file after the document title', async () => {

--- a/tests/unit/specs/composables/useDocumentDownload.spec.js
+++ b/tests/unit/specs/composables/useDocumentDownload.spec.js
@@ -1,3 +1,4 @@
+import { ref } from 'vue'
 import { mount, flushPromises } from '@vue/test-utils'
 
 import { useDocumentDownload } from '@/composables/useDocumentDownload'
@@ -7,7 +8,7 @@ import CoreSetup from '~tests/unit/CoreSetup'
 import { apiInstance } from '@/api/apiInstance'
 
 describe('useDocumentDownload composable', () => {
-  let core, plugins
+  let core, plugins, wrapper
 
   beforeEach(() => {
     core = CoreSetup.init().useAll()
@@ -17,6 +18,10 @@ describe('useDocumentDownload composable', () => {
     plugins = core.plugins
     URL.createObjectURL = vi.fn().mockReturnValue('blob:fake-url')
     apiInstance.getStructureManifest = vi.fn().mockResolvedValue(null)
+    // Plain property assignments on the api singleton survive
+    // `vi.restoreAllMocks`, so every probe is stubbed here rather than relying
+    // on a stub set by an earlier test to leak into the next one
+    apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
   })
 
   afterEach(() => {
@@ -36,7 +41,7 @@ describe('useDocumentDownload composable', () => {
       },
       template: '<div></div>'
     }
-    mount(TestComponent, { global: { plugins } })
+    wrapper = mount(TestComponent, { global: { plugins } })
     return result
   }
 
@@ -256,6 +261,20 @@ describe('useDocumentDownload composable', () => {
       await flushPromises()
       expect(hasMarkdown.value).toBe(true)
     })
+
+    // A recycled component keeps its manifest when it is handed another
+    // document: the page count of the previous one must never be reused
+    it('should be false again when the document changes', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 3, formats: ['md'] })
+      const document = ref(markdownDocument('md-first'))
+      const { hasMarkdown, fetchStatuses } = mountComposable(document, { immediate: false })
+      await fetchStatuses()
+      await flushPromises()
+      expect(hasMarkdown.value).toBe(true)
+      document.value = markdownDocument('md-second')
+      expect(hasMarkdown.value).toBe(false)
+    })
   })
 
   describe('fetchMarkdownStatus', () => {
@@ -296,7 +315,9 @@ describe('useDocumentDownload composable', () => {
       const anchor = { href: '', download: '', click: vi.fn() }
       const originalCreateElement = window.document.createElement.bind(window.document)
       vi.spyOn(window.document, 'createElement').mockImplementation((tag) => {
-        if (tag === 'a') return anchor
+        if (tag === 'a') {
+          return anchor
+        }
         return originalCreateElement(tag)
       })
       return anchor
@@ -381,6 +402,36 @@ describe('useDocumentDownload composable', () => {
       expect(anchor.click).not.toHaveBeenCalled()
       expect(URL.createObjectURL).not.toHaveBeenCalled()
     })
+
+    it('should report an error toast when a page fails to load', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
+      apiInstance.getStructurePage = vi.fn().mockRejectedValue(new Error('boom'))
+      stubAnchor()
+      const doc = new Document({ _id: 'md-toasted-page', _index: 'test-index', _source: { title: 'test' } })
+      const { downloadMarkdown } = mountComposable(doc)
+      await flushPromises()
+      const toastError = vi.spyOn(wrapper.vm.$toast, 'error')
+      await downloadMarkdown()
+      expect(toastError).toHaveBeenCalledWith('The markdown could not be downloaded.')
+    })
+
+    it('should ignore a second call while the pages are still being fetched', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
+      const resolvers = []
+      apiInstance.getStructurePage = vi.fn(() => new Promise(resolve => resolvers.push(resolve)))
+      const anchor = stubAnchor()
+      const doc = new Document({ _id: 'md-double-click', _index: 'test-index', _source: { title: 'test' } })
+      const { downloadMarkdown } = mountComposable(doc)
+      await flushPromises()
+      const pending = downloadMarkdown()
+      await downloadMarkdown()
+      expect(apiInstance.getStructurePage).toHaveBeenCalledTimes(1)
+      resolvers.forEach(resolve => resolve('# Page'))
+      await pending
+      expect(anchor.click).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('isDownloadingMarkdown', () => {
@@ -388,7 +439,9 @@ describe('useDocumentDownload composable', () => {
       const anchor = { href: '', download: '', click: vi.fn() }
       const originalCreateElement = window.document.createElement.bind(window.document)
       vi.spyOn(window.document, 'createElement').mockImplementation((tag) => {
-        if (tag === 'a') return anchor
+        if (tag === 'a') {
+          return anchor
+        }
         return originalCreateElement(tag)
       })
       return anchor

--- a/tests/unit/specs/composables/useDocumentDownload.spec.js
+++ b/tests/unit/specs/composables/useDocumentDownload.spec.js
@@ -7,6 +7,35 @@ import Document from '@/api/resources/Document'
 import CoreSetup from '~tests/unit/CoreSetup'
 import { apiInstance } from '@/api/apiInstance'
 
+const FORMAT = Object.freeze({
+  MARKDOWN: 'md',
+  XHTML: 'xhtml'
+})
+
+// One id per case, so a failing assertion names the scenario it came from
+const DOCUMENT_ID = Object.freeze({
+  PENDING_MANIFEST: 'md-pending',
+  NO_ARTIFACT: 'md-none',
+  EMPTY_MANIFEST: 'md-empty',
+  XHTML_ONLY: 'md-xhtml-only',
+  AVAILABLE: 'md-available',
+  BEFORE_CHANGE: 'md-first',
+  AFTER_CHANGE: 'md-second',
+  LAZY_PROBE: 'md-lazy',
+  EXPLICIT_PROBE: 'md-explicit',
+  EVERY_PAGE: 'md-pages',
+  JOINED_PAGES: 'md-join',
+  NAMED_FILE: 'md-name',
+  WITHOUT_MARKDOWN: 'md-absent',
+  FAILING_PAGE: 'md-failing-page',
+  TOASTED_PAGE: 'md-toasted-page',
+  DOUBLE_CLICK: 'md-double-click',
+  IDLE: 'md-idle',
+  DOWNLOADING: 'md-pending-download',
+  FAILED_DOWNLOAD: 'md-failed-download',
+  NO_ARTIFACT_DOWNLOAD: 'md-no-artifact'
+})
+
 describe('useDocumentDownload composable', () => {
   let core, plugins, wrapper
 
@@ -32,6 +61,10 @@ describe('useDocumentDownload composable', () => {
 
   function mockGetSource(response) {
     apiInstance.elasticsearch.getSource = vi.fn().mockResolvedValue(response)
+  }
+
+  function mockStructureManifest(pages, formats = [FORMAT.MARKDOWN]) {
+    apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages, formats })
   }
 
   function stubAnchor() {
@@ -229,33 +262,33 @@ describe('useDocumentDownload composable', () => {
 
     it('should be false before the manifest is fetched', () => {
       apiInstance.getStructureManifest = vi.fn(() => new Promise(() => {}))
-      const { hasMarkdown } = mountComposable(markdownDocument('md-pending'))
+      const { hasMarkdown } = mountComposable(markdownDocument(DOCUMENT_ID.PENDING_MANIFEST))
       expect(hasMarkdown.value).toBe(false)
     })
 
     it('should be false when the document has no structure artifact', async () => {
-      const { hasMarkdown } = mountComposable(markdownDocument('md-none'))
+      const { hasMarkdown } = mountComposable(markdownDocument(DOCUMENT_ID.NO_ARTIFACT))
       await flushPromises()
       expect(hasMarkdown.value).toBe(false)
     })
 
     it('should be false when the manifest reports zero pages', async () => {
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 0, formats: ['md'] })
-      const { hasMarkdown } = mountComposable(markdownDocument('md-empty'))
+      mockStructureManifest(0)
+      const { hasMarkdown } = mountComposable(markdownDocument(DOCUMENT_ID.EMPTY_MANIFEST))
       await flushPromises()
       expect(hasMarkdown.value).toBe(false)
     })
 
     it('should be false when markdown is not among the available formats', async () => {
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 3, formats: ['xhtml'] })
-      const { hasMarkdown } = mountComposable(markdownDocument('md-xhtml-only'))
+      mockStructureManifest(3, [FORMAT.XHTML])
+      const { hasMarkdown } = mountComposable(markdownDocument(DOCUMENT_ID.XHTML_ONLY))
       await flushPromises()
       expect(hasMarkdown.value).toBe(false)
     })
 
     it('should be true when the manifest reports markdown pages', async () => {
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 3, formats: ['md', 'xhtml'] })
-      const { hasMarkdown } = mountComposable(markdownDocument('md-available'))
+      mockStructureManifest(3, [FORMAT.MARKDOWN, FORMAT.XHTML])
+      const { hasMarkdown } = mountComposable(markdownDocument(DOCUMENT_ID.AVAILABLE))
       await flushPromises()
       expect(hasMarkdown.value).toBe(true)
     })
@@ -263,20 +296,20 @@ describe('useDocumentDownload composable', () => {
     // A recycled component keeps its manifest when it is handed another
     // document: the page count of the previous one must never be reused
     it('should be false again when the document changes', async () => {
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 3, formats: ['md'] })
-      const document = ref(markdownDocument('md-first'))
+      mockStructureManifest(3)
+      const document = ref(markdownDocument(DOCUMENT_ID.BEFORE_CHANGE))
       const { hasMarkdown, fetchStatuses } = mountComposable(document, { immediate: false })
       await fetchStatuses()
       await flushPromises()
       expect(hasMarkdown.value).toBe(true)
-      document.value = markdownDocument('md-second')
+      document.value = markdownDocument(DOCUMENT_ID.AFTER_CHANGE)
       expect(hasMarkdown.value).toBe(false)
     })
   })
 
   describe('fetchMarkdownStatus', () => {
     it('should not probe the manifest when immediate is false', async () => {
-      const doc = new Document({ _id: 'md-lazy', _index: 'test-index', _source: { title: 'test' } })
+      const doc = new Document({ _id: DOCUMENT_ID.LAZY_PROBE, _index: 'test-index', _source: { title: 'test' } })
       mountComposable(doc, { immediate: false })
       await flushPromises()
       expect(apiInstance.getStructureManifest).not.toHaveBeenCalled()
@@ -284,12 +317,13 @@ describe('useDocumentDownload composable', () => {
 
     it('should probe the manifest when fetchStatuses is called', async () => {
       apiInstance.isDocumentDownloadable = vi.fn().mockResolvedValue(true)
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
-      const doc = new Document({ _id: 'md-explicit', _index: 'test-index', _source: { title: 'test' } })
+      mockStructureManifest(1)
+      const id = DOCUMENT_ID.EXPLICIT_PROBE
+      const doc = new Document({ _id: id, _index: 'test-index', _source: { title: 'test' } })
       const { fetchStatuses, hasMarkdown } = mountComposable(doc, { immediate: false })
       await fetchStatuses()
       await flushPromises()
-      expect(apiInstance.getStructureManifest).toHaveBeenCalledWith('test-index', 'md-explicit', 'md-explicit')
+      expect(apiInstance.getStructureManifest).toHaveBeenCalledWith('test-index', id, id)
       expect(hasMarkdown.value).toBe(true)
     })
 
@@ -314,24 +348,25 @@ describe('useDocumentDownload composable', () => {
     }
 
     it('should request every page of the artifact', async () => {
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 3, formats: ['md'] })
+      mockStructureManifest(3)
       apiInstance.getStructurePage = vi.fn().mockResolvedValue('page')
       stubAnchor()
-      const doc = new Document({ _id: 'md-pages', _index: 'test-index', _source: { title: 'test' } })
+      const id = DOCUMENT_ID.EVERY_PAGE
+      const doc = new Document({ _id: id, _index: 'test-index', _source: { title: 'test' } })
       const { downloadMarkdown } = mountComposable(doc)
       await flushPromises()
       await downloadMarkdown()
       expect(apiInstance.getStructurePage).toHaveBeenCalledTimes(3)
-      expect(apiInstance.getStructurePage).toHaveBeenCalledWith('test-index', 'md-pages', 1, 'md-pages')
-      expect(apiInstance.getStructurePage).toHaveBeenCalledWith('test-index', 'md-pages', 2, 'md-pages')
-      expect(apiInstance.getStructurePage).toHaveBeenCalledWith('test-index', 'md-pages', 3, 'md-pages')
+      expect(apiInstance.getStructurePage).toHaveBeenCalledWith('test-index', id, 1, id)
+      expect(apiInstance.getStructurePage).toHaveBeenCalledWith('test-index', id, 2, id)
+      expect(apiInstance.getStructurePage).toHaveBeenCalledWith('test-index', id, 3, id)
     })
 
     it('should join the pages with a horizontal rule', async () => {
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 2, formats: ['md'] })
+      mockStructureManifest(2)
       apiInstance.getStructurePage = vi.fn((index, id, page) => Promise.resolve(`# Page ${page}`))
       stubAnchor()
-      const doc = new Document({ _id: 'md-join', _index: 'test-index', _source: { title: 'test' } })
+      const doc = new Document({ _id: DOCUMENT_ID.JOINED_PAGES, _index: 'test-index', _source: { title: 'test' } })
       const { downloadMarkdown } = mountComposable(doc)
       await flushPromises()
       await downloadMarkdown()
@@ -341,10 +376,10 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should name the file after the document title', async () => {
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
+      mockStructureManifest(1)
       apiInstance.getStructurePage = vi.fn().mockResolvedValue('# Only page')
       const anchor = stubAnchor()
-      const doc = new Document({ _id: 'md-name', _index: 'test-index', _source: { title: 'my-doc' } })
+      const doc = new Document({ _id: DOCUMENT_ID.NAMED_FILE, _index: 'test-index', _source: { title: 'my-doc' } })
       const { downloadMarkdown } = mountComposable(doc)
       await flushPromises()
       await downloadMarkdown()
@@ -355,7 +390,7 @@ describe('useDocumentDownload composable', () => {
     it('should do nothing when the document has no markdown', async () => {
       apiInstance.getStructurePage = vi.fn().mockResolvedValue('# Nope')
       const anchor = stubAnchor()
-      const doc = new Document({ _id: 'md-absent', _index: 'test-index', _source: { title: 'test' } })
+      const doc = new Document({ _id: DOCUMENT_ID.WITHOUT_MARKDOWN, _index: 'test-index', _source: { title: 'test' } })
       const { downloadMarkdown } = mountComposable(doc)
       await flushPromises()
       await downloadMarkdown()
@@ -364,12 +399,12 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should resolve without downloading when a page fails to load', async () => {
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 2, formats: ['md'] })
+      mockStructureManifest(2)
       apiInstance.getStructurePage = vi.fn((index, id, page) => {
         return page === 2 ? Promise.reject(new Error('boom')) : Promise.resolve('# Page 1')
       })
       const anchor = stubAnchor()
-      const doc = new Document({ _id: 'md-failing-page', _index: 'test-index', _source: { title: 'test' } })
+      const doc = new Document({ _id: DOCUMENT_ID.FAILING_PAGE, _index: 'test-index', _source: { title: 'test' } })
       const { downloadMarkdown } = mountComposable(doc)
       await flushPromises()
       await expect(downloadMarkdown()).resolves.toBeUndefined()
@@ -378,10 +413,10 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should report an error toast when a page fails to load', async () => {
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
+      mockStructureManifest(1)
       apiInstance.getStructurePage = vi.fn().mockRejectedValue(new Error('boom'))
       stubAnchor()
-      const doc = new Document({ _id: 'md-toasted-page', _index: 'test-index', _source: { title: 'test' } })
+      const doc = new Document({ _id: DOCUMENT_ID.TOASTED_PAGE, _index: 'test-index', _source: { title: 'test' } })
       const { downloadMarkdown } = mountComposable(doc)
       await flushPromises()
       const toastError = vi.spyOn(wrapper.vm.$toast, 'error')
@@ -390,11 +425,11 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should ignore a second call while the pages are still being fetched', async () => {
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
+      mockStructureManifest(1)
       const resolvers = []
       apiInstance.getStructurePage = vi.fn(() => new Promise(resolve => resolvers.push(resolve)))
       const anchor = stubAnchor()
-      const doc = new Document({ _id: 'md-double-click', _index: 'test-index', _source: { title: 'test' } })
+      const doc = new Document({ _id: DOCUMENT_ID.DOUBLE_CLICK, _index: 'test-index', _source: { title: 'test' } })
       const { downloadMarkdown } = mountComposable(doc)
       await flushPromises()
       const pending = downloadMarkdown()
@@ -408,21 +443,21 @@ describe('useDocumentDownload composable', () => {
 
   describe('isDownloadingMarkdown', () => {
     it('should be false before any download starts', async () => {
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
-      const doc = new Document({ _id: 'md-idle', _index: 'test-index', _source: { title: 'test' } })
+      mockStructureManifest(1)
+      const doc = new Document({ _id: DOCUMENT_ID.IDLE, _index: 'test-index', _source: { title: 'test' } })
       const { isDownloadingMarkdown } = mountComposable(doc)
       await flushPromises()
       expect(isDownloadingMarkdown.value).toBe(false)
     })
 
     it('should be true while the pages are being fetched', async () => {
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 2, formats: ['md'] })
+      mockStructureManifest(2)
       // Every page must be resolvable: Promise.all only settles once the last
       // one does, so keeping a single resolver would hang the download.
       const resolvers = []
       apiInstance.getStructurePage = vi.fn(() => new Promise(resolve => resolvers.push(resolve)))
       stubAnchor()
-      const doc = new Document({ _id: 'md-pending-download', _index: 'test-index', _source: { title: 'test' } })
+      const doc = new Document({ _id: DOCUMENT_ID.DOWNLOADING, _index: 'test-index', _source: { title: 'test' } })
       const { downloadMarkdown, isDownloadingMarkdown } = mountComposable(doc)
       await flushPromises()
       const pending = downloadMarkdown()
@@ -434,10 +469,10 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should be false again once a page fails', async () => {
-      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
+      mockStructureManifest(1)
       apiInstance.getStructurePage = vi.fn().mockRejectedValue(new Error('boom'))
       stubAnchor()
-      const doc = new Document({ _id: 'md-failed-download', _index: 'test-index', _source: { title: 'test' } })
+      const doc = new Document({ _id: DOCUMENT_ID.FAILED_DOWNLOAD, _index: 'test-index', _source: { title: 'test' } })
       const { downloadMarkdown, isDownloadingMarkdown } = mountComposable(doc)
       await flushPromises()
       await downloadMarkdown()
@@ -445,7 +480,8 @@ describe('useDocumentDownload composable', () => {
     })
 
     it('should stay false when the document has no markdown', async () => {
-      const doc = new Document({ _id: 'md-no-artifact', _index: 'test-index', _source: { title: 'test' } })
+      const { NO_ARTIFACT_DOWNLOAD } = DOCUMENT_ID
+      const doc = new Document({ _id: NO_ARTIFACT_DOWNLOAD, _index: 'test-index', _source: { title: 'test' } })
       const { downloadMarkdown, isDownloadingMarkdown } = mountComposable(doc)
       await flushPromises()
       await downloadMarkdown()

--- a/tests/unit/specs/composables/useDocumentDownload.spec.js
+++ b/tests/unit/specs/composables/useDocumentDownload.spec.js
@@ -382,4 +382,66 @@ describe('useDocumentDownload composable', () => {
       expect(URL.createObjectURL).not.toHaveBeenCalled()
     })
   })
+
+  describe('isDownloadingMarkdown', () => {
+    function stubAnchor() {
+      const anchor = { href: '', download: '', click: vi.fn() }
+      const originalCreateElement = window.document.createElement.bind(window.document)
+      vi.spyOn(window.document, 'createElement').mockImplementation((tag) => {
+        if (tag === 'a') return anchor
+        return originalCreateElement(tag)
+      })
+      return anchor
+    }
+
+    it('should be false before any download starts', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
+      const doc = new Document({ _id: 'md-idle', _index: 'test-index', _source: { title: 'test' } })
+      const { isDownloadingMarkdown } = mountComposable(doc)
+      await flushPromises()
+      expect(isDownloadingMarkdown.value).toBe(false)
+    })
+
+    it('should be true while the pages are being fetched', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 2, formats: ['md'] })
+      // Every page must be resolvable: Promise.all only settles once the last
+      // one does, so keeping a single resolver would hang the download.
+      const resolvers = []
+      apiInstance.getStructurePage = vi.fn(() => new Promise(resolve => resolvers.push(resolve)))
+      stubAnchor()
+      const doc = new Document({ _id: 'md-pending-download', _index: 'test-index', _source: { title: 'test' } })
+      const { downloadMarkdown, isDownloadingMarkdown } = mountComposable(doc)
+      await flushPromises()
+      const pending = downloadMarkdown()
+      await flushPromises()
+      expect(isDownloadingMarkdown.value).toBe(true)
+      resolvers.forEach(resolve => resolve('# Page'))
+      await pending
+      expect(isDownloadingMarkdown.value).toBe(false)
+    })
+
+    it('should be false again once a page fails', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 1, formats: ['md'] })
+      apiInstance.getStructurePage = vi.fn().mockRejectedValue(new Error('boom'))
+      stubAnchor()
+      const doc = new Document({ _id: 'md-failed-download', _index: 'test-index', _source: { title: 'test' } })
+      const { downloadMarkdown, isDownloadingMarkdown } = mountComposable(doc)
+      await flushPromises()
+      await downloadMarkdown()
+      expect(isDownloadingMarkdown.value).toBe(false)
+    })
+
+    it('should stay false when the document has no markdown', async () => {
+      mockGetSource({ content_translated: [] })
+      apiInstance.getStructureManifest = vi.fn().mockResolvedValue(null)
+      const doc = new Document({ _id: 'md-no-artifact', _index: 'test-index', _source: { title: 'test' } })
+      const { downloadMarkdown, isDownloadingMarkdown } = mountComposable(doc)
+      await flushPromises()
+      await downloadMarkdown()
+      expect(isDownloadingMarkdown.value).toBe(false)
+    })
+  })
 })

--- a/tests/unit/specs/composables/useDocumentDownload.spec.js
+++ b/tests/unit/specs/composables/useDocumentDownload.spec.js
@@ -327,7 +327,7 @@ describe('useDocumentDownload composable', () => {
       expect(apiInstance.getStructurePage).toHaveBeenCalledWith('test-index', 'md-pages', 3, 'md-pages')
     })
 
-    it('should join the pages with a blank line', async () => {
+    it('should join the pages with a horizontal rule', async () => {
       mockGetSource({ content_translated: [] })
       apiInstance.getStructureManifest = vi.fn().mockResolvedValue({ pages: 2, formats: ['md'] })
       apiInstance.getStructurePage = vi.fn((index, id, page) => Promise.resolve(`# Page ${page}`))
@@ -338,7 +338,7 @@ describe('useDocumentDownload composable', () => {
       await downloadMarkdown()
       const [blob] = URL.createObjectURL.mock.calls.at(-1)
       expect(blob.type).toBe('text/markdown;charset=utf-8')
-      await expect(readBlob(blob)).resolves.toBe('# Page 1\n\n# Page 2')
+      await expect(readBlob(blob)).resolves.toBe('# Page 1\n\n---\n\n# Page 2')
     })
 
     it('should name the file after the document title', async () => {


### PR DESCRIPTION
Adds a "Download markdown" button to the document download popover, for documents that have a Markdown structure artifact. The button only appears when the artifact's manifest advertises Markdown pages; clicking it fetches every page, joins them with a horizontal rule and saves a single `.md` file. Closes icij/datashare#2192.

- feat(api): read the structure artifact manifest and pages, bypassing `sendAction` so a 404 (no artifact, the common case) doesn't toast an error
- feat(document): detect a document's markdown artifact and expose `hasMarkdown` / `downloadMarkdown` / `isDownloadingMarkdown` from `useDocumentDownload`
- feat(document): add the markdown download button to the download popover, with a loading state while the pages are fetched
- fix(document): guard the download against a stale manifest (recycled row, late probe) and against repeat clicks
- fix(document): report a failed download once via a toast instead of failing silently or once per page
- refactor(document): share a `downloadBlob` helper instead of repeating the detached-anchor click in three places

> [!IMPORTANT]
> Depends on https://github.com/ICIJ/datashare/pull/2306, which must be merged first.
