### PR TITLE
fix: prevent flaky-adjacent timeout in useSearchBreadcrumb spec

### DIFF
--- a/tests/unit/specs/composables/useSearchBreadcrumb.spec.js
+++ b/tests/unit/specs/composables/useSearchBreadcrumb.spec.js
@@ -1,11 +1,24 @@
 import { mount } from '@vue/test-utils'
+import { createRouter, createWebHashHistory } from 'vue-router'
+import { createPinia, setActivePinia } from 'pinia'
 
 import CoreSetup from '~tests/unit/CoreSetup'
 import { useSearchBreadcrumb } from '@/composables/useSearchBreadcrumb'
 import { useSearchStore } from '@/store/modules'
+import { routes } from '@/router'
 
 describe('useSearchBreadcrumb composable', () => {
   let core, plugins, searchStore
+
+  // The "search" route lazily imports the whole Search view subtree, whose
+  // setup() reads from the search store. Resolve it once here, on a
+  // throwaway router/pinia, so that cost isn't paid inside a single test's
+  // timeout.
+  beforeAll(async () => {
+    setActivePinia(createPinia())
+    const router = createRouter({ routes, history: createWebHashHistory() })
+    await router.push({ name: 'search' })
+  })
 
   beforeEach(() => {
     core = CoreSetup.init().useAll().useRouterWithoutGuards()


### PR DESCRIPTION
Fixes icij/datashare#2337

`clearEntry`'s `refreshRoute()` navigates to the `search` route, which lazily imports the whole Search view subtree on first resolution - that cost was landing inside a single test (~9.4s, vs the 10s Vitest timeout). Added a `beforeAll` that resolves it once on a throwaway router/pinia, so subsequent `beforeEach` navigations hit a warm import cache.

Test time dropped from ~9.4s to ~15ms for the affected test.