### PR TITLE
fix: remove router injection warning + a filter-panel flash bug

### DIFF
--- a/src/components/Badge/BadgeFilterHeader.vue
+++ b/src/components/Badge/BadgeFilterHeader.vue
@@ -4,6 +4,7 @@ import { AppIcon } from '@icij/murmur'
 import { useI18n } from 'vue-i18n'
 
 import filters from '@/store/filters'
+import builtinFilterIcons from '@/store/filters/icons'
 
 const props = defineProps({
   name: {
@@ -18,7 +19,7 @@ const filter = computed(() => {
 })
 
 const icon = computed(() => {
-  return filter.value.options.icon
+  return filter.value.options.icon ?? builtinFilterIcons[props.name]
 })
 </script>
 

--- a/src/components/Filter/FilterModal/FilterModalTitle.vue
+++ b/src/components/Filter/FilterModal/FilterModalTitle.vue
@@ -1,25 +1,29 @@
 <script setup>
+import { computed } from 'vue'
 import { AppIcon } from '@icij/murmur'
 import { useI18n } from 'vue-i18n'
 
 import FiltersPanelSectionFilterTitleSort from '@/components/FiltersPanel/FiltersPanelSectionFilterTitleSort'
+import builtinFilterIcons from '@/store/filters/icons'
 
 const sort = defineModel('sort', { type: Object })
 
-defineProps({
+const props = defineProps({
   filter: {
     type: Object,
     required: true
   }
 })
 const { t } = useI18n()
+
+const icon = computed(() => props.filter.icon ?? builtinFilterIcons[props.filter.name])
 </script>
 
 <template>
   <div class="d-flex align-items-center text-start">
     <span class="flex-grow-1 text-truncate">
       <app-icon
-        :name="filter.icon"
+        :name="icon"
         class="me-2"
       />
       {{ t(`filter.${filter.name}`) }}

--- a/src/components/Filter/FilterType/FilterType.vue
+++ b/src/components/Filter/FilterType/FilterType.vue
@@ -20,6 +20,7 @@ import FiltersPanelSectionFilterEntry from '@/components/FiltersPanel/FiltersPan
 import FilterTypeAll from '@/components/Filter/FilterType/FilterTypeAll'
 import settings from '@/utils/settings'
 import { useSearchStore } from '@/store/modules'
+import builtinFilterIcons from '@/store/filters/icons'
 
 const query = defineModel('query', { type: String, default: '' })
 const collapse = defineModel('collapse', { type: Boolean, default: null })
@@ -46,6 +47,8 @@ const { filter, modal, hideCount, overlayShow } = defineProps({
 
 const opened = refWhenever(collapse, value => value === false || modal === true)
 const { t } = useI18n()
+
+const icon = computed(() => filter.icon ?? builtinFilterIcons[filter.name])
 
 const pages = reactive([])
 const expand = ref(false)
@@ -266,7 +269,7 @@ defineExpose({ entries, aggregateOver, count })
     :hide-exclude="filter.hideExclude"
     :hide-expand="filter.hideExpand"
     :title="t(`filter.${filter.name}`)"
-    :icon="filter.icon"
+    :icon="icon"
     :count="count"
     :loading="isLoading"
     :modal="modal"

--- a/src/components/Search/SearchParameter/SearchParameterFilter.vue
+++ b/src/components/Search/SearchParameter/SearchParameterFilter.vue
@@ -10,6 +10,7 @@ import SearchParameterQueryTerm from './SearchParameterQueryTerm'
 import { VARIANT, variantValidator } from '@/enums/variants'
 import * as types from '@/store/filters'
 import filtersDefs from '@/store/filters'
+import builtinFilterIcons from '@/store/filters/icons'
 
 const props = defineProps({
   name: {
@@ -83,7 +84,7 @@ const term = computed(() => {
 })
 
 const icon = computed(() => {
-  return props.icon ?? filter.value?.options?.icon ?? IPhMagnifyingGlass
+  return props.icon ?? filter.value?.options?.icon ?? builtinFilterIcons[field.value] ?? IPhMagnifyingGlass
 })
 
 const iconLabel = computed(() => {

--- a/src/components/Task/TaskBatchSearch/TaskBatchSearchForm.vue
+++ b/src/components/Task/TaskBatchSearch/TaskBatchSearchForm.vue
@@ -88,7 +88,10 @@ const queryTemplate = computed(() => {
   return JSON.stringify(query)
 })
 
-const uri = computed(() => formSearchStore.stringifyBaseRouteQuery)
+const uri = computed(() => {
+  const { href = null } = router.resolve({ name: 'search', query: formSearchStore.toBaseRouteQuery }) ?? {}
+  return href
+})
 
 const isValid = computed(() => name.value.trim(' ').length > 0 && csv.value !== null)
 

--- a/src/store/filters/icons.js
+++ b/src/store/filters/icons.js
@@ -1,0 +1,39 @@
+import { markRaw } from 'vue'
+
+import IPhCirclesThreePlus from '~icons/ph/circles-three-plus'
+import IPhStar from '~icons/ph/star'
+import IPhHash from '~icons/ph/hash'
+import IPhUsers from '~icons/ph/users'
+import IPhTreeStructure from '~icons/ph/tree-structure'
+import IPhFile from '~icons/ph/file'
+import IPhFiles from '~icons/ph/files'
+import IPhCalendarBlank from '~icons/ph/calendar-blank'
+import IPhGlobe from '~icons/ph/globe'
+import IPhUserSquare from '~icons/ph/user-square'
+import IPhBuildings from '~icons/ph/buildings'
+import IPhMapPin from '~icons/ph/map-pin'
+import IPhEnvelope from '~icons/ph/envelope'
+import IPhPaperclip from '~icons/ph/paperclip'
+import IPhCalendarPlus from '~icons/ph/calendar-plus'
+
+import { CONTENT_TYPE_CATEGORY_FILTER_NAME } from '@/store/filters/FilterContentTypeCategory'
+
+// Icons for the built-in filters, keyed by filter `name`. Kept out of
+// `store/filters/index.js` so they don't ship in the eager core chunk.
+export default {
+  project: markRaw(IPhCirclesThreePlus),
+  starred: markRaw(IPhStar),
+  tags: markRaw(IPhHash),
+  recommendedBy: markRaw(IPhUsers),
+  path: markRaw(IPhTreeStructure),
+  contentType: markRaw(IPhFile),
+  [CONTENT_TYPE_CATEGORY_FILTER_NAME]: markRaw(IPhFiles),
+  creationDate: markRaw(IPhCalendarBlank),
+  language: markRaw(IPhGlobe),
+  namedEntityPerson: markRaw(IPhUserSquare),
+  namedEntityOrganization: markRaw(IPhBuildings),
+  namedEntityLocation: markRaw(IPhMapPin),
+  namedEntityEmail: markRaw(IPhEnvelope),
+  extractionLevel: markRaw(IPhPaperclip),
+  indexingDate: markRaw(IPhCalendarPlus)
+}

--- a/src/store/filters/icons.js
+++ b/src/store/filters/icons.js
@@ -20,7 +20,10 @@ import { CONTENT_TYPE_CATEGORY_FILTER_NAME } from '@/store/filters/FilterContent
 
 // Icons for the built-in filters, keyed by filter `name`. Kept out of
 // `store/filters/index.js` so they don't ship in the eager core chunk.
-export default {
+// Object.create(null): consumers index this map with user-typed field
+// names (e.g. SearchParameterFilter.vue), and a plain {} would resolve
+// prototype keys like `toString`/`constructor` instead of undefined.
+export default Object.assign(Object.create(null), {
   project: markRaw(IPhCirclesThreePlus),
   starred: markRaw(IPhStar),
   tags: markRaw(IPhHash),
@@ -36,4 +39,4 @@ export default {
   namedEntityEmail: markRaw(IPhEnvelope),
   extractionLevel: markRaw(IPhPaperclip),
   indexingDate: markRaw(IPhCalendarPlus)
-}
+})

--- a/src/store/filters/index.js
+++ b/src/store/filters/index.js
@@ -1,21 +1,3 @@
-import { markRaw } from 'vue'
-
-import IPhCirclesThreePlus from '~icons/ph/circles-three-plus'
-import IPhStar from '~icons/ph/star'
-import IPhHash from '~icons/ph/hash'
-import IPhUsers from '~icons/ph/users'
-import IPhTreeStructure from '~icons/ph/tree-structure'
-import IPhFile from '~icons/ph/file'
-import IPhFiles from '~icons/ph/files'
-import IPhCalendarBlank from '~icons/ph/calendar-blank'
-import IPhGlobe from '~icons/ph/globe'
-import IPhUserSquare from '~icons/ph/user-square'
-import IPhBuildings from '~icons/ph/buildings'
-import IPhMapPin from '~icons/ph/map-pin'
-import IPhEnvelope from '~icons/ph/envelope'
-import IPhPaperclip from '~icons/ph/paperclip'
-import IPhCalendarPlus from '~icons/ph/calendar-plus'
-
 import { MODE_NAME } from '@/mode/index'
 import { namedEntityCategoryTranslation } from '@/store/filters/FilterEntity'
 import { CONTENT_TYPE_CATEGORY_FILTER_NAME } from '@/store/filters/FilterContentTypeCategory'
@@ -46,7 +28,6 @@ export default [
     options: {
       name: 'project',
       key: '_index',
-      icon: markRaw(IPhCirclesThreePlus),
       order: 0,
       section: 'documentsInfo',
       preference: 'filter-project',
@@ -64,7 +45,6 @@ export default [
     options: {
       name: 'starred',
       key: '_id',
-      icon: markRaw(IPhStar),
       order: 10,
       section: 'userData',
       preference: 'filter-starred',
@@ -81,7 +61,6 @@ export default [
     options: {
       name: 'tags',
       key: 'tags',
-      icon: markRaw(IPhHash),
       order: 20,
       section: 'userData',
       preference: 'filter-tags'
@@ -92,7 +71,6 @@ export default [
     options: {
       name: 'recommendedBy',
       key: '_id',
-      icon: markRaw(IPhUsers),
       modes: [MODE_NAME.SERVER],
       order: 30,
       section: 'userData',
@@ -109,7 +87,6 @@ export default [
     options: {
       name: 'path',
       key: 'byDirname',
-      icon: markRaw(IPhTreeStructure),
       order: 35,
       section: 'documentsInfo',
       hideAll: true,
@@ -123,7 +100,6 @@ export default [
     options: {
       name: 'contentType',
       key: 'contentType',
-      icon: markRaw(IPhFile),
       order: 40,
       section: 'documentsInfo',
       preference: 'filter-content-type',
@@ -138,7 +114,6 @@ export default [
     options: {
       name: CONTENT_TYPE_CATEGORY_FILTER_NAME,
       key: CONTENT_TYPE_CATEGORY_FILTER_NAME,
-      icon: markRaw(IPhFiles),
       order: 45,
       section: 'documentsInfo',
       hidden: true
@@ -149,7 +124,6 @@ export default [
     options: {
       name: 'creationDate',
       key: 'metadata.tika_metadata_dcterms_created',
-      icon: markRaw(IPhCalendarBlank),
       order: 50,
       hideAll: true,
       hideSearch: true,
@@ -165,7 +139,6 @@ export default [
     options: {
       name: 'language',
       key: 'language',
-      icon: markRaw(IPhGlobe),
       order: 60,
       section: 'documentsInfo',
       preference: 'filter-language',
@@ -177,7 +150,6 @@ export default [
     options: {
       name: 'namedEntityPerson',
       key: 'byMentions',
-      icon: markRaw(IPhUserSquare),
       category: namedEntityCategoryTranslation.namedEntityPerson,
       order: 70,
       section: 'entities',
@@ -189,7 +161,6 @@ export default [
     options: {
       name: 'namedEntityOrganization',
       key: 'byMentions',
-      icon: markRaw(IPhBuildings),
       category: namedEntityCategoryTranslation.namedEntityOrganization,
       order: 80,
       section: 'entities',
@@ -201,7 +172,6 @@ export default [
     options: {
       name: 'namedEntityLocation',
       key: 'byMentions',
-      icon: markRaw(IPhMapPin),
       category: namedEntityCategoryTranslation.namedEntityLocation,
       order: 90,
       section: 'entities',
@@ -213,7 +183,6 @@ export default [
     options: {
       name: 'namedEntityEmail',
       key: 'byMentions',
-      icon: markRaw(IPhEnvelope),
       category: namedEntityCategoryTranslation.namedEntityEmail,
       order: 100,
       section: 'entities',
@@ -225,7 +194,6 @@ export default [
     options: {
       name: 'extractionLevel',
       key: 'extractionLevel',
-      icon: markRaw(IPhPaperclip),
       hideSearch: true,
       order: 110,
       section: 'documentsInfo',
@@ -238,7 +206,6 @@ export default [
     options: {
       name: 'indexingDate',
       key: 'extractionDate',
-      icon: markRaw(IPhCalendarPlus),
       hideSearch: true,
       order: 120,
       section: 'documentsInfo'

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -15,7 +15,6 @@ import toString from 'lodash/toString'
 import uniq from 'lodash/uniq'
 import lucene from 'lucene'
 import { ref, computed, toRaw } from 'vue'
-import { useRouter } from 'vue-router'
 
 import EsDocList from '@/api/resources/EsDocList'
 import { runAsyncSearch } from '@/api/asyncSearch'
@@ -150,20 +149,6 @@ export const useSearchStore = defineSuffixedStore('search', () => {
       fields: fields.value,
       operator: searchOperator.value
     }
-  })
-
-  const stringifyBaseRouteQuery = computed(() => {
-    const name = 'search'
-    const query = toBaseRouteQuery.value
-    // Router is resolved lazily here (rather than eagerly at store-setup
-    // time) because this store is instantiated during Core.configure(),
-    // before the router plugin is installed on the app — calling
-    // useRouter() at setup time throws a "Symbol(router) not found"
-    // injection warning on every boot. By the time anything actually reads
-    // this computed, the app (and router) are fully mounted.
-    const router = useRouter()
-    const { href = null } = router?.resolve({ name, query }) ?? {}
-    return href
   })
 
   const retrieveQueryTerms = computed(() => {
@@ -1113,7 +1098,6 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     toRouteQuery,
     toRouteQueryWithStamp,
     toSearchParams,
-    stringifyBaseRouteQuery,
     retrieveQueryTerms,
     retrieveContentQueryTerms,
     page,

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -26,6 +26,17 @@ import { defineSuffixedStore } from '@/store/defineSuffixedStore'
 import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 import settings from '@/utils/settings'
 
+/**
+ * Assign `value` to `ref` only if it actually changed, to avoid churning the
+ * ref's identity (and false-triggering reference-watching consumers) when
+ * called with an equivalent value.
+ */
+function assignIfChanged(target, value) {
+  if (!isEqual(target.value, value)) {
+    target.value = value
+  }
+}
+
 export const useSearchStore = defineSuffixedStore('search', () => {
   const error = ref(null)
   const field = ref(settings.defaultSearchField)
@@ -352,9 +363,7 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     // Direct assign (not setIndices) — setIndices' compact() drops falsy
     // entries, turning setIndex('') into indices.value = [] instead of [''].
     // Core.js relies on setIndex('') when a user has no projects.
-    if (!isEqual(indices.value, [value])) {
-      indices.value = [value]
-    }
+    assignIfChanged(indices, [value])
   }
 
   /**
@@ -373,12 +382,10 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     // (every filter edit re-applies `index`/`indices` from the URL), so an
     // unconditional reassignment churns `indices.value`'s identity even
     // when the project selection is unchanged. Consumers that watch
-    // `searchStore.indices` by reference (e.g. PathTree.vue, via
+    // `searchStore.indices` by reference (e.g. FilterTypePath.vue, via
     // `projects = computed(() => searchStore.indices)`) then see a false
     // "changed" signal and reload/flash their content for no reason.
-    if (!isEqual(indices.value, cleaned)) {
-      indices.value = cleaned
-    }
+    assignIfChanged(indices, cleaned)
   }
 
   /**

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -47,9 +47,7 @@ export const useSearchStore = defineSuffixedStore('search', () => {
 
   const index = computed({
     get: () => indices.value[0],
-    set: (value) => {
-      indices.value = [value]
-    }
+    set: setIndex
   })
 
   const searchOperator = computed(() => appStore.getSettings('search', 'searchOperator') ?? SEARCH_OPERATORS.OR)

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -366,7 +366,12 @@ export const useSearchStore = defineSuffixedStore('search', () => {
    * @param {string} value - The index to set for the search.
    */
   function setIndex(value) {
-    setIndices([value])
+    // Direct assign (not setIndices) — setIndices' compact() drops falsy
+    // entries, turning setIndex('') into indices.value = [] instead of [''].
+    // Core.js relies on setIndex('') when a user has no projects.
+    if (!isEqual(indices.value, [value])) {
+      indices.value = [value]
+    }
   }
 
   /**

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -366,7 +366,7 @@ export const useSearchStore = defineSuffixedStore('search', () => {
    * @param {string} value - The index to set for the search.
    */
   function setIndex(value) {
-    indices.value = [value]
+    setIndices([value])
   }
 
   /**
@@ -380,7 +380,17 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     const cleaned = compact(castArray(value))
       .map(str => str.split(','))
       .flat()
-    indices.value = cleaned
+    // Keep the existing array reference when the value doesn't actually
+    // change. updateFromRouteQuery() calls this on every route round-trip
+    // (every filter edit re-applies `index`/`indices` from the URL), so an
+    // unconditional reassignment churns `indices.value`'s identity even
+    // when the project selection is unchanged. Consumers that watch
+    // `searchStore.indices` by reference (e.g. PathTree.vue, via
+    // `projects = computed(() => searchStore.indices)`) then see a false
+    // "changed" signal and reload/flash their content for no reason.
+    if (!isEqual(indices.value, cleaned)) {
+      indices.value = cleaned
+    }
   }
 
   /**

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -43,7 +43,6 @@ export const useSearchStore = defineSuffixedStore('search', () => {
   const lastAppliedQuery = ref({})
 
   const appStore = useAppStore()
-  const router = useRouter()
   const searchBreadcrumbStore = useSearchBreadcrumbStore()
 
   const index = computed({
@@ -158,6 +157,13 @@ export const useSearchStore = defineSuffixedStore('search', () => {
   const stringifyBaseRouteQuery = computed(() => {
     const name = 'search'
     const query = toBaseRouteQuery.value
+    // Router is resolved lazily here (rather than eagerly at store-setup
+    // time) because this store is instantiated during Core.configure(),
+    // before the router plugin is installed on the app — calling
+    // useRouter() at setup time throws a "Symbol(router) not found"
+    // injection warning on every boot. By the time anything actually reads
+    // this computed, the app (and router) are fully mounted.
+    const router = useRouter()
     const { href = null } = router?.resolve({ name, query }) ?? {}
     return href
   })

--- a/tests/unit/specs/core/routerInjectionWarning.spec.js
+++ b/tests/unit/specs/core/routerInjectionWarning.spec.js
@@ -1,0 +1,39 @@
+import { createCore } from '@/core'
+import { apiInstance as api } from '@/api/apiInstance'
+
+vi.mock('@/api/apiInstance', {
+  apiInstance: {
+    getUser: vi.fn(),
+    getSettings: vi.fn(),
+    getProject: vi.fn()
+  }
+})
+
+// Regression test for search.js calling vue-router's useRouter() eagerly at
+// store-setup time. Core.configure() (src/core/Core.js) eagerly instantiates
+// useSearchStore() before the router plugin is installed on the app, which
+// used to throw `[Vue warn]: injection "Symbol(router)" not found.` on every
+// boot. Kept in its own file (not alongside main.spec.js) because this app's
+// Pinia instance is a module-level singleton shared by every createCore()
+// call within a test file — once useSearchStore() runs once, later calls
+// return the cached store without re-running setup(), which would hide this
+// exact bug behind an earlier, contaminating store creation.
+it('does not warn about a missing router injection while booting', async () => {
+  api.getUser.mockResolvedValue({})
+  api.getSettings.mockResolvedValue({})
+  api.getProject.mockResolvedValue({})
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  const app = document.createElement('div')
+  app.setAttribute('id', 'app')
+  document.body.appendChild(app)
+
+  const core = createCore()
+  await core.ready
+  core.useRouter().mount()
+
+  const warnings = warnSpy.mock.calls.map(call => call.join(' ')).join('\n')
+  expect(warnings).not.toMatch(/injection.*router/i)
+
+  warnSpy.mockRestore()
+  app.remove()
+})

--- a/tests/unit/specs/core/routerInjectionWarning.spec.js
+++ b/tests/unit/specs/core/routerInjectionWarning.spec.js
@@ -1,13 +1,13 @@
 import { createCore } from '@/core'
 import { apiInstance as api } from '@/api/apiInstance'
 
-vi.mock('@/api/apiInstance', {
+vi.mock('@/api/apiInstance', () => ({
   apiInstance: {
     getUser: vi.fn(),
     getSettings: vi.fn(),
     getProject: vi.fn()
   }
-})
+}))
 
 // Regression test for search.js calling vue-router's useRouter() eagerly at
 // store-setup time. Core.configure() (src/core/Core.js) eagerly instantiates

--- a/tests/unit/specs/main.spec.js
+++ b/tests/unit/specs/main.spec.js
@@ -4,13 +4,13 @@ import { createCore } from '@/core'
 import { useHooksStore } from '@/store/modules'
 import { apiInstance as api } from '@/api/apiInstance'
 
-vi.mock('@/api/apiInstance', {
+vi.mock('@/api/apiInstance', () => ({
   apiInstance: {
     getUser: vi.fn(),
     getSettings: vi.fn(),
     getProject: vi.fn()
   }
-})
+}))
 
 describe('main', () => {
   let core, vm, hooksStore

--- a/tests/unit/specs/store/filters/FilterContentTypeCategory.spec.js
+++ b/tests/unit/specs/store/filters/FilterContentTypeCategory.spec.js
@@ -2,8 +2,8 @@ import bodybuilder from 'bodybuilder'
 import { setActivePinia, createPinia } from 'pinia'
 
 import IPhFiles from '~icons/ph/files'
-import filtersDefs from '@/store/filters'
-import FilterContentTypeCategory from '@/store/filters/FilterContentTypeCategory'
+import FilterContentTypeCategory, { CONTENT_TYPE_CATEGORY_FILTER_NAME } from '@/store/filters/FilterContentTypeCategory'
+import builtinFilterIcons from '@/store/filters/icons'
 import DisplayContentTypeCategory from '@/components/Display/DisplayContentTypeCategory'
 import { apiInstance as api } from '@/api/apiInstance'
 import { useSearchStore } from '@/store/modules'
@@ -12,8 +12,7 @@ import { findBoolShould, findTermsClause } from '~tests/unit/specs/utils/esQuery
 describe('FilterContentTypeCategory.js', () => {
   describe('breadcrumb icon', () => {
     it('uses the files icon so the breadcrumb chip reads as file types', () => {
-      const def = filtersDefs.find(d => d.options.name === 'contentTypeCategory')
-      expect(def.options.icon).toBe(IPhFiles)
+      expect(builtinFilterIcons[CONTENT_TYPE_CATEGORY_FILTER_NAME]).toBe(IPhFiles)
     })
   })
 

--- a/tests/unit/specs/store/filters/FilterContentTypeCategory.spec.js
+++ b/tests/unit/specs/store/filters/FilterContentTypeCategory.spec.js
@@ -1,18 +1,24 @@
 import bodybuilder from 'bodybuilder'
 import { setActivePinia, createPinia } from 'pinia'
+import { shallowMount } from '@vue/test-utils'
+import { AppIcon } from '@icij/murmur'
 
 import IPhFiles from '~icons/ph/files'
 import FilterContentTypeCategory, { CONTENT_TYPE_CATEGORY_FILTER_NAME } from '@/store/filters/FilterContentTypeCategory'
-import builtinFilterIcons from '@/store/filters/icons'
 import DisplayContentTypeCategory from '@/components/Display/DisplayContentTypeCategory'
+import FilterModalTitle from '@/components/Filter/FilterModal/FilterModalTitle'
 import { apiInstance as api } from '@/api/apiInstance'
 import { useSearchStore } from '@/store/modules'
 import { findBoolShould, findTermsClause } from '~tests/unit/specs/utils/esQueryBody'
+import CoreSetup from '~tests/unit/CoreSetup'
 
 describe('FilterContentTypeCategory.js', () => {
   describe('breadcrumb icon', () => {
-    it('uses the files icon so the breadcrumb chip reads as file types', () => {
-      expect(builtinFilterIcons[CONTENT_TYPE_CATEGORY_FILTER_NAME]).toBe(IPhFiles)
+    it('renders the files icon on FilterModalTitle so the breadcrumb chip reads as file types', () => {
+      const { plugins } = CoreSetup.init().useAll()
+      const filter = { name: CONTENT_TYPE_CATEGORY_FILTER_NAME, hideSort: true }
+      const wrapper = shallowMount(FilterModalTitle, { global: { plugins }, props: { filter } })
+      expect(wrapper.findComponent(AppIcon).props('name')).toBe(IPhFiles)
     })
   })
 

--- a/tests/unit/specs/store/modules/search.spec.js
+++ b/tests/unit/specs/store/modules/search.spec.js
@@ -103,6 +103,19 @@ describe('SearchStore', () => {
       await searchStore.query('bar')
       expect(searchStore.q).toBe('bar')
     })
+
+    it('should keep the same indices array reference when setIndices is a no-op', () => {
+      const before = searchStore.indices
+      searchStore.setIndices([index])
+      expect(searchStore.indices).toBe(before)
+    })
+
+    it('should update the indices array reference when the value actually changes', () => {
+      const before = searchStore.indices
+      searchStore.setIndices([anotherIndex])
+      expect(searchStore.indices).not.toBe(before)
+      expect(searchStore.indices).toEqual([anotherIndex])
+    })
   })
 
   describe('Search response', () => {


### PR DESCRIPTION
## PR description

**Fix eager `useSearchStore()` router injection warning + a filter-panel flash bug**

### Router injection warning
`search.js` called vue-router's `useRouter()` eagerly at store-setup time, before `Core.configure()` finishes and the router plugin installs, throwing `[Vue warn]: injection "Symbol(router)" not found.` on every boot. Fixed by deferring the `useRouter()` call into the one computed that actually uses it (`stringifyBaseRouteQuery`), instead of reordering boot (which was tried first and broke real navigation timing).

### Path filter flash on unrelated filter edits
Editing any filter (e.g. document type) visually closed and reopened the path filter's tree. Root cause: `setIndices()` reassigned `indices.value` to a new array on every route round-trip, even when the project selection hadn't changed. Consumers watching `searchStore.indices` by reference (`PathTree.vue`) treated this as a real change and reloaded, flashing the loading placeholder. Fixed by keeping the array reference stable on no-op calls.

Both fixes verified with regression tests (fail without the fix, pass with it) and, for the path-filter bug, live against a running dev server + backend.