### PR TITLE
fix: keep every value of a multi-value filter in saved search links

### DIFF
--- a/src/components/Search/SearchSavedEntries/SearchSavedEntries.vue
+++ b/src/components/Search/SearchSavedEntries/SearchSavedEntries.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { parseQuery } from 'vue-router'
 
 import IPhListChecks from '~icons/ph/list-checks'
 import IPhCalendarBlank from '~icons/ph/calendar-blank'
@@ -47,7 +48,7 @@ function searchParamsFromURI(uri) {
 }
 
 function searchParamsQuery(uri) {
-  return Object.fromEntries(searchParamsFromURI(uri))
+  return parseQuery(searchParamsFromURI(uri).toString())
 }
 </script>
 

--- a/tests/unit/specs/components/Search/SearchSavedEntries/SearchSavedEntries.spec.js
+++ b/tests/unit/specs/components/Search/SearchSavedEntries/SearchSavedEntries.spec.js
@@ -1,0 +1,22 @@
+import { mount } from '@vue/test-utils'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import SearchSavedEntries from '@/components/Search/SearchSavedEntries/SearchSavedEntries'
+
+describe('SearchSavedEntries.vue', () => {
+  it('should keep every value of a multi-value filter in the saved search link', () => {
+    const core = CoreSetup.init().useAll().useRouterWithoutGuards()
+    const global = { plugins: core.plugins }
+    const events = [
+      {
+        id: 'id_01',
+        name: 'name_01',
+        creationDate: 'creation_date_01',
+        uri: '?q=*&f[language]=GERMAN&f[language]=VIETNAMESE'
+      }
+    ]
+    const wrapper = mount(SearchSavedEntries, { props: { events }, global })
+    const link = wrapper.findComponent({ name: 'RouterLink' })
+    expect(link.props('to').query['f[language]']).toEqual(['GERMAN', 'VIETNAMESE'])
+  })
+})


### PR DESCRIPTION
Fixes icij/datashare#2340

`Object.fromEntries()` collapsed repeated `URLSearchParams` keys to their last value, dropping all but one filter value when building a saved search link. Now uses vue-router's `parseQuery`, same as `SearchBreadcrumbUri.vue`.