### PR TITLE
feat: render the document text tab as markdown

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -409,6 +409,18 @@ export class Api {
     return data
   }
 
+  /**
+   * Count a query's occurrences in a document's markdown structure pages,
+   * per page. Bypasses `sendAction` because it runs on every (throttled)
+   * keystroke: the caller degrades a failure to zero occurrences instead of
+   * toasting it.
+   */
+  async searchStructurePages(index, id, query, routing) {
+    const url = Api.getFullUrl(`/api/${index}/artifacts/structure/search/${id}`)
+    const { data } = await this.axios.request({ url, method: Method.GET, params: { query, routing } })
+    return data
+  }
+
   login(username, password) {
     return this.sendAction('/auth/login', {
       method: Method.POST,

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -405,7 +405,7 @@ export class Api {
    */
   async getStructurePage(index, id, page, routing) {
     const url = Api.getFullUrl(`/api/${index}/artifacts/structure/${id}/${page}`)
-    const { data } = await this.axios.request({ url, method: Method.GET, params: { routing }, responseType: 'text' })
+    const { data } = await this.requestArtifact({ url, params: { routing }, responseType: 'text' })
     return data
   }
 
@@ -417,8 +417,25 @@ export class Api {
    */
   async searchStructurePages(index, id, query, routing) {
     const url = Api.getFullUrl(`/api/${index}/artifacts/structure/search/${id}`)
-    const { data } = await this.axios.request({ url, method: Method.GET, params: { query, routing } })
+    const { data } = await this.requestArtifact({ url, params: { query, routing } })
     return data
+  }
+
+  /**
+   * Request an artifact endpoint outside `sendAction`, while still reporting an
+   * expired session on the error bus. Without this, callers that degrade a
+   * failure to "no results" would swallow a 401 and never offer a re-login.
+   */
+  async requestArtifact(config) {
+    try {
+      return await this.axios.request({ method: Method.GET, ...config })
+    }
+    catch (error) {
+      if (error.response?.status === 401) {
+        this.eventBus?.emit('http::error', error)
+      }
+      throw error
+    }
   }
 
   login(username, password) {

--- a/src/components/Document/DocumentContent.vue
+++ b/src/components/Document/DocumentContent.vue
@@ -72,7 +72,7 @@ const markdownMatches = ref([])
 const markdownAppliedTerm = ref('')
 // Set at the end of `onMounted`, so the mode watcher can tell a real, later mode
 // flip apart from the manifest probe settling `isMarkdownMode` during the mount.
-const isMounted = ref(false)
+let isMounted = false
 
 const isTranslation = computed(() => {
   return !!props.targetLanguage && props.targetLanguage !== 'original'
@@ -240,7 +240,7 @@ watch(isMarkdownMode, async (markdown) => {
   await syncPagePosition(markdown)
   // `hasMarkdown` flips during `onMounted`'s manifest probe, so without this gate
   // that flip would duplicate the search the mount is about to issue itself.
-  if (isMounted.value && hasLocalSearchTerms.value) {
+  if (isMounted && hasLocalSearchTerms.value) {
     await retrieveOccurrencesAndUpdateContent()
   }
 })
@@ -254,7 +254,16 @@ watch(docId, async () => {
   markdownPage.value = 1
   markdownMatches.value = []
   markdownAppliedTerm.value = ''
-  await fetchManifest()
+  maxOffsetTranslations.value = {}
+  syncedPages.value = []
+  localSearchIndexes.value = []
+  localSearchOccurrences.value = 0
+  localSearchIndex.value = 0
+  // An occurrence fetch issued for the document being left would otherwise
+  // resolve into the state of the one arriving: no other watcher supersedes it
+  // when the search term itself is unchanged across the swap.
+  lastOccurrencesRetrieval++
+  await loadDocumentContent()
 })
 
 watch(contentPipeline, async () => {
@@ -266,19 +275,31 @@ onMounted(async () => {
   // `finally`, because a mount step rejecting must not leave the flag stuck
   // `false` and suppress every later mode-flip search for this instance.
   try {
-    await Promise.all([loadMaxOffset(), fetchManifest()])
-    await syncPages()
-    if (props.q) {
-      await retrieveOccurrencesAndUpdateContent()
-    }
-    else {
-      await activateContentSlice({ offset: 0 })
-    }
+    await loadDocumentContent()
   }
   finally {
-    isMounted.value = true
+    isMounted = true
   }
 })
+
+// Shared with the `docId` watcher: this sequence describes a document, not a
+// mount, and the host can swap the document without remounting.
+async function loadDocumentContent() {
+  await Promise.all([loadMaxOffset(), fetchManifest()])
+  await syncPages()
+  // Slices are keyed by offset alone, so a watcher woken by the reset above can
+  // have cached one sliced against the length and page map of the previous
+  // document. Only now are both of them known for this one.
+  Object.keys(contentSlices).forEach(key => delete contentSlices[key])
+  activeContentSliceOffset.value = 0
+  currentContentPage.value = ''
+  if (hasLocalSearchTerms.value) {
+    await retrieveOccurrencesAndUpdateContent()
+  }
+  else {
+    await activateContentSlice({ offset: 0 })
+  }
+}
 
 // A single-page artifact whose only page renders to nothing has no markdown
 // worth showing, so the tab goes back to plain text. With more pages, a blank

--- a/src/components/Document/DocumentContent.vue
+++ b/src/components/Document/DocumentContent.vue
@@ -209,8 +209,8 @@ watch(page, async () => {
   await activateContentSlice({ offset })
 })
 
-watch(isMarkdownMode, (markdown) => {
-  syncPagePosition(markdown)
+watch(isMarkdownMode, async (markdown) => {
+  await syncPagePosition(markdown)
 })
 
 watch(contentPipeline, async () => {
@@ -232,14 +232,25 @@ onMounted(async () => {
 // Both paginations describe the same physical pages when their counts match,
 // so the page number survives the toggle; anything else has no page
 // correspondence and goes back to the first page.
-function syncPagePosition(markdown) {
+async function syncPagePosition(markdown) {
+  // A translation forces text mode through its own contract (start at offset
+  // 0, handled by the targetLanguage watcher): its offsets describe another
+  // language than the one `syncedPages`/`offsets` were computed for, so this
+  // function must not touch the page position in that case.
+  if (isTranslation.value) {
+    return
+  }
   const aligned = !!syncedPages.value?.length && syncedPages.value.length === markdownPagesCount.value
   if (markdown) {
     markdownPage.value = aligned ? offsets.value.indexOf(activeContentSliceOffset.value) + 1 || 1 : 1
+    return
   }
-  else {
-    activeContentSliceOffset.value = aligned ? offsets.value[markdownPage.value - 1] ?? 0 : 0
-  }
+  // The restored page needs its text slice loaded, and going through
+  // `activateContentSlice` also registers this offset as the current
+  // activation, so the activation the mode flip triggered for the previous
+  // offset cannot clobber it once it resolves.
+  const offset = aligned ? offsets.value[markdownPage.value - 1] ?? 0 : 0
+  await activateContentSlice({ offset })
 }
 
 const loadMaxOffset = waitFor(async function (targetLanguage = props.targetLanguage) {
@@ -384,9 +395,19 @@ async function activateContentSliceAround(desiredOffset = activeTermOffset.value
   return activateContentSlice({ offset })
 }
 
+let lastContentSliceActivation = 0
+
 const activateContentSlice = waitFor(async function ({ offset = 0 } = {}) {
+  const activation = ++lastContentSliceActivation
   await loadContentSliceOnce({ offset })
   await cookAllContentSlices()
+  // A newer activation was requested while this one was loading: `page` is
+  // derived from the active offset and the page watcher activates it back, so
+  // writing a superseded offset here makes the two activations overwrite each
+  // other forever instead of settling on the offset the user asked for.
+  if (activation !== lastContentSliceActivation) {
+    return
+  }
   activeContentSliceOffset.value = offset
   const { cookedContent = null } = getContentSlice({ offset: activeContentSliceOffset.value }) ?? {}
   currentContentPage.value = cookedContent

--- a/src/components/Document/DocumentContent.vue
+++ b/src/components/Document/DocumentContent.vue
@@ -19,6 +19,7 @@ import { useMode } from '@/composables/useMode'
 import { useStructureArtifact } from '@/composables/useStructureArtifact'
 import { useWait } from '@/composables/useWait'
 import DocumentAttachments from '@/components/Document/DocumentAttachments'
+import DocumentContentDropdown from '@/components/Document/DocumentContentDropdown'
 import DocumentContentMarkdown from '@/components/Document/DocumentContentMarkdown'
 import DocumentGlobalSearchTerms from '@/components/Document/DocumentGlobalSearchTerms/DocumentGlobalSearchTerms'
 import DocumentLocalSearch from '@/components/Document/DocumentLocalSearch/DocumentLocalSearch'
@@ -586,6 +587,13 @@ async function loadContentSliceAround(desiredOffset) {
           />
         </div>
         <hook name="document.content.toolbox.pagination:after" />
+        <document-content-dropdown
+          v-if="hasMarkdown"
+          v-model="preferMarkdown"
+          :markdown-disabled="isMarkdownEmpty"
+          :translation="isTranslation"
+          class="flex-shrink-0 ms-auto"
+        />
       </div>
       <document-global-search-terms
         :document="document"
@@ -599,28 +607,6 @@ async function loadContentSliceAround(desiredOffset) {
         name="document.content.togglers:before"
         x-class="d-flex flex-row justify-content-end align-items-center"
       />
-      <b-form-radio-group
-        v-if="hasMarkdown"
-        v-model="preferMarkdown"
-        buttons
-        button-variant="outline-secondary"
-        size="sm"
-        :disabled="isTranslation"
-        :title="isTranslation ? t('documentContent.view.translationTooltip') : undefined"
-        :aria-label="t('documentContent.view.ariaLabel')"
-        class="document-content__togglers__view"
-      >
-        <b-form-radio
-          :value="true"
-          :disabled="isMarkdownEmpty"
-          class="document-content__togglers__view__markdown"
-        >
-          {{ t('documentContent.view.markdown') }}
-        </b-form-radio>
-        <b-form-radio :value="false">
-          {{ t('documentContent.view.text') }}
-        </b-form-radio>
-      </b-form-radio-group>
       <hook
         name="document.content.togglers:after"
         x-class="d-flex flex-row justify-content-end align-items-center"

--- a/src/components/Document/DocumentContent.vue
+++ b/src/components/Document/DocumentContent.vue
@@ -16,8 +16,10 @@ import { addLocalSearchMarksClassByOffsets } from '@/utils/strings'
 import { useCompact } from '@/composables/useCompact'
 import { useConfig } from '@/composables/useConfig'
 import { useMode } from '@/composables/useMode'
+import { useStructureArtifact } from '@/composables/useStructureArtifact'
 import { useWait } from '@/composables/useWait'
 import DocumentAttachments from '@/components/Document/DocumentAttachments'
+import DocumentContentMarkdown from '@/components/Document/DocumentContentMarkdown'
 import DocumentGlobalSearchTerms from '@/components/Document/DocumentGlobalSearchTerms/DocumentGlobalSearchTerms'
 import DocumentLocalSearch from '@/components/Document/DocumentLocalSearch/DocumentLocalSearch'
 import Hook from '@/components/Hook/Hook'
@@ -53,6 +55,22 @@ const searchStore = useSearchStore.inject()
 const elementRef = useTemplateRef('element')
 const { compact } = useCompact(elementRef, { threshold: toRef(props, 'compactThreshold') })
 const { waitFor, isLoading } = useWait()
+const { hasMarkdown, pages: markdownPagesCount, fetchManifest } = useStructureArtifact(toRef(props, 'document'))
+
+const preferMarkdown = ref(true)
+const markdownPage = ref(1)
+
+const isTranslation = computed(() => {
+  return !!props.targetLanguage && props.targetLanguage !== 'original'
+})
+
+const isMarkdownMode = computed(() => {
+  return hasMarkdown.value && !isTranslation.value && preferMarkdown.value
+})
+
+// Task 6 replaces this with the real match logic; kept as a placeholder so
+// the template compiles before markdown-native search exists.
+const activeMarkdownMatch = computed(() => 0)
 
 const docIndex = computed(() => props.document?.index)
 const docId = computed(() => props.document?.id)
@@ -100,7 +118,7 @@ const activeTermOffset = computed(() => {
 })
 
 const showPagination = computed(() => {
-  return nbPages.value > 1 && loadedOnce.value
+  return nbPages.value > 1 && (isMarkdownMode.value || loadedOnce.value)
 })
 
 const hasLocalSearchTerms = computed(() => {
@@ -115,16 +133,24 @@ const isRightToLeft = computed(() => {
 const classList = computed(() => {
   return {
     'document-content--paginated': showPagination.value,
+    'document-content--markdown': isMarkdownMode.value,
     'document-content--rtl': isRightToLeft.value
   }
 })
 
 const page = computed({
   get() {
+    if (isMarkdownMode.value) {
+      return markdownPage.value
+    }
     return offsets.value.indexOf(activeContentSliceOffset.value) + 1 || 1
   },
   set(value) {
     scrollToDocumentStart()
+    if (isMarkdownMode.value) {
+      markdownPage.value = value
+      return
+    }
     activeContentSliceOffset.value = offsets.value[value - 1] || 0
   }
 })
@@ -137,6 +163,9 @@ const maxOffset = computed(() => {
 })
 
 const nbPages = computed(() => {
+  if (isMarkdownMode.value) {
+    return markdownPagesCount.value
+  }
   if (syncedPages.value?.length) {
     return syncedPages.value.length
   }
@@ -173,8 +202,15 @@ watch(toRef(props, 'targetLanguage'), async (value) => {
 })
 
 watch(page, async () => {
+  if (isMarkdownMode.value) {
+    return
+  }
   const offset = activeContentSliceOffset.value
   await activateContentSlice({ offset })
+})
+
+watch(isMarkdownMode, (markdown) => {
+  syncPagePosition(markdown)
 })
 
 watch(contentPipeline, async () => {
@@ -183,7 +219,7 @@ watch(contentPipeline, async () => {
 })
 
 onMounted(async () => {
-  await loadMaxOffset()
+  await Promise.all([loadMaxOffset(), fetchManifest()])
   await syncPages()
   if (props.q) {
     await retrieveOccurrencesAndUpdateContent()
@@ -192,6 +228,19 @@ onMounted(async () => {
     await activateContentSlice({ offset: 0 })
   }
 })
+
+// Both paginations describe the same physical pages when their counts match,
+// so the page number survives the toggle; anything else has no page
+// correspondence and goes back to the first page.
+function syncPagePosition(markdown) {
+  const aligned = !!syncedPages.value?.length && syncedPages.value.length === markdownPagesCount.value
+  if (markdown) {
+    markdownPage.value = aligned ? offsets.value.indexOf(activeContentSliceOffset.value) + 1 || 1 : 1
+  }
+  else {
+    activeContentSliceOffset.value = aligned ? offsets.value[markdownPage.value - 1] ?? 0 : 0
+  }
+}
 
 const loadMaxOffset = waitFor(async function (targetLanguage = props.targetLanguage) {
   const key = targetLanguage ?? 'original'
@@ -424,6 +473,23 @@ async function loadContentSliceAround(desiredOffset) {
         name="document.content.togglers:before"
         x-class="d-flex flex-row justify-content-end align-items-center"
       />
+      <b-form-radio-group
+        v-if="hasMarkdown"
+        v-model="preferMarkdown"
+        buttons
+        button-variant="outline-secondary"
+        size="sm"
+        :disabled="isTranslation"
+        :title="isTranslation ? t('documentContent.view.translationTooltip') : undefined"
+        class="document-content__togglers__view"
+      >
+        <b-form-radio :value="true">
+          {{ t('documentContent.view.markdown') }}
+        </b-form-radio>
+        <b-form-radio :value="false">
+          {{ t('documentContent.view.text') }}
+        </b-form-radio>
+      </b-form-radio-group>
       <hook
         name="document.content.togglers:after"
         x-class="d-flex flex-row justify-content-end align-items-center"
@@ -432,8 +498,17 @@ async function loadContentSliceAround(desiredOffset) {
     <div class="document-content__wrapper">
       <slot name="before-content" />
       <hook name="document.content.body:before" />
+      <document-content-markdown
+        v-if="isMarkdownMode"
+        class="document-content__body document-content__body--markdown"
+        :document="document"
+        :page="markdownPage"
+        :term="localSearchTerm"
+        :active-match="activeMarkdownMatch"
+        @fallback="preferMarkdown = false"
+      />
       <div
-        v-if="hasExtractedContent"
+        v-else-if="hasExtractedContent"
         class="document-content__body"
         v-html="currentContentPage"
       />
@@ -476,6 +551,10 @@ async function loadContentSliceAround(desiredOffset) {
 
   &__body {
     word-break: break-all;
+  }
+
+  &__body--markdown {
+    word-break: normal;
   }
 
   &--rtl &__body {

--- a/src/components/Document/DocumentContent.vue
+++ b/src/components/Document/DocumentContent.vue
@@ -60,6 +60,10 @@ const { hasMarkdown, pages: markdownPagesCount, fetchManifest } = useStructureAr
 const preferMarkdown = ref(true)
 const markdownPage = ref(1)
 const markdownMatches = ref([])
+// Set at the end of `onMounted`, so the mode watcher can tell a real, later
+// mode flip apart from the manifest probe settling `isMarkdownMode` during
+// the initial mount.
+const isMounted = ref(false)
 
 const isTranslation = computed(() => {
   return !!props.targetLanguage && props.targetLanguage !== 'original'
@@ -129,6 +133,11 @@ const showPagination = computed(() => {
 const hasLocalSearchTerms = computed(() => {
   return localSearchTerm.value && localSearchTerm.value.length > 0
 })
+
+// The structure-pages endpoint answers 400 to a blank query, and the marks
+// rendered by `DocumentContentMarkdown` must match what it counted, so both
+// the request and the template read this single, trimmed value.
+const markdownSearchTerm = computed(() => localSearchTerm.value?.trim() ?? '')
 
 const isRightToLeft = computed(() => {
   const language = props.targetLanguage ?? get(props.document, 'source.language', null)
@@ -216,7 +225,13 @@ watch(page, async () => {
 
 watch(isMarkdownMode, async (markdown) => {
   await syncPagePosition(markdown)
-  if (hasLocalSearchTerms.value) {
+  // `hasMarkdown` flips during `onMounted`'s manifest probe, which fires this
+  // watcher before the mount has even chosen whether to run a search at all;
+  // gating on `isMounted` keeps that flip from duplicating the search that
+  // `onMounted`'s own `q` branch is about to issue. Real mode flips (a user
+  // toggle, or a translation forcing text mode) all happen after mount, so
+  // this gate never blocks them.
+  if (isMounted.value && hasLocalSearchTerms.value) {
     await retrieveOccurrencesAndUpdateContent()
   }
 })
@@ -235,6 +250,7 @@ onMounted(async () => {
   else {
     await activateContentSlice({ offset: 0 })
   }
+  isMounted.value = true
 })
 
 // Both paginations describe the same physical pages when their counts match,
@@ -389,14 +405,21 @@ function updateMarkdownContent() {
   }
 }
 
+let lastOccurrencesRetrieval = 0
+
 async function retrieveTotalOccurrences() {
+  // A mode flip mid-flight can start the other path's retrieval before this
+  // one's response lands; this counter mirrors `lastContentSliceActivation`
+  // so only the newest retrieval is allowed to write its results, whichever
+  // response arrives last.
+  const retrieval = ++lastOccurrencesRetrieval
   if (isMarkdownMode.value) {
-    return retrieveMarkdownOccurrences()
+    return retrieveMarkdownOccurrences(retrieval)
   }
-  return retrieveTextOccurrences()
+  return retrieveTextOccurrences(retrieval)
 }
 
-async function retrieveTextOccurrences() {
+async function retrieveTextOccurrences(retrieval) {
   try {
     if (!hasLocalSearchTerms.value) {
       throw new Error('No local search terms')
@@ -404,30 +427,41 @@ async function retrieveTextOccurrences() {
     const query = localSearchTerm.value
     const targetLanguage = props.targetLanguage
     const { count, offsets } = await api.searchDocument(docIndex.value, docId.value, query, targetLanguage, docRouting.value)
+    if (retrieval !== lastOccurrencesRetrieval) {
+      return
+    }
     localSearchIndexes.value = offsets
     localSearchOccurrences.value = count
     localSearchIndex.value = Number(!!count)
   }
   catch {
+    if (retrieval !== lastOccurrencesRetrieval) {
+      return
+    }
     localSearchIndexes.value = []
     localSearchOccurrences.value = 0
     localSearchIndex.value = 0
   }
 }
 
-async function retrieveMarkdownOccurrences() {
+async function retrieveMarkdownOccurrences(retrieval) {
   try {
-    // The endpoint answers 400 to a blank query, so trim before asking
-    const query = localSearchTerm.value?.trim()
+    const query = markdownSearchTerm.value
     if (!query) {
       throw new Error('No local search terms')
     }
     const { count, hits } = await api.searchStructurePages(docIndex.value, docId.value, query, docRouting.value)
+    if (retrieval !== lastOccurrencesRetrieval) {
+      return
+    }
     markdownMatches.value = flattenPageHits(hits)
     localSearchOccurrences.value = count
     localSearchIndex.value = Number(!!count)
   }
   catch {
+    if (retrieval !== lastOccurrencesRetrieval) {
+      return
+    }
     markdownMatches.value = []
     localSearchOccurrences.value = 0
     localSearchIndex.value = 0
@@ -576,7 +610,7 @@ async function loadContentSliceAround(desiredOffset) {
         class="document-content__body document-content__body--markdown"
         :document="document"
         :page="markdownPage"
-        :term="localSearchTerm?.trim() ?? ''"
+        :term="markdownSearchTerm"
         :active-match="activeMarkdownMatch"
         @fallback="preferMarkdown = false"
       />

--- a/src/components/Document/DocumentContent.vue
+++ b/src/components/Document/DocumentContent.vue
@@ -598,6 +598,7 @@ async function loadContentSliceAround(desiredOffset) {
         size="sm"
         :disabled="isTranslation"
         :title="isTranslation ? t('documentContent.view.translationTooltip') : undefined"
+        :aria-label="t('documentContent.view.ariaLabel')"
         class="document-content__togglers__view"
       >
         <b-form-radio :value="true">

--- a/src/components/Document/DocumentContent.vue
+++ b/src/components/Document/DocumentContent.vue
@@ -242,15 +242,25 @@ watch(contentPipeline, async () => {
 })
 
 onMounted(async () => {
-  await Promise.all([loadMaxOffset(), fetchManifest()])
-  await syncPages()
-  if (props.q) {
-    await retrieveOccurrencesAndUpdateContent()
+  // A rejected mount step (a transient network failure, most plausibly from
+  // `loadMaxOffset`'s or `syncPages`' own API calls) must not leave the flag
+  // stuck `false` forever: that would silently suppress every later,
+  // legitimate mode-flip search for this component instance's whole
+  // lifetime. `finally` sets it regardless of how the body finished, without
+  // swallowing the failure itself.
+  try {
+    await Promise.all([loadMaxOffset(), fetchManifest()])
+    await syncPages()
+    if (props.q) {
+      await retrieveOccurrencesAndUpdateContent()
+    }
+    else {
+      await activateContentSlice({ offset: 0 })
+    }
   }
-  else {
-    await activateContentSlice({ offset: 0 })
+  finally {
+    isMounted.value = true
   }
-  isMounted.value = true
 })
 
 // Both paginations describe the same physical pages when their counts match,

--- a/src/components/Document/DocumentContent.vue
+++ b/src/components/Document/DocumentContent.vue
@@ -58,6 +58,10 @@ const { waitFor, isLoading } = useWait()
 const { hasMarkdown, pages: markdownPagesCount, fetchManifest } = useStructureArtifact(toRef(props, 'document'))
 
 const preferMarkdown = ref(true)
+// An artifact can be listed in the manifest and still hold no markdown at all.
+// That only shows once its first page comes back empty, so the toggle is built
+// from the manifest and this runtime finding together.
+const isMarkdownEmpty = ref(false)
 const markdownPage = ref(1)
 const markdownMatches = ref([])
 // Set at the end of `onMounted`, so the mode watcher can tell a real, later
@@ -262,6 +266,11 @@ onMounted(async () => {
     isMounted.value = true
   }
 })
+
+function fallbackToTextForEmptyMarkdown() {
+  isMarkdownEmpty.value = true
+  preferMarkdown.value = false
+}
 
 // Both paginations describe the same physical pages when their counts match,
 // so the page number survives the toggle; anything else has no page
@@ -601,7 +610,11 @@ async function loadContentSliceAround(desiredOffset) {
         :aria-label="t('documentContent.view.ariaLabel')"
         class="document-content__togglers__view"
       >
-        <b-form-radio :value="true">
+        <b-form-radio
+          :value="true"
+          :disabled="isMarkdownEmpty"
+          class="document-content__togglers__view__markdown"
+        >
           {{ t('documentContent.view.markdown') }}
         </b-form-radio>
         <b-form-radio :value="false">
@@ -624,6 +637,7 @@ async function loadContentSliceAround(desiredOffset) {
         :term="localSearchOccurrences ? markdownSearchTerm : ''"
         :active-match="activeMarkdownMatch"
         @fallback="preferMarkdown = false"
+        @empty="fallbackToTextForEmptyMarkdown"
       />
       <div
         v-else-if="hasExtractedContent"

--- a/src/components/Document/DocumentContent.vue
+++ b/src/components/Document/DocumentContent.vue
@@ -8,6 +8,7 @@ import isEmpty from 'lodash/isEmpty'
 import iteratee from 'lodash/iteratee'
 import minBy from 'lodash/minBy'
 import range from 'lodash/range'
+import sortBy from 'lodash/sortBy'
 import throttle from 'lodash/throttle'
 import { useI18n } from 'vue-i18n'
 import { PaginationTiny } from '@icij/murmur'
@@ -65,9 +66,12 @@ const preferMarkdown = ref(true)
 const isMarkdownEmpty = ref(false)
 const markdownPage = ref(1)
 const markdownMatches = ref([])
-// Set at the end of `onMounted`, so the mode watcher can tell a real, later
-// mode flip apart from the manifest probe settling `isMarkdownMode` during
-// the initial mount.
+// The term the occurrence counts were computed for. The marks a page renders
+// have to match what the backend counted, so this only moves when a search
+// actually ran, not on every keystroke.
+const markdownAppliedTerm = ref('')
+// Set at the end of `onMounted`, so the mode watcher can tell a real, later mode
+// flip apart from the manifest probe settling `isMarkdownMode` during the mount.
 const isMounted = ref(false)
 
 const isTranslation = computed(() => {
@@ -131,6 +135,13 @@ const activeTermOffset = computed(() => {
   return localSearchIndexes.value[localSearchIndex.value - 1]
 })
 
+// `indexOf` answers -1 for an offset that starts no page, which the 1-based
+// conversion turns into 0: that offset belongs to the first page.
+function pageForOffset(offset) {
+  const pageIndex = offsets.value.indexOf(offset)
+  return pageIndex + 1 || 1
+}
+
 const showPagination = computed(() => {
   return nbPages.value > 1 && (isMarkdownMode.value || loadedOnce.value)
 })
@@ -139,9 +150,7 @@ const hasLocalSearchTerms = computed(() => {
   return localSearchTerm.value && localSearchTerm.value.length > 0
 })
 
-// The structure-pages endpoint answers 400 to a blank query, and the marks
-// rendered by `DocumentContentMarkdown` must match what it counted, so both
-// the request and the template read this single, trimmed value.
+// The structure-pages endpoint answers 400 to a blank query.
 const markdownSearchTerm = computed(() => localSearchTerm.value?.trim() ?? '')
 
 const isRightToLeft = computed(() => {
@@ -152,7 +161,6 @@ const isRightToLeft = computed(() => {
 const classList = computed(() => {
   return {
     'document-content--paginated': showPagination.value,
-    'document-content--markdown': isMarkdownMode.value,
     'document-content--rtl': isRightToLeft.value
   }
 })
@@ -162,7 +170,7 @@ const page = computed({
     if (isMarkdownMode.value) {
       return markdownPage.value
     }
-    return offsets.value.indexOf(activeContentSliceOffset.value) + 1 || 1
+    return pageForOffset(activeContentSliceOffset.value)
   },
   set(value) {
     scrollToDocumentStart()
@@ -230,15 +238,23 @@ watch(page, async () => {
 
 watch(isMarkdownMode, async (markdown) => {
   await syncPagePosition(markdown)
-  // `hasMarkdown` flips during `onMounted`'s manifest probe, which fires this
-  // watcher before the mount has even chosen whether to run a search at all;
-  // gating on `isMounted` keeps that flip from duplicating the search that
-  // `onMounted`'s own `q` branch is about to issue. Real mode flips (a user
-  // toggle, or a translation forcing text mode) all happen after mount, so
-  // this gate never blocks them.
+  // `hasMarkdown` flips during `onMounted`'s manifest probe, so without this gate
+  // that flip would duplicate the search the mount is about to issue itself.
   if (isMounted.value && hasLocalSearchTerms.value) {
     await retrieveOccurrencesAndUpdateContent()
   }
+})
+
+// The manifest, the page and the matches all describe one document. The mount
+// probe cannot cover a host that swaps the prop without remounting, so the
+// document identity re-runs it and clears what belonged to the previous one.
+watch(docId, async () => {
+  preferMarkdown.value = true
+  isMarkdownEmpty.value = false
+  markdownPage.value = 1
+  markdownMatches.value = []
+  markdownAppliedTerm.value = ''
+  await fetchManifest()
 })
 
 watch(contentPipeline, async () => {
@@ -247,12 +263,8 @@ watch(contentPipeline, async () => {
 })
 
 onMounted(async () => {
-  // A rejected mount step (a transient network failure, most plausibly from
-  // `loadMaxOffset`'s or `syncPages`' own API calls) must not leave the flag
-  // stuck `false` forever: that would silently suppress every later,
-  // legitimate mode-flip search for this component instance's whole
-  // lifetime. `finally` sets it regardless of how the body finished, without
-  // swallowing the failure itself.
+  // `finally`, because a mount step rejecting must not leave the flag stuck
+  // `false` and suppress every later mode-flip search for this instance.
   try {
     await Promise.all([loadMaxOffset(), fetchManifest()])
     await syncPages()
@@ -268,7 +280,13 @@ onMounted(async () => {
   }
 })
 
+// A single-page artifact whose only page renders to nothing has no markdown
+// worth showing, so the tab goes back to plain text. With more pages, a blank
+// one (a scanned cover page) says nothing about the rest of the artifact.
 function fallbackToTextForEmptyMarkdown() {
+  if (markdownPagesCount.value > 1) {
+    return
+  }
   isMarkdownEmpty.value = true
   preferMarkdown.value = false
 }
@@ -286,7 +304,7 @@ async function syncPagePosition(markdown) {
   }
   const aligned = !!syncedPages.value?.length && syncedPages.value.length === markdownPagesCount.value
   if (markdown) {
-    markdownPage.value = aligned ? offsets.value.indexOf(activeContentSliceOffset.value) + 1 || 1 : 1
+    markdownPage.value = aligned ? pageForOffset(activeContentSliceOffset.value) : 1
     return
   }
   // The restored page needs its text slice loaded, and going through
@@ -322,7 +340,7 @@ const mustSyncPages = async function () {
   // * The server has an artifact directory configured
     && !!config.get('artifactDir')
   // * The user is not requesting a translation
-    && (!props.targetLanguage || props.targetLanguage === 'original')
+    && !isTranslation.value
   // * The Tika version used to extract the document is the same as the one used by the server
     && await sameTikaVersion()
 }
@@ -440,58 +458,67 @@ async function retrieveTotalOccurrences() {
 }
 
 async function retrieveTextOccurrences(retrieval) {
+  const { count = 0, offsets = [] } = await fetchTextOccurrences()
+  if (retrieval !== lastOccurrencesRetrieval) {
+    return
+  }
+  localSearchIndexes.value = offsets
+  localSearchOccurrences.value = count
+  localSearchIndex.value = Number(!!count)
+}
+
+async function fetchTextOccurrences() {
+  if (!hasLocalSearchTerms.value) {
+    return {}
+  }
+  const query = localSearchTerm.value
+  const targetLanguage = props.targetLanguage
   try {
-    if (!hasLocalSearchTerms.value) {
-      throw new Error('No local search terms')
-    }
-    const query = localSearchTerm.value
-    const targetLanguage = props.targetLanguage
-    const { count, offsets } = await api.searchDocument(docIndex.value, docId.value, query, targetLanguage, docRouting.value)
-    if (retrieval !== lastOccurrencesRetrieval) {
-      return
-    }
-    localSearchIndexes.value = offsets
-    localSearchOccurrences.value = count
-    localSearchIndex.value = Number(!!count)
+    return await api.searchDocument(docIndex.value, docId.value, query, targetLanguage, docRouting.value)
   }
   catch {
-    if (retrieval !== lastOccurrencesRetrieval) {
-      return
-    }
-    localSearchIndexes.value = []
-    localSearchOccurrences.value = 0
-    localSearchIndex.value = 0
+    return {}
   }
 }
 
 async function retrieveMarkdownOccurrences(retrieval) {
+  const { query, matches } = await fetchMarkdownOccurrences()
+  if (retrieval !== lastOccurrencesRetrieval) {
+    return
+  }
+  markdownMatches.value = matches
+  // The response also carries a `count`, which can exceed the hits it returns
+  // when the backend scans only part of the artifact. Counting what we can
+  // actually navigate to keeps the counter and the next/previous buttons from
+  // disagreeing about how many occurrences there are.
+  localSearchOccurrences.value = matches.length
+  // Nothing to mark when the backend found nothing; keeping the term empty also
+  // keeps a client-side fold from marking what the counter does not know about.
+  markdownAppliedTerm.value = matches.length ? query : ''
+  localSearchIndex.value = Number(!!matches.length)
+}
+
+// The query is captured and handed back so the applied term always describes the
+// counts written next to it, even when the user has typed on since.
+async function fetchMarkdownOccurrences() {
+  const query = markdownSearchTerm.value
+  if (!query) {
+    return { query, matches: [] }
+  }
   try {
-    const query = markdownSearchTerm.value
-    if (!query) {
-      throw new Error('No local search terms')
-    }
-    const { count, hits } = await api.searchStructurePages(docIndex.value, docId.value, query, docRouting.value)
-    if (retrieval !== lastOccurrencesRetrieval) {
-      return
-    }
-    markdownMatches.value = flattenPageHits(hits)
-    localSearchOccurrences.value = count
-    localSearchIndex.value = Number(!!count)
+    const { hits } = await api.searchStructurePages(docIndex.value, docId.value, query, docRouting.value)
+    return { query, matches: flattenPageHits(hits) }
   }
   catch {
-    if (retrieval !== lastOccurrencesRetrieval) {
-      return
-    }
-    markdownMatches.value = []
-    localSearchOccurrences.value = 0
-    localSearchIndex.value = 0
+    return { query, matches: [] }
   }
 }
 
-// One entry per occurrence, in page order, so the flat local search index
-// maps straight to a page and a 1-based rank within that page.
-function flattenPageHits(hits = []) {
-  return hits.flatMap(({ page, count }) => {
+// One entry per occurrence, sorted by page, so the flat local search index maps
+// straight to a page and a 1-based rank within that page. The order is imposed
+// here rather than assumed of the response, since next/previous walks this list.
+function flattenPageHits(hits) {
+  return sortBy(hits ?? [], 'page').flatMap(({ page, count }) => {
     return range(count).map(nth => ({ page, nth: nth + 1 }))
   })
 }
@@ -569,7 +596,6 @@ async function loadContentSliceAround(desiredOffset) {
           v-model:active-index="localSearchIndex"
           :compact="compact"
           :loading="isLoading"
-          :disabled="!hasExtractedContent && !isMarkdownMode"
           :occurrences="localSearchOccurrences"
           class="flex-grow-1"
         />
@@ -620,7 +646,8 @@ async function loadContentSliceAround(desiredOffset) {
         class="document-content__body document-content__body--markdown"
         :document="document"
         :page="markdownPage"
-        :term="localSearchOccurrences ? markdownSearchTerm : ''"
+        :term="markdownAppliedTerm"
+        :global-search-terms="globalSearchTerms"
         :active-match="activeMarkdownMatch"
         @fallback="preferMarkdown = false"
         @empty="fallbackToTextForEmptyMarkdown"

--- a/src/components/Document/DocumentContent.vue
+++ b/src/components/Document/DocumentContent.vue
@@ -621,7 +621,7 @@ async function loadContentSliceAround(desiredOffset) {
         class="document-content__body document-content__body--markdown"
         :document="document"
         :page="markdownPage"
-        :term="markdownSearchTerm"
+        :term="localSearchOccurrences ? markdownSearchTerm : ''"
         :active-match="activeMarkdownMatch"
         @fallback="preferMarkdown = false"
       />
@@ -640,7 +640,7 @@ async function loadContentSliceAround(desiredOffset) {
       <slot name="after-content" />
     </div>
     <document-attachments
-      v-show="loadedOnce"
+      v-show="loadedOnce || isMarkdownMode"
       :document="document"
     />
     <hook name="document.content:after" />

--- a/src/components/Document/DocumentContent.vue
+++ b/src/components/Document/DocumentContent.vue
@@ -59,6 +59,7 @@ const { hasMarkdown, pages: markdownPagesCount, fetchManifest } = useStructureAr
 
 const preferMarkdown = ref(true)
 const markdownPage = ref(1)
+const markdownMatches = ref([])
 
 const isTranslation = computed(() => {
   return !!props.targetLanguage && props.targetLanguage !== 'original'
@@ -68,9 +69,13 @@ const isMarkdownMode = computed(() => {
   return hasMarkdown.value && !isTranslation.value && preferMarkdown.value
 })
 
-// Task 6 replaces this with the real match logic; kept as a placeholder so
-// the template compiles before markdown-native search exists.
-const activeMarkdownMatch = computed(() => 0)
+const activeMarkdownMatch = computed(() => {
+  const match = markdownMatches.value[localSearchIndex.value - 1]
+  if (match && match.page === markdownPage.value) {
+    return match.nth
+  }
+  return 0
+})
 
 const docIndex = computed(() => props.document?.index)
 const docId = computed(() => props.document?.id)
@@ -211,6 +216,9 @@ watch(page, async () => {
 
 watch(isMarkdownMode, async (markdown) => {
   await syncPagePosition(markdown)
+  if (hasLocalSearchTerms.value) {
+    await retrieveOccurrencesAndUpdateContent()
+  }
 })
 
 watch(contentPipeline, async () => {
@@ -367,11 +375,28 @@ async function retrieveOccurrencesAndUpdateContent() {
 }
 
 async function updateContent() {
+  if (isMarkdownMode.value) {
+    return updateMarkdownContent()
+  }
   await activateContentSliceAround()
   await jumpToActiveLocalSearchTerm()
 }
 
+function updateMarkdownContent() {
+  const match = markdownMatches.value[localSearchIndex.value - 1]
+  if (match) {
+    markdownPage.value = match.page
+  }
+}
+
 async function retrieveTotalOccurrences() {
+  if (isMarkdownMode.value) {
+    return retrieveMarkdownOccurrences()
+  }
+  return retrieveTextOccurrences()
+}
+
+async function retrieveTextOccurrences() {
   try {
     if (!hasLocalSearchTerms.value) {
       throw new Error('No local search terms')
@@ -388,6 +413,33 @@ async function retrieveTotalOccurrences() {
     localSearchOccurrences.value = 0
     localSearchIndex.value = 0
   }
+}
+
+async function retrieveMarkdownOccurrences() {
+  try {
+    // The endpoint answers 400 to a blank query, so trim before asking
+    const query = localSearchTerm.value?.trim()
+    if (!query) {
+      throw new Error('No local search terms')
+    }
+    const { count, hits } = await api.searchStructurePages(docIndex.value, docId.value, query, docRouting.value)
+    markdownMatches.value = flattenPageHits(hits)
+    localSearchOccurrences.value = count
+    localSearchIndex.value = Number(!!count)
+  }
+  catch {
+    markdownMatches.value = []
+    localSearchOccurrences.value = 0
+    localSearchIndex.value = 0
+  }
+}
+
+// One entry per occurrence, in page order, so the flat local search index
+// maps straight to a page and a 1-based rank within that page.
+function flattenPageHits(hits = []) {
+  return hits.flatMap(({ page, count }) => {
+    return range(count).map(nth => ({ page, nth: nth + 1 }))
+  })
 }
 
 async function activateContentSliceAround(desiredOffset = activeTermOffset.value) {
@@ -463,7 +515,7 @@ async function loadContentSliceAround(desiredOffset) {
           v-model:active-index="localSearchIndex"
           :compact="compact"
           :loading="isLoading"
-          :disabled="!hasExtractedContent"
+          :disabled="!hasExtractedContent && !isMarkdownMode"
           :occurrences="localSearchOccurrences"
           class="flex-grow-1"
         />
@@ -524,7 +576,7 @@ async function loadContentSliceAround(desiredOffset) {
         class="document-content__body document-content__body--markdown"
         :document="document"
         :page="markdownPage"
-        :term="localSearchTerm"
+        :term="localSearchTerm?.trim() ?? ''"
         :active-match="activeMarkdownMatch"
         @fallback="preferMarkdown = false"
       />

--- a/src/components/Document/DocumentContentDropdown.vue
+++ b/src/components/Document/DocumentContentDropdown.vue
@@ -1,0 +1,76 @@
+<script setup>
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { AppIcon } from '@icij/murmur'
+
+import AppDropdown from '@/components/AppDropdown/AppDropdown'
+
+/**
+ * Whether the extracted text is rendered as formatted markdown rather than plain text.
+ */
+const preferMarkdown = defineModel({ type: Boolean, default: true })
+
+const props = defineProps({
+  /**
+   * The structure artifact exists but holds no markdown, so the formatted
+   * rendering has nothing to show.
+   */
+  markdownDisabled: {
+    type: Boolean,
+    default: false
+  },
+  /**
+   * A translation is displayed. Translations are only available as plain text,
+   * so the choice is out of the user's hands until they go back to the original.
+   */
+  translation: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const { t } = useI18n()
+
+// A translation renders as plain text whatever the stored preference is, so the
+// active entry must follow what the body actually shows rather than what the
+// user picked on an earlier document.
+const isMarkdownActive = computed(() => preferMarkdown.value && !props.translation)
+</script>
+
+<template>
+  <app-dropdown
+    teleport-to="body"
+    boundary="viewport"
+    :aria-label="t('documentContent.view.ariaLabel')"
+    class="document-content-dropdown"
+  >
+    <b-dropdown-item-button
+      :active="isMarkdownActive"
+      :disabled="markdownDisabled || translation"
+      button-class="document-content-dropdown__markdown"
+      @click="preferMarkdown = true"
+    >
+      <span class="d-flex align-items-center gap-2">
+        <app-icon><i-ph-article /></app-icon>
+        {{ t('documentContent.view.markdown') }}
+      </span>
+    </b-dropdown-item-button>
+    <b-dropdown-item-button
+      :active="!isMarkdownActive"
+      :disabled="translation"
+      button-class="document-content-dropdown__text"
+      @click="preferMarkdown = false"
+    >
+      <span class="d-flex align-items-center gap-2">
+        <app-icon><i-ph-text-align-left /></app-icon>
+        {{ t('documentContent.view.text') }}
+      </span>
+    </b-dropdown-item-button>
+    <b-dropdown-text
+      v-if="translation"
+      text-class="document-content-dropdown__reason"
+    >
+      {{ t('documentContent.view.translationTooltip') }}
+    </b-dropdown-text>
+  </app-dropdown>
+</template>

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -2,8 +2,9 @@
 import { computed, nextTick, reactive, ref, toRef, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { addLocalSearchMarksClassInHtml } from '@/utils/strings'
+import { addSearchMarksClassInHtml } from '@/utils/strings'
 import { renderMarkdown } from '@/utils/markdown'
+import { useUtils } from '@/composables/useUtils'
 import { usePipelinesStore } from '@/store/modules'
 import { apiInstance as api } from '@/api/apiInstance'
 
@@ -38,12 +39,20 @@ const props = defineProps({
   activeMatch: {
     type: Number,
     default: 0
+  },
+  /**
+   * Terms of the global search to mark in the rendered page
+   */
+  globalSearchTerms: {
+    type: Array,
+    default: () => []
   }
 })
 
 const emit = defineEmits(['fallback', 'empty'])
 
 const { t } = useI18n()
+const { getTermIndexColor } = useUtils()
 const pipelinesStore = usePipelinesStore()
 const elementRef = useTemplateRef('element')
 
@@ -60,7 +69,16 @@ function cacheKeyFor(page) {
 }
 
 const markedHtml = computed(() => {
-  return addLocalSearchMarksClassInHtml(renderedPages[cacheKeyFor(props.page)] ?? '', props.term)
+  const html = renderedPages[cacheKeyFor(props.page)] ?? ''
+  const locallyMarked = addSearchMarksClassInHtml(html, props.term)
+  // Global marks go on last so they nest inside the local ones, the order the
+  // `extracted-text` pipeline chain produces for the plain text view. Unlike that
+  // chain, a `regex` term is matched literally: this marker walks text nodes so it
+  // never marks inside an href, which a regex over rendered HTML would.
+  return props.globalSearchTerms.reduce((marked, { label }, index) => {
+    const style = `border-color: ${getTermIndexColor(index)}`
+    return addSearchMarksClassInHtml(marked, label, { className: 'global-search-term', style })
+  }, locallyMarked)
 })
 
 // A legitimately empty structure page renders to an empty string, which is
@@ -75,39 +93,37 @@ async function loadPage() {
   // A page switch (or a document switch, or a retry click) can start a new
   // `loadPage` while a previous one is still in flight. This counter mirrors
   // `lastContentSliceActivation`/`lastOccurrencesRetrieval` in
-  // `DocumentContent.vue`: a superseded call's failure must not replace the
-  // page the user is actually looking at, and its `finally` must not clear
-  // the loading state of the call that superseded it.
+  // `DocumentContent.vue`: only the newest load may write the error and the
+  // loading state, so a superseded one cannot clear the spinner of the call
+  // that superseded it, nor report its failure over the page now on screen.
   const load = ++lastPageLoad
   error.value = null
   loading.value = true
+  let loadError = null
   try {
     await renderPageOnce()
-    if (load === lastPageLoad) {
-      reportEmptyArtifact()
-    }
   }
-  catch (loadError) {
-    if (load === lastPageLoad) {
-      error.value = loadError
-    }
+  catch (failure) {
+    loadError = failure
   }
-  finally {
-    if (load === lastPageLoad) {
-      loading.value = false
-    }
+  if (load !== lastPageLoad) {
+    return
+  }
+  error.value = loadError
+  loading.value = false
+  if (!loadError) {
+    reportEmptyPage()
   }
 }
 
-// An artifact whose very first page renders to nothing has no markdown worth
-// showing at all, so the tab goes back to the plain text view instead of an
-// empty document. A later page can legitimately be blank (a blank page in a
-// PDF) without saying anything about the artifact, hence the page check.
+// A page can legitimately be blank (a blank cover page in a scanned PDF) without
+// saying anything about the artifact as a whole, so this only reports what it
+// knows: the page it shows has no content. Whether that means the artifact holds
+// no markdown at all is the parent's call, since it knows the page count.
 // This is `empty` rather than `fallback` because the two are not equivalent to
 // the parent: a fetch error can be retried, an empty artifact cannot.
-function reportEmptyArtifact() {
-  const isEmptyArtifact = props.page === 1 && !hasPageContent.value
-  if (isEmptyArtifact) {
+function reportEmptyPage() {
+  if (!hasPageContent.value) {
     emit('empty')
   }
 }
@@ -128,9 +144,9 @@ async function renderPageOnce() {
   renderedPages[targetCacheKey] = await renderMarkdown(markdown)
 }
 
-// Plugins can transform the markdown body through the `markdown-text`
-// category; core registers nothing under it, so by default this resolves
-// to the marked HTML unchanged.
+// Plugins can transform the markdown body through the `markdown-text` category;
+// core registers nothing under it, so by default this resolves to the marked
+// HTML unchanged.
 async function cookHtml(html) {
   cookedHtml.value = await pipelinesStore.applyPipelineChainByCategory('markdown-text')(html)
   await nextTick()
@@ -151,11 +167,17 @@ function activateMatch() {
   active.scrollIntoView({ block: 'center', inline: 'nearest', behavior: 'instant' })
 }
 
-watch(toRef(props, 'page'), loadPage, { immediate: true })
-// The page number can stay the same while the document itself changes (e.g.
-// switching documents while both are on page 1), so the document identity
-// needs its own watcher to trigger a reload.
-watch(() => props.document?.id, loadPage)
+// The page number can stay the same while the document itself changes (both on
+// page 1), and the page can change on its own, so the pair is watched together:
+// two watchers would fire twice and issue the same request twice.
+watch([() => props.page, () => props.document?.id], ([, id], [, previousId]) => {
+  if (id !== previousId) {
+    // Rendered pages are worth keeping while the reader pages through a document,
+    // not once they have left it.
+    Object.keys(renderedPages).forEach(key => delete renderedPages[key])
+  }
+  loadPage()
+}, { immediate: true })
 watch(markedHtml, cookHtml, { immediate: true })
 watch(toRef(props, 'activeMatch'), activateMatch, { flush: 'post' })
 </script>

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -144,11 +144,21 @@ async function renderPageOnce() {
   renderedPages[targetCacheKey] = await renderMarkdown(markdown)
 }
 
+let lastCook = 0
+
 // Plugins can transform the markdown body through the `markdown-text` category;
 // core registers nothing under it, so by default this resolves to the marked
 // HTML unchanged.
 async function cookHtml(html) {
-  cookedHtml.value = await pipelinesStore.applyPipelineChainByCategory('markdown-text')(html)
+  // A registered pipeline can be asynchronous, so two cooks can overlap and
+  // resolve out of order. Same counter pattern as `loadPage` above: only the
+  // newest may write, otherwise a slower cook paints over the page on screen.
+  const cook = ++lastCook
+  const cooked = await pipelinesStore.applyPipelineChainByCategory('markdown-text')(html)
+  if (cook !== lastCook) {
+    return
+  }
+  cookedHtml.value = cooked
   await nextTick()
   activateMatch()
 }

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -52,8 +52,15 @@ const cookedHtml = ref('')
 const error = ref(null)
 const loading = ref(false)
 
+// The cache is keyed by document identity as well as page number, so a
+// document swap can never serve another document's cached page, and a
+// response for a page/document pair can never land under a different one.
+function cacheKeyFor(page) {
+  return `${props.document.id}:${page}`
+}
+
 const markedHtml = computed(() => {
-  return addLocalSearchMarksClassInHtml(renderedPages[props.page] ?? '', props.term)
+  return addLocalSearchMarksClassInHtml(renderedPages[cacheKeyFor(props.page)] ?? '', props.term)
 })
 
 async function loadPage() {
@@ -71,12 +78,17 @@ async function loadPage() {
 }
 
 async function renderPageOnce() {
-  if (renderedPages[props.page]) {
+  // Capture the page and document once: re-reading `props` after the
+  // `await` below could pick up values changed by navigation while this
+  // fetch was in flight, and would write the response under the wrong key.
+  const targetPage = props.page
+  const targetCacheKey = cacheKeyFor(targetPage)
+  if (renderedPages[targetCacheKey]) {
     return
   }
   const { index, id, routing } = props.document
-  const markdown = await api.getStructurePage(index, id, props.page, routing)
-  renderedPages[props.page] = await renderMarkdown(markdown)
+  const markdown = await api.getStructurePage(index, id, targetPage, routing)
+  renderedPages[targetCacheKey] = await renderMarkdown(markdown)
 }
 
 // Plugins can transform the markdown body through the `markdown-text`
@@ -103,6 +115,10 @@ function activateMatch() {
 }
 
 watch(toRef(props, 'page'), loadPage, { immediate: true })
+// The page number can stay the same while the document itself changes (e.g.
+// switching documents while both are on page 1), so the document identity
+// needs its own watcher to trigger a reload.
+watch(() => props.document?.id, loadPage)
 watch(markedHtml, cookHtml, { immediate: true })
 watch(toRef(props, 'activeMatch'), activateMatch, { flush: 'post' })
 </script>

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -243,87 +243,8 @@ watch(toRef(props, 'activeMatch'), activateMatch, { flush: 'post' })
     <!-- eslint-disable-next-line vue/no-v-html -->
     <div
       v-else
-      class="document-content-markdown__body"
+      class="document-content-markdown__body markdown-body"
       v-html="cookedHtml"
     />
   </div>
 </template>
-
-<style lang="scss" scoped>
-.document-content-markdown {
-  &__body {
-    :deep(h1),
-    :deep(h2),
-    :deep(h3),
-    :deep(h4),
-    :deep(h5),
-    :deep(h6) {
-      margin-top: $spacer-lg;
-      margin-bottom: $spacer;
-      font-weight: $font-weight-semibold;
-      line-height: 1.25;
-    }
-
-    :deep(h1) {
-      font-size: 2rem;
-      padding-bottom: 0.3em;
-      border-bottom: 1px solid var(--bs-border-color-translucent);
-    }
-
-    :deep(h2) {
-      font-size: 1.5rem;
-      padding-bottom: 0.3em;
-      border-bottom: 1px solid var(--bs-border-color-translucent);
-    }
-
-    :deep(h3) {
-      font-size: 1.25rem;
-    }
-
-    :deep(h4) {
-      font-size: 1rem;
-    }
-
-    :deep(h5) {
-      font-size: 0.875rem;
-    }
-
-    :deep(h6) {
-      font-size: 0.85rem;
-      color: var(--bs-secondary-color);
-    }
-
-    :deep(table) {
-      border-collapse: collapse;
-      margin-bottom: $spacer;
-
-      th,
-      td {
-        border: 1px solid var(--bs-border-color);
-        padding: 6px 13px;
-      }
-
-      th {
-        font-weight: $font-weight-semibold;
-      }
-
-      tr:nth-child(2n) {
-        background-color: var(--bs-tertiary-bg);
-      }
-    }
-
-    :deep(pre) {
-      padding: $spacer;
-      overflow-x: auto;
-      background: var(--bs-tertiary-bg);
-      border-radius: var(--bs-border-radius);
-    }
-
-    :deep(blockquote) {
-      margin: 0;
-      padding-left: $spacer;
-      border-left: 4px solid var(--bs-border-color);
-    }
-  }
-}
-</style>

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -1,0 +1,197 @@
+<script setup>
+import { computed, nextTick, reactive, ref, toRef, useTemplateRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { addLocalSearchMarksClassInHtml } from '@/utils/strings'
+import { renderMarkdown } from '@/utils/markdown'
+import { usePipelinesStore } from '@/store/modules'
+import { apiInstance as api } from '@/api/apiInstance'
+
+/**
+ * Display one markdown structure page of a document, with local search marks.
+ */
+const props = defineProps({
+  /**
+   * The selected document
+   */
+  document: {
+    type: Object,
+    required: true
+  },
+  /**
+   * The structure page to display (1-based)
+   */
+  page: {
+    type: Number,
+    default: 1
+  },
+  /**
+   * Local search term to mark in the rendered page
+   */
+  term: {
+    type: String,
+    default: ''
+  },
+  /**
+   * 1-based index of the mark to activate in this page, 0 for none
+   */
+  activeMatch: {
+    type: Number,
+    default: 0
+  }
+})
+
+const emit = defineEmits(['fallback'])
+
+const { t } = useI18n()
+const pipelinesStore = usePipelinesStore()
+const elementRef = useTemplateRef('element')
+
+const renderedPages = reactive({})
+const cookedHtml = ref('')
+const error = ref(null)
+const loading = ref(false)
+
+const markedHtml = computed(() => {
+  return addLocalSearchMarksClassInHtml(renderedPages[props.page] ?? '', props.term)
+})
+
+async function loadPage() {
+  error.value = null
+  loading.value = true
+  try {
+    await renderPageOnce()
+  }
+  catch (loadError) {
+    error.value = loadError
+  }
+  finally {
+    loading.value = false
+  }
+}
+
+async function renderPageOnce() {
+  if (renderedPages[props.page]) {
+    return
+  }
+  const { index, id, routing } = props.document
+  const markdown = await api.getStructurePage(index, id, props.page, routing)
+  renderedPages[props.page] = await renderMarkdown(markdown)
+}
+
+// Plugins can transform the markdown body through the `markdown-text`
+// category; core registers nothing under it, so by default this resolves
+// to the marked HTML unchanged.
+async function cookHtml(html) {
+  cookedHtml.value = await pipelinesStore.applyPipelineChainByCategory('markdown-text')(html)
+  await nextTick()
+  activateMatch()
+}
+
+function activateMatch() {
+  const marks = elementRef.value?.querySelectorAll('.local-search-term') ?? []
+  marks.forEach(mark => mark.classList.remove('local-search-term--active'))
+  if (!props.activeMatch || !marks.length) {
+    return
+  }
+  // Counts come from the markdown source while marks come from the rendered
+  // DOM, so the nth match may not exist here: clamp to the last mark rather
+  // than highlighting nothing.
+  const active = marks[Math.min(props.activeMatch, marks.length) - 1]
+  active.classList.add('local-search-term--active')
+  active.scrollIntoView({ block: 'center', inline: 'nearest', behavior: 'instant' })
+}
+
+watch(toRef(props, 'page'), loadPage, { immediate: true })
+watch(markedHtml, cookHtml, { immediate: true })
+watch(toRef(props, 'activeMatch'), activateMatch, { flush: 'post' })
+</script>
+
+<template>
+  <div
+    ref="element"
+    class="document-content-markdown"
+  >
+    <div
+      v-if="loading"
+      class="document-content-markdown__loading p-3 text-center"
+    >
+      <b-spinner />
+    </div>
+    <b-alert
+      v-else-if="error"
+      :model-value="true"
+      variant="warning"
+      class="document-content-markdown__error"
+    >
+      {{ t('documentContentMarkdown.error') }}
+      <div class="mt-2 d-flex gap-2">
+        <b-button
+          size="sm"
+          variant="outline-secondary"
+          class="document-content-markdown__error__retry"
+          @click="loadPage"
+        >
+          {{ t('documentContentMarkdown.retry') }}
+        </b-button>
+        <b-button
+          size="sm"
+          variant="outline-secondary"
+          class="document-content-markdown__error__fallback"
+          @click="emit('fallback')"
+        >
+          {{ t('documentContentMarkdown.fallback') }}
+        </b-button>
+      </div>
+    </b-alert>
+    <!--
+      Safe to use v-html here: `cookedHtml` derives from renderMarkdown(), which
+      sanitizes the content (no raw HTML, no remote images, hardened links),
+      plus our own mark tags.
+    -->
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <div
+      v-else
+      class="document-content-markdown__body"
+      v-html="cookedHtml"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.document-content-markdown {
+  &__body {
+    :deep(h1),
+    :deep(h2),
+    :deep(h3),
+    :deep(h4),
+    :deep(h5),
+    :deep(h6) {
+      margin-top: $spacer;
+    }
+
+    :deep(table) {
+      border-collapse: collapse;
+
+      th,
+      td {
+        border: 1px solid var(--bs-border-color);
+        padding: $spacer-xxs $spacer-xs;
+      }
+    }
+
+    :deep(pre) {
+      padding: $spacer;
+      overflow-x: auto;
+      background: var(--bs-tertiary-bg);
+      border-radius: var(--bs-border-radius);
+    }
+
+    :deep(blockquote) {
+      margin: 0;
+      padding-left: $spacer;
+      border-left: 4px solid var(--bs-border-color);
+    }
+  }
+}
+</style>

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -248,16 +248,57 @@ watch(toRef(props, 'activeMatch'), activateMatch, { flush: 'post' })
     :deep(h4),
     :deep(h5),
     :deep(h6) {
-      margin-top: $spacer;
+      margin-top: $spacer-lg;
+      margin-bottom: $spacer;
+      font-weight: $font-weight-semibold;
+      line-height: 1.25;
+    }
+
+    :deep(h1) {
+      font-size: 2rem;
+      padding-bottom: 0.3em;
+      border-bottom: 1px solid var(--bs-border-color-translucent);
+    }
+
+    :deep(h2) {
+      font-size: 1.5rem;
+      padding-bottom: 0.3em;
+      border-bottom: 1px solid var(--bs-border-color-translucent);
+    }
+
+    :deep(h3) {
+      font-size: 1.25rem;
+    }
+
+    :deep(h4) {
+      font-size: 1rem;
+    }
+
+    :deep(h5) {
+      font-size: 0.875rem;
+    }
+
+    :deep(h6) {
+      font-size: 0.85rem;
+      color: var(--bs-secondary-color);
     }
 
     :deep(table) {
       border-collapse: collapse;
+      margin-bottom: $spacer;
 
       th,
       td {
         border: 1px solid var(--bs-border-color);
-        padding: $spacer-xxs $spacer-xs;
+        padding: 6px 13px;
+      }
+
+      th {
+        font-weight: $font-weight-semibold;
+      }
+
+      tr:nth-child(2n) {
+        background-color: var(--bs-tertiary-bg);
       }
     }
 

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -63,17 +63,36 @@ const markedHtml = computed(() => {
   return addLocalSearchMarksClassInHtml(renderedPages[cacheKeyFor(props.page)] ?? '', props.term)
 })
 
+// A legitimately empty structure page renders to an empty string, which is
+// still a cache hit: falling back to it here (rather than re-deriving
+// emptiness from `cookedHtml`, which updates only after the async pipeline
+// resolves) keeps the no-content message free of the pipeline's own timing.
+const hasPageContent = computed(() => !!renderedPages[cacheKeyFor(props.page)])
+
+let lastPageLoad = 0
+
 async function loadPage() {
+  // A page switch (or a document switch, or a retry click) can start a new
+  // `loadPage` while a previous one is still in flight. This counter mirrors
+  // `lastContentSliceActivation`/`lastOccurrencesRetrieval` in
+  // `DocumentContent.vue`: a superseded call's failure must not replace the
+  // page the user is actually looking at, and its `finally` must not clear
+  // the loading state of the call that superseded it.
+  const load = ++lastPageLoad
   error.value = null
   loading.value = true
   try {
     await renderPageOnce()
   }
   catch (loadError) {
-    error.value = loadError
+    if (load === lastPageLoad) {
+      error.value = loadError
+    }
   }
   finally {
-    loading.value = false
+    if (load === lastPageLoad) {
+      loading.value = false
+    }
   }
 }
 
@@ -83,7 +102,9 @@ async function renderPageOnce() {
   // fetch was in flight, and would write the response under the wrong key.
   const targetPage = props.page
   const targetCacheKey = cacheKeyFor(targetPage)
-  if (renderedPages[targetCacheKey]) {
+  // `in` (rather than a truthiness check) treats an already-cached empty
+  // page as a hit instead of re-fetching it on every visit.
+  if (targetCacheKey in renderedPages) {
     return
   }
   const { index, id, routing } = props.document
@@ -160,6 +181,12 @@ watch(toRef(props, 'activeMatch'), activateMatch, { flush: 'post' })
         </b-button>
       </div>
     </b-alert>
+    <div
+      v-else-if="!hasPageContent"
+      class="document-content-markdown__no-content text-center p-3"
+    >
+      {{ t('documentContent.noContent') }}
+    </div>
     <!--
       Safe to use v-html here: `cookedHtml` derives from renderMarkdown(), which
       sanitizes the content (no raw HTML, no remote images, hardened links),

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -41,7 +41,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['fallback'])
+const emit = defineEmits(['fallback', 'empty'])
 
 const { t } = useI18n()
 const pipelinesStore = usePipelinesStore()
@@ -83,6 +83,9 @@ async function loadPage() {
   loading.value = true
   try {
     await renderPageOnce()
+    if (load === lastPageLoad) {
+      reportEmptyArtifact()
+    }
   }
   catch (loadError) {
     if (load === lastPageLoad) {
@@ -93,6 +96,19 @@ async function loadPage() {
     if (load === lastPageLoad) {
       loading.value = false
     }
+  }
+}
+
+// An artifact whose very first page renders to nothing has no markdown worth
+// showing at all, so the tab goes back to the plain text view instead of an
+// empty document. A later page can legitimately be blank (a blank page in a
+// PDF) without saying anything about the artifact, hence the page check.
+// This is `empty` rather than `fallback` because the two are not equivalent to
+// the parent: a fetch error can be retried, an empty artifact cannot.
+function reportEmptyArtifact() {
+  const isEmptyArtifact = props.page === 1 && !hasPageContent.value
+  if (isEmptyArtifact) {
+    emit('empty')
   }
 }
 

--- a/src/components/Document/DocumentViewer/DocumentViewerMarkdown.vue
+++ b/src/components/Document/DocumentViewer/DocumentViewerMarkdown.vue
@@ -67,7 +67,7 @@ watch(() => props.document, load, { immediate: true })
     <!-- eslint-disable-next-line vue/no-v-html -->
     <div
       v-else
-      class="markdown-viewer__content shadow-sm border p-3 mx-auto"
+      class="markdown-viewer__content markdown-body shadow-sm border p-3 mx-auto"
       v-html="html"
     />
   </div>
@@ -80,79 +80,6 @@ watch(() => props.document, load, { immediate: true })
 
   &__content {
     max-width: 1012px;
-
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-      margin-top: $spacer-lg;
-      margin-bottom: $spacer;
-      font-weight: $font-weight-semibold;
-      line-height: 1.25;
-    }
-
-    h1 {
-      font-size: 2rem;
-      padding-bottom: 0.3em;
-      border-bottom: 1px solid var(--bs-border-color-translucent);
-    }
-
-    h2 {
-      font-size: 1.5rem;
-      padding-bottom: 0.3em;
-      border-bottom: 1px solid var(--bs-border-color-translucent);
-    }
-
-    h3 {
-      font-size: 1.25rem;
-    }
-
-    h4 {
-      font-size: 1rem;
-    }
-
-    h5 {
-      font-size: 0.875rem;
-    }
-
-    h6 {
-      font-size: 0.85rem;
-      color: var(--bs-secondary-color);
-    }
-
-    table {
-      border-collapse: collapse;
-      margin-bottom: $spacer;
-
-      th,
-      td {
-        border: 1px solid var(--bs-border-color);
-        padding: 6px 13px;
-      }
-
-      th {
-        font-weight: $font-weight-semibold;
-      }
-
-      tr:nth-child(2n) {
-        background-color: var(--bs-tertiary-bg);
-      }
-    }
-
-    pre {
-      padding: $spacer;
-      overflow-x: auto;
-      background: var(--bs-tertiary-bg);
-      border-radius: var(--bs-border-radius);
-    }
-
-    blockquote {
-      margin: 0;
-      padding-left: $spacer;
-      border-left: 4px solid var(--bs-border-color);
-    }
   }
 }
 </style>

--- a/src/components/Document/DocumentViewer/DocumentViewerMarkdown.vue
+++ b/src/components/Document/DocumentViewer/DocumentViewerMarkdown.vue
@@ -87,16 +87,57 @@ watch(() => props.document, load, { immediate: true })
     h4,
     h5,
     h6 {
-      margin-top: $spacer;
+      margin-top: $spacer-lg;
+      margin-bottom: $spacer;
+      font-weight: $font-weight-semibold;
+      line-height: 1.25;
+    }
+
+    h1 {
+      font-size: 2rem;
+      padding-bottom: 0.3em;
+      border-bottom: 1px solid var(--bs-border-color-translucent);
+    }
+
+    h2 {
+      font-size: 1.5rem;
+      padding-bottom: 0.3em;
+      border-bottom: 1px solid var(--bs-border-color-translucent);
+    }
+
+    h3 {
+      font-size: 1.25rem;
+    }
+
+    h4 {
+      font-size: 1rem;
+    }
+
+    h5 {
+      font-size: 0.875rem;
+    }
+
+    h6 {
+      font-size: 0.85rem;
+      color: var(--bs-secondary-color);
     }
 
     table {
       border-collapse: collapse;
+      margin-bottom: $spacer;
 
       th,
       td {
         border: 1px solid var(--bs-border-color);
-        padding: $spacer-xxs $spacer-xs;
+        padding: 6px 13px;
+      }
+
+      th {
+        font-weight: $font-weight-semibold;
+      }
+
+      tr:nth-child(2n) {
+        background-color: var(--bs-tertiary-bg);
       }
     }
 

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -19,7 +19,7 @@ const MARKDOWN_PAGE_SEPARATOR = '\n\n---\n\n'
 export function useDocumentDownload(document, { immediate = true } = {}) {
   const documentStore = useDocumentStore()
   const documentDownloadStore = useDocumentDownloadStore()
-  const { toastedPromise } = useToast()
+  const { toast } = useToast()
   const { locale, t } = useI18n()
 
   const documentRef = toRef(document)
@@ -113,8 +113,7 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
   async function fetchMarkdownPages() {
     const { index, id, routing } = documentRef.value
     const requests = range(1, markdownPages.value + 1).map(page => api.getStructurePage(index, id, page, routing))
-    const errorMessage = t('documentDownloadPopover.downloadMarkdownError')
-    return toastedPromise(Promise.all(requests), { errorMessage })
+    return Promise.all(requests)
   }
 
   async function downloadMarkdown() {
@@ -129,9 +128,13 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
       const pages = await fetchMarkdownPages()
       downloadBlob(pages.join(MARKDOWN_PAGE_SEPARATOR), `${title}.md`, MARKDOWN_MIME_TYPE)
     }
-    catch {
-      // toastedPromise already reported the failure; swallow the rejection so
-      // it doesn't escape the template's click handler.
+    catch (error) {
+      // An expired session already gets its own "log back in" toast from the
+      // error bus, and stacking a download failure on top of it only tells the
+      // user something they cannot act on.
+      if (error?.response?.status !== 401) {
+        toast.error(t('documentDownloadPopover.downloadMarkdownError'))
+      }
     }
     finally {
       isDownloadingMarkdown.value = false

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -106,17 +106,13 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     availableTranslations.value = await documentDownloadStore.fetchTranslationStatus({ index, id, routing })
   }
 
-  // Shared with the download button: `useStructureArtifact` probes the
-  // structure manifest once and both this composable and the Text tab read
-  // from it.
-  const { manifest: structureManifest, hasMarkdown, fetchManifest: fetchMarkdownStatus } = useStructureArtifact(documentRef)
+  const { hasMarkdown, pages: markdownPages, fetchManifest: fetchMarkdownStatus } = useStructureArtifact(documentRef)
 
   const isDownloadingMarkdown = ref(false)
 
   async function fetchMarkdownPages() {
     const { index, id, routing } = documentRef.value
-    const { pages } = structureManifest.value
-    const requests = range(1, pages + 1).map(page => api.getStructurePage(index, id, page, routing))
+    const requests = range(1, markdownPages.value + 1).map(page => api.getStructurePage(index, id, page, routing))
     const errorMessage = t('documentDownloadPopover.downloadMarkdownError')
     return toastedPromise(Promise.all(requests), { errorMessage })
   }

--- a/src/composables/useDocumentDownload.js
+++ b/src/composables/useDocumentDownload.js
@@ -4,13 +4,13 @@ import range from 'lodash/range'
 
 import { apiInstance as api } from '@/api/apiInstance'
 import { useDocumentDownloadStore, useDocumentStore } from '@/store/modules'
+import { useStructureArtifact } from '@/composables/useStructureArtifact'
 import { useToast } from '@/composables/useToast'
 import { downloadBlob } from '@/utils/download'
 import settings from '@/utils/settings'
 
 const TEXT_MIME_TYPE = 'text/plain;charset=UTF-8'
 const MARKDOWN_MIME_TYPE = 'text/markdown;charset=UTF-8'
-const MARKDOWN_FORMAT = 'md'
 
 // Blank lines on both sides of the rule: `---` directly under a text line is a
 // setext heading underline, not a page break.
@@ -106,24 +106,10 @@ export function useDocumentDownload(document, { immediate = true } = {}) {
     availableTranslations.value = await documentDownloadStore.fetchTranslationStatus({ index, id, routing })
   }
 
-  // The manifest carries the id of the document it describes: a component
-  // handed another document (a recycled row, a slow probe resolving after the
-  // user moved on) must not offer the page count of the previous one.
-  const structureManifest = ref(null)
-
-  const hasMarkdown = computed(() => {
-    const { documentId, pages = 0, formats = [] } = structureManifest.value ?? {}
-    return documentId === documentRef.value.id && pages > 0 && formats.includes(MARKDOWN_FORMAT)
-  })
-
-  async function fetchMarkdownStatus() {
-    const { index, id, routing } = documentRef.value
-    if (!index || !id) {
-      return
-    }
-    const manifest = await api.getStructureManifest(index, id, routing)
-    structureManifest.value = { ...manifest, documentId: id }
-  }
+  // Shared with the download button: `useStructureArtifact` probes the
+  // structure manifest once and both this composable and the Text tab read
+  // from it.
+  const { manifest: structureManifest, hasMarkdown, fetchManifest: fetchMarkdownStatus } = useStructureArtifact(documentRef)
 
   const isDownloadingMarkdown = ref(false)
 

--- a/src/composables/useStructureArtifact.js
+++ b/src/composables/useStructureArtifact.js
@@ -1,0 +1,42 @@
+import { computed, ref, toRef } from 'vue'
+
+import { apiInstance as api } from '@/api/apiInstance'
+
+const MARKDOWN_FORMAT = 'md'
+
+/**
+ * Probe the structure artifact manifest of a document and tell whether a
+ * markdown rendering is available for it.
+ *
+ * @param {Object|import('vue').Ref|Function} document - Document with `index`, `id` and `routing`.
+ * @returns {Object} `{ manifest, hasMarkdown, pages, fetchManifest }`
+ */
+export function useStructureArtifact(document) {
+  const documentRef = toRef(document)
+  const manifest = ref(null)
+
+  // The manifest carries the id of the document it describes: a component
+  // handed another document (a slow probe resolving after the user moved on)
+  // must not trust the manifest of the previous one.
+  const hasMarkdown = computed(() => {
+    const { documentId, pages = 0, formats = [] } = manifest.value ?? {}
+    return documentId === documentRef.value?.id && pages > 0 && formats.includes(MARKDOWN_FORMAT)
+  })
+
+  const pages = computed(() => {
+    return hasMarkdown.value ? manifest.value.pages : 0
+  })
+
+  async function fetchManifest() {
+    const { index, id, routing } = documentRef.value ?? {}
+    if (!index || !id) {
+      return
+    }
+    const fetched = await api.getStructureManifest(index, id, routing)
+    manifest.value = { ...fetched, documentId: id }
+  }
+
+  return { manifest, hasMarkdown, pages, fetchManifest }
+}
+
+export default useStructureArtifact

--- a/src/composables/useStructureArtifact.js
+++ b/src/composables/useStructureArtifact.js
@@ -9,7 +9,7 @@ const MARKDOWN_FORMAT = 'md'
  * markdown rendering is available for it.
  *
  * @param {Object|import('vue').Ref|Function} document - Document with `index`, `id` and `routing`.
- * @returns {Object} `{ manifest, hasMarkdown, pages, fetchManifest }`
+ * @returns {Object} `{ hasMarkdown, pages, fetchManifest }`
  */
 export function useStructureArtifact(document) {
   const documentRef = toRef(document)
@@ -27,16 +27,23 @@ export function useStructureArtifact(document) {
     return hasMarkdown.value ? manifest.value.pages : 0
   })
 
+  let lastFetch = 0
+
   async function fetchManifest() {
     const { index, id, routing } = documentRef.value ?? {}
     if (!index || !id) {
       return
     }
+    const fetch = ++lastFetch
     const fetched = await api.getStructureManifest(index, id, routing)
-    manifest.value = { ...fetched, documentId: id }
+    // A probe for a document the user has already left can resolve after the
+    // one for the document on screen, so only the newest may write.
+    if (fetch === lastFetch) {
+      manifest.value = { ...fetched, documentId: id }
+    }
   }
 
-  return { manifest, hasMarkdown, pages, fetchManifest }
+  return { hasMarkdown, pages, fetchManifest }
 }
 
 export default useStructureArtifact

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -443,6 +443,11 @@
   "documentContent": {
     "noContent": "No content extracted for this document"
   },
+  "documentContentMarkdown": {
+    "error": "The formatted view of this page could not be loaded.",
+    "retry": "Try again",
+    "fallback": "View as plain text"
+  },
   "documentViewerImage": {
     "rotateCounterClockwise": "Rotate 90° to the left",
     "rotateClockwise": "Rotate 90° to the right"

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -441,7 +441,12 @@
     }
   },
   "documentContent": {
-    "noContent": "No content extracted for this document"
+    "noContent": "No content extracted for this document",
+    "view": {
+      "markdown": "Formatted",
+      "text": "Plain text",
+      "translationTooltip": "Translations are only available as plain text"
+    }
   },
   "documentContentMarkdown": {
     "error": "The formatted view of this page could not be loaded.",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -445,7 +445,8 @@
     "view": {
       "markdown": "Formatted",
       "text": "Plain text",
-      "translationTooltip": "Translations are only available as plain text"
+      "translationTooltip": "Translations are only available as plain text",
+      "ariaLabel": "Text rendering"
     }
   },
   "documentContentMarkdown": {

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -443,6 +443,11 @@
   "documentContent": {
     "noContent": "Aucun contenu extrait pour ce document"
   },
+  "documentContentMarkdown": {
+    "error": "Impossible de charger la mise en forme de cette page.",
+    "retry": "Réessayer",
+    "fallback": "Afficher en texte brut"
+  },
   "documentViewerImage": {
     "rotateCounterClockwise": "Tourner 90° à gauche",
     "rotateClockwise": "Tourner 90° à droite"

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -445,7 +445,8 @@
     "view": {
       "markdown": "Mise en forme",
       "text": "Texte brut",
-      "translationTooltip": "Les traductions ne sont disponibles qu'en texte brut"
+      "translationTooltip": "Les traductions ne sont disponibles qu'en texte brut",
+      "ariaLabel": "Rendu du texte"
     }
   },
   "documentContentMarkdown": {

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -441,7 +441,12 @@
     }
   },
   "documentContent": {
-    "noContent": "Aucun contenu extrait pour ce document"
+    "noContent": "Aucun contenu extrait pour ce document",
+    "view": {
+      "markdown": "Mise en forme",
+      "text": "Texte brut",
+      "translationTooltip": "Les traductions ne sont disponibles qu'en texte brut"
+    }
   },
   "documentContentMarkdown": {
     "error": "Impossible de charger la mise en forme de cette page.",

--- a/src/main.scss
+++ b/src/main.scss
@@ -15,6 +15,7 @@
 // Must be after bootstrap
 @import './utils/alerts.scss';
 @import './utils/buttons.scss';
+@import './utils/markdown.scss';
 @import './utils/nprogress.scss';
 
 :root {

--- a/src/utils/markdown.js
+++ b/src/utils/markdown.js
@@ -69,6 +69,14 @@ function isDelimiterRow(line) {
   return line.includes('|') && line.includes('-') && delimiterRowPattern.test(line)
 }
 
+// 4+ leading spaces (or a leading tab) make a line part of an indented code
+// block, not a table, regardless of what precedes it.
+const indentedCodePattern = /^(?: {4}|\t)/
+
+function isIndentedCode(line) {
+  return indentedCodePattern.test(line)
+}
+
 // Count the cells a GFM delimiter row declares, so a synthesized header can
 // match it exactly (GFM requires the header and delimiter row cell counts to
 // be equal, or the table is rejected).
@@ -98,15 +106,18 @@ export function normalizeHeaderlessTables(source) {
   const lines = source.split('\n')
   const normalizedLines = []
   // Fence state, tracked so a delimiter-looking line inside a fenced code
-  // block (a code sample, not an actual table) is never touched.
+  // block (a code sample, not an actual table) is never touched. The
+  // closing-fence pattern only ever changes when a new fence opens, so it is
+  // built once here rather than once per line while inside the fence.
   let fenceChar = null
   let fenceMinLength = 0
+  let closeFencePattern = null
 
   lines.forEach((line, index) => {
     if (fenceChar) {
-      const closesFence = new RegExp(`^\\s{0,3}${fenceChar}{${fenceMinLength},}\\s*$`).test(line)
-      if (closesFence) {
+      if (closeFencePattern.test(line)) {
         fenceChar = null
+        closeFencePattern = null
       }
       normalizedLines.push(line)
       return
@@ -116,15 +127,18 @@ export function normalizeHeaderlessTables(source) {
     if (fenceOpenMatch) {
       fenceChar = fenceOpenMatch[1][0]
       fenceMinLength = fenceOpenMatch[1].length
+      closeFencePattern = new RegExp(`^\\s{0,3}${fenceChar}{${fenceMinLength},}\\s*$`)
       normalizedLines.push(line)
       return
     }
 
     // A table block is headerless when its delimiter row is preceded by a
     // blank line (or nothing, at the very start of the document): a real
-    // header line would be the non-blank line right above it instead.
+    // header line would be the non-blank line right above it instead. A
+    // 4+-space indent makes the line an indented code block instead, even
+    // when the line above it is blank.
     const previousLine = lines[index - 1]
-    const startsHeaderlessTable = isDelimiterRow(line) && (previousLine === undefined || previousLine.trim() === '')
+    const startsHeaderlessTable = !isIndentedCode(line) && isDelimiterRow(line) && (previousLine === undefined || previousLine.trim() === '')
     if (startsHeaderlessTable) {
       normalizedLines.push(buildEmptyHeaderRow(countDelimiterCells(line)))
     }

--- a/src/utils/markdown.js
+++ b/src/utils/markdown.js
@@ -46,6 +46,44 @@ function rehypeHardenLinks() {
   }
 }
 
+// The text a header cell renders, with any inline formatting collapsed to
+// its plain text. A synthesized header cell has no children at all, and a
+// literal "| |" in the source can also leave a single whitespace text node,
+// so both must be checked the same way.
+function headerCellText(cellNode) {
+  let text = ''
+  visit(cellNode, 'text', (textNode) => {
+    text += textNode.value
+  })
+  return text
+}
+
+// normalizeHeaderlessTables synthesizes a header row purely so remark-gfm's
+// grammar accepts the table; that row carries no real data and must not
+// reach the reader. Drop a <thead> only when every one of its header cells
+// is empty (or whitespace-only, which is what the synthesized row produces)
+// so a table with even partially real header text keeps its thead intact.
+function rehypeDropEmptyTableHeader() {
+  return (tree) => {
+    visit(tree, 'element', (node, index, parent) => {
+      if (node.tagName !== 'thead' || parent === undefined || index === undefined) {
+        return
+      }
+      const headerCells = []
+      visit(node, 'element', (cellNode) => {
+        if (cellNode.tagName === 'th') {
+          headerCells.push(cellNode)
+        }
+      })
+      const allCellsEmpty = headerCells.length > 0 && headerCells.every(cell => headerCellText(cell).trim() === '')
+      if (allCellsEmpty) {
+        parent.children.splice(index, 1)
+        return index
+      }
+    })
+  }
+}
+
 // Built once and reused. remarkRehype defaults allowDangerousHtml:false, so raw
 // HTML embedded in the markdown is dropped before it can reach the output.
 const processor = unified()
@@ -53,6 +91,7 @@ const processor = unified()
   .use(remarkGfm)
   .use(remarkRehype)
   .use(rehypeHardenLinks)
+  .use(rehypeDropEmptyTableHeader)
   .use(rehypeSanitize, schema)
   .use(rehypeStringify)
 

--- a/src/utils/markdown.js
+++ b/src/utils/markdown.js
@@ -56,6 +56,84 @@ const processor = unified()
   .use(rehypeSanitize, schema)
   .use(rehypeStringify)
 
+// A line made solely of pipes, dashes, colons and whitespace, with at least
+// one pipe and one dash, is a GFM table delimiter row (e.g. "|---|---|"). A
+// bare "---" or "***" has no pipe, so it stays a thematic break, not a match.
+const delimiterRowPattern = /^[\s|:-]+$/
+
+// The opening (or closing) line of a fenced code block: up to 3 leading
+// spaces, then 3+ backticks or 3+ tildes.
+const fenceLinePattern = /^\s{0,3}(`{3,}|~{3,})/
+
+function isDelimiterRow(line) {
+  return line.includes('|') && line.includes('-') && delimiterRowPattern.test(line)
+}
+
+// Count the cells a GFM delimiter row declares, so a synthesized header can
+// match it exactly (GFM requires the header and delimiter row cell counts to
+// be equal, or the table is rejected).
+function countDelimiterCells(line) {
+  const trimmedLine = line.trim()
+  const withoutEdgePipes = trimmedLine.replace(/^\|/, '').replace(/\|$/, '')
+  return withoutEdgePipes.split('|').length
+}
+
+// An empty-cell header row with the same cell count as the delimiter row it
+// will sit above, so the pair together forms a syntactically valid GFM table.
+function buildEmptyHeaderRow(cellCount) {
+  return `|${new Array(cellCount).fill(' ').join('|')}|`
+}
+
+/**
+ * Insert a synthesized empty header row above any GFM table delimiter row
+ * that starts a table block without one. remark-gfm requires a header row
+ * above the delimiter row to recognize a table at all; some real-world
+ * documents omit it, so those lines would otherwise render as a plain
+ * paragraph instead of a table.
+ *
+ * @param {string} source - Raw markdown text.
+ * @returns {string} Markdown text with missing table headers synthesized.
+ */
+export function normalizeHeaderlessTables(source) {
+  const lines = source.split('\n')
+  const normalizedLines = []
+  // Fence state, tracked so a delimiter-looking line inside a fenced code
+  // block (a code sample, not an actual table) is never touched.
+  let fenceChar = null
+  let fenceMinLength = 0
+
+  lines.forEach((line, index) => {
+    if (fenceChar) {
+      const closesFence = new RegExp(`^\\s{0,3}${fenceChar}{${fenceMinLength},}\\s*$`).test(line)
+      if (closesFence) {
+        fenceChar = null
+      }
+      normalizedLines.push(line)
+      return
+    }
+
+    const fenceOpenMatch = line.match(fenceLinePattern)
+    if (fenceOpenMatch) {
+      fenceChar = fenceOpenMatch[1][0]
+      fenceMinLength = fenceOpenMatch[1].length
+      normalizedLines.push(line)
+      return
+    }
+
+    // A table block is headerless when its delimiter row is preceded by a
+    // blank line (or nothing, at the very start of the document): a real
+    // header line would be the non-blank line right above it instead.
+    const previousLine = lines[index - 1]
+    const startsHeaderlessTable = isDelimiterRow(line) && (previousLine === undefined || previousLine.trim() === '')
+    if (startsHeaderlessTable) {
+      normalizedLines.push(buildEmptyHeaderRow(countDelimiterCells(line)))
+    }
+    normalizedLines.push(line)
+  })
+
+  return normalizedLines.join('\n')
+}
+
 /**
  * Convert Markdown source to sanitized, safe-to-render HTML.
  *
@@ -68,5 +146,5 @@ export async function renderMarkdown(source) {
   if (!source) {
     return ''
   }
-  return String(await processor.process(source))
+  return String(await processor.process(normalizeHeaderlessTables(source)))
 }

--- a/src/utils/markdown.js
+++ b/src/utils/markdown.js
@@ -46,37 +46,27 @@ function rehypeHardenLinks() {
   }
 }
 
-// The text a header cell renders, with any inline formatting collapsed to
-// its plain text. A synthesized header cell has no children at all, and a
-// literal "| |" in the source can also leave a single whitespace text node,
-// so both must be checked the same way.
-function headerCellText(cellNode) {
-  let text = ''
-  visit(cellNode, 'text', (textNode) => {
-    text += textNode.value
+// The rows and cells a header is made of; anything else inside it is content.
+const tableStructureTags = ['tr', 'th', 'td']
+
+function isEmptyHeader(node) {
+  return (node.children ?? []).every((child) => {
+    if (child.type === 'text') {
+      return child.value.trim() === ''
+    }
+    return tableStructureTags.includes(child.tagName) && isEmptyHeader(child)
   })
-  return text
 }
 
 // normalizeHeaderlessTables synthesizes a header row purely so remark-gfm's
-// grammar accepts the table; that row carries no real data and must not
-// reach the reader. Drop a <thead> only when every one of its header cells
-// is empty (or whitespace-only, which is what the synthesized row produces)
-// so a table with even partially real header text keeps its thead intact.
+// grammar accepts the table; that row carries no real data and must not reach
+// the reader. A header row the document does contain but leaves blank (authors
+// write those for column alignment) is indistinguishable from it here, and
+// renders the same either way: one empty row of cells, so it goes too.
 function rehypeDropEmptyTableHeader() {
   return (tree) => {
     visit(tree, 'element', (node, index, parent) => {
-      if (node.tagName !== 'thead' || parent === undefined || index === undefined) {
-        return
-      }
-      const headerCells = []
-      visit(node, 'element', (cellNode) => {
-        if (cellNode.tagName === 'th') {
-          headerCells.push(cellNode)
-        }
-      })
-      const allCellsEmpty = headerCells.length > 0 && headerCells.every(cell => headerCellText(cell).trim() === '')
-      if (allCellsEmpty) {
+      if (node.tagName === 'thead' && isEmptyHeader(node)) {
         parent.children.splice(index, 1)
         return index
       }
@@ -95,39 +85,57 @@ const processor = unified()
   .use(rehypeSanitize, schema)
   .use(rehypeStringify)
 
-// A line made solely of pipes, dashes, colons and whitespace, with at least
-// one pipe and one dash, is a GFM table delimiter row (e.g. "|---|---|"). A
-// bare "---" or "***" has no pipe, so it stays a thematic break, not a match.
-const delimiterRowPattern = /^[\s|:-]+$/
+// A GFM delimiter cell: one or more dashes, optionally anchored by alignment
+// colons. A bare "---" line has no pipe at all, so it stays a thematic break.
+const delimiterCellPattern = /^:?-+:?$/
+
+// A bullet or ordered list marker. "- |" satisfies the delimiter-cell grammar
+// but remark parses it as a list, so the marker is ruled out first.
+const listItemPattern = /^\s*(?:[-*+]|\d{1,9}[.)])\s/
 
 // The opening (or closing) line of a fenced code block: up to 3 leading
 // spaces, then 3+ backticks or 3+ tildes.
 const fenceLinePattern = /^\s{0,3}(`{3,}|~{3,})/
 
-function isDelimiterRow(line) {
-  return line.includes('|') && line.includes('-') && delimiterRowPattern.test(line)
-}
-
 // 4+ leading spaces (or a leading tab) make a line part of an indented code
 // block, not a table, regardless of what precedes it.
 const indentedCodePattern = /^(?: {4}|\t)/
 
-function isIndentedCode(line) {
-  return indentedCodePattern.test(line)
+function splitCells(line) {
+  const withoutEdgePipes = line.trim().replace(/^\|/, '').replace(/\|$/, '')
+  return withoutEdgePipes.split('|')
 }
 
-// Count the cells a GFM delimiter row declares, so a synthesized header can
-// match it exactly (GFM requires the header and delimiter row cell counts to
-// be equal, or the table is rejected).
-function countDelimiterCells(line) {
-  const trimmedLine = line.trim()
-  const withoutEdgePipes = trimmedLine.replace(/^\|/, '').replace(/\|$/, '')
-  return withoutEdgePipes.split('|').length
+function isDelimiterRow(line) {
+  if (!line.includes('|') || listItemPattern.test(line)) {
+    return false
+  }
+  return splitCells(line).every(cell => delimiterCellPattern.test(cell.trim()))
+}
+
+// GFM needs a row below the delimiter row as well. Without one, synthesizing a
+// header builds a table with no body, and the reader loses the line's own text.
+function isTableBodyRow(line) {
+  return line !== undefined && line.includes('|')
+}
+
+// A table block is headerless when its delimiter row is preceded by a blank line
+// (or nothing, at the very start of the document): a real header would be the
+// non-blank line right above it instead.
+function startsHeaderlessTable(lines, index) {
+  const line = lines[index]
+  const previousLine = lines[index - 1]
+  const isAtBlockStart = previousLine === undefined || previousLine.trim() === ''
+  return isAtBlockStart
+    && !indentedCodePattern.test(line)
+    && isDelimiterRow(line)
+    && isTableBodyRow(lines[index + 1])
 }
 
 // An empty-cell header row with the same cell count as the delimiter row it
 // will sit above, so the pair together forms a syntactically valid GFM table.
-function buildEmptyHeaderRow(cellCount) {
+function buildEmptyHeaderRow(delimiterLine) {
+  const cellCount = splitCells(delimiterLine).length
   return `|${new Array(cellCount).fill(' ').join('|')}|`
 }
 
@@ -139,23 +147,18 @@ function buildEmptyHeaderRow(cellCount) {
  * paragraph instead of a table.
  *
  * @param {string} source - Raw markdown text.
- * @returns {string} Markdown text with missing table headers synthesized.
+ * @returns {string} The rewritten markdown.
  */
 export function normalizeHeaderlessTables(source) {
   const lines = source.split('\n')
   const normalizedLines = []
-  // Fence state, tracked so a delimiter-looking line inside a fenced code
-  // block (a code sample, not an actual table) is never touched. The
-  // closing-fence pattern only ever changes when a new fence opens, so it is
-  // built once here rather than once per line while inside the fence.
-  let fenceChar = null
-  let fenceMinLength = 0
+  // Tracked so a delimiter-looking line inside a fenced code block (a code
+  // sample, not a table) is never touched. Non-null means "inside a fence".
   let closeFencePattern = null
 
   lines.forEach((line, index) => {
-    if (fenceChar) {
+    if (closeFencePattern) {
       if (closeFencePattern.test(line)) {
-        fenceChar = null
         closeFencePattern = null
       }
       normalizedLines.push(line)
@@ -164,22 +167,14 @@ export function normalizeHeaderlessTables(source) {
 
     const fenceOpenMatch = line.match(fenceLinePattern)
     if (fenceOpenMatch) {
-      fenceChar = fenceOpenMatch[1][0]
-      fenceMinLength = fenceOpenMatch[1].length
-      closeFencePattern = new RegExp(`^\\s{0,3}${fenceChar}{${fenceMinLength},}\\s*$`)
+      const fence = fenceOpenMatch[1]
+      closeFencePattern = new RegExp(`^\\s{0,3}${fence[0]}{${fence.length},}\\s*$`)
       normalizedLines.push(line)
       return
     }
 
-    // A table block is headerless when its delimiter row is preceded by a
-    // blank line (or nothing, at the very start of the document): a real
-    // header line would be the non-blank line right above it instead. A
-    // 4+-space indent makes the line an indented code block instead, even
-    // when the line above it is blank.
-    const previousLine = lines[index - 1]
-    const startsHeaderlessTable = !isIndentedCode(line) && isDelimiterRow(line) && (previousLine === undefined || previousLine.trim() === '')
-    if (startsHeaderlessTable) {
-      normalizedLines.push(buildEmptyHeaderRow(countDelimiterCells(line)))
+    if (startsHeaderlessTable(lines, index)) {
+      normalizedLines.push(buildEmptyHeaderRow(line))
     }
     normalizedLines.push(line)
   })

--- a/src/utils/markdown.scss
+++ b/src/utils/markdown.scss
@@ -1,0 +1,77 @@
+// Typography of a rendered markdown body, shared by every component that shows
+// one: the document text tab and the markdown viewer render the same artifact
+// and must not drift apart. Sized like GitHub renders markdown.
+.markdown-body {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin-top: $spacer-lg;
+    margin-bottom: $spacer;
+    font-weight: $font-weight-semibold;
+    line-height: 1.25;
+  }
+
+  h1 {
+    font-size: 2rem;
+    padding-bottom: 0.3em;
+    border-bottom: 1px solid var(--bs-border-color-translucent);
+  }
+
+  h2 {
+    font-size: 1.5rem;
+    padding-bottom: 0.3em;
+    border-bottom: 1px solid var(--bs-border-color-translucent);
+  }
+
+  h3 {
+    font-size: 1.25rem;
+  }
+
+  h4 {
+    font-size: 1rem;
+  }
+
+  h5 {
+    font-size: 0.875rem;
+  }
+
+  h6 {
+    font-size: 0.85rem;
+    color: var(--bs-secondary-color);
+  }
+
+  table {
+    border-collapse: collapse;
+    margin-bottom: $spacer;
+
+    th,
+    td {
+      border: 1px solid var(--bs-border-color);
+      padding: 6px 13px;
+    }
+
+    th {
+      font-weight: $font-weight-semibold;
+    }
+
+    tr:nth-child(2n) {
+      background-color: var(--bs-tertiary-bg);
+    }
+  }
+
+  pre {
+    padding: $spacer;
+    overflow-x: auto;
+    background: var(--bs-tertiary-bg);
+    border-radius: var(--bs-border-radius);
+  }
+
+  blockquote {
+    margin: 0;
+    padding-left: $spacer;
+    border-left: 4px solid var(--bs-border-color);
+  }
+}

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -95,11 +95,23 @@ export function foldWithSourceIndexes(value = '') {
 function findFoldedMatches(text, foldedTerm) {
   const { folded, sourceIndexes } = foldWithSourceIndexes(text)
   const matches = []
+  // A single source character whose fold repeats the term (e.g. the 'ﬀ'
+  // ligature folding to 'ff', matched twice by the term 'f') can produce two
+  // folded matches that map back to the very same source range. Wrapping
+  // that range twice would nest one mark inside another (and, once the first
+  // wrap splits the text node, the second wrap's offsets would no longer
+  // even exist), so duplicate ranges are dropped here before they reach the
+  // wrapper.
+  const seenRanges = new Set()
   let at = folded.indexOf(foldedTerm)
   while (at !== -1) {
     const start = sourceIndexes[at]
     const end = sourceIndexes[at + foldedTerm.length - 1] + 1
-    matches.push({ start, end })
+    const rangeKey = `${start}:${end}`
+    if (!seenRanges.has(rangeKey)) {
+      seenRanges.add(rangeKey)
+      matches.push({ start, end })
+    }
     at = folded.indexOf(foldedTerm, at + foldedTerm.length)
   }
   return matches

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -63,6 +63,95 @@ export function addLocalSearchMarksClassByOffsets({ content = '', term = '', off
 }
 
 /**
+ * Fold a string roughly the way the backend artifact search does: lowercase,
+ * NFKD-decompose and strip combining marks. Returns the folded string plus, for
+ * each folded char, the index of the source char it came from, so a match found
+ * in folded text can be mapped back to the original string even when the fold
+ * changes its length (a ligature expands, a combining mark disappears).
+ *
+ * @param {string} [value=''] - The string to fold.
+ * @return {Object} - An object with the `folded` string and its `sourceIndexes` map.
+ */
+export function foldWithSourceIndexes(value = '') {
+  const folded = []
+  const sourceIndexes = []
+  for (let index = 0; index < value.length; index++) {
+    const decomposed = value[index].toLowerCase().normalize('NFKD').replace(/\p{M}/gu, '')
+    for (const character of decomposed) {
+      folded.push(character)
+      sourceIndexes.push(index)
+    }
+  }
+  return { folded: folded.join(''), sourceIndexes }
+}
+
+/**
+ * Find every folded-term match in a text string, mapped back to source offsets.
+ *
+ * @param {string} text - The source text to search in.
+ * @param {string} foldedTerm - The already-folded term to search for.
+ * @return {Object[]} - A list of `{ start, end }` source ranges.
+ */
+function findFoldedMatches(text, foldedTerm) {
+  const { folded, sourceIndexes } = foldWithSourceIndexes(text)
+  const matches = []
+  let at = folded.indexOf(foldedTerm)
+  while (at !== -1) {
+    const start = sourceIndexes[at]
+    const end = sourceIndexes[at + foldedTerm.length - 1] + 1
+    matches.push({ start, end })
+    at = folded.indexOf(foldedTerm, at + foldedTerm.length)
+  }
+  return matches
+}
+
+/**
+ * Wrap each matched range of a text node in a mark tag. Ranges are applied last
+ * to first so earlier offsets stay valid while the node is being split.
+ *
+ * @param {Text} node - The text node to mark.
+ * @param {Object[]} matches - The `{ start, end }` ranges to wrap.
+ */
+function wrapTextNodeMatches(node, matches) {
+  for (const { start, end } of [...matches].reverse()) {
+    const range = node.ownerDocument.createRange()
+    range.setStart(node, start)
+    range.setEnd(node, end)
+    const mark = node.ownerDocument.createElement('mark')
+    mark.className = 'local-search-term'
+    range.surroundContents(mark)
+  }
+}
+
+/**
+ * Highlight term occurrences inside an HTML string, matching text nodes only
+ * (never attributes, never across element boundaries), with the same case and
+ * diacritic folding as the backend artifact search.
+ *
+ * @param {string} [html=''] - The HTML content to mark.
+ * @param {string} [term=''] - The search term.
+ * @return {string} - The HTML with `<mark class="local-search-term">` around matches.
+ */
+export function addLocalSearchMarksClassInHtml(html = '', term = '') {
+  const trimmedTerm = term.trim()
+  if (!trimmedTerm) {
+    return html
+  }
+  const { folded: foldedTerm } = foldWithSourceIndexes(trimmedTerm)
+  const parsed = new DOMParser().parseFromString(html, 'text/html')
+  const walker = parsed.createTreeWalker(parsed.body, NodeFilter.SHOW_TEXT)
+  // Collect first: wrapping mutates the tree and would derail a live walker
+  const textNodes = []
+  while (walker.nextNode()) {
+    textNodes.push(walker.currentNode)
+  }
+  for (const node of textNodes) {
+    wrapTextNodeMatches(node, findFoldedMatches(node.nodeValue, foldedTerm))
+  }
+  return parsed.body.innerHTML
+}
+
+/**
  * Highlight search term occurrences in the given content.
  *
  * @param {string} [content='<div></div>'] - The HTML content to search in.

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -138,6 +138,9 @@ export function addLocalSearchMarksClassInHtml(html = '', term = '') {
     return html
   }
   const { folded: foldedTerm } = foldWithSourceIndexes(trimmedTerm)
+  if (!foldedTerm) {
+    return html
+  }
   const parsed = new DOMParser().parseFromString(html, 'text/html')
   const walker = parsed.createTreeWalker(parsed.body, NodeFilter.SHOW_TEXT)
   // Collect first: wrapping mutates the tree and would derail a live walker

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -62,27 +62,47 @@ export function addLocalSearchMarksClassByOffsets({ content = '', term = '', off
   return chunks.join('')
 }
 
+const combiningMarkPattern = /\p{M}/gu
+
+function foldCharacter(character) {
+  return character.normalize('NFKD').replace(combiningMarkPattern, '').toLowerCase()
+}
+
 /**
- * Fold a string roughly the way the backend artifact search does: lowercase,
- * NFKD-decompose and strip combining marks. Returns the folded string plus, for
- * each folded char, the index of the source char it came from, so a match found
- * in folded text can be mapped back to the original string even when the fold
+ * Fold a string roughly the way the backend artifact search does: NFKD-decompose,
+ * strip combining marks and lowercase. Returns the folded string plus, for each
+ * folded char, the start and end offsets of the source it came from, so a match
+ * found in folded text maps back to the original string even when the fold
  * changes its length (a ligature expands, a combining mark disappears).
  *
  * @param {string} [value=''] - The string to fold.
- * @return {Object} - An object with the `folded` string and its `sourceIndexes` map.
+ * @return {Object} - The `folded` string with its `sourceIndexes` and `sourceEnds` maps.
  */
 export function foldWithSourceIndexes(value = '') {
   const folded = []
   const sourceIndexes = []
-  for (let index = 0; index < value.length; index++) {
-    const decomposed = value[index].toLowerCase().normalize('NFKD').replace(/\p{M}/gu, '')
-    for (const character of decomposed) {
-      folded.push(character)
+  const sourceEnds = []
+  let index = 0
+  // Iterating code points (not code units) so an astral char reaches `normalize`
+  // whole: a lone surrogate folds to nothing, and the backend folds the string.
+  for (const character of value) {
+    const end = index + character.length
+    const decomposed = foldCharacter(character)
+    for (const foldedCharacter of decomposed) {
+      folded.push(foldedCharacter)
       sourceIndexes.push(index)
+      sourceEnds.push(end)
     }
+    // A source char that folds to nothing (a combining mark standing on its own,
+    // as decomposed text writes accents) has no folded position of its own, so
+    // the letter it decorates has to own it: a match ending on that letter must
+    // cover the mark too, or the accent is left outside the highlight.
+    if (!decomposed && sourceEnds.length) {
+      sourceEnds[sourceEnds.length - 1] = end
+    }
+    index = end
   }
-  return { folded: folded.join(''), sourceIndexes }
+  return { folded: folded.join(''), sourceIndexes, sourceEnds }
 }
 
 /**
@@ -93,22 +113,18 @@ export function foldWithSourceIndexes(value = '') {
  * @return {Object[]} - A list of `{ start, end }` source ranges.
  */
 function findFoldedMatches(text, foldedTerm) {
-  const { folded, sourceIndexes } = foldWithSourceIndexes(text)
+  const { folded, sourceIndexes, sourceEnds } = foldWithSourceIndexes(text)
   const matches = []
-  // A single source character whose fold repeats the term (e.g. the 'ﬀ'
-  // ligature folding to 'ff', matched twice by the term 'f', or the 'Ⅲ'
-  // roman numeral folding to 'iii', matched twice by the term 'ii') can
-  // produce folded matches that map back to identical or overlapping source
-  // ranges. Wrapping an overlapping range would let the wider range's
-  // `surroundContents` empty the text node the narrower range still expects
-  // to address, throwing once `wrapTextNodeMatches` reaches it; each
-  // candidate's start is compared against the last kept range's end, so this
-  // also catches a narrower range nested entirely inside a wider one.
+  // A single source char whose fold repeats the term (the 'ﬀ' ligature folds to
+  // 'ff', matched twice by the term 'f') maps several folded matches back to the
+  // same source range. Wrapping one range splits the node the next one still
+  // addresses, so a candidate starting before the last kept range's end is
+  // dropped; comparing against that end also catches a nested range.
   let lastKeptEnd = -1
   let at = folded.indexOf(foldedTerm)
   while (at !== -1) {
     const start = sourceIndexes[at]
-    const end = sourceIndexes[at + foldedTerm.length - 1] + 1
+    const end = sourceEnds[at + foldedTerm.length - 1]
     if (start >= lastKeptEnd) {
       matches.push({ start, end })
       lastKeptEnd = end
@@ -118,21 +134,24 @@ function findFoldedMatches(text, foldedTerm) {
   return matches
 }
 
-/**
- * Wrap each matched range of a text node in a mark tag. Ranges are applied last
- * to first so earlier offsets stay valid while the node is being split.
- *
- * @param {Text} node - The text node to mark.
- * @param {Object[]} matches - The `{ start, end }` ranges to wrap.
- */
-function wrapTextNodeMatches(node, matches) {
+// Ranges are applied last to first so earlier offsets stay valid while the node
+// is being split.
+function wrapTextNodeMatches(node, matches, { className, style }) {
   for (const { start, end } of [...matches].reverse()) {
-    const range = node.ownerDocument.createRange()
-    range.setStart(node, start)
-    range.setEnd(node, end)
+    // splitText rather than a Range: a live Range stays attached to the document
+    // and every later mutation has to update all the earlier ones, which makes
+    // marking a page quadratic in its number of matches.
+    const match = node.splitText(start)
+    if (end - start < match.nodeValue.length) {
+      match.splitText(end - start)
+    }
     const mark = node.ownerDocument.createElement('mark')
-    mark.className = 'local-search-term'
-    range.surroundContents(mark)
+    mark.className = className
+    if (style) {
+      mark.setAttribute('style', style)
+    }
+    match.parentNode.replaceChild(mark, match)
+    mark.appendChild(match)
   }
 }
 
@@ -143,9 +162,12 @@ function wrapTextNodeMatches(node, matches) {
  *
  * @param {string} [html=''] - The HTML content to mark.
  * @param {string} [term=''] - The search term.
- * @return {string} - The HTML with `<mark class="local-search-term">` around matches.
+ * @param {Object} [options={}] - The mark options.
+ * @param {string} [options.className='local-search-term'] - Class of the mark tags.
+ * @param {string} [options.style=''] - Inline style of the mark tags.
+ * @return {string} - The HTML with `<mark>` around matches.
  */
-export function addLocalSearchMarksClassInHtml(html = '', term = '') {
+export function addSearchMarksClassInHtml(html = '', term = '', { className = 'local-search-term', style = '' } = {}) {
   const trimmedTerm = term.trim()
   if (!trimmedTerm) {
     return html
@@ -162,7 +184,7 @@ export function addLocalSearchMarksClassInHtml(html = '', term = '') {
     textNodes.push(walker.currentNode)
   }
   for (const node of textNodes) {
-    wrapTextNodeMatches(node, findFoldedMatches(node.nodeValue, foldedTerm))
+    wrapTextNodeMatches(node, findFoldedMatches(node.nodeValue, foldedTerm), { className, style })
   }
   return parsed.body.innerHTML
 }

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -96,21 +96,22 @@ function findFoldedMatches(text, foldedTerm) {
   const { folded, sourceIndexes } = foldWithSourceIndexes(text)
   const matches = []
   // A single source character whose fold repeats the term (e.g. the 'ﬀ'
-  // ligature folding to 'ff', matched twice by the term 'f') can produce two
-  // folded matches that map back to the very same source range. Wrapping
-  // that range twice would nest one mark inside another (and, once the first
-  // wrap splits the text node, the second wrap's offsets would no longer
-  // even exist), so duplicate ranges are dropped here before they reach the
-  // wrapper.
-  const seenRanges = new Set()
+  // ligature folding to 'ff', matched twice by the term 'f', or the 'Ⅲ'
+  // roman numeral folding to 'iii', matched twice by the term 'ii') can
+  // produce folded matches that map back to identical or overlapping source
+  // ranges. Wrapping an overlapping range would let the wider range's
+  // `surroundContents` empty the text node the narrower range still expects
+  // to address, throwing once `wrapTextNodeMatches` reaches it; each
+  // candidate's start is compared against the last kept range's end, so this
+  // also catches a narrower range nested entirely inside a wider one.
+  let lastKeptEnd = -1
   let at = folded.indexOf(foldedTerm)
   while (at !== -1) {
     const start = sourceIndexes[at]
     const end = sourceIndexes[at + foldedTerm.length - 1] + 1
-    const rangeKey = `${start}:${end}`
-    if (!seenRanges.has(rangeKey)) {
-      seenRanges.add(rangeKey)
+    if (start >= lastKeptEnd) {
       matches.push({ start, end })
+      lastKeptEnd = end
     }
     at = folded.indexOf(foldedTerm, at + foldedTerm.length)
   }

--- a/tests/unit/specs/api/index.spec.js
+++ b/tests/unit/specs/api/index.spec.js
@@ -762,5 +762,27 @@ describe('Datashare backend client', () => {
       EventBus.off('http::error', mockCallback)
       expect(mockCallback).not.toBeCalled()
     })
+
+    // An expired session is not "no results": the caller cannot tell them apart,
+    // so the bus has to carry the 401 to the re-login prompt.
+    it('should emit an http error when the session has expired', async () => {
+      const error = Object.assign(new Error('Unauthorized'), { response: { status: 401 } })
+      axios.request.mockRejectedValue(error)
+      const mockCallback = vi.fn()
+      EventBus.on('http::error', mockCallback)
+      await expect(api.searchStructurePages('foo', 'doc-id', 'needle', 'root-id')).rejects.toThrow('Unauthorized')
+      EventBus.off('http::error', mockCallback)
+      expect(mockCallback).toBeCalledWith(error)
+    })
+
+    it('should emit an http error when the session expires while reading a page', async () => {
+      const error = Object.assign(new Error('Unauthorized'), { response: { status: 401 } })
+      axios.request.mockRejectedValue(error)
+      const mockCallback = vi.fn()
+      EventBus.on('http::error', mockCallback)
+      await expect(api.getStructurePage('foo', 'doc-id', 3, 'root-id')).rejects.toThrow('Unauthorized')
+      EventBus.off('http::error', mockCallback)
+      expect(mockCallback).toBeCalledWith(error)
+    })
   })
 })

--- a/tests/unit/specs/api/index.spec.js
+++ b/tests/unit/specs/api/index.spec.js
@@ -732,4 +732,35 @@ describe('Datashare backend client', () => {
       expect(mockCallback).not.toBeCalled()
     })
   })
+
+  describe('searchStructurePages', () => {
+    it('should send a GET request on the structure search url with the query', async () => {
+      axios.request.mockResolvedValue({ data: { count: 0, pages: 2, scanned: 2, hits: [] } })
+      await api.searchStructurePages('foo', 'doc-id', 'needle', 'root-id')
+      expect(axios.request).toBeCalledWith(
+        expect.objectContaining({
+          url: Api.getFullUrl('/api/foo/artifacts/structure/search/doc-id'),
+          method: 'GET',
+          params: { query: 'needle', routing: 'root-id' }
+        })
+      )
+    })
+
+    it('should return the hits payload', async () => {
+      const data = { count: 3, pages: 4, scanned: 4, hits: [{ page: 2, count: 1 }, { page: 3, count: 2 }] }
+      axios.request.mockResolvedValue({ data })
+      expect(await api.searchStructurePages('foo', 'doc-id', 'needle', 'root-id')).toEqual(data)
+    })
+
+    // The search runs on every (throttled) keystroke: a transient failure must degrade
+    // silently in the caller instead of stacking one error toast per keystroke.
+    it('should not emit an http error when the search fails', async () => {
+      axios.request.mockRejectedValue(new Error('Network Error'))
+      const mockCallback = vi.fn()
+      EventBus.on('http::error', mockCallback)
+      await expect(api.searchStructurePages('foo', 'doc-id', 'needle', 'root-id')).rejects.toThrow('Network Error')
+      EventBus.off('http::error', mockCallback)
+      expect(mockCallback).not.toBeCalled()
+    })
+  })
 })

--- a/tests/unit/specs/components/Document/DocumentContent.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContent.spec.js
@@ -5,6 +5,7 @@ import { IndexedDocument, letData } from '~tests/unit/es_utils'
 import { letTextContent } from '~tests/unit/api_mock'
 import CoreSetup from '~tests/unit/CoreSetup'
 import DocumentContent from '@/components/Document/DocumentContent'
+import DocumentLocalSearch from '@/components/Document/DocumentLocalSearch/DocumentLocalSearch'
 import { apiInstance as api } from '@/api/apiInstance'
 import { useDocumentStore } from '@/store/modules'
 
@@ -34,6 +35,17 @@ vi.mock('@/api/apiInstance', async (importOriginal) => {
 })
 
 window.HTMLElement.prototype.scrollIntoView = vi.fn()
+
+// A promise whose resolution is controlled from the outside, so a test can
+// resolve two competing requests in a deterministic, arbitrary order instead
+// of relying on timers.
+function createDeferredPromise() {
+  const deferred = {}
+  deferred.promise = new Promise((resolve) => {
+    deferred.resolve = resolve
+  })
+  return deferred
+}
 
 describe('DocumentContent.vue', () => {
   let core, documentStore
@@ -314,9 +326,12 @@ describe('DocumentContent.vue', () => {
     it('never disables the local search input in markdown mode, even without extracted text', async () => {
       const { document } = await mockDocumentContentSlice('')
       const { plugins } = core
-      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins, renderStubDefaultSlot: true } })
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
       await flushPromises()
-      const input = wrapper.find('document-local-search-stub')
+      // `disabled` is a fallthrough attribute on `DocumentLocalSearch` (not a
+      // declared prop), so it cannot be read through `.props()`; assert
+      // through the component locator instead of a raw tag/class selector.
+      const input = wrapper.findComponent(DocumentLocalSearch)
       expect(input.attributes('disabled')).toBe('false')
     })
 
@@ -461,13 +476,21 @@ describe('DocumentContent.vue', () => {
       it('searches the structure pages instead of the raw content', async () => {
         const { document } = await mockDocumentContentSlice('Hello world')
         const { plugins } = core
-        shallowMount(DocumentContent, { props: { document, q: ' hello ' }, global: { plugins } })
+        const wrapper = shallowMount(DocumentContent, { props: { document, q: ' hello ' }, global: { plugins } })
         await flushPromises()
         // Assert on the leading arguments only: the routing value depends on how the
         // fixture document was indexed, and this test is about the trimmed query.
         const [project, documentId, query] = api.searchStructurePages.mock.calls[0]
         expect([project, documentId, query]).toEqual([index, 'document', 'hello'])
         expect(api.searchDocument).not.toBeCalled()
+        // A markdown document opened with `q` must search exactly once: the mode
+        // watcher firing during `onMounted`'s manifest probe must not duplicate
+        // the search `onMounted`'s own `q` branch already issues.
+        expect(api.searchStructurePages).toBeCalledTimes(1)
+        // The same trimmed term that was sent to the endpoint must be the one
+        // used to mark matches, so the DOM marks match what the backend counted.
+        const markdownBody = wrapper.findComponent({ name: 'DocumentContentMarkdown' })
+        expect(markdownBody.props('term')).toBe('hello')
       })
 
       it('lands on the first hit page with the occurrences count', async () => {
@@ -515,6 +538,55 @@ describe('DocumentContent.vue', () => {
         await flushPromises()
         const [project, documentId, query] = api.searchDocument.mock.calls[0]
         expect([project, documentId, query]).toEqual([index, 'document', 'hello'])
+      })
+
+      // Ruling 1's actual scenario: a translation forces text mode (rather than
+      // the user toggling `preferMarkdown` directly), and the search MUST
+      // switch from `searchStructurePages` back to `searchDocument`.
+      it('re-runs the search through the raw content when a translation forces plain text', async () => {
+        api.searchDocument.mockResolvedValue({ count: 1, offsets: [0] })
+        const { document } = await mockDocumentContentSlice('Hello world')
+        const { plugins } = core
+        const wrapper = shallowMount(DocumentContent, { props: { document, q: 'hello' }, global: { plugins } })
+        await flushPromises()
+        await wrapper.setProps({ targetLanguage: 'ENGLISH' })
+        await flushPromises()
+        expect(wrapper.vm.isMarkdownMode).toBe(false)
+        const [project, documentId, query] = api.searchDocument.mock.calls[0]
+        expect([project, documentId, query]).toEqual([index, 'document', 'hello'])
+      })
+
+      it('keeps only the newest occurrence retrieval when a mode flip interleaves two responses', async () => {
+        const { document } = await mockDocumentContentSlice('Hello world')
+        const { plugins } = core
+        const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+        await flushPromises()
+
+        const markdownDeferred = createDeferredPromise()
+        const textDeferred = createDeferredPromise()
+        api.searchStructurePages.mockReturnValue(markdownDeferred.promise)
+        api.searchDocument.mockReturnValue(textDeferred.promise)
+
+        // Start a markdown search that stays in flight (the server-side page
+        // scan is slow)...
+        wrapper.vm.localSearchTerm = 'foo'
+        await flushPromises()
+        // ...then flip to plain text before it resolves: this starts a second,
+        // competing retrieval through the raw-content endpoint.
+        wrapper.vm.preferMarkdown = false
+        await flushPromises()
+
+        // The newer (text) request wins the race by resolving first.
+        textDeferred.resolve({ count: 1, offsets: [5] })
+        await flushPromises()
+        // The stale markdown response lands after: it must not clobber the
+        // already-written, consistent text-mode result.
+        markdownDeferred.resolve({ count: 9, pages: 9, scanned: 9, hits: [{ page: 1, count: 9 }] })
+        await flushPromises()
+
+        expect(wrapper.vm.localSearchOccurrences).toBe(1)
+        expect(wrapper.vm.localSearchIndexes).toEqual([5])
+        expect(wrapper.vm.localSearchIndex).toBe(1)
       })
     })
   })

--- a/tests/unit/specs/components/Document/DocumentContent.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContent.spec.js
@@ -24,7 +24,11 @@ vi.mock('@/api/apiInstance', async (importOriginal) => {
       searchDocument: vi.fn(),
       getStructureManifest: vi.fn().mockResolvedValue(null),
       getStructurePage: vi.fn().mockResolvedValue(''),
-      searchStructurePages: vi.fn().mockResolvedValue({ count: 0, pages: 0, scanned: 0, hits: [] })
+      searchStructurePages: vi.fn().mockResolvedValue({ count: 0, pages: 0, scanned: 0, hits: [] }),
+      // Only consulted by `sameTikaVersion` when a document is a PDF; the
+      // resolved version must match the `PDF_ARTIFACT_TIKA_VERSION` metadata
+      // set by `withPdfArtifactMetadata` below for `mustSyncPages` to pass.
+      getVersion: vi.fn().mockResolvedValue({ ds: { extractorVersion: '1.2.3' } })
     }
   }
 })
@@ -46,10 +50,11 @@ describe('DocumentContent.vue', () => {
     vi.resetAllMocks()
   })
 
-  async function mockDocumentContentSlice(content = '', { language = 'ENGLISH' } = {}) {
+  async function mockDocumentContentSlice(content = '', { language = 'ENGLISH', configureDocument = document => document } = {}) {
     const contentSlice = letTextContent().withContent(content).getResponse()
     // Index the document
-    await letData(es).have(new IndexedDocument(id, index).withContent(content).withLanguage(language)).commit()
+    const indexedDocument = configureDocument(new IndexedDocument(id, index).withContent(content).withLanguage(language))
+    await letData(es).have(indexedDocument).commit()
     // Mock the `getDocumentSlice` method
     api.getDocumentSlice.mockImplementation(async (project, documentId, offset, limit) => {
       // Modify the returned content according to passed parameters
@@ -324,6 +329,12 @@ describe('DocumentContent.vue', () => {
       const wrapper = shallowMount(DocumentContent, { props, global: { plugins } })
       await flushPromises()
       expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).exists()).toBe(false)
+      // The toggle must stay visible (so the user understands why they are
+      // stuck in plain text) but disabled while a translation is selected.
+      const toggle = wrapper.find('.document-content__togglers__view')
+      expect(toggle.exists()).toBe(true)
+      expect(toggle.attributes('disabled')).toBe('true')
+      expect(toggle.attributes('title')).toBe('Translations are only available as plain text')
     })
 
     it('paginates by the manifest page count in markdown mode', async () => {
@@ -354,6 +365,75 @@ describe('DocumentContent.vue', () => {
       wrapper.vm.preferMarkdown = false
       await flushPromises()
       expect(wrapper.vm.page).toBe(1)
+    })
+
+    it('does not fetch a text slice while paginating in markdown mode', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      const callsBeforePaginating = api.getDocumentSlice.mock.calls.length
+      wrapper.vm.page = 2
+      await flushPromises()
+      expect(api.getDocumentSlice.mock.calls.length).toBe(callsBeforePaginating)
+    })
+
+    // The page-sync logic only ever runs against a real, non-empty
+    // `syncedPages` when `mustSyncPages` gates it open, which requires a PDF
+    // document, a configured `artifactDir`, and a Tika version matching the
+    // mocked `getVersion` response. Without this, `syncedPages` stays `[]`
+    // and every assertion below would hold trivially regardless of whether
+    // the sync logic exists at all.
+    describe('page position sync against a real pdf pagination', () => {
+      const PDF_ARTIFACT_TIKA_VERSION = '1.2.3'
+
+      function withPdfArtifactMetadata(document) {
+        return document
+          .withContentType('application/pdf')
+          .withMetadata({ tika_metadata_tika_version: PDF_ARTIFACT_TIKA_VERSION })
+      }
+
+      beforeEach(() => {
+        core.config.set('artifactDir', '/artifacts')
+      })
+
+      afterEach(() => {
+        core.config.set('artifactDir', undefined)
+      })
+
+      it('keeps the page position when toggling to an aligned plain text pagination', async () => {
+        api.getPages.mockResolvedValue({ pages: [[0, 19], [20, 39], [40, 59]] })
+        const { document } = await mockDocumentContentSlice('x'.repeat(60), { configureDocument: withPdfArtifactMetadata })
+        const { plugins } = core
+        const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+        await flushPromises()
+        wrapper.vm.page = 2
+        await flushPromises()
+        wrapper.vm.preferMarkdown = false
+        await flushPromises()
+        expect(wrapper.vm.page).toBe(2)
+        // The kept page must also be the activated text slice, otherwise the
+        // pagination says page 2 while the body still shows page 1.
+        expect(wrapper.vm.activeContentSliceOffset).toBe(20)
+      })
+
+      it('resets an unaligned plain text pagination back to the first page', async () => {
+        api.getPages.mockResolvedValue({ pages: [[0, 29], [30, 59]] })
+        const { document } = await mockDocumentContentSlice('x'.repeat(60), { configureDocument: withPdfArtifactMetadata })
+        const { plugins } = core
+        const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+        await flushPromises()
+        wrapper.vm.page = 2
+        await flushPromises()
+        // Manufacture a stale, non-zero offset a real navigation could have
+        // left behind, so the assertion below actually exercises the reset
+        // instead of trivially matching an offset that never moved.
+        wrapper.vm.activeContentSliceOffset = 30
+        wrapper.vm.preferMarkdown = false
+        await flushPromises()
+        expect(wrapper.vm.page).toBe(1)
+        expect(wrapper.vm.activeContentSliceOffset).toBe(0)
+      })
     })
   })
 })

--- a/tests/unit/specs/components/Document/DocumentContent.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContent.spec.js
@@ -588,6 +588,23 @@ describe('DocumentContent.vue', () => {
         expect(wrapper.vm.localSearchIndexes).toEqual([5])
         expect(wrapper.vm.localSearchIndex).toBe(1)
       })
+
+      it('still re-runs a later mode-flip search even if the initial mount sequence failed', async () => {
+        const { document } = await mockDocumentContentSlice('Hello world')
+        const { plugins } = core
+        // A transient mount-time failure (here, `loadMaxOffset`'s own call to
+        // `getDocumentSlice`, which is awaited inside `onMounted`'s
+        // `Promise.all` with no catch) must not permanently disable later,
+        // legitimate mode-flip searches.
+        api.getDocumentSlice.mockRejectedValueOnce(new Error('Network Error'))
+        api.searchDocument.mockResolvedValue({ count: 1, offsets: [0] })
+        const wrapper = shallowMount(DocumentContent, { props: { document, q: 'hello' }, global: { plugins } })
+        await flushPromises()
+        wrapper.vm.preferMarkdown = false
+        await flushPromises()
+        const [project, documentId, query] = api.searchDocument.mock.calls[0]
+        expect([project, documentId, query]).toEqual([index, 'document', 'hello'])
+      })
     })
   })
 })

--- a/tests/unit/specs/components/Document/DocumentContent.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContent.spec.js
@@ -311,6 +311,15 @@ describe('DocumentContent.vue', () => {
       expect(wrapper.find('.document-content__togglers__view').exists()).toBe(false)
     })
 
+    it('never disables the local search input in markdown mode, even without extracted text', async () => {
+      const { document } = await mockDocumentContentSlice('')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins, renderStubDefaultSlot: true } })
+      await flushPromises()
+      const input = wrapper.find('document-local-search-stub')
+      expect(input.attributes('disabled')).toBe('false')
+    })
+
     it('renders the plain text body once the toggle is set to text', async () => {
       const { document } = await mockDocumentContentSlice('Hello world')
       const { plugins } = core
@@ -433,6 +442,79 @@ describe('DocumentContent.vue', () => {
         await flushPromises()
         expect(wrapper.vm.page).toBe(1)
         expect(wrapper.vm.activeContentSliceOffset).toBe(0)
+      })
+    })
+
+    describe('local search', () => {
+      beforeEach(() => {
+        api.searchStructurePages.mockResolvedValue({
+          count: 3,
+          pages: 3,
+          scanned: 3,
+          hits: [
+            { page: 2, count: 1 },
+            { page: 3, count: 2 }
+          ]
+        })
+      })
+
+      it('searches the structure pages instead of the raw content', async () => {
+        const { document } = await mockDocumentContentSlice('Hello world')
+        const { plugins } = core
+        shallowMount(DocumentContent, { props: { document, q: ' hello ' }, global: { plugins } })
+        await flushPromises()
+        // Assert on the leading arguments only: the routing value depends on how the
+        // fixture document was indexed, and this test is about the trimmed query.
+        const [project, documentId, query] = api.searchStructurePages.mock.calls[0]
+        expect([project, documentId, query]).toEqual([index, 'document', 'hello'])
+        expect(api.searchDocument).not.toBeCalled()
+      })
+
+      it('lands on the first hit page with the occurrences count', async () => {
+        const { document } = await mockDocumentContentSlice('Hello world')
+        const { plugins } = core
+        const wrapper = shallowMount(DocumentContent, { props: { document, q: 'hello' }, global: { plugins } })
+        await flushPromises()
+        expect(wrapper.vm.localSearchOccurrences).toBe(3)
+        expect(wrapper.vm.localSearchIndex).toBe(1)
+        expect(wrapper.vm.markdownPage).toBe(2)
+      })
+
+      it('navigates to the next occurrence page and match', async () => {
+        const { document } = await mockDocumentContentSlice('Hello world')
+        const { plugins } = core
+        const wrapper = shallowMount(DocumentContent, { props: { document, q: 'hello' }, global: { plugins } })
+        await flushPromises()
+        wrapper.vm.localSearchIndex = 2
+        await flushPromises()
+        expect(wrapper.vm.markdownPage).toBe(3)
+        expect(wrapper.vm.activeMarkdownMatch).toBe(1)
+        wrapper.vm.localSearchIndex = 3
+        await flushPromises()
+        expect(wrapper.vm.markdownPage).toBe(3)
+        expect(wrapper.vm.activeMarkdownMatch).toBe(2)
+      })
+
+      it('degrades to zero occurrences when the search fails', async () => {
+        api.searchStructurePages.mockRejectedValue(new Error('Network Error'))
+        const { document } = await mockDocumentContentSlice('Hello world')
+        const { plugins } = core
+        const wrapper = shallowMount(DocumentContent, { props: { document, q: 'hello' }, global: { plugins } })
+        await flushPromises()
+        expect(wrapper.vm.localSearchOccurrences).toBe(0)
+        expect(wrapper.vm.localSearchIndex).toBe(0)
+      })
+
+      it('re-runs the search through the raw content when toggling to plain text', async () => {
+        api.searchDocument.mockResolvedValue({ count: 1, offsets: [0] })
+        const { document } = await mockDocumentContentSlice('Hello world')
+        const { plugins } = core
+        const wrapper = shallowMount(DocumentContent, { props: { document, q: 'hello' }, global: { plugins } })
+        await flushPromises()
+        wrapper.vm.preferMarkdown = false
+        await flushPromises()
+        const [project, documentId, query] = api.searchDocument.mock.calls[0]
+        expect([project, documentId, query]).toEqual([index, 'document', 'hello'])
       })
     })
   })

--- a/tests/unit/specs/components/Document/DocumentContent.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContent.spec.js
@@ -595,11 +595,18 @@ describe('DocumentContent.vue', () => {
         // A transient mount-time failure (here, `loadMaxOffset`'s own call to
         // `getDocumentSlice`, which is awaited inside `onMounted`'s
         // `Promise.all` with no catch) must not permanently disable later,
-        // legitimate mode-flip searches.
+        // legitimate mode-flip searches. `onMounted`'s rejection is expected
+        // and asserted below through an app-level error handler, rather than
+        // left to escape as an unhandled rejection: Vue delivers it there
+        // (`runtime-core.cjs.js`'s `handleError`) before it would otherwise
+        // log-and-rethrow.
         api.getDocumentSlice.mockRejectedValueOnce(new Error('Network Error'))
         api.searchDocument.mockResolvedValue({ count: 1, offsets: [0] })
-        const wrapper = shallowMount(DocumentContent, { props: { document, q: 'hello' }, global: { plugins } })
+        const errorHandler = vi.fn()
+        const global = { plugins, config: { errorHandler } }
+        const wrapper = shallowMount(DocumentContent, { props: { document, q: 'hello' }, global })
         await flushPromises()
+        expect(errorHandler).toBeCalledWith(new Error('Network Error'), expect.anything(), expect.anything())
         wrapper.vm.preferMarkdown = false
         await flushPromises()
         const [project, documentId, query] = api.searchDocument.mock.calls[0]

--- a/tests/unit/specs/components/Document/DocumentContent.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContent.spec.js
@@ -502,6 +502,16 @@ describe('DocumentContent.vue', () => {
         expect(markdownBody.props('term')).toBe('hello')
       })
 
+      it('keeps the attachments block visible when markdown mode is entered through the q prop', async () => {
+        const { document } = await mockDocumentContentSlice('Hello world')
+        const { plugins } = core
+        const wrapper = shallowMount(DocumentContent, { props: { document, q: 'hello' }, global: { plugins } })
+        await flushPromises()
+        const attachments = wrapper.findComponent({ name: 'DocumentAttachments' })
+        expect(attachments.exists()).toBe(true)
+        expect(attachments.attributes('style')).not.toContain('display: none')
+      })
+
       it('lands on the first hit page with the occurrences count', async () => {
         const { document } = await mockDocumentContentSlice('Hello world')
         const { plugins } = core
@@ -535,6 +545,17 @@ describe('DocumentContent.vue', () => {
         await flushPromises()
         expect(wrapper.vm.localSearchOccurrences).toBe(0)
         expect(wrapper.vm.localSearchIndex).toBe(0)
+      })
+
+      it('does not pass the search term down to the markdown body when the search finds zero occurrences', async () => {
+        api.searchStructurePages.mockResolvedValue({ count: 0, pages: 0, scanned: 3, hits: [] })
+        const { document } = await mockDocumentContentSlice('Hello world')
+        const { plugins } = core
+        const wrapper = shallowMount(DocumentContent, { props: { document, q: 'hello' }, global: { plugins } })
+        await flushPromises()
+        expect(wrapper.vm.localSearchOccurrences).toBe(0)
+        const markdownBody = wrapper.findComponent({ name: 'DocumentContentMarkdown' })
+        expect(markdownBody.props('term')).toBe('')
       })
 
       it('re-runs the search through the raw content when toggling to plain text', async () => {
@@ -616,6 +637,9 @@ describe('DocumentContent.vue', () => {
         const wrapper = shallowMount(DocumentContent, { props: { document, q: 'hello' }, global })
         await flushPromises()
         expect(errorHandler).toBeCalledWith(new Error('Network Error'), expect.anything(), expect.anything())
+        // A second, unrelated Vue-dispatched error inside this test must not
+        // slip by unnoticed just because the expected error also occurred.
+        expect(errorHandler).toBeCalledTimes(1)
         wrapper.vm.preferMarkdown = false
         await flushPromises()
         const [project, documentId, query] = api.searchDocument.mock.calls[0]

--- a/tests/unit/specs/components/Document/DocumentContent.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContent.spec.js
@@ -335,6 +335,15 @@ describe('DocumentContent.vue', () => {
       expect(input.attributes('disabled')).toBe('false')
     })
 
+    it('gives the view toggle radiogroup an accessible name', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      const toggle = wrapper.find('.document-content__togglers__view')
+      expect(toggle.attributes('aria-label')).toBeTruthy()
+    })
+
     it('renders the plain text body once the toggle is set to text', async () => {
       const { document } = await mockDocumentContentSlice('Hello world')
       const { plugins } = core

--- a/tests/unit/specs/components/Document/DocumentContent.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContent.spec.js
@@ -261,6 +261,31 @@ describe('DocumentContent.vue', () => {
       expect(wrapper.vm.getContentSlice().content).toBe('this is a content')
     })
 
+    it('should not carry the previous document page and slices over to the next one', async () => {
+      const { document } = await mockDocumentContentSlice('a'.repeat(60))
+      // Both documents are served by the same mock, keyed by id, so the
+      // assertions below can tell whose slice ended up on screen.
+      api.getDocumentSlice.mockImplementation(async (project, documentId, offset, limit) => {
+        const content = (documentId === id ? 'a' : 'b').repeat(60)
+        return { content: content.substring(offset, offset + limit), offset, limit, maxOffset: 60 }
+      })
+      const { plugins } = core
+      const props = { document, pageSize: 10 }
+      const wrapper = shallowMount(DocumentContent, { global: { plugins }, props })
+      await flushPromises()
+      wrapper.vm.page = 3
+      await flushPromises()
+      expect(wrapper.vm.activeContentSliceOffset).toBe(20)
+      const other = { index: document.index, id: 'other-document-id', routing: 'other-document-id' }
+      await wrapper.setProps({ document: other })
+      await flushPromises()
+      expect(wrapper.vm.page).toBe(1)
+      expect(wrapper.vm.activeContentSliceOffset).toBe(0)
+      expect(wrapper.vm.currentContentPage).toContain('bbbbbbbbbb')
+      expect(wrapper.vm.currentContentPage).not.toContain('a')
+      wrapper.unmount()
+    })
+
     it('should lazy load 2 slices of 10 characters of a long text document', async () => {
       // Create a document with a small content text length
       const content = 'this is a content from Elastic Search doc which looks huge'

--- a/tests/unit/specs/components/Document/DocumentContent.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContent.spec.js
@@ -139,7 +139,7 @@ describe('DocumentContent.vue', () => {
       expect(wrapper.find('.document-content--rtl').exists()).toBeFalsy()
     })
 
-    it('should display "No content extracted for this document" and disable the search input when the extracted text is empty', async () => {
+    it('should display "No content extracted for this document" when the extracted text is empty', async () => {
       const { document } = await mockDocumentContentSlice('')
       const { plugins } = core
       const props = { document }
@@ -149,9 +149,6 @@ describe('DocumentContent.vue', () => {
       const element = wrapper.find('.document-content__body--no-content')
       expect(element.exists()).toBeTruthy()
       expect(element.text()).toBe('No content extracted for this document')
-      const input = wrapper.find('document-local-search-stub')
-      expect(input.exists()).toBeTruthy()
-      expect(input.attributes('disabled')).toBe('true')
     })
   })
 
@@ -297,6 +294,30 @@ describe('DocumentContent.vue', () => {
       expect(wrapper.find('div.document-content__body').exists()).toBe(false)
     })
 
+    it('counts the occurrences it can navigate to, not the ones the backend reports', async () => {
+      // `count` can exceed `hits` when the backend scans only part of the artifact:
+      // counting the rest would leave next/previous with nowhere to go.
+      api.searchStructurePages.mockResolvedValue({ count: 120, pages: 3, scanned: 1, hits: [{ page: 1, count: 2 }] })
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document, q: 'hello' }, global: { plugins } })
+      await flushPromises()
+      expect(wrapper.findComponent(DocumentLocalSearch).props('occurrences')).toBe(2)
+    })
+
+    it('walks the occurrences in page order whatever order the response uses', async () => {
+      const hits = [{ page: 3, count: 1 }, { page: 1, count: 1 }]
+      api.searchStructurePages.mockResolvedValue({ count: 2, pages: 3, scanned: 3, hits })
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document, q: 'hello' }, global: { plugins } })
+      await flushPromises()
+      expect(wrapper.vm.markdownPage).toBe(1)
+      wrapper.vm.localSearchIndex = 2
+      await flushPromises()
+      expect(wrapper.vm.markdownPage).toBe(3)
+    })
+
     it('renders the plain text body when the document has no markdown', async () => {
       api.getStructureManifest.mockResolvedValue(null)
       const { document } = await mockDocumentContentSlice('Hello world')
@@ -324,16 +345,20 @@ describe('DocumentContent.vue', () => {
       expect(wrapper.findComponent(DocumentContentDropdown).exists()).toBe(false)
     })
 
-    it('never disables the local search input in markdown mode, even without extracted text', async () => {
-      const { document } = await mockDocumentContentSlice('')
+    it('re-probes the manifest and drops the markdown state when the document changes', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
       const { plugins } = core
       const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
       await flushPromises()
-      // `disabled` is a fallthrough attribute on `DocumentLocalSearch` (not a
-      // declared prop), so it cannot be read through `.props()`; assert
-      // through the component locator instead of a raw tag/class selector.
-      const input = wrapper.findComponent(DocumentLocalSearch)
-      expect(input.attributes('disabled')).toBe('false')
+      wrapper.vm.preferMarkdown = false
+      wrapper.vm.markdownPage = 3
+      await flushPromises()
+      const other = { index: document.index, id: 'other-document-id', routing: 'other-document-id' }
+      await wrapper.setProps({ document: other })
+      await flushPromises()
+      expect(api.getStructureManifest).toHaveBeenLastCalledWith(other.index, other.id, other.routing)
+      expect(wrapper.vm.markdownPage).toBe(1)
+      expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).exists()).toBe(true)
     })
 
     it('renders the plain text body once the toggle is set to text', async () => {
@@ -361,7 +386,8 @@ describe('DocumentContent.vue', () => {
       expect(dropdown.props('translation')).toBe(true)
     })
 
-    it('falls back to plain text and disables the formatted option when the artifact is empty', async () => {
+    it('falls back to plain text and disables the formatted option when the only page is empty', async () => {
+      api.getStructureManifest.mockResolvedValue({ pages: 1, formats: ['md'] })
       const { document } = await mockDocumentContentSlice('Hello world')
       const { plugins } = core
       const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
@@ -374,6 +400,18 @@ describe('DocumentContent.vue', () => {
       const dropdown = wrapper.findComponent(DocumentContentDropdown)
       expect(dropdown.exists()).toBe(true)
       expect(dropdown.props('markdownDisabled')).toBe(true)
+    })
+
+    it('keeps the formatted view when a single page of a multi-page artifact is empty', async () => {
+      // A blank cover page in a scanned PDF says nothing about the other pages.
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      wrapper.findComponent({ name: 'DocumentContentMarkdown' }).vm.$emit('empty')
+      await flushPromises()
+      expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).exists()).toBe(true)
+      expect(wrapper.findComponent(DocumentContentDropdown).props('markdownDisabled')).toBe(false)
     })
 
     it('keeps the formatted option available when the user falls back from a page error', async () => {

--- a/tests/unit/specs/components/Document/DocumentContent.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContent.spec.js
@@ -5,6 +5,7 @@ import { IndexedDocument, letData } from '~tests/unit/es_utils'
 import { letTextContent } from '~tests/unit/api_mock'
 import CoreSetup from '~tests/unit/CoreSetup'
 import DocumentContent from '@/components/Document/DocumentContent'
+import DocumentContentDropdown from '@/components/Document/DocumentContentDropdown'
 import DocumentLocalSearch from '@/components/Document/DocumentLocalSearch/DocumentLocalSearch'
 import { apiInstance as api } from '@/api/apiInstance'
 import { useDocumentStore } from '@/store/modules'
@@ -306,21 +307,21 @@ describe('DocumentContent.vue', () => {
       expect(wrapper.find('div.document-content__body').exists()).toBe(true)
     })
 
-    it('shows the view toggle only when the document has markdown', async () => {
+    it('shows the view dropdown only when the document has markdown', async () => {
       const { document } = await mockDocumentContentSlice('Hello world')
       const { plugins } = core
       const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
       await flushPromises()
-      expect(wrapper.find('.document-content__togglers__view').exists()).toBe(true)
+      expect(wrapper.findComponent(DocumentContentDropdown).exists()).toBe(true)
     })
 
-    it('hides the view toggle when the document has no markdown', async () => {
+    it('hides the view dropdown when the document has no markdown', async () => {
       api.getStructureManifest.mockResolvedValue(null)
       const { document } = await mockDocumentContentSlice('Hello world')
       const { plugins } = core
       const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
       await flushPromises()
-      expect(wrapper.find('.document-content__togglers__view').exists()).toBe(false)
+      expect(wrapper.findComponent(DocumentContentDropdown).exists()).toBe(false)
     })
 
     it('never disables the local search input in markdown mode, even without extracted text', async () => {
@@ -333,15 +334,6 @@ describe('DocumentContent.vue', () => {
       // through the component locator instead of a raw tag/class selector.
       const input = wrapper.findComponent(DocumentLocalSearch)
       expect(input.attributes('disabled')).toBe('false')
-    })
-
-    it('gives the view toggle radiogroup an accessible name', async () => {
-      const { document } = await mockDocumentContentSlice('Hello world')
-      const { plugins } = core
-      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
-      await flushPromises()
-      const toggle = wrapper.find('.document-content__togglers__view')
-      expect(toggle.attributes('aria-label')).toBeTruthy()
     })
 
     it('renders the plain text body once the toggle is set to text', async () => {
@@ -362,45 +354,37 @@ describe('DocumentContent.vue', () => {
       const wrapper = shallowMount(DocumentContent, { props, global: { plugins } })
       await flushPromises()
       expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).exists()).toBe(false)
-      // The toggle must stay visible (so the user understands why they are
-      // stuck in plain text) but disabled while a translation is selected.
-      const toggle = wrapper.find('.document-content__togglers__view')
-      expect(toggle.exists()).toBe(true)
-      expect(toggle.attributes('disabled')).toBe('true')
-      expect(toggle.attributes('title')).toBe('Translations are only available as plain text')
+      // The dropdown must stay visible (so the user understands why they are
+      // stuck in plain text) and say why, while a translation is selected.
+      const dropdown = wrapper.findComponent(DocumentContentDropdown)
+      expect(dropdown.exists()).toBe(true)
+      expect(dropdown.props('translation')).toBe(true)
     })
 
     it('falls back to plain text and disables the formatted option when the artifact is empty', async () => {
       const { document } = await mockDocumentContentSlice('Hello world')
       const { plugins } = core
-      // The radio group must render its own slot here: the assertions are on
-      // the formatted option itself, not on the group.
-      const stubs = { BFormRadioGroup: false }
-      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins, stubs } })
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
       await flushPromises()
       wrapper.findComponent({ name: 'DocumentContentMarkdown' }).vm.$emit('empty')
       await flushPromises()
       expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).exists()).toBe(false)
       expect(wrapper.find('div.document-content__body').exists()).toBe(true)
-      // The toggle stays visible, only the formatted option is out of reach.
-      expect(wrapper.find('.document-content__togglers__view').exists()).toBe(true)
-      const markdownOption = wrapper.find('.document-content__togglers__view__markdown')
-      expect(markdownOption.attributes('disabled')).toBe('true')
+      // The dropdown stays visible, only the formatted entry is out of reach.
+      const dropdown = wrapper.findComponent(DocumentContentDropdown)
+      expect(dropdown.exists()).toBe(true)
+      expect(dropdown.props('markdownDisabled')).toBe(true)
     })
 
     it('keeps the formatted option available when the user falls back from a page error', async () => {
       const { document } = await mockDocumentContentSlice('Hello world')
       const { plugins } = core
-      // The radio group must render its own slot here: the assertions are on
-      // the formatted option itself, not on the group.
-      const stubs = { BFormRadioGroup: false }
-      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins, stubs } })
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
       await flushPromises()
       wrapper.findComponent({ name: 'DocumentContentMarkdown' }).vm.$emit('fallback')
       await flushPromises()
       expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).exists()).toBe(false)
-      const markdownOption = wrapper.find('.document-content__togglers__view__markdown')
-      expect(markdownOption.attributes('disabled')).toBe('false')
+      expect(wrapper.findComponent(DocumentContentDropdown).props('markdownDisabled')).toBe(false)
     })
 
     it('paginates by the manifest page count in markdown mode', async () => {

--- a/tests/unit/specs/components/Document/DocumentContent.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContent.spec.js
@@ -21,7 +21,10 @@ vi.mock('@/api/apiInstance', async (importOriginal) => {
       ...apiInstance,
       getDocumentSlice: vi.fn(),
       getPages: vi.fn().mockResolvedValue([]),
-      searchDocument: vi.fn()
+      searchDocument: vi.fn(),
+      getStructureManifest: vi.fn().mockResolvedValue(null),
+      getStructurePage: vi.fn().mockResolvedValue(''),
+      searchStructurePages: vi.fn().mockResolvedValue({ count: 0, pages: 0, scanned: 0, hits: [] })
     }
   }
 })
@@ -258,6 +261,99 @@ describe('DocumentContent.vue', () => {
       // Continue to load content
       await wrapper.vm.loadContentSlice({ offset: 10 })
       expect(wrapper.vm.getContentSlice({ offset: 10 }).content).toBe('content fr')
+    })
+  })
+
+  describe('markdown mode', () => {
+    beforeEach(() => {
+      api.getStructureManifest.mockResolvedValue({ pages: 3, formats: ['md'] })
+      api.getStructurePage.mockResolvedValue('# Hello world')
+    })
+
+    it('renders the markdown body by default when the document has markdown', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).exists()).toBe(true)
+      expect(wrapper.find('div.document-content__body').exists()).toBe(false)
+    })
+
+    it('renders the plain text body when the document has no markdown', async () => {
+      api.getStructureManifest.mockResolvedValue(null)
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).exists()).toBe(false)
+      expect(wrapper.find('div.document-content__body').exists()).toBe(true)
+    })
+
+    it('shows the view toggle only when the document has markdown', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      expect(wrapper.find('.document-content__togglers__view').exists()).toBe(true)
+    })
+
+    it('hides the view toggle when the document has no markdown', async () => {
+      api.getStructureManifest.mockResolvedValue(null)
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      expect(wrapper.find('.document-content__togglers__view').exists()).toBe(false)
+    })
+
+    it('renders the plain text body once the toggle is set to text', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      wrapper.vm.preferMarkdown = false
+      await flushPromises()
+      expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).exists()).toBe(false)
+      expect(wrapper.find('div.document-content__body').exists()).toBe(true)
+    })
+
+    it('forces the plain text body when a translation is selected', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const props = { document, targetLanguage: 'ENGLISH' }
+      const wrapper = shallowMount(DocumentContent, { props, global: { plugins } })
+      await flushPromises()
+      expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).exists()).toBe(false)
+    })
+
+    it('paginates by the manifest page count in markdown mode', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      expect(wrapper.vm.nbPages).toBe(3)
+    })
+
+    it('navigates markdown pages through the page model', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      wrapper.vm.page = 2
+      await flushPromises()
+      expect(wrapper.vm.markdownPage).toBe(2)
+    })
+
+    it('goes back to the first page when toggling to unaligned plain text', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      wrapper.vm.page = 2
+      await flushPromises()
+      wrapper.vm.preferMarkdown = false
+      await flushPromises()
+      expect(wrapper.vm.page).toBe(1)
     })
   })
 })

--- a/tests/unit/specs/components/Document/DocumentContent.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContent.spec.js
@@ -370,6 +370,39 @@ describe('DocumentContent.vue', () => {
       expect(toggle.attributes('title')).toBe('Translations are only available as plain text')
     })
 
+    it('falls back to plain text and disables the formatted option when the artifact is empty', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      // The radio group must render its own slot here: the assertions are on
+      // the formatted option itself, not on the group.
+      const stubs = { BFormRadioGroup: false }
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins, stubs } })
+      await flushPromises()
+      wrapper.findComponent({ name: 'DocumentContentMarkdown' }).vm.$emit('empty')
+      await flushPromises()
+      expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).exists()).toBe(false)
+      expect(wrapper.find('div.document-content__body').exists()).toBe(true)
+      // The toggle stays visible, only the formatted option is out of reach.
+      expect(wrapper.find('.document-content__togglers__view').exists()).toBe(true)
+      const markdownOption = wrapper.find('.document-content__togglers__view__markdown')
+      expect(markdownOption.attributes('disabled')).toBe('true')
+    })
+
+    it('keeps the formatted option available when the user falls back from a page error', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      // The radio group must render its own slot here: the assertions are on
+      // the formatted option itself, not on the group.
+      const stubs = { BFormRadioGroup: false }
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins, stubs } })
+      await flushPromises()
+      wrapper.findComponent({ name: 'DocumentContentMarkdown' }).vm.$emit('fallback')
+      await flushPromises()
+      expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).exists()).toBe(false)
+      const markdownOption = wrapper.find('.document-content__togglers__view__markdown')
+      expect(markdownOption.attributes('disabled')).toBe('false')
+    })
+
     it('paginates by the manifest page count in markdown mode', async () => {
       const { document } = await mockDocumentContentSlice('Hello world')
       const { plugins } = core

--- a/tests/unit/specs/components/Document/DocumentContentDropdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContentDropdown.spec.js
@@ -1,0 +1,90 @@
+import { mount } from '@vue/test-utils'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import DocumentContentDropdown from '@/components/Document/DocumentContentDropdown'
+
+describe('DocumentContentDropdown.vue', () => {
+  const factory = (props = {}) => {
+    const { plugins } = CoreSetup.init().useAll()
+
+    return mount(DocumentContentDropdown, {
+      props: { modelValue: true, ...props },
+      global: { plugins, stubs: { teleport: true } }
+    })
+  }
+
+  const findMarkdownEntry = wrapper => wrapper.find('.document-content-dropdown__markdown')
+  const findTextEntry = wrapper => wrapper.find('.document-content-dropdown__text')
+
+  it('teleports the dropdown menu to the body so it is not clipped by an ancestor stacking context', () => {
+    const dropdown = factory().findComponent({ name: 'BDropdown' })
+    expect(dropdown.props('teleportTo')).toBe('body')
+  })
+
+  it('constrains the dropdown menu to the viewport boundary', () => {
+    const dropdown = factory().findComponent({ name: 'BDropdown' })
+    expect(dropdown.props('boundary')).toBe('viewport')
+  })
+
+  it('gives the icon-only toggle an accessible name', () => {
+    const dropdown = factory().findComponent({ name: 'BDropdown' })
+    expect(dropdown.props('ariaLabel')).toBe('Text rendering')
+  })
+
+  it('marks the formatted entry as the active one when markdown is preferred', () => {
+    const wrapper = factory({ modelValue: true })
+    expect(findMarkdownEntry(wrapper).classes()).toContain('active')
+    expect(findTextEntry(wrapper).classes()).not.toContain('active')
+  })
+
+  it('marks the plain text entry as the active one when markdown is not preferred', () => {
+    const wrapper = factory({ modelValue: false })
+    expect(findMarkdownEntry(wrapper).classes()).not.toContain('active')
+    expect(findTextEntry(wrapper).classes()).toContain('active')
+  })
+
+  it('prefers markdown when the formatted entry is clicked', async () => {
+    const wrapper = factory({ modelValue: false })
+    await findMarkdownEntry(wrapper).trigger('click')
+    expect(wrapper.emitted('update:modelValue')).toEqual([[true]])
+  })
+
+  it('drops the markdown preference when the plain text entry is clicked', async () => {
+    const wrapper = factory({ modelValue: true })
+    await findTextEntry(wrapper).trigger('click')
+    expect(wrapper.emitted('update:modelValue')).toEqual([[false]])
+  })
+
+  it('puts the formatted entry out of reach when the artifact holds no markdown', () => {
+    const wrapper = factory({ modelValue: false, markdownDisabled: true })
+    expect(findMarkdownEntry(wrapper).attributes('disabled')).toBeDefined()
+    expect(findTextEntry(wrapper).attributes('disabled')).toBeUndefined()
+  })
+
+  describe('when a translation is displayed', () => {
+    const factoryWithTranslation = () => factory({ modelValue: true, translation: true })
+
+    it('marks plain text as active, since that is what the body actually shows', () => {
+      const wrapper = factoryWithTranslation()
+      expect(findMarkdownEntry(wrapper).classes()).not.toContain('active')
+      expect(findTextEntry(wrapper).classes()).toContain('active')
+    })
+
+    it('puts both entries out of reach', () => {
+      const wrapper = factoryWithTranslation()
+      expect(findMarkdownEntry(wrapper).attributes('disabled')).toBeDefined()
+      expect(findTextEntry(wrapper).attributes('disabled')).toBeDefined()
+    })
+
+    it('states the reason in the menu, where a title tooltip would be invisible to touch and keyboard users', () => {
+      const wrapper = factoryWithTranslation()
+      const reason = wrapper.find('.document-content-dropdown__reason')
+      expect(reason.text()).toBe('Translations are only available as plain text')
+    })
+
+    it('says nothing about translations when none is displayed', () => {
+      const wrapper = factory({ modelValue: true })
+      expect(wrapper.find('.document-content-dropdown__reason').exists()).toBe(false)
+    })
+  })
+})

--- a/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
@@ -1,0 +1,95 @@
+import { mount, flushPromises } from '@vue/test-utils'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import DocumentContentMarkdown from '@/components/Document/DocumentContentMarkdown'
+import { apiInstance as api } from '@/api/apiInstance'
+
+vi.mock('@/api/apiInstance', async (importOriginal) => {
+  const { apiInstance } = await importOriginal()
+
+  return {
+    apiInstance: {
+      ...apiInstance,
+      getStructurePage: vi.fn()
+    }
+  }
+})
+
+window.HTMLElement.prototype.scrollIntoView = vi.fn()
+
+describe('DocumentContentMarkdown.vue', () => {
+  const document = { index: 'foo', id: 'doc-id', routing: 'root-id' }
+
+  let core
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    core = CoreSetup.init().useAll()
+    api.getStructurePage.mockResolvedValue('# Hello *world*')
+  })
+
+  async function mountComponent(props = {}) {
+    const { plugins } = core
+    const wrapper = mount(DocumentContentMarkdown, { props: { document, page: 1, ...props }, global: { plugins } })
+    await flushPromises()
+    await flushPromises()
+    return wrapper
+  }
+
+  it('fetches and renders the markdown page as sanitized html', async () => {
+    const wrapper = await mountComponent()
+    expect(api.getStructurePage).toBeCalledWith('foo', 'doc-id', 1, 'root-id')
+    expect(wrapper.find('h1').text()).toBe('Hello world')
+    expect(wrapper.find('em').text()).toBe('world')
+  })
+
+  it('fetches a page only once', async () => {
+    const wrapper = await mountComponent()
+    await wrapper.setProps({ page: 2 })
+    await flushPromises()
+    await wrapper.setProps({ page: 1 })
+    await flushPromises()
+    const firstPageCalls = api.getStructurePage.mock.calls.filter(([, , page]) => page === 1)
+    expect(firstPageCalls).toHaveLength(1)
+  })
+
+  it('marks the term occurrences in the rendered page', async () => {
+    api.getStructurePage.mockResolvedValue('# Hello world\n\nhello again')
+    const wrapper = await mountComponent({ term: 'hello' })
+    expect(wrapper.findAll('mark.local-search-term')).toHaveLength(2)
+  })
+
+  it('activates the nth mark and scrolls to it', async () => {
+    api.getStructurePage.mockResolvedValue('hello and hello')
+    const wrapper = await mountComponent({ term: 'hello', activeMatch: 2 })
+    const marks = wrapper.findAll('mark.local-search-term')
+    expect(marks[0].classes()).not.toContain('local-search-term--active')
+    expect(marks[1].classes()).toContain('local-search-term--active')
+  })
+
+  it('clamps the active mark to the marks the dom actually shows', async () => {
+    api.getStructurePage.mockResolvedValue('a single hello')
+    const wrapper = await mountComponent({ term: 'hello', activeMatch: 5 })
+    const marks = wrapper.findAll('mark.local-search-term')
+    expect(marks).toHaveLength(1)
+    expect(marks[0].classes()).toContain('local-search-term--active')
+  })
+
+  it('shows an inline error with a retry button when the page fetch fails', async () => {
+    api.getStructurePage.mockRejectedValue(new Error('Network Error'))
+    const wrapper = await mountComponent()
+    expect(wrapper.find('.document-content-markdown__error').exists()).toBe(true)
+    api.getStructurePage.mockResolvedValue('# Recovered')
+    await wrapper.find('.document-content-markdown__error__retry').trigger('click')
+    await flushPromises()
+    await flushPromises()
+    expect(wrapper.find('h1').text()).toBe('Recovered')
+  })
+
+  it('emits fallback when the user asks for the plain text view', async () => {
+    api.getStructurePage.mockRejectedValue(new Error('Network Error'))
+    const wrapper = await mountComponent()
+    await wrapper.find('.document-content-markdown__error__fallback').trigger('click')
+    expect(wrapper.emitted('fallback')).toHaveLength(1)
+  })
+})

--- a/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
@@ -74,6 +74,53 @@ describe('DocumentContentMarkdown.vue', () => {
     expect(wrapper.find('h1').text()).toBe('Page two')
   })
 
+  it('fetches an empty page only once across two visits', async () => {
+    api.getStructurePage.mockResolvedValue('')
+    const wrapper = await mountComponent()
+    await wrapper.setProps({ page: 2 })
+    await flushPromises()
+    await wrapper.setProps({ page: 1 })
+    await flushPromises()
+    const firstPageCalls = api.getStructurePage.mock.calls.filter(([, , page]) => page === 1)
+    expect(firstPageCalls).toHaveLength(1)
+  })
+
+  it('shows the no-content message instead of an empty body for an empty page', async () => {
+    api.getStructurePage.mockResolvedValue('')
+    const wrapper = await mountComponent()
+    expect(wrapper.find('.document-content-markdown__body').exists()).toBe(false)
+    expect(wrapper.text()).toContain('No content extracted for this document')
+  })
+
+  it('does not let a superseded page fetch fail over a newer page that already loaded', async () => {
+    let resolvePageTwo
+    const pageTwoPromise = new Promise((resolve) => {
+      resolvePageTwo = resolve
+    })
+    let rejectPageOne
+    const pageOnePromise = new Promise((_resolve, reject) => {
+      rejectPageOne = reject
+    })
+    api.getStructurePage.mockImplementation((index, id, page) => {
+      return page === 1 ? pageOnePromise : pageTwoPromise
+    })
+    const wrapper = mount(DocumentContentMarkdown, { props: { document, page: 1 }, global: { plugins: core.plugins } })
+    await flushPromises()
+    await wrapper.setProps({ page: 2 })
+    await flushPromises()
+    // Page 2 (the page the user is now looking at) resolves successfully first
+    resolvePageTwo('# Page two')
+    await flushPromises()
+    await flushPromises()
+    expect(wrapper.find('h1').text()).toBe('Page two')
+    // Page 1's stale, superseded request fails only after page 2 has rendered
+    rejectPageOne(new Error('Network Error'))
+    await flushPromises()
+    await flushPromises()
+    expect(wrapper.find('h1').text()).toBe('Page two')
+    expect(wrapper.find('.document-content-markdown__error').exists()).toBe(false)
+  })
+
   it('reloads when the document changes even if the page number stays the same', async () => {
     const wrapper = await mountComponent()
     api.getStructurePage.mockResolvedValue('# Other document')

--- a/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
@@ -93,21 +93,39 @@ describe('DocumentContentMarkdown.vue', () => {
     expect(wrapper.text()).toContain('No content extracted for this document')
   })
 
-  it('emits empty when the first page is empty, so the tab goes back to plain text', async () => {
+  it('emits empty when the page it shows is empty, so the parent can go back to plain text', async () => {
     api.getStructurePage.mockResolvedValue('')
     const wrapper = await mountComponent()
     expect(wrapper.emitted('empty')).toHaveLength(1)
   })
 
-  it('does not emit empty for an empty page in the middle of the document', async () => {
+  it('does not emit empty for a page that has content', async () => {
     api.getStructurePage.mockImplementation((index, id, page) => {
       return Promise.resolve(page === 1 ? '# Page one' : '')
     })
     const wrapper = await mountComponent()
+    expect(wrapper.emitted('empty')).toBeUndefined()
     await wrapper.setProps({ page: 2 })
     await flushPromises()
     expect(wrapper.text()).toContain('No content extracted for this document')
-    expect(wrapper.emitted('empty')).toBeUndefined()
+    expect(wrapper.emitted('empty')).toHaveLength(1)
+  })
+
+  it('drops the rendered page cache when the document changes', async () => {
+    const wrapper = await mountComponent()
+    await wrapper.setProps({ document: { index: 'foo', id: 'other-id', routing: 'other-id' } })
+    await flushPromises()
+    await wrapper.setProps({ document })
+    await flushPromises()
+    const firstDocumentCalls = api.getStructurePage.mock.calls.filter(([, id]) => id === 'doc-id')
+    expect(firstDocumentCalls).toHaveLength(2)
+  })
+
+  it('marks the global search terms inside the local ones', async () => {
+    api.getStructurePage.mockResolvedValue('lorem ipsum dolor')
+    const wrapper = await mountComponent({ term: 'ipsum dolor', globalSearchTerms: [{ label: 'dolor' }] })
+    const html = wrapper.find('.document-content-markdown__body').html()
+    expect(html).toContain('<mark class="local-search-term">ipsum <mark class="global-search-term"')
   })
 
   // An empty artifact is permanent, a failed fetch is not: the parent disables

--- a/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
@@ -53,6 +53,37 @@ describe('DocumentContentMarkdown.vue', () => {
     expect(firstPageCalls).toHaveLength(1)
   })
 
+  it('does not let a stale in-flight fetch for a previous page overwrite the current page', async () => {
+    let resolvePageOne
+    const pageOnePromise = new Promise((resolve) => {
+      resolvePageOne = resolve
+    })
+    api.getStructurePage.mockImplementation((index, id, page) => {
+      return page === 1 ? pageOnePromise : Promise.resolve('# Page two')
+    })
+    const wrapper = mount(DocumentContentMarkdown, { props: { document, page: 1 }, global: { plugins: core.plugins } })
+    await flushPromises()
+    await wrapper.setProps({ page: 2 })
+    await flushPromises()
+    await flushPromises()
+    expect(wrapper.find('h1').text()).toBe('Page two')
+    // The page-1 fetch resolves only now, after navigation moved on to page 2
+    resolvePageOne('# Page one (stale)')
+    await flushPromises()
+    await flushPromises()
+    expect(wrapper.find('h1').text()).toBe('Page two')
+  })
+
+  it('reloads when the document changes even if the page number stays the same', async () => {
+    const wrapper = await mountComponent()
+    api.getStructurePage.mockResolvedValue('# Other document')
+    await wrapper.setProps({ document: { index: 'foo', id: 'other-doc-id', routing: 'root-id' } })
+    await flushPromises()
+    await flushPromises()
+    expect(api.getStructurePage).toBeCalledWith('foo', 'other-doc-id', 1, 'root-id')
+    expect(wrapper.find('h1').text()).toBe('Other document')
+  })
+
   it('marks the term occurrences in the rendered page', async () => {
     api.getStructurePage.mockResolvedValue('# Hello world\n\nhello again')
     const wrapper = await mountComponent({ term: 'hello' })

--- a/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
@@ -93,6 +93,31 @@ describe('DocumentContentMarkdown.vue', () => {
     expect(wrapper.text()).toContain('No content extracted for this document')
   })
 
+  it('emits empty when the first page is empty, so the tab goes back to plain text', async () => {
+    api.getStructurePage.mockResolvedValue('')
+    const wrapper = await mountComponent()
+    expect(wrapper.emitted('empty')).toHaveLength(1)
+  })
+
+  it('does not emit empty for an empty page in the middle of the document', async () => {
+    api.getStructurePage.mockImplementation((index, id, page) => {
+      return Promise.resolve(page === 1 ? '# Page one' : '')
+    })
+    const wrapper = await mountComponent()
+    await wrapper.setProps({ page: 2 })
+    await flushPromises()
+    expect(wrapper.text()).toContain('No content extracted for this document')
+    expect(wrapper.emitted('empty')).toBeUndefined()
+  })
+
+  // An empty artifact is permanent, a failed fetch is not: the parent disables
+  // the formatted option on the first and keeps it available on the second.
+  it('emits empty rather than fallback when the first page is empty', async () => {
+    api.getStructurePage.mockResolvedValue('')
+    const wrapper = await mountComponent()
+    expect(wrapper.emitted('fallback')).toBeUndefined()
+  })
+
   it('does not let a superseded page fetch fail over a newer page that already loaded', async () => {
     let resolvePageTwo
     const pageTwoPromise = new Promise((resolve) => {

--- a/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
@@ -2,6 +2,7 @@ import { mount, flushPromises } from '@vue/test-utils'
 
 import CoreSetup from '~tests/unit/CoreSetup'
 import DocumentContentMarkdown from '@/components/Document/DocumentContentMarkdown'
+import { usePipelinesStore } from '@/store/modules'
 import { apiInstance as api } from '@/api/apiInstance'
 
 vi.mock('@/api/apiInstance', async (importOriginal) => {
@@ -169,5 +170,24 @@ describe('DocumentContentMarkdown.vue', () => {
     const wrapper = await mountComponent()
     await wrapper.find('.document-content-markdown__error__fallback').trigger('click')
     expect(wrapper.emitted('fallback')).toHaveLength(1)
+  })
+
+  describe('sanitization boundary', () => {
+    it('runs a plugin registered under the markdown-text category on the rendered body', async () => {
+      const pipelinesStore = usePipelinesStore()
+      pipelinesStore.register({ category: 'markdown-text', type: html => html.replace('Hello', 'Bonjour') })
+      const wrapper = await mountComponent()
+      expect(wrapper.find('h1').text()).toBe('Bonjour world')
+    })
+
+    it('does not route the markdown body through the extracted-text pipeline chain', async () => {
+      // The repo's own SanitizeHtml pipeline whitelists only `mark` and `p`:
+      // if the markdown body ever flowed through the `extracted-text:post`
+      // chain, this would strip the `<h1>` down to plain text.
+      const pipelinesStore = usePipelinesStore()
+      pipelinesStore.register({ name: 'extracted-text-sanitize-html', type: 'SanitizeHtml', category: 'extracted-text:post' })
+      const wrapper = await mountComponent()
+      expect(wrapper.find('h1').exists()).toBe(true)
+    })
   })
 })

--- a/tests/unit/specs/components/Document/DocumentTranslation/DocumentTranslation.spec.js
+++ b/tests/unit/specs/components/Document/DocumentTranslation/DocumentTranslation.spec.js
@@ -16,7 +16,10 @@ vi.mock('@/api/apiInstance', async (importOriginal) => {
     apiInstance: {
       ...apiInstance,
       getDocumentSlice: vi.fn(),
-      getPages: vi.fn().mockResolvedValue([])
+      getPages: vi.fn().mockResolvedValue([]),
+      // `DocumentContent` probes the structure artifact on mount; resolving
+      // `null` fails closed so markdown mode stays off in this file.
+      getStructureManifest: vi.fn().mockResolvedValue(null)
     }
   }
 })

--- a/tests/unit/specs/components/Document/DocumentViewer/DocumentViewerMarkdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentViewer/DocumentViewerMarkdown.spec.js
@@ -78,6 +78,28 @@ describe('DocumentViewerMarkdown.vue', () => {
     expect(error.text()).not.toBe(messages.document.notAvailable)
   })
 
+  it('renders ordinary markdown, including a table with a header row, unchanged', async () => {
+    // `renderMarkdown` (and its headerless-table normalization) is shared
+    // with the Text tab's markdown page; this pins the View tab's output for
+    // a normal document so a future change to that shared normalizer cannot
+    // silently alter it here.
+    const source = ['# Title', '', '| a | b |', '| - | - |', '| 1 | 2 |', '', 'Some prose about it.'].join('\n')
+    apiInstance.getSource.mockResolvedValue(source)
+    const { plugins } = CoreSetup.init().useAll()
+    const wrapper = shallowMount(DocumentViewerMarkdown, {
+      global: { plugins },
+      props: { document: { url: 'doc.md' } }
+    })
+    await flushPromises()
+
+    const content = wrapper.find('.markdown-viewer__content')
+    expect(content.html()).toContain('<h1>Title</h1>')
+    expect(content.find('table').exists()).toBe(true)
+    expect(content.find('th').text()).toBe('a')
+    expect(content.find('td').text()).toBe('1')
+    expect(content.html()).toContain('<p>Some prose about it.</p>')
+  })
+
   it('shows the generic not-available message for non-404 failures', async () => {
     apiInstance.getSource.mockRejectedValue({ response: { status: 500 } })
     const { plugins } = CoreSetup.init().useAll()

--- a/tests/unit/specs/composables/useDocumentDownload.spec.js
+++ b/tests/unit/specs/composables/useDocumentDownload.spec.js
@@ -29,6 +29,7 @@ const DOCUMENT_ID = Object.freeze({
   WITHOUT_MARKDOWN: 'md-absent',
   FAILING_PAGE: 'md-failing-page',
   TOASTED_PAGE: 'md-toasted-page',
+  EXPIRED_SESSION: 'md-expired-session',
   DOUBLE_CLICK: 'md-double-click',
   IDLE: 'md-idle',
   DOWNLOADING: 'md-pending-download',
@@ -422,6 +423,19 @@ describe('useDocumentDownload composable', () => {
       const toastError = vi.spyOn(wrapper.vm.$toast, 'error')
       await downloadMarkdown()
       expect(toastError).toHaveBeenCalledWith('The markdown could not be downloaded.')
+    })
+
+    it('should leave an expired session to the single log-back-in toast', async () => {
+      mockStructureManifest(1)
+      const unauthorized = Object.assign(new Error('Unauthorized'), { response: { status: 401 } })
+      apiInstance.getStructurePage = vi.fn().mockRejectedValue(unauthorized)
+      stubAnchor()
+      const doc = new Document({ _id: DOCUMENT_ID.EXPIRED_SESSION, _index: 'test-index', _source: { title: 'test' } })
+      const { downloadMarkdown } = mountComposable(doc)
+      await flushPromises()
+      const toastError = vi.spyOn(wrapper.vm.$toast, 'error')
+      await downloadMarkdown()
+      expect(toastError).not.toHaveBeenCalled()
     })
 
     it('should ignore a second call while the pages are still being fetched', async () => {

--- a/tests/unit/specs/composables/useStructureArtifact.spec.js
+++ b/tests/unit/specs/composables/useStructureArtifact.spec.js
@@ -1,0 +1,80 @@
+import { ref } from 'vue'
+
+import { useStructureArtifact } from '@/composables/useStructureArtifact'
+import { apiInstance as api } from '@/api/apiInstance'
+
+vi.mock('@/api/apiInstance', async (importOriginal) => {
+  const { apiInstance } = await importOriginal()
+
+  return {
+    apiInstance: {
+      ...apiInstance,
+      getStructureManifest: vi.fn()
+    }
+  }
+})
+
+describe('useStructureArtifact', () => {
+  const document = { index: 'foo', id: 'doc-id', routing: 'root-id' }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('probes the manifest of the given document', async () => {
+    api.getStructureManifest.mockResolvedValue({ pages: 3, formats: ['md'] })
+    const { fetchManifest } = useStructureArtifact(document)
+    await fetchManifest()
+    expect(api.getStructureManifest).toBeCalledWith('foo', 'doc-id', 'root-id')
+  })
+
+  it('has markdown when the manifest advertises md pages', async () => {
+    api.getStructureManifest.mockResolvedValue({ pages: 3, formats: ['md', 'xhtml'] })
+    const { hasMarkdown, pages, fetchManifest } = useStructureArtifact(document)
+    await fetchManifest()
+    expect(hasMarkdown.value).toBe(true)
+    expect(pages.value).toBe(3)
+  })
+
+  it('has no markdown before the probe resolves', () => {
+    const { hasMarkdown, pages } = useStructureArtifact(document)
+    expect(hasMarkdown.value).toBe(false)
+    expect(pages.value).toBe(0)
+  })
+
+  it('has no markdown when the probe fails closed', async () => {
+    api.getStructureManifest.mockResolvedValue(null)
+    const { hasMarkdown, fetchManifest } = useStructureArtifact(document)
+    await fetchManifest()
+    expect(hasMarkdown.value).toBe(false)
+  })
+
+  it('has no markdown when the md format is missing', async () => {
+    api.getStructureManifest.mockResolvedValue({ pages: 3, formats: ['xhtml'] })
+    const { hasMarkdown, fetchManifest } = useStructureArtifact(document)
+    await fetchManifest()
+    expect(hasMarkdown.value).toBe(false)
+  })
+
+  it('has no markdown when the manifest has zero pages', async () => {
+    api.getStructureManifest.mockResolvedValue({ pages: 0, formats: ['md'] })
+    const { hasMarkdown, fetchManifest } = useStructureArtifact(document)
+    await fetchManifest()
+    expect(hasMarkdown.value).toBe(false)
+  })
+
+  it('ignores a manifest that describes another document', async () => {
+    api.getStructureManifest.mockResolvedValue({ pages: 3, formats: ['md'] })
+    const documentRef = ref(document)
+    const { hasMarkdown, fetchManifest } = useStructureArtifact(documentRef)
+    await fetchManifest()
+    documentRef.value = { index: 'foo', id: 'other-id', routing: 'other-id' }
+    expect(hasMarkdown.value).toBe(false)
+  })
+
+  it('does not probe without a document id', async () => {
+    const { fetchManifest } = useStructureArtifact({ index: 'foo' })
+    await fetchManifest()
+    expect(api.getStructureManifest).not.toBeCalled()
+  })
+})

--- a/tests/unit/specs/utils/markdown.spec.js
+++ b/tests/unit/specs/utils/markdown.spec.js
@@ -141,6 +141,13 @@ describe('normalizeHeaderlessTables', () => {
     expect(normalizeHeaderlessTables(source)).toBe(source)
   })
 
+  it('does not touch a headerless-looking delimiter row inside a 4-space-indented code block', () => {
+    // 4+ leading spaces make this an indented code block, not a table, even
+    // though the line right above it is blank.
+    const source = ['    some code', '', '    |---|---|', ''].join('\n')
+    expect(normalizeHeaderlessTables(source)).toBe(source)
+  })
+
   it('makes renderMarkdown produce a <table> for a real headerless GFM table', async () => {
     const html = await renderMarkdown('|---|---|\n| a | b |\n| c | d |\n')
     expect(html).toContain('<table>')

--- a/tests/unit/specs/utils/markdown.spec.js
+++ b/tests/unit/specs/utils/markdown.spec.js
@@ -151,7 +151,59 @@ describe('normalizeHeaderlessTables', () => {
   it('makes renderMarkdown produce a <table> for a real headerless GFM table', async () => {
     const html = await renderMarkdown('|---|---|\n| a | b |\n| c | d |\n')
     expect(html).toContain('<table>')
-    expect(html).toContain('<th></th>')
     expect(html).toContain('<td>a</td>')
+  })
+})
+
+describe('renderMarkdown table header stripping', () => {
+  it('drops the synthesized thead entirely, leaving the data rows intact as tbody rows', async () => {
+    const html = await renderMarkdown('|---|---|\n| a | b |\n| c | d |\n')
+    expect(html).toContain('<table>')
+    expect(html).not.toContain('<thead>')
+    expect(html).not.toContain('<th>')
+    expect(html).toContain('<tbody>')
+    expect(html).toContain('<td>a</td>')
+    expect(html).toContain('<td>b</td>')
+    expect(html).toContain('<td>c</td>')
+    expect(html).toContain('<td>d</td>')
+  })
+
+  it('drops a thead whose header cells are whitespace-only, not just literally empty', async () => {
+    // A header row that is present in the source but made only of spaces must
+    // be treated the same as a fully empty one: it carries no real data.
+    const html = await renderMarkdown('|   |   |\n|---|---|\n| a | b |\n')
+    expect(html).not.toContain('<thead>')
+    expect(html).toContain('<td>a</td>')
+  })
+
+  it('keeps a thead whose header cells all have real text', async () => {
+    const html = await renderMarkdown('| a | b |\n|---|---|\n| 1 | 2 |\n')
+    expect(html).toContain('<thead>')
+    expect(html).toContain('<th>a</th>')
+    expect(html).toContain('<th>b</th>')
+  })
+
+  it('keeps a thead when only some of its header cells are empty', async () => {
+    // Dropping the thead here would lose the real "b" header data.
+    const html = await renderMarkdown('|  | b |\n|---|---|\n| 1 | 2 |\n')
+    expect(html).toContain('<thead>')
+    expect(html).toContain('<th></th>')
+    expect(html).toContain('<th>b</th>')
+  })
+
+  it('does not affect an unrelated part of the document', async () => {
+    const html = await renderMarkdown(['# Title', '', '|---|---|', '| a | b |', '', 'Some prose.', ''].join('\n'))
+    expect(html).toContain('<h1>Title</h1>')
+    expect(html).not.toContain('<thead>')
+    expect(html).toContain('<p>Some prose.</p>')
+  })
+
+  it('handles a headerless table and a normal table in the same document independently', async () => {
+    const source = ['|---|---|', '| a | b |', '', '| x | y |', '|---|---|', '| 1 | 2 |', ''].join('\n')
+    const html = await renderMarkdown(source)
+    const [firstTable, secondTable] = html.split('</table>')
+    expect(firstTable).not.toContain('<thead>')
+    expect(secondTable).toContain('<thead>')
+    expect(secondTable).toContain('<th>x</th>')
   })
 })

--- a/tests/unit/specs/utils/markdown.spec.js
+++ b/tests/unit/specs/utils/markdown.spec.js
@@ -1,4 +1,4 @@
-import { renderMarkdown } from '@/utils/markdown'
+import { renderMarkdown, normalizeHeaderlessTables } from '@/utils/markdown'
 
 describe('renderMarkdown', () => {
   it('renders GFM features', async () => {
@@ -62,5 +62,89 @@ describe('renderMarkdown', () => {
 
   it('returns an empty string for empty input', async () => {
     expect(await renderMarkdown('')).toBe('')
+  })
+})
+
+describe('normalizeHeaderlessTables', () => {
+  it('synthesizes an empty header row above a delimiter row that starts a table block', () => {
+    const source = '|---|---|\n| a | b |\n'
+    expect(normalizeHeaderlessTables(source)).toBe('| | |\n|---|---|\n| a | b |\n')
+  })
+
+  it('synthesizes a header row with the same cell count as the delimiter row', () => {
+    const source = '|---|---|---|\n| a | b | c |\n'
+    const normalized = normalizeHeaderlessTables(source)
+    const [headerLine, delimiterLine] = normalized.split('\n')
+    expect(headerLine).toBe('| | | |')
+    expect(delimiterLine).toBe('|---|---|---|')
+  })
+
+  it('fixes multiple headerless tables in the same document', () => {
+    const source = ['|---|---|', '| a | b |', '', '|--|--|--|', '| 1 | 2 | 3 |', ''].join('\n')
+    const normalized = normalizeHeaderlessTables(source)
+    expect(normalized).toBe(['| | |', '|---|---|', '| a | b |', '', '| | | |', '|--|--|--|', '| 1 | 2 | 3 |', ''].join('\n'))
+  })
+
+  it('fires when the delimiter row is the very first line of the document', () => {
+    // index 0 has no preceding line at all; that must still count as "headerless".
+    const source = '|---|---|\n| a | b |\n'
+    expect(normalizeHeaderlessTables(source).startsWith('| | |\n')).toBe(true)
+  })
+
+  it('fires when the delimiter row is the very last line, with no data rows after it', () => {
+    const source = 'Intro.\n\n|---|---|'
+    expect(normalizeHeaderlessTables(source)).toBe('Intro.\n\n| | |\n|---|---|')
+  })
+
+  it('does not touch a delimiter row that already has a header above it', () => {
+    const source = '| a | b |\n|---|---|\n| 1 | 2 |\n'
+    expect(normalizeHeaderlessTables(source)).toBe(source)
+  })
+
+  it('does not treat a bare thematic break as a delimiter row', () => {
+    // "---" has no pipe: it is a thematic break, not a table delimiter.
+    const source = 'Above.\n\n---\n\nBelow.\n'
+    expect(normalizeHeaderlessTables(source)).toBe(source)
+  })
+
+  it('does not treat a pipe-containing line without dashes as a delimiter row', () => {
+    const source = '| not a delimiter |\n'
+    expect(normalizeHeaderlessTables(source)).toBe(source)
+  })
+
+  it('does not touch a headerless-looking table inside a fenced code block (backtick fence)', () => {
+    const source = ['```', '|---|---|', '| a | b |', '```', ''].join('\n')
+    expect(normalizeHeaderlessTables(source)).toBe(source)
+  })
+
+  it('does not touch a headerless-looking table inside a fenced code block (tilde fence)', () => {
+    const source = ['~~~', '|---|---|', '| a | b |', '~~~', ''].join('\n')
+    expect(normalizeHeaderlessTables(source)).toBe(source)
+  })
+
+  it('leaves a headerless table nested in a blockquote untouched (not corrupted, not fixed)', () => {
+    // The leading "> " breaks the plain-delimiter pattern, so this is a known
+    // limitation rather than a regression: the source passes through unchanged.
+    const source = '> |---|---|\n> | a | b |\n'
+    expect(normalizeHeaderlessTables(source)).toBe(source)
+  })
+
+  it('is idempotent: running it twice has the same effect as running it once', () => {
+    const source = '|---|---|\n| a | b |\n'
+    const once = normalizeHeaderlessTables(source)
+    const twice = normalizeHeaderlessTables(once)
+    expect(twice).toBe(once)
+  })
+
+  it('leaves markdown with no headerless tables byte-identical', () => {
+    const source = ['# Title', '', '| a | b |', '| - | - |', '| 1 | 2 |', '', 'Some prose about it.', ''].join('\n')
+    expect(normalizeHeaderlessTables(source)).toBe(source)
+  })
+
+  it('makes renderMarkdown produce a <table> for a real headerless GFM table', async () => {
+    const html = await renderMarkdown('|---|---|\n| a | b |\n| c | d |\n')
+    expect(html).toContain('<table>')
+    expect(html).toContain('<th></th>')
+    expect(html).toContain('<td>a</td>')
   })
 })

--- a/tests/unit/specs/utils/markdown.spec.js
+++ b/tests/unit/specs/utils/markdown.spec.js
@@ -91,9 +91,32 @@ describe('normalizeHeaderlessTables', () => {
     expect(normalizeHeaderlessTables(source).startsWith('| | |\n')).toBe(true)
   })
 
-  it('fires when the delimiter row is the very last line, with no data rows after it', () => {
+  it('does not fire when no table row follows the delimiter row', () => {
+    // Synthesizing a header here would build a table with no body rows, and
+    // the line's own text would vanish from the rendered output.
     const source = 'Intro.\n\n|---|---|'
-    expect(normalizeHeaderlessTables(source)).toBe('Intro.\n\n| | |\n|---|---|')
+    expect(normalizeHeaderlessTables(source)).toBe(source)
+  })
+
+  it('does not fire when the delimiter row is followed by a blank line', () => {
+    const source = 'INVOICE\n\n|-------------------|\n\nTotal: 100\n'
+    expect(normalizeHeaderlessTables(source)).toBe(source)
+  })
+
+  it('does not treat a list item made of pipes and dashes as a delimiter row', () => {
+    const source = 'intro\n\n- |\n- foo\n'
+    expect(normalizeHeaderlessTables(source)).toBe(source)
+  })
+
+  it('does not treat a row with a non-delimiter cell as a delimiter row', () => {
+    // GFM requires every delimiter cell to hold at least one dash.
+    const source = 'Intro.\n\n| --- |  | --- |\n| a | b | c |\n'
+    expect(normalizeHeaderlessTables(source)).toBe(source)
+  })
+
+  it('fires on an indented delimiter row (GFM needs no matching indentation)', () => {
+    const source = 'Intro.\n\n  |---|---|\n  | a | b |\n'
+    expect(normalizeHeaderlessTables(source)).toBe('Intro.\n\n| | |\n  |---|---|\n  | a | b |\n')
   })
 
   it('does not touch a delimiter row that already has a header above it', () => {
@@ -168,12 +191,26 @@ describe('renderMarkdown table header stripping', () => {
     expect(html).toContain('<td>d</td>')
   })
 
-  it('drops a thead whose header cells are whitespace-only, not just literally empty', async () => {
-    // A header row that is present in the source but made only of spaces must
-    // be treated the same as a fully empty one: it carries no real data.
+  it('also drops a blank thead the document itself contains', async () => {
+    // A header row an author left blank for column alignment is indistinguishable
+    // from a synthesized one, and renders the same: an empty row of cells.
     const html = await renderMarkdown('|   |   |\n|---|---|\n| a | b |\n')
     expect(html).not.toContain('<thead>')
     expect(html).toContain('<td>a</td>')
+  })
+
+  it('keeps a thead whose header cells hold no text node', async () => {
+    const html = await renderMarkdown('| ![a](https://e.org/a.png) | ![b](https://e.org/b.png) |\n|---|---|\n| 1 | 2 |\n')
+    expect(html).toContain('<thead>')
+    expect(html).toContain('<td>1</td>')
+  })
+
+  it('keeps the text of a rule-like line instead of turning it into an empty table', async () => {
+    const html = await renderMarkdown('INVOICE\n\n|-------------------|\n\nTotal: 100\n')
+    expect(html).toContain('INVOICE')
+    expect(html).toContain('|-------------------|')
+    expect(html).toContain('Total: 100')
+    expect(html).not.toContain('<table>')
   })
 
   it('keeps a thead whose header cells all have real text', async () => {

--- a/tests/unit/specs/utils/strings.spec.js
+++ b/tests/unit/specs/utils/strings.spec.js
@@ -234,5 +234,14 @@ describe('strings', () => {
     it('returns the html untouched when the search term folds to nothing', () => {
       expect(addLocalSearchMarksClassInHtml('<p>Hello</p>', '́')).toBe('<p>Hello</p>')
     })
+
+    it('does not nest marks when a ligature folds to a repeated term', () => {
+      // 'ﬀ' folds to 'ff', so the term 'f' matches twice inside it, both
+      // mapping back to the same source range: that must produce one mark,
+      // not one nested inside the other.
+      const marked = addLocalSearchMarksClassInHtml('<p>aﬀb</p>', 'f')
+      expect(marked.match(/<mark class="local-search-term">/g)).toHaveLength(1)
+      expect(marked).not.toContain('<mark class="local-search-term"><mark')
+    })
   })
 })

--- a/tests/unit/specs/utils/strings.spec.js
+++ b/tests/unit/specs/utils/strings.spec.js
@@ -230,5 +230,9 @@ describe('strings', () => {
       expect(addLocalSearchMarksClassInHtml(html, '  ')).toBe(html)
       expect(addLocalSearchMarksClassInHtml(html, '')).toBe(html)
     })
+
+    it('returns the html untouched when the search term folds to nothing', () => {
+      expect(addLocalSearchMarksClassInHtml('<p>Hello</p>', '́')).toBe('<p>Hello</p>')
+    })
   })
 })

--- a/tests/unit/specs/utils/strings.spec.js
+++ b/tests/unit/specs/utils/strings.spec.js
@@ -243,5 +243,22 @@ describe('strings', () => {
       expect(marked.match(/<mark class="local-search-term">/g)).toHaveLength(1)
       expect(marked).not.toContain('<mark class="local-search-term"><mark')
     })
+
+    it('does not throw on overlapping (non-identical) folded ranges from a ligature', () => {
+      // 'ﬀ' folds to 'ff', so the term 'ff' matches at offsets 0 and 1 inside
+      // the single source character, producing overlapping (not identical)
+      // ranges [{0,2},{1,3}] that must not both be wrapped.
+      expect(() => addLocalSearchMarksClassInHtml('<p>fﬀf</p>', 'ff')).not.toThrow()
+      const marked = addLocalSearchMarksClassInHtml('<p>fﬀf</p>', 'ff')
+      expect(marked.match(/<mark class="local-search-term">/g)).toHaveLength(1)
+    })
+
+    it('does not throw on overlapping (non-identical) folded ranges from a roman numeral', () => {
+      // 'Ⅲ' folds to 'iii', so the term 'ii' matches at offsets 0 and 1 inside
+      // the single source character, producing overlapping ranges [{0,1},{0,2}].
+      expect(() => addLocalSearchMarksClassInHtml('<p>Ⅲi</p>', 'ii')).not.toThrow()
+      const marked = addLocalSearchMarksClassInHtml('<p>Ⅲi</p>', 'ii')
+      expect(marked.match(/<mark class="local-search-term">/g)).toHaveLength(1)
+    })
   })
 })

--- a/tests/unit/specs/utils/strings.spec.js
+++ b/tests/unit/specs/utils/strings.spec.js
@@ -1,4 +1,4 @@
-import { addLocalSearchMarksClass, addLocalSearchMarksClassByOffsets, isUrl, getConsonants } from '@/utils/strings'
+import { addLocalSearchMarksClass, addLocalSearchMarksClassByOffsets, isUrl, getConsonants, foldWithSourceIndexes, addLocalSearchMarksClassInHtml } from '@/utils/strings'
 
 describe('strings', () => {
   describe('addLocalSearchMarksClass', () => {
@@ -179,6 +179,56 @@ describe('strings', () => {
 
     it('get 0 consonants from `oui` string', () => {
       expect(getConsonants('oui')).toHaveLength(0)
+    })
+  })
+
+  describe('foldWithSourceIndexes', () => {
+    it('lowercases and strips diacritics', () => {
+      expect(foldWithSourceIndexes('Société').folded).toBe('societe')
+    })
+
+    it('maps every folded char back to its source index', () => {
+      const { folded, sourceIndexes } = foldWithSourceIndexes('Où')
+      expect(folded).toBe('ou')
+      expect(sourceIndexes).toEqual([0, 1])
+    })
+
+    it('keeps the map aligned when the fold expands a ligature', () => {
+      const { folded, sourceIndexes } = foldWithSourceIndexes('aﬀb')
+      expect(folded).toBe('affb')
+      expect(sourceIndexes).toEqual([0, 1, 1, 2])
+    })
+  })
+
+  describe('addLocalSearchMarksClassInHtml', () => {
+    it('wraps a case-insensitive match in a mark tag', () => {
+      const html = '<p>Hello World</p>'
+      const marked = addLocalSearchMarksClassInHtml(html, 'world')
+      expect(marked).toBe('<p>Hello <mark class="local-search-term">World</mark></p>')
+    })
+
+    it('marks a diacritic variant of the term', () => {
+      const html = '<p>La société écran</p>'
+      const marked = addLocalSearchMarksClassInHtml(html, 'societe')
+      expect(marked).toContain('<mark class="local-search-term">société</mark>')
+    })
+
+    it('marks every occurrence across elements', () => {
+      const html = '<h1>data</h1><p>data and data</p>'
+      const marked = addLocalSearchMarksClassInHtml(html, 'data')
+      expect(marked.match(/<mark class="local-search-term">/g)).toHaveLength(3)
+    })
+
+    it('never matches across element boundaries or inside attributes', () => {
+      const html = '<p><a href="https://data.example.org" title="data">a link</a></p>'
+      const marked = addLocalSearchMarksClassInHtml(html, 'data')
+      expect(marked).toBe(html)
+    })
+
+    it('returns the html untouched for a blank term', () => {
+      const html = '<p>Hello</p>'
+      expect(addLocalSearchMarksClassInHtml(html, '  ')).toBe(html)
+      expect(addLocalSearchMarksClassInHtml(html, '')).toBe(html)
     })
   })
 })

--- a/tests/unit/specs/utils/strings.spec.js
+++ b/tests/unit/specs/utils/strings.spec.js
@@ -1,4 +1,4 @@
-import { addLocalSearchMarksClass, addLocalSearchMarksClassByOffsets, isUrl, getConsonants, foldWithSourceIndexes, addLocalSearchMarksClassInHtml } from '@/utils/strings'
+import { addLocalSearchMarksClass, addLocalSearchMarksClassByOffsets, isUrl, getConsonants, foldWithSourceIndexes, addSearchMarksClassInHtml } from '@/utils/strings'
 
 describe('strings', () => {
   describe('addLocalSearchMarksClass', () => {
@@ -198,48 +198,76 @@ describe('strings', () => {
       expect(folded).toBe('affb')
       expect(sourceIndexes).toEqual([0, 1, 1, 2])
     })
+
+    it('folds characters outside the basic multilingual plane', () => {
+      // Iterating by code unit would hand NFKD a lone surrogate, which folds to
+      // nothing, and the backend folds the whole string.
+      expect(foldWithSourceIndexes('\u{1D400}\u{1D401}\u{1D402}').folded).toBe('abc')
+    })
+
+    it('maps an astral char back to the index of its first code unit', () => {
+      const { folded, sourceIndexes } = foldWithSourceIndexes('a\u{1D400}b')
+      expect(folded).toBe('aab')
+      expect(sourceIndexes).toEqual([0, 1, 3])
+    })
+
+    it('ends a source range past a stripped combining mark', () => {
+      const { sourceEnds } = foldWithSourceIndexes('e\u0301')
+      expect(sourceEnds).toEqual([2])
+    })
   })
 
-  describe('addLocalSearchMarksClassInHtml', () => {
+  describe('addSearchMarksClassInHtml', () => {
     it('wraps a case-insensitive match in a mark tag', () => {
       const html = '<p>Hello World</p>'
-      const marked = addLocalSearchMarksClassInHtml(html, 'world')
+      const marked = addSearchMarksClassInHtml(html, 'world')
       expect(marked).toBe('<p>Hello <mark class="local-search-term">World</mark></p>')
+    })
+
+    it('marks a decomposed diacritic without orphaning the accent', () => {
+      const html = '<p>La socie\u0301te\u0301 e\u0301cran</p>'
+      const marked = addSearchMarksClassInHtml(html, 'societe')
+      expect(marked).toBe('<p>La <mark class="local-search-term">socie\u0301te\u0301</mark> e\u0301cran</p>')
+    })
+
+    it('marks a term made of astral characters', () => {
+      const marked = addSearchMarksClassInHtml('<p>\u{1D400}\u{1D401}\u{1D402}</p>', 'abc')
+      expect(marked).toBe('<p><mark class="local-search-term">\u{1D400}\u{1D401}\u{1D402}</mark></p>')
     })
 
     it('marks a diacritic variant of the term', () => {
       const html = '<p>La société écran</p>'
-      const marked = addLocalSearchMarksClassInHtml(html, 'societe')
+      const marked = addSearchMarksClassInHtml(html, 'societe')
       expect(marked).toContain('<mark class="local-search-term">société</mark>')
     })
 
     it('marks every occurrence across elements', () => {
       const html = '<h1>data</h1><p>data and data</p>'
-      const marked = addLocalSearchMarksClassInHtml(html, 'data')
+      const marked = addSearchMarksClassInHtml(html, 'data')
       expect(marked.match(/<mark class="local-search-term">/g)).toHaveLength(3)
     })
 
     it('never matches across element boundaries or inside attributes', () => {
       const html = '<p><a href="https://data.example.org" title="data">a link</a></p>'
-      const marked = addLocalSearchMarksClassInHtml(html, 'data')
+      const marked = addSearchMarksClassInHtml(html, 'data')
       expect(marked).toBe(html)
     })
 
     it('returns the html untouched for a blank term', () => {
       const html = '<p>Hello</p>'
-      expect(addLocalSearchMarksClassInHtml(html, '  ')).toBe(html)
-      expect(addLocalSearchMarksClassInHtml(html, '')).toBe(html)
+      expect(addSearchMarksClassInHtml(html, '  ')).toBe(html)
+      expect(addSearchMarksClassInHtml(html, '')).toBe(html)
     })
 
     it('returns the html untouched when the search term folds to nothing', () => {
-      expect(addLocalSearchMarksClassInHtml('<p>Hello</p>', '́')).toBe('<p>Hello</p>')
+      expect(addSearchMarksClassInHtml('<p>Hello</p>', '́')).toBe('<p>Hello</p>')
     })
 
     it('does not nest marks when a ligature folds to a repeated term', () => {
       // 'ﬀ' folds to 'ff', so the term 'f' matches twice inside it, both
       // mapping back to the same source range: that must produce one mark,
       // not one nested inside the other.
-      const marked = addLocalSearchMarksClassInHtml('<p>aﬀb</p>', 'f')
+      const marked = addSearchMarksClassInHtml('<p>aﬀb</p>', 'f')
       expect(marked.match(/<mark class="local-search-term">/g)).toHaveLength(1)
       expect(marked).not.toContain('<mark class="local-search-term"><mark')
     })
@@ -248,16 +276,16 @@ describe('strings', () => {
       // 'ﬀ' folds to 'ff', so the term 'ff' matches at offsets 0 and 1 inside
       // the single source character, producing overlapping (not identical)
       // ranges [{0,2},{1,3}] that must not both be wrapped.
-      expect(() => addLocalSearchMarksClassInHtml('<p>fﬀf</p>', 'ff')).not.toThrow()
-      const marked = addLocalSearchMarksClassInHtml('<p>fﬀf</p>', 'ff')
+      expect(() => addSearchMarksClassInHtml('<p>fﬀf</p>', 'ff')).not.toThrow()
+      const marked = addSearchMarksClassInHtml('<p>fﬀf</p>', 'ff')
       expect(marked.match(/<mark class="local-search-term">/g)).toHaveLength(1)
     })
 
     it('does not throw on overlapping (non-identical) folded ranges from a roman numeral', () => {
       // 'Ⅲ' folds to 'iii', so the term 'ii' matches at offsets 0 and 1 inside
       // the single source character, producing overlapping ranges [{0,1},{0,2}].
-      expect(() => addLocalSearchMarksClassInHtml('<p>Ⅲi</p>', 'ii')).not.toThrow()
-      const marked = addLocalSearchMarksClassInHtml('<p>Ⅲi</p>', 'ii')
+      expect(() => addSearchMarksClassInHtml('<p>Ⅲi</p>', 'ii')).not.toThrow()
+      const marked = addSearchMarksClassInHtml('<p>Ⅲi</p>', 'ii')
       expect(marked.match(/<mark class="local-search-term">/g)).toHaveLength(1)
     })
   })


### PR DESCRIPTION
Renders the document Text tab as formatted markdown when the server has a structure artifact for the document, with a toolbar dropdown to go back to plain text. Local and global search both work on the markdown pages, marked the same way the plain text view marks them.

- feat: add a structure artifact probe composable, shared by the download popover and the Text tab
- feat: render one markdown structure page at a time, sanitized (no raw HTML, no remote images, hardened links)
- feat: move the text rendering choice into a toolbar dropdown, disabled for translations
- feat: search inside the markdown pages, with page-aware next/previous navigation
- feat: mark local and global search terms in the rendered page, folding case and diacritics like the backend does
- feat: report an expired session from the artifact requests, which otherwise degrade a failure to an empty result
- fix: render pipe tables that have no header row, and drop a table header that renders with no content
- fix: fall back to plain text when the structure artifact holds no markdown
- test: cover the utils, the composable and both components

> [!NOTE]  
> We agreed with @Soliine to move the switch to plan/formatted text to a dropdown menu, following the same logic as the one in the custom PDF viewer. This dropdown menu will hold other "text" option such as centering content, wrapping text, or copying content.

## Preview

<img width="2714" height="1766" alt="Capture d’écran 2026-08-19 à 11 33 33" src="https://github.com/user-attachments/assets/23927bdb-a735-4299-aefd-886011fe52f3" />
