### PR TITLE
fix(button): stop advanced search and modal close from looking pressed

### DIFF
--- a/src/components/AppModal/AppModalHeader.vue
+++ b/src/components/AppModal/AppModalHeader.vue
@@ -32,9 +32,16 @@ const { t } = useI18n()
 <template>
   <div class="app-modal-header w-100">
     <slot name="close">
+      <!-- `pressed` is explicitly undefined so BButton does not treat the
+           close button as a toggle: in toggle mode it flips its own `pressed`
+           model on every click, and nothing here controls it back, so the
+           button stays `.active` (and aria-pressed) once clicked. Murmur's
+           ButtonIcon casts an absent `pressed` to false, which is enough to
+           opt into that mode, hence the explicit undefined. -->
       <button-icon
         v-if="!noHeaderClose"
         :icon-left="IPhX"
+        :pressed="undefined"
         hide-label
         hide-tooltip
         tooltip-placement="right"

--- a/src/components/Button/ButtonToggleAdvancedSearch.vue
+++ b/src/components/Button/ButtonToggleAdvancedSearch.vue
@@ -44,10 +44,18 @@ const compact = computed(() => {
 </script>
 
 <template>
+  <!-- `pressed` is explicitly undefined so BButton does not treat this as a
+       toggle button: in toggle mode it flips its own `pressed` model on every
+       click and keeps the resulting `.active` class, which outlives the modal
+       and leaves the button looking pressed once it is closed. The pressed
+       state is carried by `variant` instead. Murmur's ButtonIcon casts an
+       absent `pressed` to false, which is enough to opt into that mode, hence
+       the explicit undefined. -->
   <button-icon
     :hide-label="compact"
     :label="t('buttonToggleAdvancedSearch.label')"
     :loading="loading"
+    :pressed="undefined"
     :square="compact"
     :variant="variant"
     class="button-toggle-advanced-search"

--- a/tests/unit/specs/components/AppModal/AppModalHeader.spec.js
+++ b/tests/unit/specs/components/AppModal/AppModalHeader.spec.js
@@ -1,0 +1,23 @@
+import { mount } from '@vue/test-utils'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import AppModalHeader from '@/components/AppModal/AppModalHeader'
+
+describe('AppModalHeader.vue', () => {
+  let core
+
+  beforeEach(() => {
+    core = CoreSetup.init().useAll()
+  })
+
+  it('does not leave the close button pressed after it has been clicked', async () => {
+    const wrapper = mount(AppModalHeader, { global: { plugins: core.plugins } })
+    const close = wrapper.get('.app-modal-header__close')
+
+    await close.trigger('click')
+
+    expect(wrapper.emitted('close')).toHaveLength(1)
+    expect(close.attributes('aria-pressed')).toBeUndefined()
+    expect(close.classes()).not.toContain('active')
+  })
+})

--- a/tests/unit/specs/components/Button/ButtonToggleAdvancedSearch.spec.js
+++ b/tests/unit/specs/components/Button/ButtonToggleAdvancedSearch.spec.js
@@ -1,0 +1,33 @@
+import { mount } from '@vue/test-utils'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import ButtonToggleAdvancedSearch from '@/components/Button/ButtonToggleAdvancedSearch'
+
+describe('ButtonToggleAdvancedSearch.vue', () => {
+  let core
+
+  const mountButton = (props = {}) =>
+    mount(ButtonToggleAdvancedSearch, {
+      global: { plugins: core.plugins },
+      props
+    })
+
+  beforeEach(() => {
+    core = CoreSetup.init().useAll()
+  })
+
+  it('does not look pressed anymore once the modal is closed', async () => {
+    const wrapper = mountButton({ active: false })
+    await wrapper.get('button').trigger('click')
+    expect(wrapper.emitted('update:active')).toEqual([[true]])
+
+    // The parent owns the model: it echoes the click back, then flips it again
+    // when the modal closes itself (cancel, escape, backdrop…).
+    await wrapper.setProps({ active: true })
+    await wrapper.setProps({ active: false })
+
+    expect(wrapper.get('button').classes()).toContain('btn-outline-tertiary')
+    expect(wrapper.get('button').classes()).not.toContain('active')
+    expect(wrapper.get('button').attributes('aria-pressed')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Murmur's `ButtonIcon` always forwards a boolean `pressed` to `BButton` (its prop is Boolean-cast, so an absent value becomes `false`), which is enough to put `BButton` in toggle mode. In that mode `BButton` flips its own `pressed` model on every click and nothing controls it back, so the `.active` class sticks and flips with each click.

That left the advanced search button gray (`.btn-outline-tertiary.active` fills with `#C7C7C7`) once the modal was closed, and the modal's close button looking focused (`.btn-outline-secondary.active` adds a light glow) since the advanced search modal stays mounted between opens.

Both buttons already show their state through `variant`, so they opt out of toggle mode instead.

- fix: keep the advanced search toggle out of `BButton`'s toggle mode so `.active` cannot outlive the modal
- fix: same for the modal header close button, which covers every modal in the app
- test: regression specs for both, asserting no stale `.active` / `aria-pressed`

Closes icij/datashare#2326