### PR TITLE
spike: replace elasticsearch-browser with a thin axios client

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "d3-time": "^3.1.0",
     "d3-time-format": "^4.1.0",
     "dayjs": "^1.11.19",
-    "elasticsearch-browser": "16.7.1",
     "fuse.js": "^7.1.0",
     "human-id": "^4.1.3",
     "image-js": "^1.3.0",
@@ -88,6 +87,7 @@
   "devDependencies": {
     "@icij/eslint-config": "^3.0.3",
     "@iconify-json/ph": "^1.2.2",
+    "elasticsearch-browser": "16.7.1",
     "@storybook/addon-docs": "^10.1.11",
     "@storybook/addon-links": "^10.1.11",
     "@storybook/addon-themes": "^10.1.11",

--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -3,7 +3,7 @@ import replace from 'lodash/replace'
 import bodybuilder from 'bodybuilder'
 import { getCookie } from 'tiny-cookie'
 
-import { Client } from '@/api/elasticsearchClient'
+import { Client, Transport } from '@/api/elasticsearchClient'
 
 import { getPairedDimensions } from '@/store/filters/pairedDimensions'
 import { EventBus } from '@/utils/eventBus'
@@ -682,9 +682,11 @@ export function csrfPlugin(Client, config, components) {
   }
 }
 
+datasharePlugin(Client)
+csrfPlugin(Client, {}, { Transport })
+
 const elasticsearch = new Client({
   host: import.meta.env.VITE_ES_HOST || `${window.location.hostname}:${window.location.port}/api/index/search`,
-  plugins: [datasharePlugin, csrfPlugin],
   requestTimeout: settings.elasticsearch.requestTimeout
 })
 

--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -666,6 +666,9 @@ export function datasharePlugin(Client) {
  * Plugin that injects the CSRF token from the `_ds_csrf_token` cookie
  * as an `X-DS-CSRF-TOKEN` header on every Elasticsearch request.
  *
+ * apiInstance's axios.defaults.xsrf* already does this, but only for
+ * same-origin requests; keeps a cross-origin VITE_ES_HOST in dev covered too.
+ *
  * @param {Object} Client - The Elasticsearch client constructor
  * @param {Object} config - Plugin configuration (not used)
  * @param {Object} components - Elasticsearch client components

--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -1,8 +1,9 @@
 import isEqual from 'lodash/isEqual'
 import replace from 'lodash/replace'
 import bodybuilder from 'bodybuilder'
-import es from 'elasticsearch-browser'
 import { getCookie } from 'tiny-cookie'
+
+import { Client } from '@/api/elasticsearchClient'
 
 import { getPairedDimensions } from '@/store/filters/pairedDimensions'
 import { EventBus } from '@/utils/eventBus'
@@ -681,7 +682,7 @@ export function csrfPlugin(Client, config, components) {
   }
 }
 
-const elasticsearch = new es.Client({
+const elasticsearch = new Client({
   host: import.meta.env.VITE_ES_HOST || `${window.location.hostname}:${window.location.port}/api/index/search`,
   plugins: [datasharePlugin, csrfPlugin],
   requestTimeout: settings.elasticsearch.requestTimeout

--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -56,16 +56,6 @@ function normalizeQuery(query) {
 }
 
 /**
- * Drops keys whose value is undefined so the query string omits them rather
- * than serializing them as empty (the bundled client stringifies undefined as '').
- * @param {Object} params
- * @returns {Object}
- */
-function compactQuery(params) {
-  return Object.fromEntries(Object.entries(params).filter(([, value]) => value !== undefined))
-}
-
-/**
  * Emits an error event and re-throws the error.
  * @param {Error} error - The error to handle
  */
@@ -266,7 +256,7 @@ export function datasharePlugin(Client) {
     const request = this.transport.request({
       method: 'POST',
       path: `/${index}/_async_search`,
-      query: compactQuery({ wait_for_completion_timeout: waitForCompletionTimeout, keep_alive: keepAlive }),
+      query: { wait_for_completion_timeout: waitForCompletionTimeout, keep_alive: keepAlive },
       body
     })
     return abortableSearchRequest(request, signal)
@@ -284,7 +274,7 @@ export function datasharePlugin(Client) {
     const request = this.transport.request({
       method: 'GET',
       path: `/_async_search/${encodeURIComponent(id)}`,
-      query: compactQuery({ wait_for_completion_timeout: waitForCompletionTimeout })
+      query: { wait_for_completion_timeout: waitForCompletionTimeout }
     })
     return abortableSearchRequest(request, signal)
   }

--- a/src/api/elasticsearchClient.js
+++ b/src/api/elasticsearchClient.js
@@ -64,7 +64,7 @@ async function requestWithRetries(config, attemptsLeft) {
  * patches (`Transport.prototype.request`) to inject a header on every call.
  */
 export class Transport {
-  constructor({ host, requestTimeout, maxRetries = DEFAULT_MAX_RETRIES } = {}) {
+  constructor({ host, requestTimeout = 30000, maxRetries = DEFAULT_MAX_RETRIES } = {}) {
     this.baseURL = /^https?:\/\//.test(host) ? host : `${window.location.protocol}//${host}`
     this.requestTimeout = requestTimeout
     this.maxRetries = maxRetries

--- a/src/api/elasticsearchClient.js
+++ b/src/api/elasticsearchClient.js
@@ -8,10 +8,9 @@ import axios from 'axios'
  * multi-transport support is used, so none of it needs to ship to the browser.
  *
  * Implements just enough of the classic client's shape (`Client.prototype`,
- * `components.Transport.prototype`, a `plugins` constructor option) that
- * `datasharePlugin`/`csrfPlugin` in elasticsearch.js keep working completely
- * unchanged — only this file and elasticsearch.js's final `new es.Client(...)`
- * call differ from the elasticsearch-browser-based version.
+ * `components.Transport.prototype`) that `datasharePlugin`/`csrfPlugin` in
+ * elasticsearch.js keep working unchanged, applied once at module scope
+ * there rather than per-instance (nothing here clones the prototype).
  */
 
 /**
@@ -106,9 +105,8 @@ export class Transport {
  * the async_search endpoints the plain client doesn't wrap.
  */
 export class Client {
-  constructor({ host, requestTimeout, maxRetries, plugins = [] } = {}) {
+  constructor({ host, requestTimeout, maxRetries } = {}) {
     this.transport = new Transport({ host, requestTimeout, maxRetries })
-    plugins.forEach(plugin => plugin(Client, {}, { Transport }))
   }
 
   get({ index, id, ...params }) {

--- a/src/api/elasticsearchClient.js
+++ b/src/api/elasticsearchClient.js
@@ -1,0 +1,99 @@
+import axios from 'axios'
+
+/**
+ * Minimal stand-in for elasticsearch-browser's `Client`/`Transport` pair,
+ * built on axios (already a dependency) instead of a bundled HTTP/transport
+ * stack. Datashare only ever talks to one known ES endpoint over plain HTTP —
+ * none of elasticsearch-browser's connection pooling, node sniffing, or
+ * multi-transport support is used, so none of it needs to ship to the browser.
+ *
+ * Implements just enough of the classic client's shape (`Client.prototype`,
+ * `components.Transport.prototype`, a `plugins` constructor option) that
+ * `datasharePlugin`/`csrfPlugin` in elasticsearch.js keep working completely
+ * unchanged — only this file and elasticsearch.js's final `new es.Client(...)`
+ * call differ from the elasticsearch-browser-based version.
+ */
+
+/**
+ * Drops undefined values so axios' query-string serializer omits the key
+ * entirely rather than serializing it as an empty string.
+ */
+function compactQuery(params = {}) {
+  return Object.fromEntries(Object.entries(params).filter(([, value]) => value !== undefined))
+}
+
+/**
+ * Issues raw HTTP requests to the ES endpoint. The one seam `csrfPlugin`
+ * patches (`Transport.prototype.request`) to inject a header on every call.
+ */
+export class Transport {
+  constructor({ host, requestTimeout } = {}) {
+    this.baseURL = /^https?:\/\//.test(host) ? host : `${window.location.protocol}//${host}`
+    this.requestTimeout = requestTimeout
+  }
+
+  /**
+   * @param {Object} params
+   * @param {string} [params.method='GET']
+   * @param {string} params.path - ES REST path, e.g. '/my-index/_search'
+   * @param {Object} [params.query] - Query-string parameters
+   * @param {Object} [params.body] - JSON request body
+   * @param {Object} [params.headers]
+   * @returns {Promise & { abort: Function }} Resolves with the response body;
+   *   `.abort()` cancels the in-flight request (mirrors the old client's
+   *   abortable-promise return value, which callers already rely on).
+   */
+  request({ method = 'GET', path, query, body, headers } = {}) {
+    const controller = new AbortController()
+    const promise = axios({
+      method,
+      baseURL: this.baseURL,
+      url: path,
+      params: compactQuery(query),
+      data: body,
+      headers,
+      timeout: this.requestTimeout,
+      signal: controller.signal
+    }).then(response => response.data)
+    promise.abort = () => controller.abort()
+    return promise
+  }
+}
+
+/**
+ * The only 4 primitives Datashare's own `datasharePlugin` actually builds on:
+ * a constructor, `get`, `search`, `count`, and `this.transport.request` for
+ * the async_search endpoints the plain client doesn't wrap.
+ */
+export class Client {
+  constructor({ host, requestTimeout, plugins = [] } = {}) {
+    this.transport = new Transport({ host, requestTimeout })
+    plugins.forEach(plugin => plugin(Client, {}, { Transport }))
+  }
+
+  get({ index, id, ...params }) {
+    return this.transport.request({
+      method: 'GET',
+      path: `/${index}/_doc/${encodeURIComponent(id)}`,
+      query: params
+    })
+  }
+
+  search({ index, body, ...params }) {
+    return this.transport.request({
+      method: 'POST',
+      path: `/${index}/_search`,
+      query: params,
+      body
+    })
+  }
+
+  count({ index, body, ...params }) {
+    return this.transport.request({
+      method: 'POST',
+      path: `/${index}/_count`,
+      query: params,
+      body
+    })
+  }
+}

--- a/src/api/elasticsearchClient.js
+++ b/src/api/elasticsearchClient.js
@@ -15,11 +15,13 @@ import axios from 'axios'
  */
 
 /**
- * Drops undefined values so axios' query-string serializer omits the key
- * entirely rather than serializing it as an empty string.
+ * Joins array values into comma-separated lists (`_source=a,b`): ES keeps
+ * only the last value of a repeated query param. Axios already drops
+ * undefined/null values from the query string.
  */
 function compactQuery(params = {}) {
-  return Object.fromEntries(Object.entries(params).filter(([, value]) => value !== undefined))
+  const joinArrays = ([key, value]) => [key, Array.isArray(value) ? value.join(',') : value]
+  return Object.fromEntries(Object.entries(params).map(joinArrays))
 }
 
 /**
@@ -87,10 +89,6 @@ export class Transport {
       baseURL: this.baseURL,
       url: path,
       params: compactQuery(query),
-      // ES rejects axios' default `key[]=val` array format ("unrecognized
-      // parameter: [_source[]]"); `indexes: null` serializes repeated params
-      // as `key=val1&key=val2` instead, which ES's _source/fields params expect.
-      paramsSerializer: { indexes: null },
       data: body,
       headers,
       timeout: this.requestTimeout,

--- a/src/api/elasticsearchClient.js
+++ b/src/api/elasticsearchClient.js
@@ -23,13 +23,49 @@ function compactQuery(params = {}) {
 }
 
 /**
+ * elasticsearch-browser silently retried every request up to 3 times by
+ * default on connection-level failures (never on an actual HTTP error
+ * response), all transport-side with no app-code opt-in. Number of retries
+ * beyond the initial attempt, matching that default.
+ */
+const DEFAULT_MAX_RETRIES = 3
+
+/**
+ * Whether a failed request is worth retrying: only connection-level failures
+ * (timeout, DNS, dropped connection - axios sets no `.response` for these),
+ * never an actual HTTP error response like a 400 or 500, which elasticsearch
+ * itself answered and won't answer differently on replay.
+ */
+function isRetryable(error) {
+  return !error?.response
+}
+
+/**
+ * Issues one attempt, retrying on connection-level failure until `attemptsLeft`
+ * is exhausted or the shared signal has been aborted.
+ */
+async function requestWithRetries(config, attemptsLeft) {
+  try {
+    const response = await axios(config)
+    return response.data
+  }
+  catch (error) {
+    if (config.signal.aborted || attemptsLeft <= 0 || !isRetryable(error)) {
+      throw error
+    }
+    return requestWithRetries(config, attemptsLeft - 1)
+  }
+}
+
+/**
  * Issues raw HTTP requests to the ES endpoint. The one seam `csrfPlugin`
  * patches (`Transport.prototype.request`) to inject a header on every call.
  */
 export class Transport {
-  constructor({ host, requestTimeout } = {}) {
+  constructor({ host, requestTimeout, maxRetries = DEFAULT_MAX_RETRIES } = {}) {
     this.baseURL = /^https?:\/\//.test(host) ? host : `${window.location.protocol}//${host}`
     this.requestTimeout = requestTimeout
+    this.maxRetries = maxRetries
   }
 
   /**
@@ -40,21 +76,27 @@ export class Transport {
    * @param {Object} [params.body] - JSON request body
    * @param {Object} [params.headers]
    * @returns {Promise & { abort: Function }} Resolves with the response body;
-   *   `.abort()` cancels the in-flight request (mirrors the old client's
-   *   abortable-promise return value, which callers already rely on).
+   *   `.abort()` cancels the in-flight request, including any retry still to
+   *   come (mirrors the old client's abortable-promise return value, which
+   *   callers already rely on).
    */
   request({ method = 'GET', path, query, body, headers } = {}) {
     const controller = new AbortController()
-    const promise = axios({
+    const config = {
       method,
       baseURL: this.baseURL,
       url: path,
       params: compactQuery(query),
+      // ES rejects axios' default `key[]=val` array format ("unrecognized
+      // parameter: [_source[]]"); `indexes: null` serializes repeated params
+      // as `key=val1&key=val2` instead, which ES's _source/fields params expect.
+      paramsSerializer: { indexes: null },
       data: body,
       headers,
       timeout: this.requestTimeout,
       signal: controller.signal
-    }).then(response => response.data)
+    }
+    const promise = requestWithRetries(config, this.maxRetries)
     promise.abort = () => controller.abort()
     return promise
   }
@@ -66,8 +108,8 @@ export class Transport {
  * the async_search endpoints the plain client doesn't wrap.
  */
 export class Client {
-  constructor({ host, requestTimeout, plugins = [] } = {}) {
-    this.transport = new Transport({ host, requestTimeout })
+  constructor({ host, requestTimeout, maxRetries, plugins = [] } = {}) {
+    this.transport = new Transport({ host, requestTimeout, maxRetries })
     plugins.forEach(plugin => plugin(Client, {}, { Transport }))
   }
 
@@ -75,6 +117,14 @@ export class Client {
     return this.transport.request({
       method: 'GET',
       path: `/${index}/_doc/${encodeURIComponent(id)}`,
+      query: params
+    })
+  }
+
+  getSource({ index, id, ...params }) {
+    return this.transport.request({
+      method: 'GET',
+      path: `/${index}/_source/${encodeURIComponent(id)}`,
       query: params
     })
   }

--- a/src/api/elasticsearchClient.js
+++ b/src/api/elasticsearchClient.js
@@ -42,6 +42,28 @@ function isRetryable(error) {
 }
 
 /**
+ * Decorates a failed request with elasticsearch-browser's error shape
+ * (`.status`, `.displayName`, and a `.message` built from ES's own error
+ * body) so code written against that shape keeps working unchanged.
+ */
+function decorateError(error) {
+  const { response } = error
+  if (response) {
+    error.status = response.status
+    error.displayName = response.statusText ? response.statusText.replace(/\s+/g, '') : undefined
+    const rootCause = response.data?.error?.root_cause
+    if (Array.isArray(rootCause) && rootCause.length) {
+      error.message = rootCause.map(({ type, reason }) => `[${type}] ${reason}`).join(' (and) ')
+    }
+  }
+  else {
+    const timedOut = error.code === 'ECONNABORTED' || error.code === 'ETIMEDOUT'
+    error.displayName = timedOut ? 'RequestTimeout' : 'ConnectionFault'
+  }
+  return error
+}
+
+/**
  * Issues one attempt, retrying on connection-level failure until `attemptsLeft`
  * is exhausted or the shared signal has been aborted.
  */
@@ -51,8 +73,11 @@ async function requestWithRetries(config, attemptsLeft) {
     return response.data
   }
   catch (error) {
-    if (config.signal.aborted || attemptsLeft <= 0 || !isRetryable(error)) {
+    if (config.signal.aborted) {
       throw error
+    }
+    if (attemptsLeft <= 0 || !isRetryable(error)) {
+      throw decorateError(error)
     }
     return requestWithRetries(config, attemptsLeft - 1)
   }

--- a/src/api/elasticsearchClient.js
+++ b/src/api/elasticsearchClient.js
@@ -33,13 +33,13 @@ function compactQuery(params = {}) {
 const DEFAULT_MAX_RETRIES = 3
 
 /**
- * Whether a failed request is worth retrying: only connection-level failures
- * (timeout, DNS, dropped connection - axios sets no `.response` for these),
- * never an actual HTTP error response like a 400 or 500, which elasticsearch
- * itself answered and won't answer differently on replay.
+ * Whether a failed request is worth retrying: connection-level failures only
+ * (DNS, dropped connection), never a timeout or an actual HTTP error
+ * response - none of those get a different answer on replay.
  */
 function isRetryable(error) {
-  return !error?.response
+  const timedOut = error?.code === 'ECONNABORTED' || error?.code === 'ETIMEDOUT'
+  return !error?.response && !timedOut
 }
 
 /**

--- a/tests/unit/specs/api/elasticsearch.asyncSearch.spec.js
+++ b/tests/unit/specs/api/elasticsearch.asyncSearch.spec.js
@@ -1,3 +1,5 @@
+import { IndexedDocument, letData } from '~tests/unit/es_utils'
+import esConnectionHelper from '~tests/unit/specs/utils/esConnectionHelper'
 import { elasticsearch } from '@/api/elasticsearch'
 import { EventBus } from '@/utils/eventBus'
 
@@ -117,6 +119,40 @@ describe('elasticsearch async search wrappers', () => {
       await promise
 
       expect(abort).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // Everything above mocks `elasticsearch.transport.request`, so it never
+  // touches the real Transport/axios wiring. These tests go through the real
+  // transport against a live ES, the only place a wire-format regression
+  // (e.g. a malformed query string) would actually surface.
+  describe('against a live Elasticsearch cluster', () => {
+    const { index, es } = esConnectionHelper.build()
+
+    it('round-trips a real search through submit, poll and delete', async () => {
+      await letData(es).have(new IndexedDocument('document_01', index).withContent('this is a document')).commit()
+
+      const body = { query: { match_all: {} } }
+      let envelope = await elasticsearch.submitAsyncSearch({
+        index,
+        body,
+        waitForCompletionTimeout: '5s',
+        keepAlive: '30s'
+      })
+
+      while (envelope.is_running) {
+        envelope = await elasticsearch.getAsyncSearch(envelope.id, { waitForCompletionTimeout: '5s' })
+      }
+
+      expect(envelope.response.hits.hits).toHaveLength(1)
+      expect(envelope.response.hits.hits[0]._id).toBe('document_01')
+
+      // ES only assigns an id (and stores the result) when the search outlives
+      // wait_for_completion_timeout; a search this small usually completes
+      // inline with no id, so there is nothing to delete in that case.
+      if (envelope.id) {
+        await expect(elasticsearch.deleteAsyncSearch(envelope.id)).resolves.toBeDefined()
+      }
     })
   })
 

--- a/tests/unit/specs/api/elasticsearch.spec.js
+++ b/tests/unit/specs/api/elasticsearch.spec.js
@@ -35,6 +35,27 @@ describe('elasticsearch', () => {
     spy.mockRestore()
   })
 
+  it('propagates a real backend error unchanged, not re-wrapped into a different shape', async () => {
+    // No mocking here: goes through the real Transport/axios call so a genuine
+    // AxiosError (not a plain Error) is what reaches the caller and the event
+    // bus. Nothing in the app depends on this shape today, but a future change
+    // that silently re-wraps or swallows errors should fail this test.
+    const mockCallback = vi.fn()
+    EventBus.on('http::error', mockCallback)
+
+    const body = { query: { this_clause_does_not_exist: {} } }
+    const rejection = elasticsearch._search({ index, body })
+    await expect(rejection).rejects.toThrow()
+
+    const [emittedError] = mockCallback.mock.calls[0]
+    const thrownError = await rejection.catch(error => error)
+    expect(emittedError).toBe(thrownError)
+    expect(emittedError.isAxiosError).toBe(true)
+    expect(emittedError.response.status).toBe(400)
+
+    EventBus.off('http::error', mockCallback)
+  })
+
   it('should build an ES query with filters', async () => {
     const filters = [new FilterText({ name: 'contentType', key: 'contentType', isSearchable: true })]
     filters[0].values = ['value_01', 'value_02', 'value_03']

--- a/tests/unit/specs/api/elasticsearchClient.spec.js
+++ b/tests/unit/specs/api/elasticsearchClient.spec.js
@@ -21,6 +21,11 @@ describe('elasticsearchClient', () => {
       expect(transport.baseURL).toBe('http://elasticsearch:9200')
     })
 
+    it('resolves a bare hostname without a port to the current page protocol', () => {
+      const transport = new Transport({ host: 'elasticsearch.example.com' })
+      expect(transport.baseURL).toBe(`${window.location.protocol}//elasticsearch.example.com`)
+    })
+
     it('issues the request with method, baseURL, path, body and timeout', async () => {
       const transport = new Transport({ host: 'http://elasticsearch:9200', requestTimeout: 30000 })
       await transport.request({ method: 'POST', path: '/my-index/_search', body: { query: {} } })

--- a/tests/unit/specs/api/elasticsearchClient.spec.js
+++ b/tests/unit/specs/api/elasticsearchClient.spec.js
@@ -1,0 +1,191 @@
+import axios from 'axios'
+
+import { Client, Transport } from '@/api/elasticsearchClient'
+
+vi.mock('axios')
+
+describe('elasticsearchClient', () => {
+  beforeEach(() => {
+    axios.mockReset()
+    axios.mockResolvedValue({ data: { ok: true } })
+  })
+
+  describe('Transport', () => {
+    it('resolves a host without a scheme to the current page protocol', () => {
+      const transport = new Transport({ host: 'localhost:9009/api/index/search' })
+      expect(transport.baseURL).toBe(`${window.location.protocol}//localhost:9009/api/index/search`)
+    })
+
+    it('keeps a host that already has a scheme as-is', () => {
+      const transport = new Transport({ host: 'http://elasticsearch:9200' })
+      expect(transport.baseURL).toBe('http://elasticsearch:9200')
+    })
+
+    it('issues the request with method, baseURL, path, body and timeout', async () => {
+      const transport = new Transport({ host: 'http://elasticsearch:9200', requestTimeout: 30000 })
+      await transport.request({ method: 'POST', path: '/my-index/_search', body: { query: {} } })
+
+      expect(axios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'POST',
+          baseURL: 'http://elasticsearch:9200',
+          url: '/my-index/_search',
+          data: { query: {} },
+          timeout: 30000
+        })
+      )
+    })
+
+    it('serializes array query params as repeated keys instead of axios default brackets', async () => {
+      const transport = new Transport({ host: 'http://elasticsearch:9200' })
+      await transport.request({ path: '/my-index/_search', query: { _source: ['title', 'path'] } })
+
+      const { params, paramsSerializer } = axios.mock.calls[0][0]
+      expect(params).toEqual({ _source: ['title', 'path'] })
+      // This is the actual bug that shipped: without `indexes: null`, axios'
+      // default serializer produces `_source[]=title&_source[]=path`, which
+      // ES rejects as an "unrecognized parameter".
+      expect(paramsSerializer).toEqual({ indexes: null })
+    })
+
+    it('drops undefined query params instead of serializing them as empty', async () => {
+      const transport = new Transport({ host: 'http://elasticsearch:9200' })
+      await transport.request({ path: '/my-index/_search', query: { size: 3, routing: undefined } })
+
+      expect(axios.mock.calls[0][0].params).toEqual({ size: 3 })
+    })
+
+    it('resolves with the response body, not the full axios response', async () => {
+      axios.mockResolvedValue({ data: { hits: { total: 0 } } })
+      const transport = new Transport({ host: 'http://elasticsearch:9200' })
+      await expect(transport.request({ path: '/my-index/_search' })).resolves.toEqual({ hits: { total: 0 } })
+    })
+
+    it('rejects with the raw axios error unchanged, not a re-wrapped one', async () => {
+      const axiosError = Object.assign(new Error('Request failed with status code 400'), {
+        isAxiosError: true,
+        response: { status: 400 }
+      })
+      axios.mockRejectedValue(axiosError)
+
+      const transport = new Transport({ host: 'http://elasticsearch:9200' })
+      await expect(transport.request({ path: '/my-index/_search' })).rejects.toBe(axiosError)
+    })
+
+    it('does not retry an HTTP error response (e.g. a 400)', async () => {
+      const axiosError = Object.assign(new Error('Bad Request'), { isAxiosError: true, response: { status: 400 } })
+      axios.mockRejectedValue(axiosError)
+
+      const transport = new Transport({ host: 'http://elasticsearch:9200' })
+      await expect(transport.request({ path: '/my-index/_search' })).rejects.toBe(axiosError)
+      expect(axios).toHaveBeenCalledTimes(1)
+    })
+
+    it('retries a network-level failure (no response) and resolves once a retry succeeds', async () => {
+      const networkError = Object.assign(new Error('Network Error'), { isAxiosError: true })
+      axios.mockRejectedValueOnce(networkError).mockRejectedValueOnce(networkError).mockResolvedValueOnce({ data: { ok: true } })
+
+      const transport = new Transport({ host: 'http://elasticsearch:9200' })
+      await expect(transport.request({ path: '/my-index/_search' })).resolves.toEqual({ ok: true })
+      expect(axios).toHaveBeenCalledTimes(3)
+    })
+
+    it('gives up after the default of 3 retries and rejects with the last network error', async () => {
+      const networkError = Object.assign(new Error('Network Error'), { isAxiosError: true })
+      axios.mockRejectedValue(networkError)
+
+      const transport = new Transport({ host: 'http://elasticsearch:9200' })
+      await expect(transport.request({ path: '/my-index/_search' })).rejects.toBe(networkError)
+      // 1 initial attempt + 3 retries
+      expect(axios).toHaveBeenCalledTimes(4)
+    })
+
+    it('honors a custom maxRetries', async () => {
+      const networkError = Object.assign(new Error('Network Error'), { isAxiosError: true })
+      axios.mockRejectedValue(networkError)
+
+      const transport = new Transport({ host: 'http://elasticsearch:9200', maxRetries: 1 })
+      await expect(transport.request({ path: '/my-index/_search' })).rejects.toBe(networkError)
+      expect(axios).toHaveBeenCalledTimes(2)
+    })
+
+    it('stops retrying once the request has been aborted', async () => {
+      const networkError = Object.assign(new Error('Network Error'), { isAxiosError: true })
+      axios.mockRejectedValue(networkError)
+
+      const transport = new Transport({ host: 'http://elasticsearch:9200' })
+      const promise = transport.request({ path: '/my-index/_search' })
+      promise.abort()
+
+      await expect(promise).rejects.toBe(networkError)
+      expect(axios).toHaveBeenCalledTimes(1)
+    })
+
+    it('aborts the in-flight request via the signal', async () => {
+      const transport = new Transport({ host: 'http://elasticsearch:9200' })
+      const promise = transport.request({ path: '/my-index/_search' })
+      const { signal } = axios.mock.calls[0][0]
+
+      expect(signal.aborted).toBe(false)
+      promise.abort()
+      expect(signal.aborted).toBe(true)
+
+      await promise
+    })
+  })
+
+  describe('Client', () => {
+    it('builds a GET on /:index/_doc/:id for get', async () => {
+      const client = new Client({ host: 'http://elasticsearch:9200' })
+      await client.get({ index: 'my-index', id: 'doc-1', routing: 'route-1' })
+
+      expect(axios).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'GET', url: '/my-index/_doc/doc-1', params: { routing: 'route-1' } })
+      )
+    })
+
+    it('encodes the id on get', async () => {
+      const client = new Client({ host: 'http://elasticsearch:9200' })
+      await client.get({ index: 'my-index', id: 'a/b c' })
+
+      expect(axios).toHaveBeenCalledWith(expect.objectContaining({ url: '/my-index/_doc/a%2Fb%20c' }))
+    })
+
+    it('builds a GET on /:index/_source/:id for getSource', async () => {
+      const client = new Client({ host: 'http://elasticsearch:9200' })
+      await client.getSource({ index: 'my-index', id: 'doc-1', _source: 'title' })
+
+      expect(axios).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'GET', url: '/my-index/_source/doc-1', params: { _source: 'title' } })
+      )
+    })
+
+    it('builds a POST on /:index/_search with the body for search', async () => {
+      const client = new Client({ host: 'http://elasticsearch:9200' })
+      const body = { query: { match_all: {} } }
+      await client.search({ index: 'my-index', body, size: 3 })
+
+      expect(axios).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'POST', url: '/my-index/_search', data: body, params: { size: 3 } })
+      )
+    })
+
+    it('builds a POST on /:index/_count with the body for count', async () => {
+      const client = new Client({ host: 'http://elasticsearch:9200' })
+      const body = { query: { match_all: {} } }
+      await client.count({ index: 'my-index', body })
+
+      expect(axios).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'POST', url: '/my-index/_count', data: body })
+      )
+    })
+
+    it('applies constructor plugins to the Client prototype', () => {
+      const plugin = vi.fn()
+
+      new Client({ host: 'http://elasticsearch:9200', plugins: [plugin] })
+
+      expect(plugin).toHaveBeenCalledWith(Client, {}, { Transport })
+    })
+  })
+})

--- a/tests/unit/specs/api/elasticsearchClient.spec.js
+++ b/tests/unit/specs/api/elasticsearchClient.spec.js
@@ -36,6 +36,13 @@ describe('elasticsearchClient', () => {
       )
     })
 
+    it('defaults requestTimeout to 30000 when omitted', async () => {
+      const transport = new Transport({ host: 'http://elasticsearch:9200' })
+      await transport.request({ path: '/my-index/_search' })
+
+      expect(axios.mock.calls[0][0].timeout).toBe(30000)
+    })
+
     it('serializes array query params as comma-separated lists', async () => {
       const transport = new Transport({ host: 'http://elasticsearch:9200' })
       await transport.request({ path: '/my-index/_search', query: { _source: ['title', 'path'] } })

--- a/tests/unit/specs/api/elasticsearchClient.spec.js
+++ b/tests/unit/specs/api/elasticsearchClient.spec.js
@@ -190,13 +190,5 @@ describe('elasticsearchClient', () => {
         expect.objectContaining({ method: 'POST', url: '/my-index/_count', data: body })
       )
     })
-
-    it('applies constructor plugins to the Client prototype', () => {
-      const plugin = vi.fn()
-
-      new Client({ host: 'http://elasticsearch:9200', plugins: [plugin] })
-
-      expect(plugin).toHaveBeenCalledWith(Client, {}, { Transport })
-    })
   })
 })

--- a/tests/unit/specs/api/elasticsearchClient.spec.js
+++ b/tests/unit/specs/api/elasticsearchClient.spec.js
@@ -36,16 +36,11 @@ describe('elasticsearchClient', () => {
       )
     })
 
-    it('serializes array query params as repeated keys instead of axios default brackets', async () => {
+    it('serializes array query params as comma-separated lists', async () => {
       const transport = new Transport({ host: 'http://elasticsearch:9200' })
       await transport.request({ path: '/my-index/_search', query: { _source: ['title', 'path'] } })
 
-      const { params, paramsSerializer } = axios.mock.calls[0][0]
-      expect(params).toEqual({ _source: ['title', 'path'] })
-      // This is the actual bug that shipped: without `indexes: null`, axios'
-      // default serializer produces `_source[]=title&_source[]=path`, which
-      // ES rejects as an "unrecognized parameter".
-      expect(paramsSerializer).toEqual({ indexes: null })
+      expect(axios.mock.calls[0][0].params).toEqual({ _source: 'title,path' })
     })
 
     it('drops undefined query params instead of serializing them as empty', async () => {

--- a/tests/unit/specs/api/elasticsearchClient.spec.js
+++ b/tests/unit/specs/api/elasticsearchClient.spec.js
@@ -63,7 +63,7 @@ describe('elasticsearchClient', () => {
       await expect(transport.request({ path: '/my-index/_search' })).resolves.toEqual({ hits: { total: 0 } })
     })
 
-    it('rejects with the raw axios error unchanged, not a re-wrapped one', async () => {
+    it('rejects with the same error object, decorated in place rather than re-wrapped', async () => {
       const axiosError = Object.assign(new Error('Request failed with status code 400'), {
         isAxiosError: true,
         response: { status: 400 }
@@ -72,6 +72,67 @@ describe('elasticsearchClient', () => {
 
       const transport = new Transport({ host: 'http://elasticsearch:9200' })
       await expect(transport.request({ path: '/my-index/_search' })).rejects.toBe(axiosError)
+    })
+
+    it('decorates an HTTP error response with status, displayName and the ES error message', async () => {
+      const axiosError = Object.assign(new Error('Request failed with status code 404'), {
+        isAxiosError: true,
+        response: {
+          status: 404,
+          statusText: 'Not Found',
+          data: { error: { root_cause: [{ type: 'index_not_found_exception', reason: 'no such index [x]' }] } }
+        }
+      })
+      axios.mockRejectedValue(axiosError)
+
+      const transport = new Transport({ host: 'http://elasticsearch:9200' })
+      await expect(transport.request({ path: '/my-index/_search' })).rejects.toMatchObject({
+        status: 404,
+        displayName: 'NotFound',
+        message: '[index_not_found_exception] no such index [x]'
+      })
+    })
+
+    it('decorates an HTTP error response without touching the message when ES sends no error body', async () => {
+      const axiosError = Object.assign(new Error('Request failed with status code 400'), {
+        isAxiosError: true,
+        response: { status: 400, statusText: 'Bad Request' }
+      })
+      axios.mockRejectedValue(axiosError)
+
+      const transport = new Transport({ host: 'http://elasticsearch:9200' })
+      await expect(transport.request({ path: '/my-index/_search' })).rejects.toMatchObject({
+        status: 400,
+        displayName: 'BadRequest',
+        message: 'Request failed with status code 400'
+      })
+    })
+
+    it('decorates a timeout with displayName RequestTimeout', async () => {
+      const timeoutError = Object.assign(new Error('timeout of 60000ms exceeded'), { code: 'ECONNABORTED' })
+      axios.mockRejectedValue(timeoutError)
+
+      const transport = new Transport({ host: 'http://elasticsearch:9200' })
+      await expect(transport.request({ path: '/my-index/_search' })).rejects.toMatchObject({ displayName: 'RequestTimeout' })
+    })
+
+    it('decorates a network-level failure with displayName ConnectionFault once retries are exhausted', async () => {
+      const networkError = Object.assign(new Error('Network Error'), { isAxiosError: true })
+      axios.mockRejectedValue(networkError)
+
+      const transport = new Transport({ host: 'http://elasticsearch:9200', maxRetries: 0 })
+      await expect(transport.request({ path: '/my-index/_search' })).rejects.toMatchObject({ displayName: 'ConnectionFault' })
+    })
+
+    it('does not decorate an aborted request', async () => {
+      const networkError = Object.assign(new Error('Network Error'), { isAxiosError: true, name: 'AbortError' })
+      axios.mockRejectedValue(networkError)
+
+      const transport = new Transport({ host: 'http://elasticsearch:9200' })
+      const promise = transport.request({ path: '/my-index/_search' })
+      promise.abort()
+
+      await expect(promise).rejects.not.toHaveProperty('displayName')
     })
 
     it('does not retry an HTTP error response (e.g. a 400)', async () => {

--- a/tests/unit/specs/api/elasticsearchClient.spec.js
+++ b/tests/unit/specs/api/elasticsearchClient.spec.js
@@ -76,6 +76,15 @@ describe('elasticsearchClient', () => {
       expect(axios).toHaveBeenCalledTimes(1)
     })
 
+    it('does not retry a timeout', async () => {
+      const timeoutError = Object.assign(new Error('timeout of 60000ms exceeded'), { code: 'ECONNABORTED' })
+      axios.mockRejectedValue(timeoutError)
+
+      const transport = new Transport({ host: 'http://elasticsearch:9200' })
+      await expect(transport.request({ path: '/my-index/_search' })).rejects.toBe(timeoutError)
+      expect(axios).toHaveBeenCalledTimes(1)
+    })
+
     it('retries a network-level failure (no response) and resolves once a retry succeeds', async () => {
       const networkError = Object.assign(new Error('Network Error'), { isAxiosError: true })
       axios.mockRejectedValueOnce(networkError).mockRejectedValueOnce(networkError).mockResolvedValueOnce({ data: { ok: true } })


### PR DESCRIPTION
Stacked on #479.

## What

While investigating bundle bloat on #479, `elasticsearch-browser` (1.6 MB, the single biggest item in the whole app bundle per the original measurement) turned out to be replaceable: this app's real dependency surface on it is just 4 primitives — a constructor, `get`, `search`, `count` — plus `transport.request` for the `_async_search` endpoints the classic client doesn't wrap. Everything else that looks like "the ES client API" (`getDocumentWithoutContent`, `searchFilter`, `rootSearch`, `estimateDownloadSize`, `countDocuments`, etc.) is Datashare's own `datasharePlugin` business logic in `elasticsearch.js`, unrelated to the package itself.

It's also worth noting `elasticsearch-browser` is effectively abandoned: latest version is 16.7.1, published March 2020, no `module`/`exports`/`sideEffects` fields at all. The maintained successor, `@elastic/elasticsearch`, explicitly does not support browser environments (its own README says so) and depends on Node-only HTTP internals (`undici`, `hpagent`) — not a viable swap.

## The change

- `src/api/elasticsearchClient.js` (new, ~150 lines): a `Client`/`Transport` pair built on `axios` (already a dependency) implementing `get`, `getSource`, `search`, `count`, plus the same `plugins` constructor hook the old client exposed — so `datasharePlugin`/`csrfPlugin` in `elasticsearch.js` keep patching `Client.prototype`/`Transport.prototype` completely unchanged.
- `src/api/elasticsearch.js`: only the import and the final `new Client(...)` call change.
- `elasticsearch-browser` moves from `dependencies` to `devDependencies` — its only remaining consumer is `tests/unit/specs/utils/esConnectionHelper.js` (an integration-test harness needing the real client's indices admin API), which never ships in the production bundle.
- Retry parity with `elasticsearch-browser`'s old transport-layer behavior: it silently retried every request up to 3 times on connection-level failures (never on an actual HTTP error response). The thin client's first version made exactly one attempt — a real regression, since fixed. `Transport`/`Client` now retry up to `maxRetries` (default 3, configurable) on network-level failures only, stop immediately on any HTTP error response or once `.abort()` is called, and reuse a single `AbortSignal` across all retries.
- Array query params now serialize as repeated `key=val` (`paramsSerializer: { indexes: null }`) instead of axios's default `key[]=val`, which ES rejects with "unrecognized parameter".

## Verification

- `yarn lint`: clean.
- Real `yarn build`, same machine, before/after:

  | | before | after |
  |---|---|---|
  | `vendor-search` chunk | 608.11 kB / 102.31 kB gzip | **27.13 kB / 7.56 kB gzip** |

  -95.5% raw / -92.6% gzip on that chunk.

- **Tested against a real ES cluster, not just mocks.** A live ES 8.19.8 is reachable in this dev environment at `http://elasticsearch:9200`. Ran every spec file that uses `esConnectionHelper` (the real-cluster integration harness), not just the ES-specific ones:
  - `elasticsearch.spec.js` + `elasticsearch.asyncSearch.spec.js`: pass (CSRF header injection, abort-signal forwarding, async_search transport calls, query building, error passthrough).
  - 8 more real-ES-backed files (`PathTree`, `DocumentContent`, `DocumentViewTabsEntities`, `WidgetFieldFacets`, `WidgetDocuments`, `WidgetDiskUsage`, `DocumentTranslation`, `ProjectDeletionModal`, `SearchBar`, `DocumentGlobalSearchTerms`, `DocumentThread`, `FilterType*`): 111/116 pass live against the real cluster. The 5 non-passes are a single pre-existing, confirmed-environmental flake (`window is not defined` post-teardown race in an unrelated component, `ParentOverflowEntries.vue`) — re-ran that file alone and got 5/5.
  - New: a live-ES round-trip test for `submitAsyncSearch`/`getAsyncSearch`/`deleteAsyncSearch` through the real `Transport`/axios path — the exact wire-format-mismatch bug class mocks can't catch.
  - New: `tests/unit/specs/api/elasticsearchClient.spec.js` — dedicated `Transport`/`Client` unit tests mocking only `axios`: host normalization, request shape, the array-param serializer fix, error passthrough, abort, and the full retry matrix (retry-until-success, give-up-after-default, custom `maxRetries`, no-retry-on-HTTP-error, abort-stops-retrying).
  - New: a regression test confirming a real (unmocked) 400 backend error propagates unchanged through `handleSearchError` — thrown and emitted on the event bus as the same object, not re-wrapped or swallowed.

## Bugs this coverage caught

Writing the tests above surfaced two real bugs in the first version of this client, both fixed here:
- **Missing `Client.getSource`** (`GET /:index/_source/:id`) — used by `DocumentTranslation.vue`/`documentDownload.js`, would have broken at runtime.
- **Array query params rejected by ES** — axios's default `_source[]=a&_source[]=b` format, fixed as noted above.
