### PR TITLE
fix(document): base the modal content's compact layout on the modal width

### DIFF
--- a/src/components/Document/DocumentModal.vue
+++ b/src/components/Document/DocumentModal.vue
@@ -63,7 +63,7 @@ onRouteUpdateNotMatch(route.name, () => hide())
       no-reduce
       no-expand
     >
-      <slot>
+      <slot v-bind="{ compact }">
         <document-view
           :id="id"
           :routing="routing"

--- a/src/views/Search/Search.vue
+++ b/src/views/Search/Search.vue
@@ -212,11 +212,13 @@ onConsumeNoRefresh({ immediate: route.name === 'search' })
                   :model-value="!!Component"
                   @hide="refreshRoute"
                 >
-                  <search-carousel v-if="hasCarousel" />
-                  <component
-                    :is="Component"
-                    :compact="!enoughFloatingSpace"
-                  />
+                  <template #default="{ compact }">
+                    <search-carousel v-if="hasCarousel" />
+                    <component
+                      :is="Component"
+                      :compact="compact"
+                    />
+                  </template>
                 </document-modal>
                 <component
                   :is="Component"


### PR DESCRIPTION
The document modal decided its content layout from the page's floating space, so the viewer could be told to render compact while the modal itself was wide (and the other way around). The modal already measures its own width for `display`, so expose that instead.

- fix: expose the document modal's own `compact` state through its default slot
- fix: render the search route's modal content with that state instead of `!enoughFloatingSpace`