### PR TITLE
refactor(search): factor the fresh-stamp route push into a composable

### DIFF
--- a/src/components/Search/SearchBar/SearchBar.vue
+++ b/src/components/Search/SearchBar/SearchBar.vue
@@ -5,7 +5,6 @@ import iteratee from 'lodash/iteratee'
 import sortBy from 'lodash/sortBy'
 import uniqueId from 'lodash/uniqueId'
 import { useI18n } from 'vue-i18n'
-import { useRouter } from 'vue-router'
 import { SelectableDropdown } from '@icij/murmur'
 
 import SearchBarInput from '@/components/Search/SearchBar/SearchBarInput'
@@ -13,6 +12,7 @@ import FieldDropdownSelector from '@/components/FieldDropdownSelector/FieldDropd
 import SearchBarInputDropdownForProjects from '@/components/Search/SearchBar/SearchBarInputDropdownForProjects'
 import { useCore } from '@/composables/useCore'
 import { useMobileDetect } from '@/composables/useMobileDetect'
+import { useRefreshRouteFromStart } from '@/composables/useRefreshRouteFromStart'
 import { useSearchSuggestions } from '@/composables/useSearchSuggestions'
 import { useSearchStore } from '@/store/modules'
 
@@ -64,10 +64,10 @@ const props = defineProps({
 defineEmits(['submit'])
 
 const core = useCore()
-const router = useRouter()
 const searchStore = useSearchStore()
 const { isMobile } = useMobileDetect()
 const { t } = useI18n()
+const { refreshRouteFromStart } = useRefreshRouteFromStart(searchStore)
 
 const searchInput = useTemplateRef('searchInput')
 
@@ -131,9 +131,10 @@ function submit() {
   searchStore.setIndices(formIndices.value)
   searchStore.setField(field.value)
   searchStore.setQuery(query.value)
+  // Reset synchronously so a caller checking the store right after submit()
+  // (no route round-trip awaited) already sees page one.
   searchStore.setFrom(0)
-  searchStore.refreshStamp()
-  router.push({ name: 'search', query: searchStore.toRouteQueryWithStamp })
+  refreshRouteFromStart()
 }
 
 function onSelectTerm(term) {

--- a/src/composables/useRefreshRouteFromStart.js
+++ b/src/composables/useRefreshRouteFromStart.js
@@ -1,0 +1,20 @@
+import { useRouter } from 'vue-router'
+
+/**
+ * Push a freshly stamped route to the first page of the search, so the search
+ * always resubmits even when the query and filters haven't changed.
+ *
+ * @param {object} searchStore - The search store instance to push a route for.
+ * @returns {{ refreshRouteFromStart: Function }}
+ */
+export function useRefreshRouteFromStart(searchStore) {
+  const router = useRouter()
+
+  function refreshRouteFromStart() {
+    searchStore.refreshStamp()
+    const query = { ...searchStore.toRouteQueryWithStamp, from: 0 }
+    return router.push({ name: 'search', query })
+  }
+
+  return { refreshRouteFromStart }
+}

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -3,8 +3,6 @@ import castArray from 'lodash/castArray'
 import get from 'lodash/get'
 import identity from 'lodash/identity'
 import isObject from 'lodash/isObject'
-import range from 'lodash/range'
-import random from 'lodash/random'
 import toString from 'lodash/toString'
 import without from 'lodash/without'
 import { useRouter, useRoute } from 'vue-router'
@@ -15,6 +13,7 @@ import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 import { useCore } from '@/composables/useCore'
 import { useMode } from '@/composables/useMode'
 import { useContentTypeCategoryAvailability } from '@/composables/useContentTypeCategoryAvailability'
+import { useRefreshRouteFromStart } from '@/composables/useRefreshRouteFromStart'
 import { onAfterRouteUpdate } from '@/composables/onAfterRouteUpdate'
 import FilterType from '@/components/Filter/FilterType/FilterType'
 import FilterTypeFileTypes from '@/components/Filter/FilterType/FilterTypeFileTypes'
@@ -43,6 +42,7 @@ export function useSearchFilter() {
   const { t, te } = useI18n()
   const core = useCore()
   const { isServer } = useMode(core)
+  const { refreshRouteFromStart } = useRefreshRouteFromStart(searchStore)
   // Drives the read-layer degradation in getFilterPairedDimensions: when the
   // contentTypeCategory field is missing from the selected indices' mapping,
   // the contentType filter falls back to single-dimension behavior so paired
@@ -320,14 +320,6 @@ export function useSearchFilter() {
   function refreshRoute() {
     const name = 'search'
     const query = searchStore.toRouteQuery
-    return router.push({ name, query })
-  }
-
-  function refreshRouteFromStart() {
-    const name = 'search'
-    const seed = range(6).map(() => random(97, 122))
-    const stamp = String.fromCharCode.apply(null, seed)
-    const query = { ...searchStore.toRouteQuery, stamp, from: 0 }
     return router.push({ name, query })
   }
 

--- a/tests/unit/specs/composables/useRefreshRouteFromStart.spec.js
+++ b/tests/unit/specs/composables/useRefreshRouteFromStart.spec.js
@@ -1,0 +1,54 @@
+import { createApp } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import { useRefreshRouteFromStart } from '@/composables/useRefreshRouteFromStart'
+import { useSearchStore } from '@/store/modules'
+
+describe('useRefreshRouteFromStart', () => {
+  function withSetup(composable, plugins) {
+    let result
+    const app = createApp({
+      setup() {
+        result = composable()
+        return {}
+      }
+    })
+    plugins.forEach(plugin => app.use(plugin))
+    app.mount(document.createElement('div'))
+    return result
+  }
+
+  it('pushes a route to page one with the store query and a fresh stamp', async () => {
+    const core = CoreSetup.init().useAll().useRouterWithoutGuards()
+    const searchStore = useSearchStore()
+    searchStore.setQuery('+Paris +London')
+    searchStore.setFrom(2)
+    const initialStamp = searchStore.toRouteQueryWithStamp.stamp
+
+    const { refreshRouteFromStart } = withSetup(() => useRefreshRouteFromStart(searchStore), core.plugins)
+    await refreshRouteFromStart()
+    await flushPromises()
+
+    const { query } = core.router.currentRoute.value
+    expect(query.q).toBe('+Paris +London')
+    expect(query.from).toBe('0')
+    expect(query.stamp).not.toBe(initialStamp)
+  })
+
+  it('refreshes the stamp on every call, so an unchanged query still resubmits', async () => {
+    const core = CoreSetup.init().useAll().useRouterWithoutGuards()
+    const searchStore = useSearchStore()
+
+    const { refreshRouteFromStart } = withSetup(() => useRefreshRouteFromStart(searchStore), core.plugins)
+    await refreshRouteFromStart()
+    await flushPromises()
+    const firstStamp = core.router.currentRoute.value.query.stamp
+
+    await refreshRouteFromStart()
+    await flushPromises()
+    const secondStamp = core.router.currentRoute.value.query.stamp
+
+    expect(secondStamp).not.toBe(firstStamp)
+  })
+})


### PR DESCRIPTION
Follow-up to #496 (review suggestion): `SearchBar.vue`'s `submit()` and `useSearchFilter`'s `refreshRouteFromStart()` (used by the advanced search, filters, indices and search-operator changes) both push a fresh route to page one so the search always resubmits, but each rolled its own version — one regenerating a random stamp inline, the other going through the store's `refreshStamp()`/`toRouteQueryWithStamp`. Nothing kept them in sync, so the two could silently drift apart again.

Extracted the shared behavior into `useRefreshRouteFromStart()`, used by both. It takes the search store as a parameter instead of resolving it itself: some components use a suffixed/disposable store instance (`useSearchStore.inject()`) rather than the default one, so the composable must reuse the caller's own store reference rather than risk resolving a different one.

Refactoring made assisted by Claude