### PR TITLE
feat(search): Clear filters preserves locks + Unlock filters

### DIFF
--- a/src/components/Search/SearchBreadcrumbForm/SearchBreadcrumbForm.vue
+++ b/src/components/Search/SearchBreadcrumbForm/SearchBreadcrumbForm.vue
@@ -26,6 +26,10 @@ const props = defineProps({
     type: Boolean,
     default: true
   },
+  lockedFiltersCount: {
+    type: Number,
+    default: 0
+  },
   wrapperClass: {
     type: [String, Array, Object]
   },
@@ -44,6 +48,7 @@ const emit = defineEmits([
   'clear:filters',
   'clear:query',
   'clear:all',
+  'unlock:all',
   'save:search',
   'create:alert',
   'click:entry-x'
@@ -90,9 +95,11 @@ const isEmpty = computed(() => !slots.default && !props.entries.length)
           :disabled-clear-filters-and-query="disabledClearFiltersAndQuery"
           :disabled-save-search="disabledSaveSearch"
           :disabled-create-alert="disabledCreateAlert"
+          :locked-filters-count="lockedFiltersCount"
           @clear:filters="emit('clear:filters')"
           @clear:query="emit('clear:query')"
           @clear:all="emit('clear:all')"
+          @unlock:all="emit('unlock:all')"
           @save:search="emit('save:search')"
           @create:alert="emit('create:alert')"
         />

--- a/src/components/Search/SearchBreadcrumbForm/SearchBreadcrumbFormFooter.vue
+++ b/src/components/Search/SearchBreadcrumbForm/SearchBreadcrumbFormFooter.vue
@@ -74,7 +74,7 @@ const emit = defineEmits(['clear:filters', 'clear:query', 'clear:all', 'unlock:a
         :icon-left="IPhLockOpen"
         @click="emit('unlock:all')"
       >
-        {{ t('searchBreadcrumbFormFooter.unlockAll', { count: lockedFiltersCount }) }}
+        {{ t('searchBreadcrumbFormFooter.unlockFilters', { count: lockedFiltersCount }) }}
       </button-icon>
       <button-icon
         :disabled="disabledSaveSearch"

--- a/src/components/Search/SearchBreadcrumbForm/SearchBreadcrumbFormFooter.vue
+++ b/src/components/Search/SearchBreadcrumbForm/SearchBreadcrumbFormFooter.vue
@@ -43,6 +43,18 @@ const emit = defineEmits(['clear:filters', 'clear:query', 'clear:all', 'unlock:a
     compact-auto
   >
     <template #compact>
+      <!--
+        Whenever Story 6 (icij/datashare#2332) lands, this button's slot is
+        replaced by "Apply locked filters" while a lock conflicts with the
+        active search — see the spec's Story 4 section for the full rule.
+      -->
+      <button-icon
+        v-if="lockedFiltersCount > 0"
+        :icon-left="IPhLockOpen"
+        @click="emit('unlock:all')"
+      >
+        {{ t('searchBreadcrumbFormFooter.unlockFilters', { count: lockedFiltersCount }) }}
+      </button-icon>
       <button-icon
         :disabled="disabledClearFilters"
         :icon-left="IPhEraser"
@@ -63,18 +75,6 @@ const emit = defineEmits(['clear:filters', 'clear:query', 'clear:all', 'unlock:a
         @click="emit('clear:all')"
       >
         {{ t('searchBreadcrumbFormFooter.clearFiltersAndQuery') }}
-      </button-icon>
-      <!--
-        Whenever Story 6 (icij/datashare#2332) lands, this button's slot is
-        replaced by "Apply locked filters" while a lock conflicts with the
-        active search — see the spec's Story 4 section for the full rule.
-      -->
-      <button-icon
-        v-if="lockedFiltersCount > 0"
-        :icon-left="IPhLockOpen"
-        @click="emit('unlock:all')"
-      >
-        {{ t('searchBreadcrumbFormFooter.unlockFilters', { count: lockedFiltersCount }) }}
       </button-icon>
       <button-icon
         :disabled="disabledSaveSearch"

--- a/src/components/Search/SearchBreadcrumbForm/SearchBreadcrumbFormFooter.vue
+++ b/src/components/Search/SearchBreadcrumbForm/SearchBreadcrumbFormFooter.vue
@@ -6,6 +6,7 @@ import IPhXCircle from '~icons/ph/x-circle'
 import IPhArrowCounterClockwise from '~icons/ph/arrow-counter-clockwise'
 import IPhFloppyDiskBack from '~icons/ph/floppy-disk-back'
 import IPhSiren from '~icons/ph/siren'
+import IPhLockOpen from '~icons/ph/lock-open'
 
 import FormActions from '@/components/Form/FormActions/FormActions'
 
@@ -24,10 +25,14 @@ defineProps({
   },
   disabledCreateAlert: {
     type: Boolean
+  },
+  lockedFiltersCount: {
+    type: Number,
+    default: 0
   }
 })
 const { t } = useI18n()
-const emit = defineEmits(['clear:filters', 'clear:query', 'clear:all', 'save:search', 'create:alert'])
+const emit = defineEmits(['clear:filters', 'clear:query', 'clear:all', 'unlock:all', 'save:search', 'create:alert'])
 </script>
 
 <template>
@@ -35,44 +40,59 @@ const emit = defineEmits(['clear:filters', 'clear:query', 'clear:all', 'save:sea
     class="search-breadcrumb-form-footer"
     variant="link"
     end
+    compact-auto
   >
-    <button-icon
-      :disabled="disabledClearFilters"
-      :icon-left="IPhEraser"
-      @click="emit('clear:filters')"
-    >
-      {{ t('searchBreadcrumbFormFooter.clearFilters') }}
-    </button-icon>
-    <button-icon
-      :disabled="disabledClearQuery"
-      :icon-left="IPhXCircle"
-      @click="emit('clear:query')"
-    >
-      {{ t('searchBreadcrumbFormFooter.clearQuery') }}
-    </button-icon>
-    <button-icon
-      :disabled="disabledClearFiltersAndQuery"
-      :icon-left="IPhArrowCounterClockwise"
-      @click="emit('clear:all')"
-    >
-      {{ t('searchBreadcrumbFormFooter.clearFiltersAndQuery') }}
-    </button-icon>
-    <button-icon
-      :disabled="disabledSaveSearch"
-      variant="outline-dark"
-      :icon-left="IPhFloppyDiskBack"
-      @click="emit('save:search')"
-    >
-      {{ t('searchBreadcrumbFormFooter.saveSearch') }}
-    </button-icon>
-    <button-icon
-      v-if="false /* Disabled until the feature is implemented */"
-      :disabled="!disabledCreateAlert"
-      variant="outline-dark"
-      :icon-left="IPhSiren"
-      @click="emit('create:alert')"
-    >
-      {{ t('searchBreadcrumbFormFooter.createAlert') }}
-    </button-icon>
+    <template #compact>
+      <button-icon
+        :disabled="disabledClearFilters"
+        :icon-left="IPhEraser"
+        @click="emit('clear:filters')"
+      >
+        {{ t('searchBreadcrumbFormFooter.clearFilters') }}
+      </button-icon>
+      <button-icon
+        :disabled="disabledClearQuery"
+        :icon-left="IPhXCircle"
+        @click="emit('clear:query')"
+      >
+        {{ t('searchBreadcrumbFormFooter.clearQuery') }}
+      </button-icon>
+      <button-icon
+        :disabled="disabledClearFiltersAndQuery"
+        :icon-left="IPhArrowCounterClockwise"
+        @click="emit('clear:all')"
+      >
+        {{ t('searchBreadcrumbFormFooter.clearFiltersAndQuery') }}
+      </button-icon>
+      <!--
+        Whenever Story 6 (icij/datashare#2332) lands, this button's slot is
+        replaced by "Apply locked filters" while a lock conflicts with the
+        active search — see the spec's Story 4 section for the full rule.
+      -->
+      <button-icon
+        v-if="lockedFiltersCount > 0"
+        :icon-left="IPhLockOpen"
+        @click="emit('unlock:all')"
+      >
+        {{ t('searchBreadcrumbFormFooter.unlockAll', { count: lockedFiltersCount }) }}
+      </button-icon>
+      <button-icon
+        :disabled="disabledSaveSearch"
+        variant="outline-dark"
+        :icon-left="IPhFloppyDiskBack"
+        @click="emit('save:search')"
+      >
+        {{ t('searchBreadcrumbFormFooter.saveSearch') }}
+      </button-icon>
+      <button-icon
+        v-if="false /* Disabled until the feature is implemented */"
+        :disabled="!disabledCreateAlert"
+        variant="outline-dark"
+        :icon-left="IPhSiren"
+        @click="emit('create:alert')"
+      >
+        {{ t('searchBreadcrumbFormFooter.createAlert') }}
+      </button-icon>
+    </template>
   </form-actions>
 </template>

--- a/src/composables/useSearchBreadcrumb.js
+++ b/src/composables/useSearchBreadcrumb.js
@@ -186,11 +186,19 @@ export function useSearchBreadcrumb() {
     return refreshRoute()
   }
 
-  const clearFiltersEntries = () => {
+  const clearFilterState = () => {
     searchStore.resetFilterValues()
+    // Exclusion mode is part of "filters" too: leaving it behind would re-apply
+    // an *included* lock in exclude mode, since resetFilterValues() wipes only
+    // `values` and mergeLockedFilters()'s conflict check keys off `values`.
+    searchStore.excludeFilters.slice().forEach(name => searchStore.includeFilter(name))
     // Locked values must survive a filter-wipe — re-merge them immediately
     // rather than waiting for the next route hydration. See icij/datashare#2330.
     searchStore.mergeLockedFilters()
+  }
+
+  const clearFiltersEntries = () => {
+    clearFilterState()
     return refreshRoute()
   }
 
@@ -200,8 +208,7 @@ export function useSearchBreadcrumb() {
   }
 
   const clearAll = () => {
-    searchStore.resetFilterValues()
-    searchStore.mergeLockedFilters()
+    clearFilterState()
     searchStore.resetQuery()
     return refreshRoute()
   }

--- a/src/composables/useSearchBreadcrumb.js
+++ b/src/composables/useSearchBreadcrumb.js
@@ -9,7 +9,7 @@ import unset from 'lodash/unset'
 import lucene from 'lucene'
 
 import { useSearchFilter } from '@/composables/useSearchFilter'
-import { useSearchBreadcrumbStore, useSearchStore } from '@/store/modules'
+import { useLockedFiltersStore, useSearchBreadcrumbStore, useSearchStore } from '@/store/modules'
 import { getCanonicalDimension, getPairedDimension } from '@/store/filters/pairedDimensions'
 import findPath from '@/utils/findPath'
 
@@ -109,6 +109,8 @@ export function useSearchBreadcrumb() {
   const searchStore = useSearchStore.inject()
   const searchBreadcrumbStore = useSearchBreadcrumbStore()
   const { setQuery, removeIndex, removeFilterValue, refreshRoute } = useSearchFilter()
+  const lockedFiltersStore = useLockedFiltersStore()
+  const lockedFiltersCount = computed(() => lockedFiltersStore.count)
 
   const count = computed(() => entries.value.length)
 
@@ -186,6 +188,9 @@ export function useSearchBreadcrumb() {
 
   const clearFiltersEntries = () => {
     searchStore.resetFilterValues()
+    // Locked values must survive a filter-wipe — re-merge them immediately
+    // rather than waiting for the next route hydration. See icij/datashare#2330.
+    searchStore.mergeLockedFilters()
     return refreshRoute()
   }
 
@@ -196,8 +201,13 @@ export function useSearchBreadcrumb() {
 
   const clearAll = () => {
     searchStore.resetFilterValues()
+    searchStore.mergeLockedFilters()
     searchStore.resetQuery()
     return refreshRoute()
+  }
+
+  const unlockAll = () => {
+    lockedFiltersStore.unlockAll()
   }
 
   return {
@@ -211,6 +221,8 @@ export function useSearchBreadcrumb() {
     clearFiltersEntries,
     clearQueryEntries,
     clearAll,
+    unlockAll,
+    lockedFiltersCount,
     count,
     hasQueryEntries,
     hasFiltersEntries,

--- a/src/composables/useSearchBreadcrumb.js
+++ b/src/composables/useSearchBreadcrumb.js
@@ -186,22 +186,8 @@ export function useSearchBreadcrumb() {
     return refreshRoute()
   }
 
-  const clearFilterState = () => {
-    searchStore.resetFilterValues()
-    // Exclusion mode is part of "filters" too: leaving it behind would re-apply
-    // an *included* lock in exclude mode, since resetFilterValues() wipes only
-    // `values` and mergeLockedFilters()'s conflict check keys off `values`.
-    searchStore.excludeFilters.slice().forEach(name => searchStore.includeFilter(name))
-    // Locked values must survive a filter-wipe — re-merge them immediately
-    // rather than waiting for the next route hydration. See icij/datashare#2330.
-    searchStore.mergeLockedFilters()
-    // mergeLockedFilters only merges values; a paired dimension's exclude mode
-    // still needs the same reconciliation updateFromRouteQuery always runs.
-    searchStore.reconcilePairedExcludeFilters()
-  }
-
   const clearFiltersEntries = () => {
-    clearFilterState()
+    searchStore.resetFilterValuesPreservingLocks()
     return refreshRoute()
   }
 
@@ -211,7 +197,7 @@ export function useSearchBreadcrumb() {
   }
 
   const clearAll = () => {
-    clearFilterState()
+    searchStore.resetFilterValuesPreservingLocks()
     searchStore.resetQuery()
     return refreshRoute()
   }

--- a/src/composables/useSearchBreadcrumb.js
+++ b/src/composables/useSearchBreadcrumb.js
@@ -204,6 +204,7 @@ export function useSearchBreadcrumb() {
 
   const unlockAll = () => {
     lockedFiltersStore.unlockAll()
+    return refreshRoute()
   }
 
   return {

--- a/src/composables/useSearchBreadcrumb.js
+++ b/src/composables/useSearchBreadcrumb.js
@@ -162,7 +162,12 @@ export function useSearchBreadcrumb() {
   })
 
   const hasQueryEntries = computed(() => !!queryEntries.value.length)
-  const hasFiltersEntries = computed(() => !!filtersEntries.value.length)
+  // Locked chips never go away on clear, so they must not count towards
+  // whether "Clear filters" has anything left to do.
+  const unlockedFiltersEntries = computed(() => {
+    return filtersEntries.value.filter(({ filter, value }) => !lockedFiltersStore.isLocked({ name: filter, value }))
+  })
+  const hasFiltersEntries = computed(() => !!unlockedFiltersEntries.value.length)
   // Enable the button whereas there is filters or queries even if one of them is empty
   const hasQueryAndFiltersEntries = computed(() => hasQueryEntries.value || hasFiltersEntries.value)
 

--- a/src/composables/useSearchBreadcrumb.js
+++ b/src/composables/useSearchBreadcrumb.js
@@ -195,6 +195,9 @@ export function useSearchBreadcrumb() {
     // Locked values must survive a filter-wipe — re-merge them immediately
     // rather than waiting for the next route hydration. See icij/datashare#2330.
     searchStore.mergeLockedFilters()
+    // mergeLockedFilters only merges values; a paired dimension's exclude mode
+    // still needs the same reconciliation updateFromRouteQuery always runs.
+    searchStore.reconcilePairedExcludeFilters()
   }
 
   const clearFiltersEntries = () => {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -2028,6 +2028,7 @@
     "clearFilters": "Clear filters",
     "clearQuery": "Clear query",
     "clearFiltersAndQuery": "Clear  filters and query",
+    "unlockAll": "Unlock all ({count})",
     "saveSearch": "Save search",
     "createAlert": "Create alert"
   },

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -2028,7 +2028,7 @@
     "clearFilters": "Clear filters",
     "clearQuery": "Clear query",
     "clearFiltersAndQuery": "Clear  filters and query",
-    "unlockAll": "Unlock all ({count})",
+    "unlockFilters": "Unlock filters ({count})",
     "saveSearch": "Save search",
     "createAlert": "Create alert"
   },

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -2028,6 +2028,7 @@
     "clearFilters": "Effacer les filtres",
     "clearQuery": "Effacer la requête",
     "clearFiltersAndQuery": "Effacer filtres et requête",
+    "unlockAll": "Déverrouiller tout ({count})",
     "saveSearch": "Sauvegarder la recherche",
     "createAlert": "Créer une alerte"
   },

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -2028,7 +2028,7 @@
     "clearFilters": "Effacer les filtres",
     "clearQuery": "Effacer la requête",
     "clearFiltersAndQuery": "Effacer filtres et requête",
-    "unlockAll": "Déverrouiller tout ({count})",
+    "unlockFilters": "Déverrouiller les filtres ({count})",
     "saveSearch": "Sauvegarder la recherche",
     "createAlert": "Créer une alerte"
   },

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -1191,6 +1191,10 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     resetFilters,
     resetFilterValues,
     resetQuery,
+    // Exposed so callers outside of route hydration (e.g. "Clear filters"
+    // preserving locks, icij/datashare#2330) can re-apply locked values
+    // on demand, not just on the next updateFromRouteQuery.
+    mergeLockedFilters,
     hasFilterValue,
     isFilterContextualized,
     isFilterExcluded,

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -1236,6 +1236,9 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     // preserving locks, icij/datashare#2330) can re-apply locked values
     // on demand, not just on the next updateFromRouteQuery.
     mergeLockedFilters,
+    // Same reasoning: mergeLockedFilters alone doesn't mirror exclude mode
+    // across a paired dimension, updateFromRouteQuery always calls both.
+    reconcilePairedExcludeFilters,
     hasFilterValue,
     isFilterContextualized,
     isFilterExcluded,

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -1232,6 +1232,10 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     resetFilters,
     resetFilterValues,
     resetQuery,
+    // Exposed so callers outside of route hydration (e.g. "Clear filters"
+    // preserving locks, icij/datashare#2330) can re-apply locked values
+    // on demand, not just on the next updateFromRouteQuery.
+    mergeLockedFilters,
     hasFilterValue,
     isFilterContextualized,
     isFilterExcluded,

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -311,6 +311,20 @@ export const useSearchStore = defineSuffixedStore('search', () => {
   }
 
   /**
+   * Reset the filter values and exclusion mode to an empty state, then
+   * re-apply the user's locked filters immediately rather than waiting for
+   * the next route hydration. This is "Clear filters" preserving locks
+   * (icij/datashare#2330): it mirrors the reset/merge/reconcile invariant
+   * updateFromRouteQuery always runs, without going through a route change.
+   */
+  function resetFilterValuesPreservingLocks() {
+    resetFilterValues()
+    excludeFilters.value = []
+    mergeLockedFilters()
+    reconcilePairedExcludeFilters()
+  }
+
+  /**
    * Reset the search query to its initial state.
    */
   function resetQuery() {
@@ -1231,14 +1245,11 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     reset,
     resetFilters,
     resetFilterValues,
-    resetQuery,
     // Exposed so callers outside of route hydration (e.g. "Clear filters"
     // preserving locks, icij/datashare#2330) can re-apply locked values
     // on demand, not just on the next updateFromRouteQuery.
-    mergeLockedFilters,
-    // Same reasoning: mergeLockedFilters alone doesn't mirror exclude mode
-    // across a paired dimension, updateFromRouteQuery always calls both.
-    reconcilePairedExcludeFilters,
+    resetFilterValuesPreservingLocks,
+    resetQuery,
     hasFilterValue,
     isFilterContextualized,
     isFilterExcluded,

--- a/src/views/Search/SearchBreadcrumb.vue
+++ b/src/views/Search/SearchBreadcrumb.vue
@@ -11,6 +11,8 @@ const {
   clearFiltersEntries,
   clearQueryEntries,
   clearAll,
+  unlockAll,
+  lockedFiltersCount,
   hasQueryEntries,
   hasFiltersEntries,
   hasQueryAndFiltersEntries
@@ -26,9 +28,11 @@ const { show: showSearchSavingModal } = useSearchSavingModal()
     :disabled-clear-query="!hasQueryEntries"
     :disabled-clear-filters="!hasFiltersEntries"
     :disabled-clear-filters-and-query="!hasQueryAndFiltersEntries"
+    :locked-filters-count="lockedFiltersCount"
     @clear:filters="clearFiltersEntries"
     @clear:query="clearQueryEntries"
     @clear:all="clearAll"
+    @unlock:all="unlockAll"
     @save:search="showSearchSavingModal"
     @click:entry-x="clearEntry"
   />

--- a/tests/unit/specs/components/Search/SearchBreadcrumbForm/SearchBreadcrumbFormFooter.spec.js
+++ b/tests/unit/specs/components/Search/SearchBreadcrumbForm/SearchBreadcrumbFormFooter.spec.js
@@ -1,0 +1,40 @@
+import { mount } from '@vue/test-utils'
+import { ButtonIcon } from '@icij/murmur'
+
+import CoreSetup from '~tests/unit/CoreSetup'
+import SearchBreadcrumbFormFooter from '@/components/Search/SearchBreadcrumbForm/SearchBreadcrumbFormFooter'
+
+describe('SearchBreadcrumbFormFooter', () => {
+  let core, plugins
+
+  beforeEach(() => {
+    core = CoreSetup.init().useAll()
+    plugins = core.plugins
+  })
+
+  function mountFooter(props = {}) {
+    return mount(SearchBreadcrumbFormFooter, { global: { plugins }, props })
+  }
+
+  it('does not render the "Unlock all" button when there are no locked filters', () => {
+    const wrapper = mountFooter({ lockedFiltersCount: 0 })
+
+    expect(wrapper.text()).not.toContain('Unlock all')
+  })
+
+  it('renders "Unlock all (N)" with the current lock count', () => {
+    const wrapper = mountFooter({ lockedFiltersCount: 3 })
+
+    expect(wrapper.text()).toContain('Unlock all (3)')
+  })
+
+  it('emits unlock:all when the button is clicked', async () => {
+    const wrapper = mountFooter({ lockedFiltersCount: 2 })
+
+    const buttons = wrapper.findAllComponents(ButtonIcon)
+    const unlockButton = buttons.find(button => button.text().includes('Unlock all'))
+    await unlockButton.trigger('click')
+
+    expect(wrapper.emitted('unlock:all')).toHaveLength(1)
+  })
+})

--- a/tests/unit/specs/components/Search/SearchBreadcrumbForm/SearchBreadcrumbFormFooter.spec.js
+++ b/tests/unit/specs/components/Search/SearchBreadcrumbForm/SearchBreadcrumbFormFooter.spec.js
@@ -16,23 +16,23 @@ describe('SearchBreadcrumbFormFooter', () => {
     return mount(SearchBreadcrumbFormFooter, { global: { plugins }, props })
   }
 
-  it('does not render the "Unlock all" button when there are no locked filters', () => {
+  it('does not render the "Unlock filters" button when there are no locked filters', () => {
     const wrapper = mountFooter({ lockedFiltersCount: 0 })
 
-    expect(wrapper.text()).not.toContain('Unlock all')
+    expect(wrapper.text()).not.toContain('Unlock filters')
   })
 
-  it('renders "Unlock all (N)" with the current lock count', () => {
+  it('renders "Unlock filters (N)" with the current lock count', () => {
     const wrapper = mountFooter({ lockedFiltersCount: 3 })
 
-    expect(wrapper.text()).toContain('Unlock all (3)')
+    expect(wrapper.text()).toContain('Unlock filters (3)')
   })
 
   it('emits unlock:all when the button is clicked', async () => {
     const wrapper = mountFooter({ lockedFiltersCount: 2 })
 
     const buttons = wrapper.findAllComponents(ButtonIcon)
-    const unlockButton = buttons.find(button => button.text().includes('Unlock all'))
+    const unlockButton = buttons.find(button => button.text().includes('Unlock filters'))
     await unlockButton.trigger('click')
 
     expect(wrapper.emitted('unlock:all')).toHaveLength(1)

--- a/tests/unit/specs/composables/useSearchBreadcrumb.spec.js
+++ b/tests/unit/specs/composables/useSearchBreadcrumb.spec.js
@@ -130,6 +130,31 @@ describe('useSearchBreadcrumb composable', () => {
       expect(searchStore.q).toBe('')
       expect(searchStore.getFilter({ name: 'contentType' }).values).toEqual(['application/pdf'])
     })
+
+    it('does not flip an included lock into excluded mode when clearing while that filter is in exclude mode', () => {
+      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
+      searchStore.excludeFilter('contentType')
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'application/pdf' })
+
+      const { clearFiltersEntries } = mountComposable()
+      clearFiltersEntries()
+
+      expect(searchStore.getFilter({ name: 'contentType' }).values).toEqual(['application/pdf'])
+      expect(searchStore.isFilterExcluded('contentType')).toBe(false)
+    })
+
+    it('clearFiltersEntries removes everything when there are zero locks', () => {
+      // Locks persist to localStorage (persist: true) across the jsdom-shared
+      // localStorage instance, so a fresh pinia alone doesn't guarantee zero
+      // locks here — clear explicitly.
+      lockedFiltersStore.unlockAll()
+      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
+
+      const { clearFiltersEntries } = mountComposable()
+      clearFiltersEntries()
+
+      expect(searchStore.getFilter({ name: 'contentType' }).values).toEqual([])
+    })
   })
 
   describe('unlockAll (icij/datashare#2330)', () => {

--- a/tests/unit/specs/composables/useSearchBreadcrumb.spec.js
+++ b/tests/unit/specs/composables/useSearchBreadcrumb.spec.js
@@ -4,7 +4,7 @@ import { createPinia, setActivePinia } from 'pinia'
 
 import CoreSetup from '~tests/unit/CoreSetup'
 import { useSearchBreadcrumb } from '@/composables/useSearchBreadcrumb'
-import { useSearchStore } from '@/store/modules'
+import { useSearchStore, useLockedFiltersStore } from '@/store/modules'
 import { routes } from '@/router'
 
 describe('useSearchBreadcrumb composable', () => {
@@ -97,6 +97,69 @@ describe('useSearchBreadcrumb composable', () => {
 
       expect(searchStore.getFilter({ name: 'contentTypeCategory' }).values).toEqual(['Documents'])
       expect(searchStore.getFilter({ name: 'contentType' }).values).toEqual(['image/png'])
+    })
+  })
+
+  describe('clearFiltersEntries / clearAll preserve locked values (icij/datashare#2330)', () => {
+    let lockedFiltersStore
+
+    beforeEach(() => {
+      lockedFiltersStore = useLockedFiltersStore()
+    })
+
+    it('clearFiltersEntries removes an unlocked value but keeps a locked one', () => {
+      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
+      searchStore.addFilterValue({ name: 'contentType', value: 'text/plain' })
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'application/pdf' })
+
+      const { clearFiltersEntries } = mountComposable()
+      clearFiltersEntries()
+
+      expect(searchStore.getFilter({ name: 'contentType' }).values).toEqual(['application/pdf'])
+    })
+
+    it('clearAll clears the query and unlocked values but keeps locked ones', () => {
+      searchStore.setQuery('foo')
+      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
+      searchStore.addFilterValue({ name: 'contentType', value: 'text/plain' })
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'application/pdf' })
+
+      const { clearAll } = mountComposable()
+      clearAll()
+
+      expect(searchStore.q).toBe('')
+      expect(searchStore.getFilter({ name: 'contentType' }).values).toEqual(['application/pdf'])
+    })
+  })
+
+  describe('unlockAll (icij/datashare#2330)', () => {
+    let lockedFiltersStore
+
+    beforeEach(() => {
+      lockedFiltersStore = useLockedFiltersStore()
+    })
+
+    it('unlocks every locked value without touching the applied filter values', () => {
+      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'application/pdf' })
+
+      const { unlockAll } = mountComposable()
+      unlockAll()
+
+      expect(lockedFiltersStore.count).toBe(0)
+      expect(searchStore.getFilter({ name: 'contentType' }).values).toEqual(['application/pdf'])
+    })
+  })
+
+  describe('lockedFiltersCount (icij/datashare#2330)', () => {
+    it('reflects the number of currently locked entries', () => {
+      const lockedFiltersStore = useLockedFiltersStore()
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'application/pdf' })
+      lockedFiltersStore.lock({ name: 'contentType', value: 'text/plain', label: 'text/plain' })
+
+      const { lockedFiltersCount } = mountComposable()
+
+      expect(lockedFiltersCount.value).toBe(2)
     })
   })
 })

--- a/tests/unit/specs/composables/useSearchBreadcrumb.spec.js
+++ b/tests/unit/specs/composables/useSearchBreadcrumb.spec.js
@@ -180,6 +180,20 @@ describe('useSearchBreadcrumb composable', () => {
       expect(lockedFiltersStore.count).toBe(0)
       expect(searchStore.getFilter({ name: 'contentType' }).values).toEqual(['application/pdf'])
     })
+
+    it('refreshes the route so a value only merged in via the lock survives the next hydration', async () => {
+      // Never applied through the route: it only exists in the store because
+      // the lock merged it in. Without a route refresh, the URL would stay
+      // empty and the value would vanish silently on the next hydration
+      // (reload, or document then Back) instead of surviving the unlock.
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'application/pdf' })
+      searchStore.updateFromRouteQuery({})
+
+      const { unlockAll } = mountComposable()
+      await unlockAll()
+
+      expect(core.router.currentRoute.value.query['f[contentType]']).toEqual(['application/pdf'])
+    })
   })
 
   describe('lockedFiltersCount (icij/datashare#2330)', () => {

--- a/tests/unit/specs/composables/useSearchBreadcrumb.spec.js
+++ b/tests/unit/specs/composables/useSearchBreadcrumb.spec.js
@@ -4,7 +4,7 @@ import { createPinia, setActivePinia } from 'pinia'
 
 import CoreSetup from '~tests/unit/CoreSetup'
 import { useSearchBreadcrumb } from '@/composables/useSearchBreadcrumb'
-import { useSearchStore, useLockedFiltersStore } from '@/store/modules'
+import { useSearchStore, useLockedFiltersStore, useSearchBreadcrumbStore } from '@/store/modules'
 import { routes } from '@/router'
 
 describe('useSearchBreadcrumb composable', () => {
@@ -193,6 +193,31 @@ describe('useSearchBreadcrumb composable', () => {
       await unlockAll()
 
       expect(core.router.currentRoute.value.query['f[contentType]']).toEqual(['application/pdf'])
+    })
+  })
+
+  describe('hasFiltersEntries (icij/datashare#2330)', () => {
+    it('is false when the only filter entry left is a locked one', () => {
+      const searchBreadcrumbStore = useSearchBreadcrumbStore()
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'application/pdf' })
+      searchBreadcrumbStore.pushSearchQuery({ 'f[contentType]': 'application/pdf' })
+
+      const { hasFiltersEntries } = mountComposable()
+
+      expect(hasFiltersEntries.value).toBe(false)
+    })
+
+    it('is true when an unlocked filter entry remains alongside a locked one', () => {
+      const searchBreadcrumbStore = useSearchBreadcrumbStore()
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'application/pdf' })
+      searchBreadcrumbStore.pushSearchQuery({
+        'f[contentType]': 'application/pdf',
+        'f[contentTypeCategory]': 'Documents'
+      })
+
+      const { hasFiltersEntries } = mountComposable()
+
+      expect(hasFiltersEntries.value).toBe(true)
     })
   })
 

--- a/tests/unit/specs/composables/useSearchBreadcrumb.spec.js
+++ b/tests/unit/specs/composables/useSearchBreadcrumb.spec.js
@@ -8,7 +8,7 @@ import { useSearchStore, useLockedFiltersStore } from '@/store/modules'
 import { routes } from '@/router'
 
 describe('useSearchBreadcrumb composable', () => {
-  let core, plugins, searchStore
+  let core, plugins, searchStore, lockedFiltersStore
 
   // The "search" route lazily imports the whole Search view subtree, whose
   // setup() reads from the search store. Resolve it once here, on a
@@ -24,6 +24,11 @@ describe('useSearchBreadcrumb composable', () => {
     core = CoreSetup.init().useAll().useRouterWithoutGuards()
     plugins = core.plugins
     searchStore = useSearchStore()
+    // CoreSetup.useAll() reuses the module-level pinia singleton (no fresh
+    // instance per test), so lockedFiltersStore state otherwise leaks across
+    // every test in this file.
+    lockedFiltersStore = useLockedFiltersStore()
+    lockedFiltersStore.unlockAll()
   })
 
   function mountComposable() {
@@ -101,12 +106,6 @@ describe('useSearchBreadcrumb composable', () => {
   })
 
   describe('clearFiltersEntries / clearAll preserve locked values (icij/datashare#2330)', () => {
-    let lockedFiltersStore
-
-    beforeEach(() => {
-      lockedFiltersStore = useLockedFiltersStore()
-    })
-
     it('clearFiltersEntries removes an unlocked value but keeps a locked one', () => {
       searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
       searchStore.addFilterValue({ name: 'contentType', value: 'text/plain' })
@@ -161,10 +160,6 @@ describe('useSearchBreadcrumb composable', () => {
     })
 
     it('clearFiltersEntries removes everything when there are zero locks', () => {
-      // Locks persist to localStorage (persist: true) across the jsdom-shared
-      // localStorage instance, so a fresh pinia alone doesn't guarantee zero
-      // locks here — clear explicitly.
-      lockedFiltersStore.unlockAll()
       searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
 
       const { clearFiltersEntries } = mountComposable()
@@ -175,12 +170,6 @@ describe('useSearchBreadcrumb composable', () => {
   })
 
   describe('unlockAll (icij/datashare#2330)', () => {
-    let lockedFiltersStore
-
-    beforeEach(() => {
-      lockedFiltersStore = useLockedFiltersStore()
-    })
-
     it('unlocks every locked value without touching the applied filter values', () => {
       searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
       lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'application/pdf' })
@@ -195,7 +184,6 @@ describe('useSearchBreadcrumb composable', () => {
 
   describe('lockedFiltersCount (icij/datashare#2330)', () => {
     it('reflects the number of currently locked entries', () => {
-      const lockedFiltersStore = useLockedFiltersStore()
       lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'application/pdf' })
       lockedFiltersStore.lock({ name: 'contentType', value: 'text/plain', label: 'text/plain' })
 

--- a/tests/unit/specs/composables/useSearchBreadcrumb.spec.js
+++ b/tests/unit/specs/composables/useSearchBreadcrumb.spec.js
@@ -143,6 +143,23 @@ describe('useSearchBreadcrumb composable', () => {
       expect(searchStore.isFilterExcluded('contentType')).toBe(false)
     })
 
+    it('reconciles a paired dimension\'s exclude mode after re-merging a locked excluded value', () => {
+      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
+      searchStore.excludeFilter('contentType')
+      searchStore.addFilterValue({ name: 'contentTypeCategory', value: 'Documents' })
+      searchStore.excludeFilter('contentTypeCategory')
+      lockedFiltersStore.lock({ name: '-contentType', value: 'application/pdf', label: 'application/pdf' })
+
+      const { clearFiltersEntries } = mountComposable()
+      clearFiltersEntries()
+
+      // mergeLockedFilters only re-excludes the locked filter's own bare name;
+      // without reconcilePairedExcludeFilters, its paired sibling would be
+      // left included even though the group must stay in lockstep.
+      expect(searchStore.isFilterExcluded('contentType')).toBe(true)
+      expect(searchStore.isFilterExcluded('contentTypeCategory')).toBe(true)
+    })
+
     it('clearFiltersEntries removes everything when there are zero locks', () => {
       // Locks persist to localStorage (persist: true) across the jsdom-shared
       // localStorage instance, so a fresh pinia alone doesn't guarantee zero

--- a/tests/unit/specs/store/modules/search.spec.js
+++ b/tests/unit/specs/store/modules/search.spec.js
@@ -1600,5 +1600,17 @@ describe('SearchStore', () => {
 
       expect(searchStore.getFilter({ name: 'contentType' })?.values ?? []).toEqual([])
     })
+
+    it('exposes mergeLockedFilters so callers can re-apply locks outside of hydration', () => {
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'application/pdf' })
+      searchStore.addFilterValue({ name: 'contentType', value: 'text/plain' })
+
+      searchStore.resetFilterValues()
+      expect(searchStore.getFilter({ name: 'contentType' }).values).toEqual([])
+
+      searchStore.mergeLockedFilters()
+
+      expect(searchStore.getFilter({ name: 'contentType' }).values).toEqual(['application/pdf'])
+    })
   })
 })

--- a/tests/unit/specs/store/modules/search.spec.js
+++ b/tests/unit/specs/store/modules/search.spec.js
@@ -1613,15 +1613,23 @@ describe('SearchStore', () => {
       expect(searchStore.getFilter({ name: 'contentType' })?.values ?? []).toEqual([])
     })
 
-    it('exposes mergeLockedFilters so callers can re-apply locks outside of hydration', () => {
+    it('exposes resetFilterValuesPreservingLocks so callers can reset then re-apply locks outside of hydration', () => {
       lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'application/pdf' })
       searchStore.addFilterValue({ name: 'contentType', value: 'text/plain' })
 
-      searchStore.resetFilterValues()
-      expect(searchStore.getFilter({ name: 'contentType' }).values).toEqual([])
+      searchStore.resetFilterValuesPreservingLocks()
 
-      searchStore.mergeLockedFilters()
+      expect(searchStore.getFilter({ name: 'contentType' }).values).toEqual(['application/pdf'])
+    })
 
+    it('resetFilterValuesPreservingLocks also clears exclusion mode before re-applying locks', () => {
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'application/pdf' })
+      searchStore.addFilterValue({ name: 'contentType', value: 'application/pdf' })
+      searchStore.excludeFilter('contentType')
+
+      searchStore.resetFilterValuesPreservingLocks()
+
+      expect(searchStore.isFilterExcluded('contentType')).toBe(false)
       expect(searchStore.getFilter({ name: 'contentType' }).values).toEqual(['application/pdf'])
     })
   })

--- a/tests/unit/specs/store/modules/search.spec.js
+++ b/tests/unit/specs/store/modules/search.spec.js
@@ -1612,5 +1612,17 @@ describe('SearchStore', () => {
 
       expect(searchStore.getFilter({ name: 'contentType' })?.values ?? []).toEqual([])
     })
+
+    it('exposes mergeLockedFilters so callers can re-apply locks outside of hydration', () => {
+      lockedFiltersStore.lock({ name: 'contentType', value: 'application/pdf', label: 'application/pdf' })
+      searchStore.addFilterValue({ name: 'contentType', value: 'text/plain' })
+
+      searchStore.resetFilterValues()
+      expect(searchStore.getFilter({ name: 'contentType' }).values).toEqual([])
+
+      searchStore.mergeLockedFilters()
+
+      expect(searchStore.getFilter({ name: 'contentType' }).values).toEqual(['application/pdf'])
+    })
   })
 })


### PR DESCRIPTION
Part of the locked filters epic (icij/datashare#2219). Stacked PR 4/6, based on #501 (#2329).

Implements icij/datashare#2330: "Clear filters" now preserves locked values while removing unlocked ones, and adds an "Unlock filters (N)" breadcrumb footer action to drop every lock without touching applied filter values.

**Stack:** #2329 ← this PR ← #2331/#2332 ← #2336

**Known issue (fixed in #503):** `toggleFilter` in the search store only flips `excludeFilters` here; it doesn't yet re-tag locked entries when a filter's include/exclude mode changes. Since a lock's storage key is mode-encoded (`contentType` vs `-contentType`), locking a value then switching that filter to exclude mode (or back) makes the existing lock entry mismatch the new key, so it silently reads as unlocked in the breadcrumb/checkbox even though the entry itself is still stored. This is addressed in #503 via `relockFilterValues`, which re-tags the entry under the new key on mode flip. Not fixed here, since this PR predates that change in the stack.
