### PR TITLE
fix: keep an unpaired filter own selection in its contextualized aggregation

### DIFF
--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -5,7 +5,7 @@ import { getCookie } from 'tiny-cookie'
 
 import { Client, Transport } from '@/api/elasticsearchClient'
 
-import { getPairedDimensions } from '@/store/filters/pairedDimensions'
+import { getPairedDimension, getPairedDimensions } from '@/store/filters/pairedDimensions'
 import { EventBus } from '@/utils/eventBus'
 import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 import settings from '@/utils/settings'
@@ -321,11 +321,7 @@ export function datasharePlugin(Client) {
     let body = filter.body(bodybuilder(), options, from, size)
 
     if (contextualize) {
-      // Exclude the bucket's own filter from the agg context so the bucket
-      // selection does not constrain its own buckets and the paired-dimension
-      // OR-combine does not trigger (only one side of the pair remains here).
-      const otherFilters = filters.filter(other => other.name !== filter.name)
-      this._applyFilters(body, otherFilters)
+      this._applyFilters(body, this._contextFilters(filter, filters))
       this._applyQueryString(body, normalizeQuery(query), fields)
     }
 
@@ -441,6 +437,29 @@ export function datasharePlugin(Client) {
       }
     }
     return this._search({ index, body, preference: PREFERENCE.MAX_EXTRACTION_DATE })
+  }
+
+  /**
+   * The filters constraining a bucket aggregation when the filter is
+   * contextualized.
+   *
+   * A paired filter (contentType ↔ contentTypeCategory) drops its own
+   * selection: its buckets would otherwise collapse to the values already
+   * picked, and its sibling keeps constraining the aggregation anyway.
+   *
+   * Every other filter keeps its own selection, so its buckets describe the
+   * current search results, which is what contextualizing is for. Without it,
+   * contextualizing a filter that is the only active one is a no-op.
+   * @private
+   * @param {Object} filter - The filter being aggregated on
+   * @param {Array} filters - Every instantiated filter
+   * @returns {Array} The filters to apply to the aggregation body
+   */
+  Client.prototype._contextFilters = function (filter, filters) {
+    if (!getPairedDimension(filter.name)) {
+      return filters
+    }
+    return filters.filter(other => other.name !== filter.name)
   }
 
   /**

--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -456,10 +456,10 @@ export function datasharePlugin(Client) {
    * @returns {Array} The filters to apply to the aggregation body
    */
   Client.prototype._contextFilters = function (filter, filters) {
-    if (!getPairedDimension(filter.name)) {
-      return filters
+    if (getPairedDimension(filter.name)) {
+      return filters.filter(other => other.name !== filter.name)
     }
-    return filters.filter(other => other.name !== filter.name)
+    return filters
   }
 
   /**

--- a/tests/unit/specs/api/elasticsearch.searchFilter.spec.js
+++ b/tests/unit/specs/api/elasticsearch.searchFilter.spec.js
@@ -1,0 +1,91 @@
+import { elasticsearch } from '@/api/elasticsearch'
+import { FilterText } from '@/store/filters'
+
+describe('elasticsearch searchFilter', () => {
+  const index = 'local-datashare'
+
+  function bindFilter(filter, values, { excluded = false } = {}) {
+    const excludeFilters = excluded ? [filter.name] : []
+    filter.bindStore({ values, excludeFilters, contextualizeFilters: [filter.name], sortFilters: {} })
+    return filter
+  }
+
+  function findTermsClause(query, field) {
+    if (query?.terms?.[field]) {
+      return query.terms[field]
+    }
+
+    const children = [query?.bool?.filter, query?.bool?.must, query?.bool?.should, query?.bool?.must_not]
+
+    for (const child of children.flat().filter(Boolean)) {
+      const found = findTermsClause(child, field)
+      if (found) {
+        return found
+      }
+    }
+
+    return null
+  }
+
+  async function contextualizedBody(filter, filters) {
+    const spy = vi.spyOn(elasticsearch, '_search').mockResolvedValue({})
+    await elasticsearch.searchFilter(index, filter, '', filters, true)
+    return spy.mock.calls[0][0].body
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('applies an unpaired filter own selection to its aggregation context', async () => {
+    const values = { tags: ['bar'] }
+    const tags = bindFilter(new FilterText({ name: 'tags', key: 'tags' }), values)
+
+    const body = await contextualizedBody(tags, [tags])
+
+    expect(findTermsClause(body.query, 'tags')).toEqual(['bar'])
+  })
+
+  it('applies both an unpaired filter own selection and the other filters', async () => {
+    const values = { tags: ['bar'], language: ['ENGLISH'] }
+    const tags = bindFilter(new FilterText({ name: 'tags', key: 'tags' }), values)
+    const language = bindFilter(new FilterText({ name: 'language', key: 'language' }), values)
+
+    const body = await contextualizedBody(tags, [tags, language])
+
+    expect(findTermsClause(body.query, 'tags')).toEqual(['bar'])
+    expect(findTermsClause(body.query, 'language')).toEqual(['ENGLISH'])
+  })
+
+  it('applies an unpaired filter own selection as a must_not when excluded', async () => {
+    const values = { tags: ['bar'] }
+    const tags = bindFilter(new FilterText({ name: 'tags', key: 'tags' }), values, { excluded: true })
+
+    const body = await contextualizedBody(tags, [tags])
+
+    // The buckets must drop the excluded values; FilterType re-adds them as
+    // zero-count entries so they stay visible in the panel.
+    expect(body.query.bool.filter.bool.must_not).toContainEqual({ terms: { tags: ['bar'] } })
+  })
+
+  it('excludes a paired filter own selection from its aggregation context', async () => {
+    const values = { contentType: ['application/pdf'], contentTypeCategory: ['DOCUMENT'] }
+    const contentType = bindFilter(new FilterText({ name: 'contentType', key: 'contentType' }), values)
+    const category = bindFilter(new FilterText({ name: 'contentTypeCategory', key: 'contentTypeCategory' }), values)
+
+    const body = await contextualizedBody(contentType, [contentType, category])
+
+    expect(findTermsClause(body.query, 'contentType')).toBeNull()
+    expect(findTermsClause(body.query, 'contentTypeCategory')).toEqual(['DOCUMENT'])
+  })
+
+  it('leaves the aggregation context unconstrained when not contextualized', async () => {
+    const values = { tags: ['bar'] }
+    const tags = bindFilter(new FilterText({ name: 'tags', key: 'tags' }), values)
+
+    const spy = vi.spyOn(elasticsearch, '_search').mockResolvedValue({})
+    await elasticsearch.searchFilter(index, tags, '', [tags], false)
+
+    expect(findTermsClause(spy.mock.calls[0][0].body.query, 'tags')).toBeNull()
+  })
+})

--- a/tests/unit/specs/store/filters/FilterContentTypeCategory.spec.js
+++ b/tests/unit/specs/store/filters/FilterContentTypeCategory.spec.js
@@ -160,11 +160,11 @@ describe('FilterContentTypeCategory.js', () => {
 
     function buildAggBody(filterName) {
       // Mirrors the body construction performed by `searchFilter`: build the
-      // bucket's own aggregation, then apply the other filters and the query.
+      // bucket's own aggregation, then apply the context filters and the query.
       const filter = searchStore.getFilter({ name: filterName })
-      const otherFilters = searchStore.instantiatedFilters.filter(other => other.name !== filter.name)
+      const contextFilters = api.elasticsearch._contextFilters(filter, searchStore.instantiatedFilters)
       const body = filter.body(bodybuilder(), {}, 0, 8)
-      api.elasticsearch._applyFilters(body, otherFilters)
+      api.elasticsearch._applyFilters(body, contextFilters)
       api.elasticsearch._applyQueryString(body, '*', [])
       return body.size(0).rawOption('track_total_hits', true).build()
     }


### PR DESCRIPTION
Contextualizing a filter that is the only active one did nothing, because `searchFilter` stripped the aggregated filter's own selection from the aggregation context. That exclusion is only needed for paired dimensions (contentType/contentTypeCategory), where the sibling still constrains the aggregation.

Fixes ICIJ/datashare#2333

- fix: keep an unpaired filter own selection in its contextualized aggregation
- test: cover the aggregation context for paired and unpaired filters
- test: build the paired-dimension agg body from the real helper instead of a hand-copied mirror