### PR TITLE
fix(search): submit the advanced search through the router

### DIFF
--- a/src/components/Search/SearchToolbar/SearchToolbar.vue
+++ b/src/components/Search/SearchToolbar/SearchToolbar.vue
@@ -31,6 +31,13 @@ watchEffect(() => {
   }
 })
 
+// Forwarded to the parent view rather than run here: an advanced search must
+// go through the router like every other search, and only the view owns the
+// navigation. Running it from the store here would leave the URL behind, and
+// the next route round-trip (pagination, sort, perPage) would then overwrite
+// the store with the URL's stale query.
+const emit = defineEmits(['advancedSearch'])
+
 const props = defineProps({
   searchBreadcrumbCounter: {
     type: Number
@@ -54,13 +61,6 @@ const classList = computed(() => {
     'search-toolbar--no-search-filters': props.noSearchFilters
   }
 })
-
-function handleAdvancedSearch({ query, field }) {
-  // Always run the query — even an empty one — so it resubmits with a fresh
-  // stamp, matching the search bar's submit behaviour. The field is applied
-  // to the store's single search `field` rather than baked into the query.
-  searchStore.query({ query, field })
-}
 </script>
 
 <template>
@@ -110,7 +110,7 @@ function handleAdvancedSearch({ query, field }) {
       v-model="showAdvancedSearch"
       :initial-query="searchStore.q"
       :initial-field="searchStore.field"
-      @search="handleAdvancedSearch"
+      @search="emit('advancedSearch', $event)"
     />
   </div>
 </template>

--- a/src/views/Search/Search.vue
+++ b/src/views/Search/Search.vue
@@ -113,6 +113,20 @@ const page = useUrlPageFromWithStore({
 
 const documentViewFloatingId = provideDocumentViewFloatingId()
 
+/**
+ * Run an advanced search submitted from the toolbar's modal. Like the search
+ * bar, it only updates the store and pushes a route: the refresh guards below
+ * turn that navigation into the actual search. Pushing keeps the URL in sync
+ * with the store, without which the next route round-trip (pagination, sort,
+ * perPage) would re-apply the URL's previous query over this one.
+ */
+function handleAdvancedSearch({ query, field }) {
+  searchStore.setQuery(query)
+  searchStore.setField(field)
+  // Resets `from` and stamps the route, so an unchanged query still resubmits.
+  refreshRouteFromStart()
+}
+
 // Refresh route query when a filter changes (either their values or if they are excluded)
 watchFilters(refreshRouteFromStart)
 // Refresh route query when projects change
@@ -157,6 +171,7 @@ onConsumeNoRefresh({ immediate: route.name === 'search' })
           v-model:is-filters-closed="isFiltersClosed"
           :search-breadcrumb-counter="searchBreadcrumbCounter"
           :no-search-filters="!enoughFloatingSpace && !isSearchRoute"
+          @advanced-search="handleAdvancedSearch"
         />
         <search-breadcrumb
           v-model:visible="toggleSearchBreadcrumb"

--- a/tests/unit/specs/components/Search/SearchToolbar/SearchToolbar.spec.js
+++ b/tests/unit/specs/components/Search/SearchToolbar/SearchToolbar.spec.js
@@ -79,20 +79,30 @@ describe('SearchToolbar.vue', () => {
     expect(wrapper.findComponent({ name: 'SearchAdvancedModal' }).attributes('initial-query')).toBe('+Paris')
   })
 
-  it('runs a store query with the emitted query and field', async () => {
+  it('forwards the modal query and field as an advancedSearch event', async () => {
     const wrapper = factory()
     wrapper.findComponent({ name: 'ButtonToggleAdvancedSearch' }).vm.$emit('update:active', true)
     await flushPromises()
     wrapper.findComponent({ name: 'SearchAdvancedModal' }).vm.$emit('search', { query: '+Paris +London', field: 'tags' })
-    expect(searchStore.query).toHaveBeenCalledWith({ query: '+Paris +London', field: 'tags' })
+    expect(wrapper.emitted('advancedSearch')).toEqual([[{ query: '+Paris +London', field: 'tags' }]])
   })
 
-  it('runs a store query even when the modal emits an empty search so it is always resubmitted', async () => {
+  it('forwards an empty advanced search so it is always resubmitted', async () => {
     const wrapper = factory()
     wrapper.findComponent({ name: 'ButtonToggleAdvancedSearch' }).vm.$emit('update:active', true)
     await flushPromises()
     wrapper.findComponent({ name: 'SearchAdvancedModal' }).vm.$emit('search', { query: '', field: 'all' })
-    expect(searchStore.query).toHaveBeenCalledWith({ query: '', field: 'all' })
+    expect(wrapper.emitted('advancedSearch')).toEqual([[{ query: '', field: 'all' }]])
+  })
+
+  it('does not run the search itself, so the URL stays the source of truth', async () => {
+    const wrapper = factory()
+    wrapper.findComponent({ name: 'ButtonToggleAdvancedSearch' }).vm.$emit('update:active', true)
+    await flushPromises()
+    wrapper.findComponent({ name: 'SearchAdvancedModal' }).vm.$emit('search', { query: '+Paris +London', field: 'tags' })
+    // Querying the store directly would leave the URL behind, and the next
+    // route round-trip would overwrite the advanced query with the stale one.
+    expect(searchStore.query).not.toHaveBeenCalled()
   })
 
   it('reduces the advanced-search toggle when the toolbar is compact', () => {

--- a/tests/unit/specs/views/Search/Search.spec.js
+++ b/tests/unit/specs/views/Search/Search.spec.js
@@ -2,6 +2,7 @@ import { shallowMount, flushPromises } from '@vue/test-utils'
 
 import CoreSetup from '~tests/unit/CoreSetup'
 import Search from '@/views/Search/Search'
+import SearchToolbar from '@/components/Search/SearchToolbar/SearchToolbar'
 import { useSearchStore } from '@/store/modules'
 
 vi.mock('@/api/apiInstance', {
@@ -10,6 +11,13 @@ vi.mock('@/api/apiInstance', {
     removeProject: vi.fn()
   }
 })
+
+// `batchQueryParamUpdate` debounces its router push by 50ms, so pagination
+// changes only reach the route after the timer fires.
+const flushDebouncedRouterPush = async () => {
+  await new Promise(resolve => setTimeout(resolve, 60))
+  await flushPromises()
+}
 
 describe('Search.vue', () => {
   let core, wrapper
@@ -62,6 +70,43 @@ describe('Search.vue', () => {
 
     expect(wrapper.vm.selectMode).toBe(false)
     expect(wrapper.vm.selection).toEqual([])
+  })
+
+  it('pushes the advanced search query into the URL so it survives later navigations', async () => {
+    // Same active pinia as the mounted component, so this is the same store instance.
+    const searchStore = useSearchStore()
+    vi.spyOn(searchStore, 'query').mockResolvedValue(undefined)
+    // A regular search bar submit leaves the query in the URL.
+    await core.router.push({ name: 'search', query: { q: 'advancedUrlTest', from: '0' } })
+    await flushPromises()
+
+    wrapper.findComponent(SearchToolbar).vm.$emit('advancedSearch', { query: '+Paris +London', field: 'tags' })
+    await flushPromises()
+
+    const { query } = core.router.currentRoute.value
+    expect(query.q).toBe('+Paris +London')
+    expect(query.field).toBe('tags')
+    // A new search always restarts from the first page.
+    expect(query.from).toBe('0')
+  })
+
+  it('keeps the advanced search query when paginating to the next page', async () => {
+    // Same active pinia as the mounted component, so this is the same store instance.
+    const searchStore = useSearchStore()
+    vi.spyOn(searchStore, 'query').mockResolvedValue(undefined)
+    await core.router.push({ name: 'search', query: { q: 'advancedPaginationTest', from: '0' } })
+    await flushPromises()
+
+    wrapper.findComponent(SearchToolbar).vm.$emit('advancedSearch', { query: '+Berlin +Vienna', field: 'all' })
+    await flushPromises()
+
+    // Going to the next page patches the current URL: the query it carries must
+    // still be the advanced one, otherwise the route round-trip overwrites the
+    // store and page 2 shows the results of the previous search.
+    wrapper.vm.page = 2
+    await flushDebouncedRouterPush()
+
+    expect(searchStore.q).toBe('+Berlin +Vienna')
   })
 
   it('runs the initial search when a reloaded noRefresh URL is stripped', async () => {


### PR DESCRIPTION
Fixes https://github.com/ICIJ/datashare/issues/2338

The advanced search modal ran its query straight from the store, leaving the URL on the previous query. Any later navigation that patches the current URL — pagination, sort, perPage — then re-applied that stale query over the advanced one, so the second page of results showed the previous search.

Forward the modal's submit to the search view, which updates the store and pushes a route the way the search bar already does. The URL stays the source of truth, the refresh guards run the search, and `from` resets to page one.

Fix made using Claude
