### PR TITLE
feat(search): lock/unlock from the Filters panel

### DIFF
--- a/src/components/Filter/FilterType/FilterType.vue
+++ b/src/components/Filter/FilterType/FilterType.vue
@@ -161,10 +161,10 @@ const hasAnyValue = computed(() => {
 })
 
 const toggleValue = async (item, checked) => {
+  // Unlocking on removal is handled centrally by useSearchFilter's
+  // removeFilterValue/removeFilterValues, so every removal path (this
+  // checkbox, the "All" toggle, breadcrumb chip removal) unlocks alike.
   await toggleFilterValue(filter, item, checked)
-  if (!checked) {
-    lockedFiltersStore.unlock({ name: lockedName.value, value: item.key })
-  }
   if (contextualize.value) {
     await aggregateOver()
   }
@@ -209,8 +209,13 @@ const excludedBucketsPage = computed(() => {
 // matching real aggregation bucket (a deleted tag, a re-indexed path).
 // Uses the exact same shape/insertion mechanism as excludedBucketsPage
 // above so it flows through bucketsWithExcludedValues unchanged.
+// Also excludes keys already synthesized by excludedBucketsPage: a value
+// that is ticked + excluded + contextualized is already rendered by that
+// mechanism regardless of locking, and de-duping here (rather than there)
+// keeps excludedBucketsPage's own semantics untouched.
 const missingLockedBucketsPage = computed(() => {
-  const realKeys = buckets.value.map(item => toString(item.key))
+  const excludedKeys = getPageBuckets(excludedBucketsPage.value).map(item => toString(item.key))
+  const realKeys = [...buckets.value.map(item => toString(item.key)), ...excludedKeys]
   const missing = lockedFiltersStore.entries
     .filter(entry => entry.name === lockedName.value && !realKeys.includes(entry.value))
     .map(entry => ({ key: entry.value, doc_count: 0, __lockedLabel: entry.label }))

--- a/src/components/Filter/FilterType/FilterType.vue
+++ b/src/components/Filter/FilterType/FilterType.vue
@@ -21,6 +21,7 @@ import FiltersPanelSectionFilterEntry from '@/components/FiltersPanel/FiltersPan
 import FilterTypeAll from '@/components/Filter/FilterType/FilterTypeAll'
 import settings from '@/utils/settings'
 import { useSearchStore, useLockedFiltersStore } from '@/store/modules'
+import { toLockedName } from '@/store/modules/lockedFilters'
 import builtinFilterIcons from '@/store/filters/icons'
 
 const query = defineModel('query', { type: String, default: '' })
@@ -148,7 +149,10 @@ const exclude = computedExcludeFilter(filter)
 // The store key for this filter's locks: the filter's own current
 // include/exclude mode, never a paired dimension's — locking a chip on one
 // side of a paired filter must never lock or affect the other side.
-const lockedName = computed(() => (exclude.value ? `-${filter.name}` : filter.name))
+// TODO(locked-filters): filter types overriding FilterType's default slot
+// (FilterTypeFileTypes, FilterTypePath, FilterTypeProject, FilterTypeStarred,
+// FilterTypeRecommendedBy) don't receive lock/unlock support yet — see follow-up issue.
+const lockedName = computed(() => toLockedName(filter.name, exclude.value))
 const sort = computedSortFilter(filter)
 const contextualize = computedContextualizeFilter(filter)
 
@@ -184,6 +188,9 @@ function toggleLock(item, locked) {
 }
 
 const bucketLabel = (bucket) => {
+  // The label is frozen at lock time and intentionally does not re-translate
+  // if the UI language changes later — the bucket is gone, so there's
+  // nothing left to re-resolve the label against.
   if (bucket?.__lockedLabel != null) {
     return bucket.__lockedLabel
   }
@@ -213,6 +220,10 @@ const excludedBucketsPage = computed(() => {
 // that is ticked + excluded + contextualized is already rendered by that
 // mechanism regardless of locking, and de-duping here (rather than there)
 // keeps excludedBucketsPage's own semantics untouched.
+// Like excludedBucketsPage above, this does not filter against the panel's
+// search box: a locked-but-missing value always stays visible regardless of
+// what the user is searching for. Consistent with existing behavior, not a
+// new gap.
 const missingLockedBucketsPage = computed(() => {
   const excludedKeys = getPageBuckets(excludedBucketsPage.value).map(item => toString(item.key))
   const realKeys = [...buckets.value.map(item => toString(item.key)), ...excludedKeys]

--- a/src/components/Filter/FilterType/FilterType.vue
+++ b/src/components/Filter/FilterType/FilterType.vue
@@ -7,6 +7,7 @@ import flatten from 'lodash/flatten'
 import get from 'lodash/get'
 import noop from 'lodash/noop'
 import setWith from 'lodash/setWith'
+import toString from 'lodash/toString'
 import uniqueId from 'lodash/uniqueId'
 import InfiniteLoading from 'v3-infinite-loading'
 import { useI18n } from 'vue-i18n'
@@ -19,7 +20,7 @@ import FiltersPanelSectionFilter from '@/components/FiltersPanel/FiltersPanelSec
 import FiltersPanelSectionFilterEntry from '@/components/FiltersPanel/FiltersPanelSectionFilterEntry'
 import FilterTypeAll from '@/components/Filter/FilterType/FilterTypeAll'
 import settings from '@/utils/settings'
-import { useSearchStore } from '@/store/modules'
+import { useSearchStore, useLockedFiltersStore } from '@/store/modules'
 import builtinFilterIcons from '@/store/filters/icons'
 
 const query = defineModel('query', { type: String, default: '' })
@@ -55,6 +56,7 @@ const expand = ref(false)
 
 const { waitFor, isLoading } = useWait({ throttle: 500 })
 const searchStore = useSearchStore.inject()
+const lockedFiltersStore = useLockedFiltersStore()
 
 const aggregateOver = () => {
   return aggregate({ clearPages: true })
@@ -143,6 +145,10 @@ const {
 } = useSearchFilter()
 
 const exclude = computedExcludeFilter(filter)
+// The store key for this filter's locks: the filter's own current
+// include/exclude mode, never a paired dimension's — locking a chip on one
+// side of a paired filter must never lock or affect the other side.
+const lockedName = computed(() => (exclude.value ? `-${filter.name}` : filter.name))
 const sort = computedSortFilter(filter)
 const contextualize = computedContextualizeFilter(filter)
 
@@ -156,12 +162,31 @@ const hasAnyValue = computed(() => {
 
 const toggleValue = async (item, checked) => {
   await toggleFilterValue(filter, item, checked)
+  if (!checked) {
+    lockedFiltersStore.unlock({ name: lockedName.value, value: item.key })
+  }
   if (contextualize.value) {
     await aggregateOver()
   }
 }
 
+function isItemLocked(item) {
+  return lockedFiltersStore.isLocked({ name: lockedName.value, value: item.key })
+}
+
+function toggleLock(item, locked) {
+  if (locked) {
+    lockedFiltersStore.lock({ name: lockedName.value, value: item.key, label: bucketLabel(item) })
+  }
+  else {
+    lockedFiltersStore.unlock({ name: lockedName.value, value: item.key })
+  }
+}
+
 const bucketLabel = (bucket) => {
+  if (bucket?.__lockedLabel != null) {
+    return bucket.__lockedLabel
+  }
   if (noBucketTranslation.value) {
     return bucket?.key?.toString()
   }
@@ -180,8 +205,20 @@ const excludedBucketsPage = computed(() => {
   return []
 })
 
+// Synthesizes a zero-count bucket for every locked value that has no
+// matching real aggregation bucket (a deleted tag, a re-indexed path).
+// Uses the exact same shape/insertion mechanism as excludedBucketsPage
+// above so it flows through bucketsWithExcludedValues unchanged.
+const missingLockedBucketsPage = computed(() => {
+  const realKeys = buckets.value.map(item => toString(item.key))
+  const missing = lockedFiltersStore.entries
+    .filter(entry => entry.name === lockedName.value && !realKeys.includes(entry.value))
+    .map(entry => ({ key: entry.value, doc_count: 0, __lockedLabel: entry.label }))
+  return setWith({}, pageBucketsPath.value.join('.'), missing, Object)
+})
+
 const bucketsWithExcludedValues = computed(() => {
-  return flatten(concat([excludedBucketsPage.value], pages).map(getPageBuckets))
+  return flatten(concat([excludedBucketsPage.value, missingLockedBucketsPage.value], pages).map(getPageBuckets))
 })
 
 const entries = computed(() => {
@@ -311,7 +348,9 @@ defineExpose({ entries, aggregateOver, count })
         :count="item.doc_count"
         :hide-count="hideCount"
         :model-value="hasValue(item)"
+        :locked="isItemLocked(item)"
         @update:model-value="toggleValue(item, $event)"
+        @update:locked="toggleLock(item, $event)"
       >
         <slot name="entry-label" />
         <template #count>

--- a/src/components/Filter/FilterType/FilterType.vue
+++ b/src/components/Filter/FilterType/FilterType.vue
@@ -151,7 +151,8 @@ const exclude = computedExcludeFilter(filter)
 // side of a paired filter must never lock or affect the other side.
 // TODO(locked-filters): filter types overriding FilterType's default slot
 // (FilterTypeFileTypes, FilterTypePath, FilterTypeProject, FilterTypeStarred,
-// FilterTypeRecommendedBy) don't receive lock/unlock support yet — see follow-up issue.
+// FilterTypeRecommendedBy) don't receive lock/unlock support yet — see
+// icij/datashare#2336.
 const lockedName = computed(() => toLockedName(filter.name, exclude.value))
 const sort = computedSortFilter(filter)
 const contextualize = computedContextualizeFilter(filter)

--- a/src/components/Filter/FilterType/FilterType.vue
+++ b/src/components/Filter/FilterType/FilterType.vue
@@ -366,6 +366,7 @@ defineExpose({ entries, aggregateOver, count })
         :hide-count="hideCount"
         :model-value="hasValue(item)"
         :locked="isItemLocked(item)"
+        lockable
         @update:model-value="toggleValue(item, $event)"
         @update:locked="toggleLock(item, $event)"
       >

--- a/src/components/Filter/FilterType/FilterType.vue
+++ b/src/components/Filter/FilterType/FilterType.vue
@@ -213,24 +213,34 @@ const excludedBucketsPage = computed(() => {
   return []
 })
 
-// Synthesizes a zero-count bucket for every locked value that has no
-// matching real aggregation bucket (a deleted tag, a re-indexed path).
-// Uses the exact same shape/insertion mechanism as excludedBucketsPage
-// above so it flows through bucketsWithExcludedValues unchanged.
-// Also excludes keys already synthesized by excludedBucketsPage: a value
-// that is ticked + excluded + contextualized is already rendered by that
-// mechanism regardless of locking, and de-duping here (rather than there)
-// keeps excludedBucketsPage's own semantics untouched.
-// Like excludedBucketsPage above, this does not filter against the panel's
-// search box: a locked-but-missing value always stays visible regardless of
-// what the user is searching for. Consistent with existing behavior, not a
-// new gap.
+// A locked value with no matching real bucket gets a synthetic zero-count row
+// so it stays visible and unlockable (a deleted tag, a re-indexed path).
+// Skipped while the panel's search box is active: real buckets are filtered
+// server-side via aggregationOptions.include, so a synthetic row would
+// outlive a query it never matched.
+const bucketKey = bucket => toString(bucket.key)
+
+const renderedBucketKeys = computed(() => {
+  const realKeys = buckets.value.map(bucketKey)
+  // excludedBucketsPage already synthesizes the ticked + excluded + contextualized
+  // case, so de-dupe here and leave that computed's own semantics untouched.
+  const excludedKeys = getPageBuckets(excludedBucketsPage.value).map(bucketKey)
+  return new Set([...realKeys, ...excludedKeys])
+})
+
+const missingLocks = computed(() => {
+  const isForThisFilter = entry => entry.name === lockedName.value
+  const isMissing = entry => !renderedBucketKeys.value.has(entry.value)
+  return lockedFiltersStore.entries.filter(entry => isForThisFilter(entry) && isMissing(entry))
+})
+
+const toSyntheticBucket = entry => ({ key: entry.value, doc_count: 0, __lockedLabel: entry.label })
+
 const missingLockedBucketsPage = computed(() => {
-  const excludedKeys = getPageBuckets(excludedBucketsPage.value).map(item => toString(item.key))
-  const realKeys = [...buckets.value.map(item => toString(item.key)), ...excludedKeys]
-  const missing = lockedFiltersStore.entries
-    .filter(entry => entry.name === lockedName.value && !realKeys.includes(entry.value))
-    .map(entry => ({ key: entry.value, doc_count: 0, __lockedLabel: entry.label }))
+  if (query.value !== '') {
+    return []
+  }
+  const missing = missingLocks.value.map(toSyntheticBucket)
   return setWith({}, pageBucketsPath.value.join('.'), missing, Object)
 })
 

--- a/src/components/Filter/FilterType/FilterType.vue
+++ b/src/components/Filter/FilterType/FilterType.vue
@@ -213,11 +213,12 @@ const excludedBucketsPage = computed(() => {
   return []
 })
 
-// A locked value with no matching real bucket gets a synthetic zero-count row
-// so it stays visible and unlockable (a deleted tag, a re-indexed path).
-// Skipped while the panel's search box is active: real buckets are filtered
-// server-side via aggregationOptions.include, so a synthetic row would
-// outlive a query it never matched.
+// A locked value with no matching real bucket gets a synthetic row so it stays
+// visible and unlockable (a deleted tag, a re-indexed path). Skipped while the
+// panel's search box is active: real buckets are filtered server-side via
+// aggregationOptions.include, so a synthetic row would outlive a query it
+// never matched. The synthetic doc_count is NaN, not 0, so showCount's
+// isNaN guard hides only these ghost rows and not a real locked value's count.
 const bucketKey = bucket => toString(bucket.key)
 
 const renderedBucketKeys = computed(() => {
@@ -234,7 +235,7 @@ const missingLocks = computed(() => {
   return lockedFiltersStore.entries.filter(entry => isForThisFilter(entry) && isMissing(entry))
 })
 
-const toSyntheticBucket = entry => ({ key: entry.value, doc_count: 0, __lockedLabel: entry.label })
+const toSyntheticBucket = entry => ({ key: entry.value, doc_count: NaN, __lockedLabel: entry.label })
 
 const missingLockedBucketsPage = computed(() => {
   if (query.value !== '') {

--- a/src/components/Filter/FilterType/FilterType.vue
+++ b/src/components/Filter/FilterType/FilterType.vue
@@ -21,7 +21,6 @@ import FiltersPanelSectionFilterEntry from '@/components/FiltersPanel/FiltersPan
 import FilterTypeAll from '@/components/Filter/FilterType/FilterTypeAll'
 import settings from '@/utils/settings'
 import { useSearchStore, useLockedFiltersStore } from '@/store/modules'
-import { toLockedName } from '@/store/modules/lockedFilters'
 import builtinFilterIcons from '@/store/filters/icons'
 
 const query = defineModel('query', { type: String, default: '' })
@@ -140,6 +139,7 @@ const {
   computedSortFilter,
   computedContextualizeFilter,
   computedExcludeFilter,
+  lockedNameFor,
   toggleFilterValue,
   getFilterPairedDimensions,
   getFilterValuesByName
@@ -148,12 +148,14 @@ const {
 const exclude = computedExcludeFilter(filter)
 // The store key for this filter's locks: the filter's own current
 // include/exclude mode, never a paired dimension's — locking a chip on one
-// side of a paired filter must never lock or affect the other side.
+// side of a paired filter must never lock or affect the other side. Shares
+// useSearchFilter's own lockedNameFor so this and every value-removal path
+// there can never key the same row's lock differently.
 // TODO(locked-filters): filter types overriding FilterType's default slot
 // (FilterTypeFileTypes, FilterTypePath, FilterTypeProject, FilterTypeStarred,
 // FilterTypeRecommendedBy) don't receive lock/unlock support yet — see
 // icij/datashare#2336.
-const lockedName = computed(() => toLockedName(filter.name, exclude.value))
+const lockedName = computed(() => lockedNameFor(filter))
 const sort = computedSortFilter(filter)
 const contextualize = computedContextualizeFilter(filter)
 

--- a/src/components/FiltersPanel/FiltersPanelSectionFilterEntry.vue
+++ b/src/components/FiltersPanel/FiltersPanelSectionFilterEntry.vue
@@ -67,7 +67,7 @@ const classList = computed(() => {
 // can be locked while unticked (e.g. after "Clear filters", which preserves
 // locks but unticks the value), and the user still needs a way to unlock it.
 const showLockButton = computed(() => Boolean(props.modelValue) || props.locked)
-const showCount = computed(() => !props.hideCount && !isNaN(props.count) && !showLockButton.value)
+const showCount = computed(() => !props.hideCount && !isNaN(props.count) && !props.locked)
 const lockLabel = computed(() => t(props.locked ? 'filtersPanelSectionFilterEntry.unlock' : 'filtersPanelSectionFilterEntry.lock'))
 </script>
 

--- a/src/components/FiltersPanel/FiltersPanelSectionFilterEntry.vue
+++ b/src/components/FiltersPanel/FiltersPanelSectionFilterEntry.vue
@@ -1,6 +1,9 @@
 <script setup>
 import { computed, nextTick, useTemplateRef } from 'vue'
-import { EllipsisTooltip as vEllipsisTooltip } from '@icij/murmur'
+import { EllipsisTooltip as vEllipsisTooltip, ButtonIcon } from '@icij/murmur'
+import { useI18n } from 'vue-i18n'
+import IPhLock from '~icons/ph/lock'
+import IPhLockOpen from '~icons/ph/lock-open'
 
 import DisplayNumber from '@/components/Display/DisplayNumber'
 
@@ -28,10 +31,16 @@ const props = defineProps({
   },
   indeterminate: {
     type: Boolean
+  },
+  locked: {
+    type: Boolean,
+    default: false
   }
 })
 
-const emit = defineEmits(['update:modelValue'])
+const emit = defineEmits(['update:modelValue', 'update:locked'])
+
+const { t } = useI18n()
 
 const checkboxRef = useTemplateRef('checkboxRef')
 
@@ -54,7 +63,9 @@ const classList = computed(() => {
   }
 })
 
-const showCount = computed(() => !props.hideCount && !isNaN(props.count))
+const showLockButton = computed(() => Boolean(props.modelValue))
+const showCount = computed(() => !props.hideCount && !isNaN(props.count) && !props.locked)
+const lockLabel = computed(() => t(props.locked ? 'filtersPanelSectionFilterEntry.unlock' : 'filtersPanelSectionFilterEntry.lock'))
 </script>
 
 <template>
@@ -79,6 +90,18 @@ const showCount = computed(() => !props.hideCount && !isNaN(props.count))
         </span>
       </slot>
     </b-form-checkbox>
+    <button-icon
+      v-if="showLockButton"
+      square
+      hide-label
+      variant="link"
+      size="sm"
+      class="filters-panel-section-filter-entry__lock"
+      :icon-left="locked ? IPhLock : IPhLockOpen"
+      :pressed="locked"
+      :label="lockLabel"
+      @click="emit('update:locked', !locked)"
+    />
     <b-badge
       v-if="showCount"
       class="filters-panel-section-filter-entry__count"
@@ -119,6 +142,11 @@ const showCount = computed(() => !props.hideCount && !isNaN(props.count))
         width: 100%;
       }
     }
+  }
+
+  &__lock {
+    flex-shrink: 0;
+    margin-right: $spacer-xs;
   }
 
   &__count {

--- a/src/components/FiltersPanel/FiltersPanelSectionFilterEntry.vue
+++ b/src/components/FiltersPanel/FiltersPanelSectionFilterEntry.vue
@@ -63,8 +63,11 @@ const classList = computed(() => {
   }
 })
 
-const showLockButton = computed(() => Boolean(props.modelValue))
-const showCount = computed(() => !props.hideCount && !isNaN(props.count) && !props.locked)
+// Show the lock button when the value is ticked OR already locked: a value
+// can be locked while unticked (e.g. after "Clear filters", which preserves
+// locks but unticks the value), and the user still needs a way to unlock it.
+const showLockButton = computed(() => Boolean(props.modelValue) || props.locked)
+const showCount = computed(() => !props.hideCount && !isNaN(props.count) && !showLockButton.value)
 const lockLabel = computed(() => t(props.locked ? 'filtersPanelSectionFilterEntry.unlock' : 'filtersPanelSectionFilterEntry.lock'))
 </script>
 

--- a/src/components/FiltersPanel/FiltersPanelSectionFilterEntry.vue
+++ b/src/components/FiltersPanel/FiltersPanelSectionFilterEntry.vue
@@ -73,7 +73,7 @@ const classList = computed(() => {
 // Gated behind `lockable` (opt-in) so consumers that never wire `update:locked`
 // don't inherit a dead button on every ticked row.
 const showLockButton = computed(() => props.lockable && (Boolean(props.modelValue) || props.locked))
-const showCount = computed(() => !props.hideCount && !isNaN(props.count) && !props.locked)
+const showCount = computed(() => !props.hideCount && !isNaN(props.count))
 const lockLabel = computed(() => t(props.locked ? 'filtersPanelSectionFilterEntry.unlock' : 'filtersPanelSectionFilterEntry.lock'))
 </script>
 

--- a/src/components/FiltersPanel/FiltersPanelSectionFilterEntry.vue
+++ b/src/components/FiltersPanel/FiltersPanelSectionFilterEntry.vue
@@ -35,6 +35,10 @@ const props = defineProps({
   locked: {
     type: Boolean,
     default: false
+  },
+  lockable: {
+    type: Boolean,
+    default: false
   }
 })
 
@@ -66,7 +70,9 @@ const classList = computed(() => {
 // Show the lock button when the value is ticked OR already locked: a value
 // can be locked while unticked (e.g. after "Clear filters", which preserves
 // locks but unticks the value), and the user still needs a way to unlock it.
-const showLockButton = computed(() => Boolean(props.modelValue) || props.locked)
+// Gated behind `lockable` (opt-in) so consumers that never wire `update:locked`
+// don't inherit a dead button on every ticked row.
+const showLockButton = computed(() => props.lockable && (Boolean(props.modelValue) || props.locked))
 const showCount = computed(() => !props.hideCount && !isNaN(props.count) && !props.locked)
 const lockLabel = computed(() => t(props.locked ? 'filtersPanelSectionFilterEntry.unlock' : 'filtersPanelSectionFilterEntry.lock'))
 </script>

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -32,6 +32,7 @@ import { CONTENT_TYPE_CATEGORY_FILTER_NAME } from '@/store/filters/FilterContent
 import FilterText from '@/store/filters/FilterText.js'
 import { PAIRED_DIMENSIONS, getCanonicalDimension, getPairedDimension, getPairedDimensions } from '@/store/filters/pairedDimensions'
 import { useAppStore, useLockedFiltersStore, useRecommendedStore, useSearchStore } from '@/store/modules'
+import { toLockedName } from '@/store/modules/lockedFilters'
 
 export function useSearchFilter() {
   const appStore = useAppStore()
@@ -281,7 +282,7 @@ export function useSearchFilter() {
   // below so unlocking never leaks across a paired filter's other side.
   function lockedNameFor(filter) {
     const instance = castFilter(filter)
-    return isFilterExcluded(instance) ? `-${instance.name}` : instance.name
+    return toLockedName(instance.name, isFilterExcluded(instance))
   }
 
   const removeFilterValue = (filter, item) => {

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -31,11 +31,12 @@ const FilterTypeStarred = defineAsyncComponent(() => import('@/components/Filter
 import { CONTENT_TYPE_CATEGORY_FILTER_NAME } from '@/store/filters/FilterContentTypeCategory'
 import FilterText from '@/store/filters/FilterText.js'
 import { PAIRED_DIMENSIONS, getCanonicalDimension, getPairedDimension, getPairedDimensions } from '@/store/filters/pairedDimensions'
-import { useAppStore, useRecommendedStore, useSearchStore } from '@/store/modules'
+import { useAppStore, useLockedFiltersStore, useRecommendedStore, useSearchStore } from '@/store/modules'
 
 export function useSearchFilter() {
   const appStore = useAppStore()
   const searchStore = useSearchStore.inject()
+  const lockedFiltersStore = useLockedFiltersStore()
   const recommendedStore = useRecommendedStore()
   const route = useRoute()
   const router = useRouter()
@@ -275,16 +276,29 @@ export function useSearchFilter() {
     return searchStore.addFilterValue({ ...instance, value })
   }
 
+  // The store key for a filter's locks: its own current include/exclude
+  // mode, never a paired dimension's — shared by every value-removal path
+  // below so unlocking never leaks across a paired filter's other side.
+  function lockedNameFor(filter) {
+    const instance = castFilter(filter)
+    return isFilterExcluded(instance) ? `-${instance.name}` : instance.name
+  }
+
   const removeFilterValue = (filter, item) => {
     const instance = castFilter(filter)
     const param = instance.itemParam(castFilterItem(item))
     const value = toString(param.value)
+    lockedFiltersStore.unlock({ name: lockedNameFor(filter), value })
     return searchStore.removeFilterValue({ ...instance, value })
   }
 
   const removeFilterValues = (filter) => {
     // setFilterValue takes a single { name, value } arg; passing [] positionally writes [undefined].
     const { name } = castFilter(filter)
+    const lockedName = lockedNameFor(filter)
+    for (const entry of lockedFiltersStore.entries.filter(entry => entry.name === lockedName)) {
+      lockedFiltersStore.unlock({ name: lockedName, value: entry.value })
+    }
     return searchStore.setFilterValue({ name, value: [] })
   }
 

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -280,8 +280,9 @@ export function useSearchFilter() {
   // The store key for a filter's locks: its own current include/exclude
   // mode, never a paired dimension's — shared by every value-removal path
   // below so unlocking never leaks across a paired filter's other side.
-  function lockedNameFor(filter) {
-    const instance = castFilter(filter)
+  // Takes an already-cast instance (not a raw filter/name) so callers that
+  // already resolved one via castFilter don't pay for a second Map lookup.
+  function lockedNameFor(instance) {
     return toLockedName(instance.name, isFilterExcluded(instance))
   }
 
@@ -289,14 +290,15 @@ export function useSearchFilter() {
     const instance = castFilter(filter)
     const param = instance.itemParam(castFilterItem(item))
     const value = toString(param.value)
-    lockedFiltersStore.unlock({ name: lockedNameFor(filter), value })
+    lockedFiltersStore.unlock({ name: lockedNameFor(instance), value })
     return searchStore.removeFilterValue({ ...instance, value })
   }
 
   const removeFilterValues = (filter) => {
     // setFilterValue takes a single { name, value } arg; passing [] positionally writes [undefined].
-    const { name } = castFilter(filter)
-    const lockedName = lockedNameFor(filter)
+    const instance = castFilter(filter)
+    const { name } = instance
+    const lockedName = lockedNameFor(instance)
     for (const entry of lockedFiltersStore.entries.filter(entry => entry.name === lockedName)) {
       lockedFiltersStore.unlock({ name: lockedName, value: entry.value })
     }

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -299,9 +299,7 @@ export function useSearchFilter() {
     const instance = castFilter(filter)
     const { name } = instance
     const lockedName = lockedNameFor(instance)
-    for (const entry of lockedFiltersStore.entries.filter(entry => entry.name === lockedName)) {
-      lockedFiltersStore.unlock({ name: lockedName, value: entry.value })
-    }
+    lockedFiltersStore.unlockWhere(entry => entry.name === lockedName)
     return searchStore.setFilterValue({ name, value: [] })
   }
 

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -291,9 +291,7 @@ export function useSearchFilter() {
     const instance = castFilter(filter)
     const { name } = instance
     const lockedName = lockedNameFor(instance)
-    for (const entry of lockedFiltersStore.entries.filter(entry => entry.name === lockedName)) {
-      lockedFiltersStore.unlock({ name: lockedName, value: entry.value })
-    }
+    lockedFiltersStore.unlockWhere(entry => entry.name === lockedName)
     return searchStore.setFilterValue({ name, value: [] })
   }
 

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -32,6 +32,7 @@ import { CONTENT_TYPE_CATEGORY_FILTER_NAME } from '@/store/filters/FilterContent
 import FilterText from '@/store/filters/FilterText.js'
 import { PAIRED_DIMENSIONS, getCanonicalDimension, getPairedDimension, getPairedDimensions } from '@/store/filters/pairedDimensions'
 import { useAppStore, useLockedFiltersStore, useRecommendedStore, useSearchStore } from '@/store/modules'
+import { toLockedName } from '@/store/modules/lockedFilters'
 
 export function useSearchFilter() {
   const appStore = useAppStore()
@@ -273,7 +274,7 @@ export function useSearchFilter() {
   // below so unlocking never leaks across a paired filter's other side.
   function lockedNameFor(filter) {
     const instance = castFilter(filter)
-    return isFilterExcluded(instance) ? `-${instance.name}` : instance.name
+    return toLockedName(instance.name, isFilterExcluded(instance))
   }
 
   const removeFilterValue = (filter, item) => {

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -270,10 +270,7 @@ export function useSearchFilter() {
   }
 
   // The store key for a filter's locks: its own current include/exclude
-  // mode, never a paired dimension's — shared by every value-removal path
-  // below so unlocking never leaks across a paired filter's other side.
-  // Takes an already-cast instance (not a raw filter/name) so callers that
-  // already resolved one via castFilter don't pay for a second Map lookup.
+  // mode, never a paired dimension's.
   function lockedNameFor(instance) {
     return toLockedName(instance.name, isFilterExcluded(instance))
   }
@@ -558,6 +555,7 @@ export function useSearchFilter() {
     isFilterContextualized,
     isFilterExcluded,
     labelToHuman,
+    lockedNameFor,
     resetSearchResponse,
     refreshRoute,
     refreshRouteFromStart,

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -272,8 +272,9 @@ export function useSearchFilter() {
   // The store key for a filter's locks: its own current include/exclude
   // mode, never a paired dimension's — shared by every value-removal path
   // below so unlocking never leaks across a paired filter's other side.
-  function lockedNameFor(filter) {
-    const instance = castFilter(filter)
+  // Takes an already-cast instance (not a raw filter/name) so callers that
+  // already resolved one via castFilter don't pay for a second Map lookup.
+  function lockedNameFor(instance) {
     return toLockedName(instance.name, isFilterExcluded(instance))
   }
 
@@ -281,14 +282,15 @@ export function useSearchFilter() {
     const instance = castFilter(filter)
     const param = instance.itemParam(castFilterItem(item))
     const value = toString(param.value)
-    lockedFiltersStore.unlock({ name: lockedNameFor(filter), value })
+    lockedFiltersStore.unlock({ name: lockedNameFor(instance), value })
     return searchStore.removeFilterValue({ ...instance, value })
   }
 
   const removeFilterValues = (filter) => {
     // setFilterValue takes a single { name, value } arg; passing [] positionally writes [undefined].
-    const { name } = castFilter(filter)
-    const lockedName = lockedNameFor(filter)
+    const instance = castFilter(filter)
+    const { name } = instance
+    const lockedName = lockedNameFor(instance)
     for (const entry of lockedFiltersStore.entries.filter(entry => entry.name === lockedName)) {
       lockedFiltersStore.unlock({ name: lockedName, value: entry.value })
     }

--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -31,11 +31,12 @@ const FilterTypeStarred = defineAsyncComponent(() => import('@/components/Filter
 import { CONTENT_TYPE_CATEGORY_FILTER_NAME } from '@/store/filters/FilterContentTypeCategory'
 import FilterText from '@/store/filters/FilterText.js'
 import { PAIRED_DIMENSIONS, getCanonicalDimension, getPairedDimension, getPairedDimensions } from '@/store/filters/pairedDimensions'
-import { useAppStore, useRecommendedStore, useSearchStore } from '@/store/modules'
+import { useAppStore, useLockedFiltersStore, useRecommendedStore, useSearchStore } from '@/store/modules'
 
 export function useSearchFilter() {
   const appStore = useAppStore()
   const searchStore = useSearchStore.inject()
+  const lockedFiltersStore = useLockedFiltersStore()
   const recommendedStore = useRecommendedStore()
   const route = useRoute()
   const router = useRouter()
@@ -267,16 +268,29 @@ export function useSearchFilter() {
     return searchStore.addFilterValue({ ...instance, value })
   }
 
+  // The store key for a filter's locks: its own current include/exclude
+  // mode, never a paired dimension's — shared by every value-removal path
+  // below so unlocking never leaks across a paired filter's other side.
+  function lockedNameFor(filter) {
+    const instance = castFilter(filter)
+    return isFilterExcluded(instance) ? `-${instance.name}` : instance.name
+  }
+
   const removeFilterValue = (filter, item) => {
     const instance = castFilter(filter)
     const param = instance.itemParam(castFilterItem(item))
     const value = toString(param.value)
+    lockedFiltersStore.unlock({ name: lockedNameFor(filter), value })
     return searchStore.removeFilterValue({ ...instance, value })
   }
 
   const removeFilterValues = (filter) => {
     // setFilterValue takes a single { name, value } arg; passing [] positionally writes [undefined].
     const { name } = castFilter(filter)
+    const lockedName = lockedNameFor(filter)
+    for (const entry of lockedFiltersStore.entries.filter(entry => entry.name === lockedName)) {
+      lockedFiltersStore.unlock({ name: lockedName, value: entry.value })
+    }
     return searchStore.setFilterValue({ name, value: [] })
   }
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -222,6 +222,10 @@
     "contextualize": "Contextualize",
     "exclude": "Exclude"
   },
+  "filtersPanelSectionFilterEntry": {
+    "lock": "Lock this filter value",
+    "unlock": "Unlock this filter value"
+  },
   "filtersPanelSectionFilterTitleToggler": {
     "toggle": "Toggle filter"
   },

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -222,6 +222,10 @@
     "contextualize": "Contextualiser",
     "exclude": "Exclure"
   },
+  "filtersPanelSectionFilterEntry": {
+    "lock": "Verrouiller cette valeur de filtre",
+    "unlock": "Déverrouiller cette valeur de filtre"
+  },
   "filtersPanelSectionFilterTitleToggler": {
     "toggle": "Filtres"
   },

--- a/src/store/modules/lockedFilters.js
+++ b/src/store/modules/lockedFilters.js
@@ -3,6 +3,31 @@ import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 
 /**
+ * Convert a bare filter name plus its current exclude state into the
+ * `-`-prefixed name convention used by locked filter entries (and by route
+ * params: `f[name]` / `f[-name]`).
+ *
+ * @param {string} name - The bare filter name (no `-` prefix).
+ * @param {boolean} excluded - Whether the filter is currently in exclude mode.
+ * @returns {string}
+ */
+export function toLockedName(name, excluded) {
+  return excluded ? `-${name}` : name
+}
+
+/**
+ * Parse a lock entry's `-`-prefixed name back into its bare name and
+ * exclude state.
+ *
+ * @param {string} lockedName - The name as stored on a lock entry.
+ * @returns {{ name: string, excluded: boolean }}
+ */
+export function parseLockedName(lockedName) {
+  const excluded = lockedName.startsWith('-')
+  return { name: excluded ? lockedName.slice(1) : lockedName, excluded }
+}
+
+/**
  * Store for managing the user's personal, cross-project locked filters.
  *
  * A lock entry is `{ name, value, label }`. `name` already carries the

--- a/src/store/modules/lockedFilters.js
+++ b/src/store/modules/lockedFilters.js
@@ -45,19 +45,24 @@ export const useLockedFiltersStore = defineStore('lockedFilters', () => {
    */
   const entries = ref([])
 
+  function entryKey(name, value) {
+    return `${name}\0${toString(value)}`
+  }
+
   /**
-   * Find the index of a lock entry matching `{ name, value }`.
+   * Maps an entry's `name`+`value` key to its index in `entries`, rebuilt
+   * whenever `entries` changes. `isLocked` is called once per rendered
+   * filter row on every re-render, so this trades an O(n) rebuild per
+   * mutation (lock/unlock, infrequent) for O(1) lookups per render (frequent)
+   * instead of an O(n) `findIndex` scan on every single one.
    *
    * @private
-   * @param {Object} params
-   * @param {string} params.name - The filter name (may carry a `-` prefix).
-   * @param {string|number} params.value - The filter value.
-   * @returns {number} The entry's index, or -1 if not locked.
    */
-  function findIndex({ name, value }) {
-    const stringValue = toString(value)
-    return entries.value.findIndex(entry => entry.name === name && entry.value === stringValue)
-  }
+  const indexByKey = computed(() => {
+    const map = new Map()
+    entries.value.forEach((entry, i) => map.set(entryKey(entry.name, entry.value), i))
+    return map
+  })
 
   /**
    * Check whether a given filter value is currently locked.
@@ -69,7 +74,7 @@ export const useLockedFiltersStore = defineStore('lockedFilters', () => {
    * @returns {boolean}
    */
   function isLocked({ name, value }) {
-    return findIndex({ name, value }) > -1
+    return indexByKey.value.has(entryKey(name, value))
   }
 
   /**
@@ -84,9 +89,9 @@ export const useLockedFiltersStore = defineStore('lockedFilters', () => {
    */
   function lock({ name, value, label }) {
     const stringValue = toString(value)
-    const index = findIndex({ name, value: stringValue })
+    const index = indexByKey.value.get(entryKey(name, stringValue))
     const entry = { name, value: stringValue, label }
-    if (index > -1) {
+    if (index !== undefined) {
       entries.value[index] = entry
     }
     else {
@@ -103,10 +108,22 @@ export const useLockedFiltersStore = defineStore('lockedFilters', () => {
    * @param {string|number} params.value - The filter value.
    */
   function unlock({ name, value }) {
-    const index = findIndex({ name, value })
-    if (index > -1) {
+    const index = indexByKey.value.get(entryKey(name, value))
+    if (index !== undefined) {
       entries.value.splice(index, 1)
     }
+  }
+
+  /**
+   * Unlock every locked entry matching `predicate`, in a single pass rather
+   * than filtering then unlocking each match one at a time (which would
+   * re-scan/re-splice `entries` once per match).
+   *
+   * @public
+   * @param {(entry: { name: string, value: string, label: string }) => boolean} predicate
+   */
+  function unlockWhere(predicate) {
+    entries.value = entries.value.filter(entry => !predicate(entry))
   }
 
   /**
@@ -129,6 +146,7 @@ export const useLockedFiltersStore = defineStore('lockedFilters', () => {
     isLocked,
     lock,
     unlock,
+    unlockWhere,
     unlockAll
   }
 }, {

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -565,7 +565,7 @@ export const useSearchStore = defineSuffixedStore('search', () => {
    * Remove a filter by its name.
    *
    * The filter itself is going away, so unlock it under both include and
-   * exclude mode, not just whichever it's currently in — every caller
+   * exclude mode, not just whichever it's currently in. Every caller
    * (FiltersMixin's unregisterFilter, useSearchFilter's removeFilter) routes
    * through here, so fixing it here covers them all instead of duplicating
    * the unlock in each one.

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -578,9 +578,7 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     if (name in values.value) {
       delete values.value[name]
     }
-    lockedFiltersStore.entries
-      .filter(entry => parseLockedName(entry.name).name === name)
-      .forEach(entry => lockedFiltersStore.unlock(entry))
+    lockedFiltersStore.unlockWhere(entry => parseLockedName(entry.name).name === name)
   }
 
   /**

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -20,7 +20,8 @@ import EsDocList from '@/api/resources/EsDocList'
 import { runAsyncSearch } from '@/api/asyncSearch'
 import filterDefs, * as filterTypes from '@/store/filters'
 import { getPairedDimensions } from '@/store/filters/pairedDimensions'
-import { useAppStore, useSearchBreadcrumbStore } from '@/store/modules'
+import { useAppStore, useLockedFiltersStore, useSearchBreadcrumbStore } from '@/store/modules'
+import { parseLockedName } from '@/store/modules/lockedFilters'
 import { apiInstance as api } from '@/api/apiInstance'
 import { defineSuffixedStore } from '@/store/defineSuffixedStore'
 import { SEARCH_OPERATORS } from '@/enums/searchOperators'
@@ -53,6 +54,7 @@ export const useSearchStore = defineSuffixedStore('search', () => {
   const lastAppliedQuery = ref({})
 
   const appStore = useAppStore()
+  const lockedFiltersStore = useLockedFiltersStore()
   const searchBreadcrumbStore = useSearchBreadcrumbStore()
 
   const index = computed({
@@ -562,6 +564,12 @@ export const useSearchStore = defineSuffixedStore('search', () => {
   /**
    * Remove a filter by its name.
    *
+   * The filter itself is going away, so unlock it under both include and
+   * exclude mode, not just whichever it's currently in — every caller
+   * (FiltersMixin's unregisterFilter, useSearchFilter's removeFilter) routes
+   * through here, so fixing it here covers them all instead of duplicating
+   * the unlock in each one.
+   *
    * @param {string} name - The name of the filter to remove.
    */
   function removeFilter(name) {
@@ -570,6 +578,9 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     if (name in values.value) {
       delete values.value[name]
     }
+    lockedFiltersStore.entries
+      .filter(entry => parseLockedName(entry.name).name === name)
+      .forEach(entry => lockedFiltersStore.unlock(entry))
   }
 
   /**

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -21,7 +21,8 @@ import { isOpenSearchDistribution } from '@/api/indexDistribution'
 import { runAsyncSearch } from '@/api/asyncSearch'
 import filterDefs, * as filterTypes from '@/store/filters'
 import { getPairedDimensions } from '@/store/filters/pairedDimensions'
-import { useAppStore, useSearchBreadcrumbStore } from '@/store/modules'
+import { useAppStore, useLockedFiltersStore, useSearchBreadcrumbStore } from '@/store/modules'
+import { parseLockedName } from '@/store/modules/lockedFilters'
 import { apiInstance as api } from '@/api/apiInstance'
 import { defineSuffixedStore } from '@/store/defineSuffixedStore'
 import { SEARCH_OPERATORS } from '@/enums/searchOperators'
@@ -54,6 +55,7 @@ export const useSearchStore = defineSuffixedStore('search', () => {
   const lastAppliedQuery = ref({})
 
   const appStore = useAppStore()
+  const lockedFiltersStore = useLockedFiltersStore()
   const searchBreadcrumbStore = useSearchBreadcrumbStore()
 
   const index = computed({
@@ -563,6 +565,12 @@ export const useSearchStore = defineSuffixedStore('search', () => {
   /**
    * Remove a filter by its name.
    *
+   * The filter itself is going away, so unlock it under both include and
+   * exclude mode, not just whichever it's currently in — every caller
+   * (FiltersMixin's unregisterFilter, useSearchFilter's removeFilter) routes
+   * through here, so fixing it here covers them all instead of duplicating
+   * the unlock in each one.
+   *
    * @param {string} name - The name of the filter to remove.
    */
   function removeFilter(name) {
@@ -571,6 +579,9 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     if (name in values.value) {
       delete values.value[name]
     }
+    lockedFiltersStore.entries
+      .filter(entry => parseLockedName(entry.name).name === name)
+      .forEach(entry => lockedFiltersStore.unlock(entry))
   }
 
   /**

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -579,9 +579,7 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     if (name in values.value) {
       delete values.value[name]
     }
-    lockedFiltersStore.entries
-      .filter(entry => parseLockedName(entry.name).name === name)
-      .forEach(entry => lockedFiltersStore.unlock(entry))
+    lockedFiltersStore.unlockWhere(entry => parseLockedName(entry.name).name === name)
   }
 
   /**

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -566,7 +566,7 @@ export const useSearchStore = defineSuffixedStore('search', () => {
    * Remove a filter by its name.
    *
    * The filter itself is going away, so unlock it under both include and
-   * exclude mode, not just whichever it's currently in — every caller
+   * exclude mode, not just whichever it's currently in. Every caller
    * (FiltersMixin's unregisterFilter, useSearchFilter's removeFilter) routes
    * through here, so fixing it here covers them all instead of duplicating
    * the unlock in each one.

--- a/tests/unit/specs/components/Filter/FilterType/FilterType.spec.js
+++ b/tests/unit/specs/components/Filter/FilterType/FilterType.spec.js
@@ -10,7 +10,7 @@ import esConnectionHelper from '~tests/unit/specs/utils/esConnectionHelper'
 import FiltersPanelSectionFilterEntry from '@/components/FiltersPanel/FiltersPanelSectionFilterEntry'
 import FilterType from '@/components/Filter/FilterType/FilterType'
 import { useContentTypeCategoryAvailability } from '@/composables/useContentTypeCategoryAvailability'
-import { useSearchStore } from '@/store/modules'
+import { useSearchStore, useLockedFiltersStore } from '@/store/modules'
 import en from '@/lang/en.json'
 import fr from '@/lang/fr.json'
 
@@ -339,6 +339,99 @@ describe('FilterType.vue', () => {
 
         expect(wrapper.vm.count).toBe(3)
       })
+    })
+  })
+
+  describe('locked filters', () => {
+    let lockedFiltersStore
+
+    beforeEach(() => {
+      const name = 'contentType'
+      const filter = searchStore.getFilter({ name })
+
+      wrapper = shallowMount(FilterType, {
+        global: {
+          plugins: core.plugins,
+          renderStubDefaultSlot: true
+        },
+        props: {
+          filter
+        }
+      })
+
+      searchStore.decontextualizeFilter(name)
+      searchStore.setIndex(index)
+      searchStore.reset()
+      searchStore.resetFilters()
+      lockedFiltersStore = useLockedFiltersStore()
+    })
+
+    it('reports a ticked value as unlocked by default', async () => {
+      await letData(es).have(new IndexedDocument('document_01', index).withContentType('application/pdf')).commit()
+      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
+
+      await wrapper.vm.aggregateOver()
+
+      expect(wrapper.findComponent(FiltersPanelSectionFilterEntry).props('locked')).toBe(false)
+    })
+
+    it('locks a value when the entry emits update:locked with true', async () => {
+      await letData(es).have(new IndexedDocument('document_01', index).withContentType('application/pdf')).commit()
+      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
+
+      await wrapper.vm.aggregateOver()
+      await wrapper.findComponent(FiltersPanelSectionFilterEntry).vm.$emit('update:locked', true)
+
+      expect(lockedFiltersStore.isLocked({ name: 'contentType', value: 'application/pdf' })).toBe(true)
+      expect(wrapper.findComponent(FiltersPanelSectionFilterEntry).props('locked')).toBe(true)
+    })
+
+    it('unlocks a value when the entry emits update:locked with false', async () => {
+      await letData(es).have(new IndexedDocument('document_01', index).withContentType('application/pdf')).commit()
+      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'PDF' })
+
+      await wrapper.vm.aggregateOver()
+      await wrapper.findComponent(FiltersPanelSectionFilterEntry).vm.$emit('update:locked', false)
+
+      expect(lockedFiltersStore.isLocked({ name: 'contentType', value: 'application/pdf' })).toBe(false)
+    })
+
+    it('locks under the "-" prefixed name when the filter is currently excluded', async () => {
+      await letData(es).have(new IndexedDocument('document_01', index).withContentType('application/pdf')).commit()
+      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
+      searchStore.excludeFilter('contentType')
+
+      await wrapper.vm.aggregateOver()
+      await wrapper.findComponent(FiltersPanelSectionFilterEntry).vm.$emit('update:locked', true)
+
+      expect(lockedFiltersStore.isLocked({ name: '-contentType', value: 'application/pdf' })).toBe(true)
+      expect(lockedFiltersStore.isLocked({ name: 'contentType', value: 'application/pdf' })).toBe(false)
+    })
+
+    it('removes the lock when the value is unticked', async () => {
+      await letData(es).have(new IndexedDocument('document_01', index).withContentType('application/pdf')).commit()
+      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'PDF' })
+
+      await wrapper.vm.aggregateOver()
+      await wrapper.findComponent(FiltersPanelSectionFilterEntry).vm.$emit('update:model-value', false)
+
+      expect(lockedFiltersStore.isLocked({ name: 'contentType', value: 'application/pdf' })).toBe(false)
+    })
+
+    it('still renders a locked value with no matching aggregation bucket, at zero count', async () => {
+      // No document with this contentType exists — simulates a deleted/re-indexed value.
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/removed', label: 'Removed Type' })
+
+      await wrapper.vm.aggregateOver()
+
+      const entry = wrapper.findAllComponents(FiltersPanelSectionFilterEntry).find(
+        w => w.props('label') === 'Removed Type'
+      )
+      expect(entry).toBeTruthy()
+      expect(entry.props('count')).toBe(0)
+      expect(entry.props('locked')).toBe(true)
     })
   })
 

--- a/tests/unit/specs/components/Filter/FilterType/FilterType.spec.js
+++ b/tests/unit/specs/components/Filter/FilterType/FilterType.spec.js
@@ -342,11 +342,17 @@ describe('FilterType.vue', () => {
     })
   })
 
+  // NOTE: this suite uses the `language` filter (rather than `contentType`)
+  // because `contentType` is rendered via FilterTypeFileTypes, which overrides
+  // FilterType's default slot entirely and does not (yet) receive lock/unlock
+  // bindings. `language` uses FilterType's own default slot unmodified, which
+  // is the only case lock/unlock support covers today — see the TODO above
+  // `lockedName` in FilterType.vue.
   describe('locked filters', () => {
     let lockedFiltersStore
 
     beforeEach(() => {
-      const name = 'contentType'
+      const name = 'language'
       const filter = searchStore.getFilter({ name })
 
       wrapper = shallowMount(FilterType, {
@@ -367,8 +373,8 @@ describe('FilterType.vue', () => {
     })
 
     it('reports a ticked value as unlocked by default', async () => {
-      await letData(es).have(new IndexedDocument('document_01', index).withContentType('application/pdf')).commit()
-      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
+      await letData(es).have(new IndexedDocument('document_01', index).withLanguage('ENGLISH')).commit()
+      searchStore.addFilterValue({ name: 'language', value: 'ENGLISH' })
 
       await wrapper.vm.aggregateOver()
 
@@ -376,58 +382,58 @@ describe('FilterType.vue', () => {
     })
 
     it('locks a value when the entry emits update:locked with true', async () => {
-      await letData(es).have(new IndexedDocument('document_01', index).withContentType('application/pdf')).commit()
-      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
+      await letData(es).have(new IndexedDocument('document_01', index).withLanguage('ENGLISH')).commit()
+      searchStore.addFilterValue({ name: 'language', value: 'ENGLISH' })
 
       await wrapper.vm.aggregateOver()
       await wrapper.findComponent(FiltersPanelSectionFilterEntry).vm.$emit('update:locked', true)
 
-      expect(lockedFiltersStore.isLocked({ name: 'contentType', value: 'application/pdf' })).toBe(true)
+      expect(lockedFiltersStore.isLocked({ name: 'language', value: 'ENGLISH' })).toBe(true)
       expect(wrapper.findComponent(FiltersPanelSectionFilterEntry).props('locked')).toBe(true)
     })
 
     it('unlocks a value when the entry emits update:locked with false', async () => {
-      await letData(es).have(new IndexedDocument('document_01', index).withContentType('application/pdf')).commit()
-      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
-      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'PDF' })
+      await letData(es).have(new IndexedDocument('document_01', index).withLanguage('ENGLISH')).commit()
+      searchStore.addFilterValue({ name: 'language', value: 'ENGLISH' })
+      lockedFiltersStore.lock({ name: 'language', value: 'ENGLISH', label: 'English' })
 
       await wrapper.vm.aggregateOver()
       await wrapper.findComponent(FiltersPanelSectionFilterEntry).vm.$emit('update:locked', false)
 
-      expect(lockedFiltersStore.isLocked({ name: 'contentType', value: 'application/pdf' })).toBe(false)
+      expect(lockedFiltersStore.isLocked({ name: 'language', value: 'ENGLISH' })).toBe(false)
     })
 
     it('locks under the "-" prefixed name when the filter is currently excluded', async () => {
-      await letData(es).have(new IndexedDocument('document_01', index).withContentType('application/pdf')).commit()
-      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
-      searchStore.excludeFilter('contentType')
+      await letData(es).have(new IndexedDocument('document_01', index).withLanguage('ENGLISH')).commit()
+      searchStore.addFilterValue({ name: 'language', value: 'ENGLISH' })
+      searchStore.excludeFilter('language')
 
       await wrapper.vm.aggregateOver()
       await wrapper.findComponent(FiltersPanelSectionFilterEntry).vm.$emit('update:locked', true)
 
-      expect(lockedFiltersStore.isLocked({ name: '-contentType', value: 'application/pdf' })).toBe(true)
-      expect(lockedFiltersStore.isLocked({ name: 'contentType', value: 'application/pdf' })).toBe(false)
+      expect(lockedFiltersStore.isLocked({ name: '-language', value: 'ENGLISH' })).toBe(true)
+      expect(lockedFiltersStore.isLocked({ name: 'language', value: 'ENGLISH' })).toBe(false)
     })
 
     it('removes the lock when the value is unticked', async () => {
-      await letData(es).have(new IndexedDocument('document_01', index).withContentType('application/pdf')).commit()
-      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
-      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'PDF' })
+      await letData(es).have(new IndexedDocument('document_01', index).withLanguage('ENGLISH')).commit()
+      searchStore.addFilterValue({ name: 'language', value: 'ENGLISH' })
+      lockedFiltersStore.lock({ name: 'language', value: 'ENGLISH', label: 'English' })
 
       await wrapper.vm.aggregateOver()
       await wrapper.findComponent(FiltersPanelSectionFilterEntry).vm.$emit('update:model-value', false)
 
-      expect(lockedFiltersStore.isLocked({ name: 'contentType', value: 'application/pdf' })).toBe(false)
+      expect(lockedFiltersStore.isLocked({ name: 'language', value: 'ENGLISH' })).toBe(false)
     })
 
     it('still renders a locked value with no matching aggregation bucket, at zero count', async () => {
-      // No document with this contentType exists — simulates a deleted/re-indexed value.
-      lockedFiltersStore.lock({ name: 'contentType', value: 'application/removed', label: 'Removed Type' })
+      // No document with this language exists — simulates a deleted/re-indexed value.
+      lockedFiltersStore.lock({ name: 'language', value: 'KLINGON', label: 'Removed Language' })
 
       await wrapper.vm.aggregateOver()
 
       const entry = wrapper.findAllComponents(FiltersPanelSectionFilterEntry).find(
-        w => w.props('label') === 'Removed Type'
+        w => w.props('label') === 'Removed Language'
       )
       expect(entry).toBeTruthy()
       expect(entry.props('count')).toBe(0)
@@ -435,31 +441,31 @@ describe('FilterType.vue', () => {
     })
 
     it('drops the synthetic locked-but-missing entry once it is unlocked', async () => {
-      lockedFiltersStore.lock({ name: 'contentType', value: 'application/removed', label: 'Removed Type' })
+      lockedFiltersStore.lock({ name: 'language', value: 'KLINGON', label: 'Removed Language' })
       await wrapper.vm.aggregateOver()
-      expect(wrapper.vm.entries.some(({ label }) => label === 'Removed Type')).toBe(true)
+      expect(wrapper.vm.entries.some(({ label }) => label === 'Removed Language')).toBe(true)
 
-      lockedFiltersStore.unlock({ name: 'contentType', value: 'application/removed' })
+      lockedFiltersStore.unlock({ name: 'language', value: 'KLINGON' })
       await wrapper.vm.aggregateOver()
 
-      expect(wrapper.vm.entries.some(({ label }) => label === 'Removed Type')).toBe(false)
+      expect(wrapper.vm.entries.some(({ label }) => label === 'Removed Language')).toBe(false)
       expect(
-        wrapper.findAllComponents(FiltersPanelSectionFilterEntry).some(w => w.props('label') === 'Removed Type')
+        wrapper.findAllComponents(FiltersPanelSectionFilterEntry).some(w => w.props('label') === 'Removed Language')
       ).toBe(false)
     })
 
     it('renders a ticked+excluded+locked value only once, even with no matching aggregation bucket', async () => {
-      // No document indexed with this contentType — it is "missing" from both
+      // No document indexed with this language — it is "missing" from both
       // excludedBucketsPage (ticked+excluded synthesis) and, absent dedup,
       // missingLockedBucketsPage (locked-but-missing synthesis) at once.
-      searchStore.contextualizeFilter('contentType')
-      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
-      searchStore.excludeFilter('contentType')
-      lockedFiltersStore.lock({ name: '-contentType', value: 'application/pdf', label: 'PDF' })
+      searchStore.contextualizeFilter('language')
+      searchStore.addFilterValue({ name: 'language', value: 'ENGLISH' })
+      searchStore.excludeFilter('language')
+      lockedFiltersStore.lock({ name: '-language', value: 'ENGLISH', label: 'English' })
 
       await wrapper.vm.aggregateOver()
 
-      const matches = wrapper.vm.entries.filter(({ value }) => value === 'application/pdf')
+      const matches = wrapper.vm.entries.filter(({ value }) => value === 'ENGLISH')
       expect(matches).toHaveLength(1)
     })
   })

--- a/tests/unit/specs/components/Filter/FilterType/FilterType.spec.js
+++ b/tests/unit/specs/components/Filter/FilterType/FilterType.spec.js
@@ -433,6 +433,35 @@ describe('FilterType.vue', () => {
       expect(entry.props('count')).toBe(0)
       expect(entry.props('locked')).toBe(true)
     })
+
+    it('drops the synthetic locked-but-missing entry once it is unlocked', async () => {
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/removed', label: 'Removed Type' })
+      await wrapper.vm.aggregateOver()
+      expect(wrapper.vm.entries.some(({ label }) => label === 'Removed Type')).toBe(true)
+
+      lockedFiltersStore.unlock({ name: 'contentType', value: 'application/removed' })
+      await wrapper.vm.aggregateOver()
+
+      expect(wrapper.vm.entries.some(({ label }) => label === 'Removed Type')).toBe(false)
+      expect(
+        wrapper.findAllComponents(FiltersPanelSectionFilterEntry).some(w => w.props('label') === 'Removed Type')
+      ).toBe(false)
+    })
+
+    it('renders a ticked+excluded+locked value only once, even with no matching aggregation bucket', async () => {
+      // No document indexed with this contentType — it is "missing" from both
+      // excludedBucketsPage (ticked+excluded synthesis) and, absent dedup,
+      // missingLockedBucketsPage (locked-but-missing synthesis) at once.
+      searchStore.contextualizeFilter('contentType')
+      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
+      searchStore.excludeFilter('contentType')
+      lockedFiltersStore.lock({ name: '-contentType', value: 'application/pdf', label: 'PDF' })
+
+      await wrapper.vm.aggregateOver()
+
+      const matches = wrapper.vm.entries.filter(({ value }) => value === 'application/pdf')
+      expect(matches).toHaveLength(1)
+    })
   })
 
   describe('language', () => {

--- a/tests/unit/specs/components/Filter/FilterType/FilterType.spec.js
+++ b/tests/unit/specs/components/Filter/FilterType/FilterType.spec.js
@@ -426,7 +426,7 @@ describe('FilterType.vue', () => {
       expect(lockedFiltersStore.isLocked({ name: 'language', value: 'ENGLISH' })).toBe(false)
     })
 
-    it('still renders a locked value with no matching aggregation bucket, at zero count', async () => {
+    it('still renders a locked value with no matching aggregation bucket, at a NaN count', async () => {
       // No document with this language exists — simulates a deleted/re-indexed value.
       lockedFiltersStore.lock({ name: 'language', value: 'KLINGON', label: 'Removed Language' })
 
@@ -436,7 +436,7 @@ describe('FilterType.vue', () => {
         w => w.props('label') === 'Removed Language'
       )
       expect(entry).toBeTruthy()
-      expect(entry.props('count')).toBe(0)
+      expect(entry.props('count')).toBeNaN()
       expect(entry.props('locked')).toBe(true)
     })
 

--- a/tests/unit/specs/components/Filter/FilterType/FilterType.spec.js
+++ b/tests/unit/specs/components/Filter/FilterType/FilterType.spec.js
@@ -440,6 +440,19 @@ describe('FilterType.vue', () => {
       expect(entry.props('locked')).toBe(true)
     })
 
+    it('does not synthesize a locked-but-missing entry while the search box is active', async () => {
+      // No document with this language exists — simulates a deleted/re-indexed value.
+      lockedFiltersStore.lock({ name: 'language', value: 'KLINGON', label: 'Removed Language' })
+
+      await wrapper.vm.aggregateOver()
+      expect(wrapper.vm.entries.some(({ label }) => label === 'Removed Language')).toBe(true)
+
+      await wrapper.setProps({ query: 'engl' })
+      await wrapper.vm.aggregateOver()
+
+      expect(wrapper.vm.entries.some(({ label }) => label === 'Removed Language')).toBe(false)
+    })
+
     it('drops the synthetic locked-but-missing entry once it is unlocked', async () => {
       lockedFiltersStore.lock({ name: 'language', value: 'KLINGON', label: 'Removed Language' })
       await wrapper.vm.aggregateOver()

--- a/tests/unit/specs/components/FiltersPanel/FiltersPanelSectionFilterEntry.spec.js
+++ b/tests/unit/specs/components/FiltersPanel/FiltersPanelSectionFilterEntry.spec.js
@@ -36,6 +36,28 @@ describe('FiltersPanelSectionFilterEntry.vue', () => {
     expect(button.attributes('aria-pressed')).toBe('true')
   })
 
+  it('still renders a lock button when the row is unticked but locked', () => {
+    const props = { label: 'Confidential', modelValue: false, locked: true }
+    const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
+    expect(findLockButton(wrapper).exists()).toBe(true)
+  })
+
+  it('uses a different accessible label when unlocked vs locked', () => {
+    const unlockedWrapper = mount(FiltersPanelSectionFilterEntry, {
+      global,
+      props: { label: 'Confidential', modelValue: true, locked: false }
+    })
+    const lockedWrapper = mount(FiltersPanelSectionFilterEntry, {
+      global,
+      props: { label: 'Confidential', modelValue: true, locked: true }
+    })
+    const unlockedLabel = findLockButton(unlockedWrapper).attributes('aria-label')
+    const lockedLabel = findLockButton(lockedWrapper).attributes('aria-label')
+    expect(unlockedLabel).toBe('Lock this filter value')
+    expect(lockedLabel).toBe('Unlock this filter value')
+    expect(unlockedLabel).not.toBe(lockedLabel)
+  })
+
   it('emits update:locked with true when clicking an unlocked button', async () => {
     const props = { label: 'Confidential', modelValue: true, locked: false }
     const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
@@ -56,9 +78,21 @@ describe('FiltersPanelSectionFilterEntry.vue', () => {
     expect(wrapper.find('.filters-panel-section-filter-entry__count').exists()).toBe(false)
   })
 
-  it('shows the count badge while ticked but not locked', () => {
+  it('hides the count badge while ticked, even when not locked, since the lock button takes its place', () => {
     const props = { label: 'Confidential', modelValue: true, locked: false, count: 5 }
     const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
+    expect(wrapper.find('.filters-panel-section-filter-entry__count').exists()).toBe(false)
+  })
+
+  it('shows the count badge while unticked and unlocked', () => {
+    const props = { label: 'Confidential', modelValue: false, locked: false, count: 5 }
+    const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
     expect(wrapper.find('.filters-panel-section-filter-entry__count').exists()).toBe(true)
+  })
+
+  it('hides the count badge while unticked but locked', () => {
+    const props = { label: 'Confidential', modelValue: false, locked: true, count: 5 }
+    const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
+    expect(wrapper.find('.filters-panel-section-filter-entry__count').exists()).toBe(false)
   })
 })

--- a/tests/unit/specs/components/FiltersPanel/FiltersPanelSectionFilterEntry.spec.js
+++ b/tests/unit/specs/components/FiltersPanel/FiltersPanelSectionFilterEntry.spec.js
@@ -1,0 +1,64 @@
+import { mount } from '@vue/test-utils'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import FiltersPanelSectionFilterEntry from '@/components/FiltersPanel/FiltersPanelSectionFilterEntry'
+
+describe('FiltersPanelSectionFilterEntry.vue', () => {
+  let global
+
+  beforeEach(() => {
+    const core = CoreSetup.init().useAll()
+    global = { plugins: core.plugins }
+  })
+
+  function findLockButton(wrapper) {
+    return wrapper.find('.filters-panel-section-filter-entry__lock')
+  }
+
+  it('does not render a lock button when the row is unticked', () => {
+    const props = { label: 'Confidential', modelValue: false, locked: false }
+    const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
+    expect(findLockButton(wrapper).exists()).toBe(false)
+  })
+
+  it('renders an unlocked lock button when the row is ticked', () => {
+    const props = { label: 'Confidential', modelValue: true, locked: false }
+    const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
+    const button = findLockButton(wrapper)
+    expect(button.exists()).toBe(true)
+    expect(button.attributes('aria-pressed')).toBe('false')
+  })
+
+  it('renders a locked lock button when the row is ticked and locked', () => {
+    const props = { label: 'Confidential', modelValue: true, locked: true }
+    const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
+    const button = findLockButton(wrapper)
+    expect(button.attributes('aria-pressed')).toBe('true')
+  })
+
+  it('emits update:locked with true when clicking an unlocked button', async () => {
+    const props = { label: 'Confidential', modelValue: true, locked: false }
+    const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
+    await findLockButton(wrapper).trigger('click')
+    expect(wrapper.emitted('update:locked')).toEqual([[true]])
+  })
+
+  it('emits update:locked with false when clicking a locked button', async () => {
+    const props = { label: 'Confidential', modelValue: true, locked: true }
+    const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
+    await findLockButton(wrapper).trigger('click')
+    expect(wrapper.emitted('update:locked')).toEqual([[false]])
+  })
+
+  it('hides the count badge while the row is locked', () => {
+    const props = { label: 'Confidential', modelValue: true, locked: true, count: 5 }
+    const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
+    expect(wrapper.find('.filters-panel-section-filter-entry__count').exists()).toBe(false)
+  })
+
+  it('shows the count badge while ticked but not locked', () => {
+    const props = { label: 'Confidential', modelValue: true, locked: false, count: 5 }
+    const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
+    expect(wrapper.find('.filters-panel-section-filter-entry__count').exists()).toBe(true)
+  })
+})

--- a/tests/unit/specs/components/FiltersPanel/FiltersPanelSectionFilterEntry.spec.js
+++ b/tests/unit/specs/components/FiltersPanel/FiltersPanelSectionFilterEntry.spec.js
@@ -78,10 +78,10 @@ describe('FiltersPanelSectionFilterEntry.vue', () => {
     expect(wrapper.find('.filters-panel-section-filter-entry__count').exists()).toBe(false)
   })
 
-  it('hides the count badge while ticked, even when not locked, since the lock button takes its place', () => {
+  it('shows the count badge while ticked but not locked', () => {
     const props = { label: 'Confidential', modelValue: true, locked: false, count: 5 }
     const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
-    expect(wrapper.find('.filters-panel-section-filter-entry__count').exists()).toBe(false)
+    expect(wrapper.find('.filters-panel-section-filter-entry__count').exists()).toBe(true)
   })
 
   it('shows the count badge while unticked and unlocked', () => {

--- a/tests/unit/specs/components/FiltersPanel/FiltersPanelSectionFilterEntry.spec.js
+++ b/tests/unit/specs/components/FiltersPanel/FiltersPanelSectionFilterEntry.spec.js
@@ -16,28 +16,34 @@ describe('FiltersPanelSectionFilterEntry.vue', () => {
   }
 
   it('does not render a lock button when the row is unticked', () => {
-    const props = { label: 'Confidential', modelValue: false, locked: false }
+    const props = { label: 'Confidential', modelValue: false, locked: false, lockable: true }
     const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
     expect(findLockButton(wrapper).exists()).toBe(false)
   })
 
-  it('renders an unlocked lock button when the row is ticked', () => {
-    const props = { label: 'Confidential', modelValue: true, locked: false }
+  it('does not render a lock button when the row is not lockable, even ticked and locked', () => {
+    const props = { label: 'Confidential', modelValue: true, locked: true, lockable: false }
+    const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
+    expect(findLockButton(wrapper).exists()).toBe(false)
+  })
+
+  it('renders an unlocked lock button when the row is ticked and lockable', () => {
+    const props = { label: 'Confidential', modelValue: true, locked: false, lockable: true }
     const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
     const button = findLockButton(wrapper)
     expect(button.exists()).toBe(true)
     expect(button.attributes('aria-pressed')).toBe('false')
   })
 
-  it('renders a locked lock button when the row is ticked and locked', () => {
-    const props = { label: 'Confidential', modelValue: true, locked: true }
+  it('renders a locked lock button when the row is ticked, lockable and locked', () => {
+    const props = { label: 'Confidential', modelValue: true, locked: true, lockable: true }
     const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
     const button = findLockButton(wrapper)
     expect(button.attributes('aria-pressed')).toBe('true')
   })
 
-  it('still renders a lock button when the row is unticked but locked', () => {
-    const props = { label: 'Confidential', modelValue: false, locked: true }
+  it('still renders a lock button when the row is unticked but locked and lockable', () => {
+    const props = { label: 'Confidential', modelValue: false, locked: true, lockable: true }
     const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
     expect(findLockButton(wrapper).exists()).toBe(true)
   })
@@ -45,11 +51,11 @@ describe('FiltersPanelSectionFilterEntry.vue', () => {
   it('uses a different accessible label when unlocked vs locked', () => {
     const unlockedWrapper = mount(FiltersPanelSectionFilterEntry, {
       global,
-      props: { label: 'Confidential', modelValue: true, locked: false }
+      props: { label: 'Confidential', modelValue: true, locked: false, lockable: true }
     })
     const lockedWrapper = mount(FiltersPanelSectionFilterEntry, {
       global,
-      props: { label: 'Confidential', modelValue: true, locked: true }
+      props: { label: 'Confidential', modelValue: true, locked: true, lockable: true }
     })
     const unlockedLabel = findLockButton(unlockedWrapper).attributes('aria-label')
     const lockedLabel = findLockButton(lockedWrapper).attributes('aria-label')
@@ -59,21 +65,21 @@ describe('FiltersPanelSectionFilterEntry.vue', () => {
   })
 
   it('emits update:locked with true when clicking an unlocked button', async () => {
-    const props = { label: 'Confidential', modelValue: true, locked: false }
+    const props = { label: 'Confidential', modelValue: true, locked: false, lockable: true }
     const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
     await findLockButton(wrapper).trigger('click')
     expect(wrapper.emitted('update:locked')).toEqual([[true]])
   })
 
   it('emits update:locked with false when clicking a locked button', async () => {
-    const props = { label: 'Confidential', modelValue: true, locked: true }
+    const props = { label: 'Confidential', modelValue: true, locked: true, lockable: true }
     const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
     await findLockButton(wrapper).trigger('click')
     expect(wrapper.emitted('update:locked')).toEqual([[false]])
   })
 
   it('hides the count badge while the row is locked', () => {
-    const props = { label: 'Confidential', modelValue: true, locked: true, count: 5 }
+    const props = { label: 'Confidential', modelValue: true, locked: true, lockable: true, count: 5 }
     const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
     expect(wrapper.find('.filters-panel-section-filter-entry__count').exists()).toBe(false)
   })
@@ -91,7 +97,7 @@ describe('FiltersPanelSectionFilterEntry.vue', () => {
   })
 
   it('hides the count badge while unticked but locked', () => {
-    const props = { label: 'Confidential', modelValue: false, locked: true, count: 5 }
+    const props = { label: 'Confidential', modelValue: false, locked: true, lockable: true, count: 5 }
     const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
     expect(wrapper.find('.filters-panel-section-filter-entry__count').exists()).toBe(false)
   })

--- a/tests/unit/specs/components/FiltersPanel/FiltersPanelSectionFilterEntry.spec.js
+++ b/tests/unit/specs/components/FiltersPanel/FiltersPanelSectionFilterEntry.spec.js
@@ -78,10 +78,10 @@ describe('FiltersPanelSectionFilterEntry.vue', () => {
     expect(wrapper.emitted('update:locked')).toEqual([[false]])
   })
 
-  it('hides the count badge while the row is locked', () => {
+  it('shows the count badge for a locked row with a real count', () => {
     const props = { label: 'Confidential', modelValue: true, locked: true, lockable: true, count: 5 }
     const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
-    expect(wrapper.find('.filters-panel-section-filter-entry__count').exists()).toBe(false)
+    expect(wrapper.find('.filters-panel-section-filter-entry__count').exists()).toBe(true)
   })
 
   it('shows the count badge while ticked but not locked', () => {
@@ -96,8 +96,8 @@ describe('FiltersPanelSectionFilterEntry.vue', () => {
     expect(wrapper.find('.filters-panel-section-filter-entry__count').exists()).toBe(true)
   })
 
-  it('hides the count badge while unticked but locked', () => {
-    const props = { label: 'Confidential', modelValue: false, locked: true, lockable: true, count: 5 }
+  it('hides the count badge for a synthesized (NaN count) locked row', () => {
+    const props = { label: 'Confidential', modelValue: false, locked: true, lockable: true, count: NaN }
     const wrapper = mount(FiltersPanelSectionFilterEntry, { global, props })
     expect(wrapper.find('.filters-panel-section-filter-entry__count').exists()).toBe(false)
   })

--- a/tests/unit/specs/composables/useSearchFilter.spec.js
+++ b/tests/unit/specs/composables/useSearchFilter.spec.js
@@ -6,7 +6,7 @@ import { vi } from 'vitest'
 import CoreSetup from '~tests/unit/CoreSetup'
 import { useSearchFilter } from '@/composables/useSearchFilter'
 import { useContentTypeCategoryAvailability } from '@/composables/useContentTypeCategoryAvailability'
-import { useAppStore, useSearchStore, useRecommendedStore } from '@/store/modules'
+import { useAppStore, useLockedFiltersStore, useSearchStore, useRecommendedStore } from '@/store/modules'
 import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 import { MODE_NAME } from '@/mode'
 
@@ -851,6 +851,58 @@ describe('useSearchFilter composable', () => {
         // category value alone must not flip the contentType "All" off.
         expect(all.value).toBe(true)
       })
+    })
+  })
+
+  describe('unlocking locked filter values on removal', () => {
+    let lockedFiltersStore
+
+    beforeEach(() => {
+      lockedFiltersStore = useLockedFiltersStore()
+    })
+
+    it('unlocks a value when removeFilterValue removes it', () => {
+      const { addFilterValue, removeFilterValue } = mountComposable()
+      addFilterValue({ name: 'language' }, { key: 'en' })
+      lockedFiltersStore.lock({ name: 'language', value: 'en', label: 'English' })
+
+      removeFilterValue({ name: 'language' }, { key: 'en' })
+
+      expect(lockedFiltersStore.isLocked({ name: 'language', value: 'en' })).toBe(false)
+    })
+
+    it('locks/unlocks under the "-" prefixed name when the filter is excluded', () => {
+      const { addFilterValue, removeFilterValue, toggleExcludeFilter } = mountComposable()
+      addFilterValue({ name: 'language' }, { key: 'en' })
+      toggleExcludeFilter({ name: 'language' }, true)
+      lockedFiltersStore.lock({ name: '-language', value: 'en', label: 'English' })
+
+      removeFilterValue({ name: 'language' }, { key: 'en' })
+
+      expect(lockedFiltersStore.isLocked({ name: '-language', value: 'en' })).toBe(false)
+    })
+
+    it('unlocks every locked value for a filter when computedAll clears it (the "All" checkbox path)', () => {
+      const { computedAll, addFilterValue } = mountComposable()
+      addFilterValue({ name: 'language' }, { key: 'en' })
+      addFilterValue({ name: 'language' }, { key: 'fr' })
+      lockedFiltersStore.lock({ name: 'language', value: 'en', label: 'English' })
+      lockedFiltersStore.lock({ name: 'language', value: 'fr', label: 'French' })
+
+      const all = computedAll({ name: 'language' })
+      all.value = true
+
+      expect(lockedFiltersStore.isLocked({ name: 'language', value: 'en' })).toBe(false)
+      expect(lockedFiltersStore.isLocked({ name: 'language', value: 'fr' })).toBe(false)
+    })
+
+    it('leaves locks untouched when the store-level resetFilterValues is used directly (Story 4 needs locks to survive "Clear filters")', () => {
+      searchStore.addFilterValue({ name: 'language', value: 'en' })
+      lockedFiltersStore.lock({ name: 'language', value: 'en', label: 'English' })
+
+      searchStore.resetFilterValues()
+
+      expect(lockedFiltersStore.isLocked({ name: 'language', value: 'en' })).toBe(true)
     })
   })
 

--- a/tests/unit/specs/composables/useSearchFilter.spec.js
+++ b/tests/unit/specs/composables/useSearchFilter.spec.js
@@ -6,7 +6,7 @@ import { vi } from 'vitest'
 import CoreSetup from '~tests/unit/CoreSetup'
 import { useSearchFilter } from '@/composables/useSearchFilter'
 import { useContentTypeCategoryAvailability } from '@/composables/useContentTypeCategoryAvailability'
-import { useAppStore, useSearchStore, useRecommendedStore } from '@/store/modules'
+import { useAppStore, useLockedFiltersStore, useSearchStore, useRecommendedStore } from '@/store/modules'
 import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 import { MODE_NAME } from '@/mode'
 
@@ -876,6 +876,58 @@ describe('useSearchFilter composable', () => {
         // category value alone must not flip the contentType "All" off.
         expect(all.value).toBe(true)
       })
+    })
+  })
+
+  describe('unlocking locked filter values on removal', () => {
+    let lockedFiltersStore
+
+    beforeEach(() => {
+      lockedFiltersStore = useLockedFiltersStore()
+    })
+
+    it('unlocks a value when removeFilterValue removes it', () => {
+      const { addFilterValue, removeFilterValue } = mountComposable()
+      addFilterValue({ name: 'language' }, { key: 'en' })
+      lockedFiltersStore.lock({ name: 'language', value: 'en', label: 'English' })
+
+      removeFilterValue({ name: 'language' }, { key: 'en' })
+
+      expect(lockedFiltersStore.isLocked({ name: 'language', value: 'en' })).toBe(false)
+    })
+
+    it('locks/unlocks under the "-" prefixed name when the filter is excluded', () => {
+      const { addFilterValue, removeFilterValue, toggleExcludeFilter } = mountComposable()
+      addFilterValue({ name: 'language' }, { key: 'en' })
+      toggleExcludeFilter({ name: 'language' }, true)
+      lockedFiltersStore.lock({ name: '-language', value: 'en', label: 'English' })
+
+      removeFilterValue({ name: 'language' }, { key: 'en' })
+
+      expect(lockedFiltersStore.isLocked({ name: '-language', value: 'en' })).toBe(false)
+    })
+
+    it('unlocks every locked value for a filter when computedAll clears it (the "All" checkbox path)', () => {
+      const { computedAll, addFilterValue } = mountComposable()
+      addFilterValue({ name: 'language' }, { key: 'en' })
+      addFilterValue({ name: 'language' }, { key: 'fr' })
+      lockedFiltersStore.lock({ name: 'language', value: 'en', label: 'English' })
+      lockedFiltersStore.lock({ name: 'language', value: 'fr', label: 'French' })
+
+      const all = computedAll({ name: 'language' })
+      all.value = true
+
+      expect(lockedFiltersStore.isLocked({ name: 'language', value: 'en' })).toBe(false)
+      expect(lockedFiltersStore.isLocked({ name: 'language', value: 'fr' })).toBe(false)
+    })
+
+    it('leaves locks untouched when the store-level resetFilterValues is used directly (Story 4 needs locks to survive "Clear filters")', () => {
+      searchStore.addFilterValue({ name: 'language', value: 'en' })
+      lockedFiltersStore.lock({ name: 'language', value: 'en', label: 'English' })
+
+      searchStore.resetFilterValues()
+
+      expect(lockedFiltersStore.isLocked({ name: 'language', value: 'en' })).toBe(true)
     })
   })
 

--- a/tests/unit/specs/composables/useSearchFilter.spec.js
+++ b/tests/unit/specs/composables/useSearchFilter.spec.js
@@ -929,6 +929,16 @@ describe('useSearchFilter composable', () => {
 
       expect(lockedFiltersStore.isLocked({ name: 'language', value: 'en' })).toBe(true)
     })
+
+    it('exposes lockedNameFor as the single source for a filter lock store key', () => {
+      const { lockedNameFor, toggleExcludeFilter } = mountComposable()
+
+      expect(lockedNameFor({ name: 'language' })).toBe('language')
+
+      toggleExcludeFilter({ name: 'language' }, true)
+
+      expect(lockedNameFor({ name: 'language' })).toBe('-language')
+    })
   })
 
   describe('refreshSearch with recommendations gated to server mode', () => {

--- a/tests/unit/specs/store/modules/lockedFilters.spec.js
+++ b/tests/unit/specs/store/modules/lockedFilters.spec.js
@@ -80,4 +80,28 @@ describe('LockedFiltersStore', () => {
     store.lock({ name: 'contentType', value: 'application/pdf', label: 'PDF' })
     expect(store.count).toBe(2)
   })
+
+  describe('unlockWhere', () => {
+    it('unlocks every entry matching the predicate, leaving the rest', () => {
+      store.lock({ name: 'tag', value: 'confidential', label: 'Confidential' })
+      store.lock({ name: 'tag', value: 'secret', label: 'Secret' })
+      store.lock({ name: '-tag', value: 'confidential', label: 'Confidential' })
+      store.lock({ name: 'contentType', value: 'application/pdf', label: 'PDF' })
+
+      store.unlockWhere(entry => entry.name === 'tag')
+
+      expect(store.entries).toEqual([
+        { name: '-tag', value: 'confidential', label: 'Confidential' },
+        { name: 'contentType', value: 'application/pdf', label: 'PDF' }
+      ])
+    })
+
+    it('does nothing when no entry matches the predicate', () => {
+      store.lock({ name: 'tag', value: 'confidential', label: 'Confidential' })
+
+      store.unlockWhere(entry => entry.name === 'notAFilter')
+
+      expect(store.entries).toHaveLength(1)
+    })
+  })
 })

--- a/tests/unit/specs/store/modules/search.spec.js
+++ b/tests/unit/specs/store/modules/search.spec.js
@@ -8,7 +8,7 @@ import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 import Document from '@/api/resources/Document'
 import EsDocList from '@/api/resources/EsDocList'
 import NamedEntity from '@/api/resources/NamedEntity'
-import { useAppStore, useSearchStore } from '@/store/modules'
+import { useAppStore, useLockedFiltersStore, useSearchStore } from '@/store/modules'
 import { apiInstance as api } from '@/api/apiInstance'
 
 describe('SearchStore', () => {
@@ -1038,6 +1038,17 @@ describe('SearchStore', () => {
       expect(searchStore.getFilter({ name: 'contentType' })).toBeUndefined()
       searchStore.resetFilters()
       expect(searchStore.getFilter({ name: 'contentType' })).toBeDefined()
+    })
+
+    it('should unlock every entry (include or exclude mode) locked on a removed filter', () => {
+      const lockedFiltersStore = useLockedFiltersStore()
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'application/pdf' })
+      lockedFiltersStore.lock({ name: '-contentType', value: 'text/plain', label: 'text/plain' })
+      lockedFiltersStore.lock({ name: 'language', value: 'ENGLISH', label: 'English' })
+
+      searchStore.removeFilter('contentType')
+
+      expect(lockedFiltersStore.entries).toEqual([{ name: 'language', value: 'ENGLISH', label: 'English' }])
     })
 
     it('should define a "language" filter correctly (name, key and type)', () => {

--- a/tests/unit/specs/store/modules/search.spec.js
+++ b/tests/unit/specs/store/modules/search.spec.js
@@ -8,7 +8,7 @@ import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 import Document from '@/api/resources/Document'
 import EsDocList from '@/api/resources/EsDocList'
 import NamedEntity from '@/api/resources/NamedEntity'
-import { useAppStore, useSearchStore } from '@/store/modules'
+import { useAppStore, useLockedFiltersStore, useSearchStore } from '@/store/modules'
 import { apiInstance as api } from '@/api/apiInstance'
 
 // This suite runs against a live Elasticsearch: pin the async route so no
@@ -1041,6 +1041,17 @@ describe('SearchStore', () => {
       expect(searchStore.getFilter({ name: 'contentType' })).toBeUndefined()
       searchStore.resetFilters()
       expect(searchStore.getFilter({ name: 'contentType' })).toBeDefined()
+    })
+
+    it('should unlock every entry (include or exclude mode) locked on a removed filter', () => {
+      const lockedFiltersStore = useLockedFiltersStore()
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'application/pdf' })
+      lockedFiltersStore.lock({ name: '-contentType', value: 'text/plain', label: 'text/plain' })
+      lockedFiltersStore.lock({ name: 'language', value: 'ENGLISH', label: 'English' })
+
+      searchStore.removeFilter('contentType')
+
+      expect(lockedFiltersStore.entries).toEqual([{ name: 'language', value: 'ENGLISH', label: 'English' }])
     })
 
     it('should define a "language" filter correctly (name, key and type)', () => {


### PR DESCRIPTION
Part of the locked filters epic (icij/datashare#2219). Stacked PR 2/6, based on #499 (icij/datashare#2327).

Implements icij/datashare#2328: a lock toggle on Filters-panel value rows, wired to the store from #2327.

## What this PR does

Adds the first user-facing interaction of the locked-filters feature: a lock toggle on each value row
in the Filters panel, so a user can pin a specific filter value (e.g. `language = ENGLISH`) so it
survives "Clear filters" and gets carried across searches/projects, independent of whether it's
currently ticked.

**Key behavior:**
- **Lock/unlock a value from its row** - clicking the lock icon on a filter value locks it into the
  new personal, cross-project `lockedFiltersStore` (from #2327); locking an unticked value also ticks
  it (one click both applies and locks).
- **Locked-but-missing values stay visible** - if a locked value's real aggregation bucket disappears
  (a deleted tag, a re-indexed path), a synthetic zero-count "ghost" row keeps it visible and
  unlockable instead of silently vanishing from the panel. This synthesis is skipped while the panel's
  search box has a query, since real buckets are already filtered server-side and a synthetic row
  would otherwise outlive a search it never matched.
- **Unlock-on-removal, everywhere a value can be removed** - unticking a value, clearing all values
  for a filter, or removing/unregistering the filter itself all clean up that value's lock, so nothing
  is left stranded in the persisted store.
- **`lockable` opt-in gate** - the lock button only renders when a consumer explicitly passes
  `lockable` to `FiltersPanelSectionFilterEntry`, currently only `FilterType.vue`'s own entry. This
  keeps the button from leaking onto rows that never wire up `update:locked` (the "All" pseudo-row,
  disposable/unrelated contexts like the batch-search creation form).

Complex/paired filters are not part of this PR (path, category, starred, recommendedBy) - those get
lock support in #501 (`FilterTypeStarred`) and #504 (`FilterTypePath`, `FilterTypeRecommendedBy`). This
PR and #501 are tightly coupled - review them together if possible.

## Important files to review

- **`src/store/modules/lockedFilters.js`** - the store itself: entry shape (`{ name, value, label }`,
  mode baked into `name` via the `-` prefix), `lock`/`unlock`/`isLocked`, and the `unlockWhere`
  helper used by every removal path below.
- **`src/components/Filter/FilterType/FilterType.vue`** - wires the lock button to the store:
  `lockedName` (line 158, the store key for this filter's locks, now delegated to
  `useSearchFilter`'s shared `lockedNameFor` so it can't drift from the removal paths' own key),
  `isItemLocked`/`toggleLock` (180-190), and `missingLockedBucketsPage` (242) which synthesizes the
  ghost row for locked-but-missing values - the trickiest piece of logic in this PR, worth the closest
  look.
- **`src/components/FiltersPanel/FiltersPanelSectionFilterEntry.vue`** - the actual lock button/icon,
  `lockable`/`locked` props.
- **`src/composables/useSearchFilter.js`** - `removeFilterValue`/`removeFilterValues`/`removeFilter`,
  where unlock-on-removal is wired in for every value-removal path, and `lockedNameFor`, the single
  shared derivation of a filter's lock store key.
- **`src/store/modules/search.js`** - `removeFilter`'s own unlock fix (covers `FiltersMixin`'s
  `unregisterFilter` too, since both route through here), and the O(1)/`unlockWhere` perf follow-ups.

## Fixed from review

Addressed directly on this PR (see inline replies for detail):
1. The lock button showed up on every ticked row regardless of whether the parent wired
   `update:locked`, leaking a dead control onto "All" rows (ticked by default) and any future consumer
   that never hooks up locking. Fixed by gating the button behind an explicit `lockable` prop, passed
   only from `FilterType.vue`'s own entry.
2. `missingLockedBucketsPage` synthesized a locked-but-missing "ghost" row unconditionally, even while
   the panel's search box had an active query, so a locked value could keep appearing under a search it
   never matched (real buckets are filtered server-side and don't have this problem). Fixed by skipping
   synthesis entirely while a query is active, and split the computed into named steps along the way.
3. The count badge was hidden for every locked row, including a real value with a genuine document
   count, to work around the synthesized ghost rows (the only ones with a meaningless count). Fixed by
   giving synthetic buckets `doc_count: NaN` instead of `0`, so the existing `isNaN` guard masks only
   the ghost rows.
4. `lockedName` in `FilterType.vue` independently re-derived the same lock-store key that
   `useSearchFilter.js`'s `lockedNameFor` already computes for every removal path. Extracted
   `lockedNameFor` as the single shared source instead, so the lock button and the removal paths can't
   key the same row's lock differently.

## Known issues

Known issues, addressed elsewhere in the stack:
1. Flipping a filter's include/exclude mode orphans its existing locks (stale entry persists, unreachable from the UI). Fixed by commit 19960b817 on the stacked branch, landing with #2332 (#503) - that fix only covers a filter's currently *active* values; a locked-but-unticked value is instead caught by the `hasConflictingLocks`/`applyLockedFilters` mechanism, also #2332. Note this commit is not part of *this* PR's branch/ancestry - it addresses the epic as a whole, not #500 standalone. Relatedly, `removeFilterValue`/`removeFilterValues` only unlock the entry filed under the filter's *current* mode, so a value locked while excluded and later unticked/cleared after the filter flips back to include can leave the same kind of orphaned `-name` entry behind outside of a bare mode-flip - worth confirming #2332's fix covers this path too, not just the mode-flip itself.
2. `parseLockedName` was flagged as unused when this PR was first opened - no longer accurate, it's used directly by this PR's own `removeFilter` fix (#1 above).
3. ~~`FiltersPanelSectionFilterEntry.vue:69` - the lock button showed up whenever a row was ticked, with no opt-in gate (leaking a non-functional lock button onto "All" rows).~~ Fixed directly on this PR via the `lockable` opt-in prop (see "Fixed from review" #1 above) rather than deferred to #501.
4. `TaskBatchSearchFormFilters.vue` reuses `FilterType.vue`, which calls the global `useLockedFiltersStore()` internally, even though the batch-search form runs its own disposable, scoped search store - locking a value there leaks into the user's real, persisted lock store, since `FilterType.vue` currently passes `lockable` unconditionally on its own entry regardless of context. Still open, planned for #501/#504 - note that #501's current diff independently reintroduces the old `hideLock` opt-out prop to address this, predating this PR's move to `lockable`; it will need rebasing onto this branch and reconciling with `lockable` rather than stacking both mechanisms.
5. Baking include/exclude mode into a `-`-prefixed string on `name` instead of storing `excluded` as its own field meant a mode flip needed a delete-under-old-key/insert-under-new-key dance. Scoped down from a full storage-format rewrite (which would've touched every caller across the stack and changed the "distinct locks per mode" behavior an existing test relies on) to a smaller `lockedFiltersStore.retag({ name, newName, value })` - an in-place rename, used by #2332's `relockFilterValues`. Landed on #504.
6. `missingLockedBucketsPage` (`FilterType.vue`) synthesizes a zero-count "ghost" row for any locked value with no matching bucket in the current aggregation - meant to cover a genuinely deleted/re-indexed value, but it's built from only the currently-loaded infinite-scroll page, so a locked value that's real but not yet loaded renders as falsely "deleted" until the user scrolls further, and always renders above real buckets regardless of sort order. Still open, planned for #504: gate on `reachedBucketsEnd` (only decide a value is missing once every real bucket has loaded), and render the synthetic row after real buckets instead of before.

Nothing left open from this PR's own review at this point - every comment from the inline review round is fixed directly on this PR (see "Fixed from review" above); the remaining items are either already known and tracked in the epic's later PRs, or forward-looking notes for whoever picks those up next.

**Stack:** #2327 ← this PR ← #2329 ← #2330 ← #2331/#2332 ← #2336
