### PR TITLE
fix(document): PDF viewer page tracking

### DIFF
--- a/src/components/Document/DocumentLocalSearch/DocumentLocalSearch.vue
+++ b/src/components/Document/DocumentLocalSearch/DocumentLocalSearch.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, useTemplateRef } from 'vue'
+import { useFocusWithin } from '@vueuse/core'
 
 import DocumentLocalSearchInput from './DocumentLocalSearchInput'
 import DocumentLocalSearchNav from './DocumentLocalSearchNav'
@@ -25,6 +26,7 @@ const props = defineProps({
 })
 
 const input = useTemplateRef('input')
+const { focused: inputFocused } = useFocusWithin(input)
 
 const disabledPrevious = computed(() => !props.modelValue || props.activeIndex <= 1)
 const disabledNext = computed(() => !props.modelValue || props.activeIndex === props.occurrences)
@@ -51,8 +53,10 @@ const findInDocumentKey = findActionKey('findInDocument')
 const findPreviousOccurrenceKey = findActionKey('findPreviousOccurrence')
 
 wheneverActionShortcut('findInDocument', focus)
-wheneverActionShortcut('findPreviousOccurrence', previous)
-wheneverActionShortcut('findNextOccurrence', () => !findPreviousOccurrenceKey.value && next())
+// Both occurrence shortcuts are bare "enter" combinations, and useMagicKeys listens on the whole
+// document: without this guard they fire from any other field, like the PDF toolbar page number.
+wheneverActionShortcut('findPreviousOccurrence', () => inputFocused.value && previous())
+wheneverActionShortcut('findNextOccurrence', () => inputFocused.value && !findPreviousOccurrenceKey.value && next())
 </script>
 
 <template>

--- a/src/components/Document/DocumentViewer/DocumentViewerPdf.vue
+++ b/src/components/Document/DocumentViewer/DocumentViewerPdf.vue
@@ -36,6 +36,7 @@ const props = defineProps({
 
 const SCROLL_IDLE_DELAY = 200
 const SCROLL_KEYS = ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' ']
+const FORM_CONTROLS = 'input, textarea, select, [contenteditable]'
 
 const documentViewStore = useDocumentViewStore()
 const src = computed(() => (documentViewStore.embeddedPdf ? null : props.document.fullUrl))
@@ -115,9 +116,20 @@ function releasePendingPage() {
   currentPage.value = currentPageBelowToolbox() ?? currentPage.value
 }
 
+/**
+ * Whether a key press scrolls the document, as opposed to moving a caret inside a form control:
+ * a space typed in the search field must not count as the reader scrolling away.
+ *
+ * @param {KeyboardEvent} event - The key press to test.
+ * @returns {boolean}
+ */
+function scrollsDocument({ key, target }) {
+  return SCROLL_KEYS.includes(key) && !target?.closest?.(FORM_CONTROLS)
+}
+
 useEventListener(window, 'scroll', settleScroll, { capture: true, passive: true })
 useEventListener(window, ['wheel', 'touchmove', 'pointerdown'], releasePendingPage, { passive: true })
-useEventListener(window, 'keydown', ({ key }) => SCROLL_KEYS.includes(key) && releasePendingPage())
+useEventListener(window, 'keydown', event => scrollsDocument(event) && releasePendingPage())
 
 /**
  * Holds the page tracking until the scroll we are about to start has settled, so the indicator
@@ -202,8 +214,13 @@ watch(highlightIndex, () => {
   }
 })
 
-// A new document swaps every page out without them reporting they stopped showing.
-watch(pdf, () => pagesBelowToolbox.clear())
+// A new document swaps every page out without them reporting they stopped showing, and a hold left
+// over from the previous one would settle against pages that are not there anymore.
+watch(pdf, () => {
+  pagesBelowToolbox.clear()
+  pendingPage.value = null
+  realignPendingPage.value = false
+})
 
 watch(src, async () => {
   blurred.value ??= await isBlurred(props.document)

--- a/src/components/Document/DocumentViewer/DocumentViewerPdf.vue
+++ b/src/components/Document/DocumentViewer/DocumentViewerPdf.vue
@@ -1,7 +1,6 @@
 <script setup>
-import VueScrollTo from 'vue-scrollto'
 import { computed, ref, useTemplateRef, toRef, watch } from 'vue'
-import { refDebounced, whenever, useElementBounding } from '@vueuse/core'
+import { refDebounced, whenever, useDebounceFn, useElementBounding, useEventListener } from '@vueuse/core'
 import { supportsPDFs as embeddable } from 'pdfobject'
 import { useI18n } from 'vue-i18n'
 
@@ -14,7 +13,6 @@ import { SCALE_FIT, SCALE_WIDTH } from '@/enums/documentViewerPdf'
 import { useCompact } from '@/composables/useCompact'
 import { useDocumentPreview } from '@/composables/useDocumentPreview'
 import { useWait } from '@/composables/useWait'
-import { useScrollParent } from '@/composables/useScrollParent'
 import { usePDF } from '@/composables/usePDF'
 import { useDocumentViewStore } from '@/store/modules/documentView'
 import AppWait from '@/components/AppWait/AppWait'
@@ -36,8 +34,9 @@ const props = defineProps({
   }
 })
 
+const SCROLL_IDLE_DELAY = 200
+
 const documentViewStore = useDocumentViewStore()
-const scrollParent = useScrollParent()
 const src = computed(() => (documentViewStore.embeddedPdf ? null : props.document.fullUrl))
 const { pdf, numPages, sizes, findHighlights, loaderId: pdfLoaderId } = usePDF(src)
 const { waitFor, isLoading } = useWait()
@@ -45,6 +44,8 @@ const { t } = useI18n()
 const { isBlurred, getBlurredContentBanner } = useDocumentPreview()
 
 const currentPage = ref(1)
+const pendingPage = ref(null)
+const realignPendingPage = ref(false)
 const rotation = documentViewStore.computedDocumentRotation(props.document)
 const scale = ref(SCALE_FIT)
 const blurred = ref(null)
@@ -58,11 +59,18 @@ const highlightTextDebounced = refDebounced(highlightText, 300)
 const highlightIndex = ref(0)
 const highlightMatches = ref([])
 const highlightOccurrences = computed(() => highlightMatches.value.length)
+const highlightPage = computed(() => highlightMatches.value[highlightIndex.value - 1]?.page)
 const isHighlightDebouncing = computed(() => highlightTextDebounced.value !== highlightText.value)
 const isHighlightLoading = computed(() => isLoading.value || isHighlightDebouncing.value)
 
 const pageScale = computed(() => (isNaN(scale.value) ? 1 : Number(scale.value)))
 const pageFitParent = computed(() => scale.value === SCALE_FIT || scale.value === SCALE_WIDTH)
+
+const style = computed(() => {
+  return {
+    '--document-viewer-pdf-toolbox-height': `${toolboxHeight.value}px`
+  }
+})
 
 const classList = computed(() => {
   return {
@@ -71,6 +79,47 @@ const classList = computed(() => {
   }
 })
 
+const settleScroll = useDebounceFn(() => {
+  if (pendingPage.value === null) {
+    return
+  }
+  // Pages render lazily while a smooth scroll runs and each resizes by a fraction of a pixel, which
+  // is enough for a page pick to land short of its target. Highlights are centered by the page.
+  if (realignPendingPage.value) {
+    scrollPageIntoView(pendingPage.value, 'instant')
+  }
+  currentPage.value = pendingPage.value
+  pendingPage.value = null
+}, SCROLL_IDLE_DELAY)
+
+useEventListener(window, 'scroll', settleScroll, { capture: true, passive: true })
+// Scrolling by hand gives up on the pending page and hands tracking straight back to the viewport.
+useEventListener(window, ['wheel', 'touchmove'], () => (pendingPage.value = null), { passive: true })
+
+/**
+ * Holds the page tracking until the scroll we are about to start has settled, so the indicator
+ * stays on the page we are heading to instead of counting every page the scroll flies past.
+ *
+ * @param {number} value - The page that scroll is heading to.
+ * @param {boolean} realign - Whether that page must be aligned again once the scroll has settled.
+ */
+function holdPageTracking(value, realign = false) {
+  pendingPage.value = value
+  realignPendingPage.value = realign
+  settleScroll()
+}
+
+/**
+ * Tracks the page currently under the toolbox, unless one of our own scrolls is in flight.
+ *
+ * @param {number} value - The page reporting itself as current.
+ */
+function trackPage(value) {
+  if (pendingPage.value === null) {
+    currentPage.value = value
+  }
+}
+
 /**
  * Gets the highlight index for a specific page.
  *
@@ -78,9 +127,22 @@ const classList = computed(() => {
  * @returns {number} - The index of the highlight match on the page, or 0 if no matches.
  */
 function getPageHighlightIndex(value) {
-  const match = highlightMatches.value[highlightIndex.value - 1]
   const firstPageMatch = highlightMatches.value.findIndex(m => m.page === value)
-  return match && match.page === value ? highlightIndex.value - firstPageMatch : 0
+  return highlightPage.value === value ? highlightIndex.value - firstPageMatch : 0
+}
+
+/**
+ * Aligns the given page with the top of the viewport, under the sticky toolbox.
+ *
+ * @param {number} value - The page number to scroll to.
+ * @param {string} behavior - Defaults to the CSS scroll-behavior, which Bootstrap
+ *   already turns into an instant jump under prefers-reduced-motion.
+ * @returns {boolean} - Whether the page is rendered and was scrolled to.
+ */
+function scrollPageIntoView(value, behavior = 'auto') {
+  const target = pageElements.value[value - 1]?.$el
+  target?.scrollIntoView({ behavior, block: 'start' })
+  return !!target
 }
 
 /**
@@ -89,12 +151,9 @@ function getPageHighlightIndex(value) {
  * @param {number} value - The page number to scroll to.
  */
 function scrollToPage(value) {
-  const target = pageElements.value[value - 1]?.$el
   // Scroll only the target exist
-  if (target) {
-    const offset = -toolboxHeight.value
-    const container = scrollParent.value
-    VueScrollTo.scrollTo(target, 0, { container, offset })
+  if (scrollPageIntoView(value)) {
+    holdPageTracking(value, true)
     // Update the page model to reflect the current page
     currentPage.value = value
   }
@@ -104,6 +163,13 @@ whenever(highlightTextDebounced, waitFor(async (value) => {
   highlightMatches.value = await findHighlights(value)
   highlightIndex.value = highlightMatches.value.length ? 1 : 0
 }))
+
+// Picking another occurrence makes the matching page scroll its highlight into view.
+watch(highlightIndex, () => {
+  if (highlightPage.value) {
+    holdPageTracking(highlightPage.value)
+  }
+})
 
 watch(src, async () => {
   blurred.value ??= await isBlurred(props.document)
@@ -124,6 +190,7 @@ watch(src, async () => {
     v-else
     class="document-viewer-pdf"
     :class="classList"
+    :style="style"
   >
     <div
       ref="toolbox"
@@ -186,8 +253,8 @@ watch(src, async () => {
           :pdf="pdf"
           :highlight-text="highlightTextDebounced"
           :highlight-index="getPageHighlightIndex(page)"
-          :scroll-offset="-toolboxHeight"
-          @visible="currentPage = page"
+          :top-offset="toolboxHeight"
+          @visible="trackPage(page)"
         />
       </template>
       <template v-else>
@@ -232,6 +299,7 @@ watch(src, async () => {
       flex-shrink: 1;
       min-width: 0;
       width: auto;
+      scroll-margin-top: var(--document-viewer-pdf-toolbox-height, 0px);
     }
   }
 

--- a/src/components/Document/DocumentViewer/DocumentViewerPdf.vue
+++ b/src/components/Document/DocumentViewer/DocumentViewerPdf.vue
@@ -35,6 +35,7 @@ const props = defineProps({
 })
 
 const SCROLL_IDLE_DELAY = 200
+const SCROLL_KEYS = ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' ']
 
 const documentViewStore = useDocumentViewStore()
 const src = computed(() => (documentViewStore.embeddedPdf ? null : props.document.fullUrl))
@@ -46,6 +47,7 @@ const { isBlurred, getBlurredContentBanner } = useDocumentPreview()
 const currentPage = ref(1)
 const pendingPage = ref(null)
 const realignPendingPage = ref(false)
+const pagesBelowToolbox = new Set()
 const rotation = documentViewStore.computedDocumentRotation(props.document)
 const scale = ref(SCALE_FIT)
 const blurred = ref(null)
@@ -79,6 +81,15 @@ const classList = computed(() => {
   }
 })
 
+/**
+ * The page the toolbox sits on, which is the topmost of the pages still showing under it.
+ *
+ * @returns {number|null} - The current page number, or null when no page is showing.
+ */
+function currentPageBelowToolbox() {
+  return pagesBelowToolbox.size ? Math.min(...pagesBelowToolbox) : null
+}
+
 const settleScroll = useDebounceFn(() => {
   if (pendingPage.value === null) {
     return
@@ -87,14 +98,26 @@ const settleScroll = useDebounceFn(() => {
   // is enough for a page pick to land short of its target. Highlights are centered by the page.
   if (realignPendingPage.value) {
     scrollPageIntoView(pendingPage.value, 'instant')
+    currentPage.value = pendingPage.value
+    pendingPage.value = null
   }
-  currentPage.value = pendingPage.value
-  pendingPage.value = null
+  else {
+    releasePendingPage()
+  }
 }, SCROLL_IDLE_DELAY)
 
+/**
+ * Gives up on the pending page and hands the tracking straight back to the viewport, so a scroll
+ * started by hand is never undone by the pending page settling behind it.
+ */
+function releasePendingPage() {
+  pendingPage.value = null
+  currentPage.value = currentPageBelowToolbox() ?? currentPage.value
+}
+
 useEventListener(window, 'scroll', settleScroll, { capture: true, passive: true })
-// Scrolling by hand gives up on the pending page and hands tracking straight back to the viewport.
-useEventListener(window, ['wheel', 'touchmove'], () => (pendingPage.value = null), { passive: true })
+useEventListener(window, ['wheel', 'touchmove', 'pointerdown'], releasePendingPage, { passive: true })
+useEventListener(window, 'keydown', ({ key }) => SCROLL_KEYS.includes(key) && releasePendingPage())
 
 /**
  * Holds the page tracking until the scroll we are about to start has settled, so the indicator
@@ -110,13 +133,21 @@ function holdPageTracking(value, realign = false) {
 }
 
 /**
- * Tracks the page currently under the toolbox, unless one of our own scrolls is in flight.
+ * Tracks whether a page still shows under the toolbox, and follows the topmost one that does
+ * unless a scroll of ours is in flight.
  *
- * @param {number} value - The page reporting itself as current.
+ * @param {number} value - The page reporting itself.
+ * @param {boolean} below - Whether that page shows under the toolbox.
  */
-function trackPage(value) {
+function trackPage(value, below) {
+  if (below) {
+    pagesBelowToolbox.add(value)
+  }
+  else {
+    pagesBelowToolbox.delete(value)
+  }
   if (pendingPage.value === null) {
-    currentPage.value = value
+    currentPage.value = currentPageBelowToolbox() ?? currentPage.value
   }
 }
 
@@ -170,6 +201,9 @@ watch(highlightIndex, () => {
     holdPageTracking(highlightPage.value)
   }
 })
+
+// A new document swaps every page out without them reporting they stopped showing.
+watch(pdf, () => pagesBelowToolbox.clear())
 
 watch(src, async () => {
   blurred.value ??= await isBlurred(props.document)
@@ -254,7 +288,7 @@ watch(src, async () => {
           :highlight-text="highlightTextDebounced"
           :highlight-index="getPageHighlightIndex(page)"
           :top-offset="toolboxHeight"
-          @visible="trackPage(page)"
+          @visible="trackPage(page, $event)"
         />
       </template>
       <template v-else>

--- a/src/components/Document/DocumentViewer/DocumentViewerPdf/DocumentViewerPdfPage.vue
+++ b/src/components/Document/DocumentViewer/DocumentViewerPdf/DocumentViewerPdfPage.vue
@@ -1,12 +1,10 @@
 <script setup>
 import '@tato30/vue-pdf/style.css'
-import VueScrollTo from 'vue-scrollto'
 import { VuePDF as VuePdf } from '@tato30/vue-pdf'
 import { computed, toRef, useTemplateRef, watch } from 'vue'
-import { useElementSize, useWindowSize, whenever, useElementVisibility } from '@vueuse/core'
+import { useElementSize, whenever, useElementVisibility } from '@vueuse/core'
 
 import { useElementVisibilityOnce } from '@/composables/useElementVisibilityOnce'
-import { useScrollParent } from '@/composables/useScrollParent'
 
 const props = defineProps({
   pdf: {
@@ -55,9 +53,7 @@ const emit = defineEmits(['visible'])
 
 const renderer = useTemplateRef('renderer')
 const element = useTemplateRef('element')
-const scrollParent = useScrollParent()
 const isVisibleOnce = useElementVisibilityOnce(element)
-const { height: windowHeight } = useWindowSize()
 // Shrink the observer root so it starts just under the sticky toolbox: whoever is left showing is
 // a candidate for the current page, and the parent keeps the topmost one. A ratio threshold cannot
 // work here, pages are often taller than the viewport and vueuse reports `isIntersecting` anyway.
@@ -97,9 +93,7 @@ function applyHighlight() {
   highlights.forEach(el => el.classList.toggle(HIGHLIGHT_ACTIVE_CLASS, el === highlight))
   // Only scroll to the highlight if the current page has a highlight index
   if (props.highlightIndex && highlight) {
-    const offset = windowHeight.value / -2
-    const container = scrollParent.value
-    VueScrollTo.scrollTo(highlight, 0, { container, offset })
+    highlight.scrollIntoView({ block: 'center' })
   }
 }
 

--- a/src/components/Document/DocumentViewer/DocumentViewerPdf/DocumentViewerPdfPage.vue
+++ b/src/components/Document/DocumentViewer/DocumentViewerPdf/DocumentViewerPdfPage.vue
@@ -2,7 +2,7 @@
 import '@tato30/vue-pdf/style.css'
 import VueScrollTo from 'vue-scrollto'
 import { VuePDF as VuePdf } from '@tato30/vue-pdf'
-import { computed, toRef, toValue, useTemplateRef, watch } from 'vue'
+import { computed, toRef, useTemplateRef, watch } from 'vue'
 import { useElementSize, useWindowSize, whenever, useElementVisibility } from '@vueuse/core'
 
 import { useElementVisibilityOnce } from '@/composables/useElementVisibilityOnce'
@@ -29,7 +29,7 @@ const props = defineProps({
     type: Number,
     default: 0
   },
-  scrollOffset: {
+  topOffset: {
     type: Number,
     default: 0
   },
@@ -49,15 +49,23 @@ const props = defineProps({
 
 const HIGHLIGHT_CLASS = 'highlight'
 const HIGHLIGHT_ACTIVE_CLASS = 'highlight--active'
+const CURRENT_PAGE_PROBE_OFFSET = 4
 
 const emit = defineEmits(['visible'])
 
 const renderer = useTemplateRef('renderer')
 const element = useTemplateRef('element')
 const scrollParent = useScrollParent()
-const isVisible = useElementVisibility(element, { threshold: 0.5 })
 const isVisibleOnce = useElementVisibilityOnce(element)
 const { height: windowHeight } = useWindowSize()
+// Shrink the observer root to a one-pixel probe line just under the sticky toolbox, so exactly one
+// page is current whatever the window height. A ratio threshold cannot work here: pages are often
+// taller than the viewport, and vueuse reports `isIntersecting`, which ignores the threshold.
+const currentPageProbe = computed(() => {
+  const top = Math.round(props.topOffset) + CURRENT_PAGE_PROBE_OFFSET
+  return `${-top}px 0px ${top + 1 - windowHeight.value}px 0px`
+})
+const isCurrent = useElementVisibility(element, { rootMargin: currentPageProbe })
 const { width } = useElementSize(element)
 watch(width, () => renderer.value?.reload())
 
@@ -88,18 +96,16 @@ function applyHighlight() {
   const highlight = highlights[props.highlightIndex - 1]
   // Remove all classes "highlight--active" from the page and highlight the current one
   highlights.forEach(el => el.classList.toggle(HIGHLIGHT_ACTIVE_CLASS, el === highlight))
-  // Only scroll to the highlight/page if the current page has a highlight index
+  // Only scroll to the highlight if the current page has a highlight index
   if (props.highlightIndex && highlight) {
-    // If no highlight is found, offset the scroll to the center of the page
-    const offset = highlight ? windowHeight.value / -2 : props.scrollOffset
+    const offset = windowHeight.value / -2
     const container = scrollParent.value
-    const target = toValue(highlight || element)
-    VueScrollTo.scrollTo(target, 0, { container, offset })
+    VueScrollTo.scrollTo(highlight, 0, { container, offset })
   }
 }
 
 whenever(toRef(props, 'highlightIndex'), applyHighlight)
-whenever(isVisible, () => emit('visible'))
+whenever(isCurrent, () => emit('visible'))
 </script>
 
 <template>

--- a/src/components/Document/DocumentViewer/DocumentViewerPdf/DocumentViewerPdfPage.vue
+++ b/src/components/Document/DocumentViewer/DocumentViewerPdf/DocumentViewerPdfPage.vue
@@ -49,7 +49,7 @@ const props = defineProps({
 
 const HIGHLIGHT_CLASS = 'highlight'
 const HIGHLIGHT_ACTIVE_CLASS = 'highlight--active'
-const CURRENT_PAGE_PROBE_OFFSET = 4
+const BELOW_TOOLBOX_OFFSET = 4
 
 const emit = defineEmits(['visible'])
 
@@ -58,14 +58,13 @@ const element = useTemplateRef('element')
 const scrollParent = useScrollParent()
 const isVisibleOnce = useElementVisibilityOnce(element)
 const { height: windowHeight } = useWindowSize()
-// Shrink the observer root to a one-pixel probe line just under the sticky toolbox, so exactly one
-// page is current whatever the window height. A ratio threshold cannot work here: pages are often
-// taller than the viewport, and vueuse reports `isIntersecting`, which ignores the threshold.
-const currentPageProbe = computed(() => {
-  const top = Math.round(props.topOffset) + CURRENT_PAGE_PROBE_OFFSET
-  return `${-top}px 0px ${top + 1 - windowHeight.value}px 0px`
+// Shrink the observer root so it starts just under the sticky toolbox: whoever is left showing is
+// a candidate for the current page, and the parent keeps the topmost one. A ratio threshold cannot
+// work here, pages are often taller than the viewport and vueuse reports `isIntersecting` anyway.
+const belowToolbox = computed(() => {
+  return `${-(Math.round(props.topOffset) + BELOW_TOOLBOX_OFFSET)}px 0px 0px 0px`
 })
-const isCurrent = useElementVisibility(element, { rootMargin: currentPageProbe })
+const isBelowToolbox = useElementVisibility(element, { rootMargin: belowToolbox })
 const { width } = useElementSize(element)
 watch(width, () => renderer.value?.reload())
 
@@ -105,7 +104,7 @@ function applyHighlight() {
 }
 
 whenever(toRef(props, 'highlightIndex'), applyHighlight)
-whenever(isCurrent, () => emit('visible'))
+watch(isBelowToolbox, visible => emit('visible', visible), { immediate: true })
 </script>
 
 <template>


### PR DESCRIPTION
Fixes the page indicator in the PDF viewer, which drifted on small windows and counted every page a scroll flew past. Closes ICIJ/datashare#2342.

- fix: track the page under a probe line below the toolbar, instead of any page merely touching the viewport (the `threshold` option had no effect, vueuse reports `isIntersecting`)
- fix: hold the indicator on the target page while a page pick or a search occurrence jump is scrolling, then realign, since lazily rendered pages resize mid-animation and the scroll lands short
- fix: only cycle search occurrences on Enter while the search field has focus, so Enter in the page field no longer does both