### PR TITLE
fix(filter): stop the paired-exclude reconciler from reverting a category-only exclude icij/datashare#2351

### DIFF
--- a/src/composables/useSearchFilter.js
+++ b/src/composables/useSearchFilter.js
@@ -54,19 +54,11 @@ export function useSearchFilter() {
     isLoading: isCategoryAvailabilityLoading
   } = useContentTypeCategoryAvailability() ?? {}
 
-  // Keep non-canonical paired dimensions in lockstep with their canonical.
-  // flush:'sync' ensures reconciliation runs within the same tick as setup,
-  // not deferred to the next render, so URL-restored drift is corrected before
-  // any computed getter or template ever reads the store.
-  watchEffect(() => {
-    for (const [canonical, paired] of Object.entries(PAIRED_DIMENSIONS)) {
-      const value = searchStore.isFilterExcluded(canonical)
-      if (searchStore.isFilterExcluded(paired) !== value) {
-        searchStore.toggleFilter(paired, value)
-      }
-    }
-  }, { flush: 'sync' })
-
+  // Note: unlike contextualize below, exclude has no dedicated sync watcher.
+  // Paired exclude updates are written one dimension at a time, so an eager
+  // watcher can observe transient half-updated states and either revert route
+  // hydration or re-apply an exclude while toggling off. Keep reconciliation
+  // lazy in isFilterExcluded, where it runs against the final written state.
   watchEffect(() => {
     for (const [canonical, paired] of Object.entries(PAIRED_DIMENSIONS)) {
       const value = searchStore.isFilterContextualized(canonical)
@@ -369,10 +361,25 @@ export function useSearchFilter() {
 
   function isFilterExcluded({ name }) {
     const dimensions = getPairedDimensions(name)
-    if (dimensions.length === 1) {
-      return searchStore.isFilterExcluded(name)
+    // Any excluded side means the pair is excluded (matches the OR semantics
+    // `filterValuesAsRouteQuery` and `reconcilePairedExcludeFilters` already
+    // use in the store), rather than trusting one dimension over the other.
+    const excluded = dimensions.some(dimension => searchStore.isFilterExcluded(dimension))
+    // Reconcile on read, additively only: propagate an exclude forward to
+    // any dimension that hasn't caught up yet (e.g. a direct store write to
+    // a single dimension that bypassed toggleExcludeFilter's own dual-write
+    // below). This only ever adds the flag, never removes it, and only runs
+    // when something actually calls this getter - unlike an eager
+    // `watchEffect` reconciler, it can't fire mid-write and observe (or
+    // act on) a transient, not-yet-finished state. See icij/datashare#2351.
+    if (excluded) {
+      dimensions.forEach((dimension) => {
+        if (!searchStore.isFilterExcluded(dimension)) {
+          searchStore.excludeFilter(dimension)
+        }
+      })
     }
-    return searchStore.isFilterExcluded(getCanonicalDimension(name))
+    return excluded
   }
 
   function computedExcludeFilter(filter, { get = null, set = null } = {}) {

--- a/tests/unit/specs/composables/useSearchFilter.spec.js
+++ b/tests/unit/specs/composables/useSearchFilter.spec.js
@@ -478,6 +478,17 @@ describe('useSearchFilter composable', () => {
       expect(searchStore.isFilterExcluded('contentType')).toBe(true)
       expect(searchStore.isFilterExcluded('contentTypeCategory')).toBe(true)
     })
+
+    // Symmetric coverage for the other hydration order: only the canonical
+    // dimension's URL key present, not the paired one.
+    it('survives route hydration when only f[-contentType] is in the URL', () => {
+      mountComposable()
+
+      searchStore.updateFromRouteQuery({ 'f[-contentType]': ['application/pdf'] })
+
+      expect(searchStore.isFilterExcluded('contentType')).toBe(true)
+      expect(searchStore.isFilterExcluded('contentTypeCategory')).toBe(true)
+    })
   })
 
   describe('isFilterExcluded (unified read with reconciliation)', () => {

--- a/tests/unit/specs/composables/useSearchFilter.spec.js
+++ b/tests/unit/specs/composables/useSearchFilter.spec.js
@@ -465,6 +465,19 @@ describe('useSearchFilter composable', () => {
       expect(searchStore.isFilterExcluded('contentType')).toBe(false)
       expect(searchStore.isFilterExcluded('contentTypeCategory')).toBe(false)
     })
+
+    // Regression test for icij/datashare#2351: with the composable mounted (so
+    // its sync watchers are live), hydrating a URL that only carries
+    // `f[-contentTypeCategory]` used to be silently reverted mid-hydration
+    // before the store's own reconciliation ran.
+    it('survives route hydration when only f[-contentTypeCategory] is in the URL', () => {
+      mountComposable()
+
+      searchStore.updateFromRouteQuery({ 'f[-contentTypeCategory]': ['DOCUMENT'] })
+
+      expect(searchStore.isFilterExcluded('contentType')).toBe(true)
+      expect(searchStore.isFilterExcluded('contentTypeCategory')).toBe(true)
+    })
   })
 
   describe('isFilterExcluded (unified read with reconciliation)', () => {
@@ -485,24 +498,25 @@ describe('useSearchFilter composable', () => {
       expect(isFilterExcluded({ name: 'contentTypeCategory' })).toBe(false)
     })
 
-    it('reconciles a divergent state using the canonical contentType when canonical is excluded', () => {
+    it('reads a divergent state as excluded when the canonical contentType is excluded', () => {
       searchStore.excludeFilter('contentType')
 
       const { isFilterExcluded } = mountComposable()
 
       expect(isFilterExcluded({ name: 'contentType' })).toBe(true)
       expect(isFilterExcluded({ name: 'contentTypeCategory' })).toBe(true)
-      expect(searchStore.isFilterExcluded('contentTypeCategory')).toBe(true)
     })
 
-    it('reconciles a divergent state using the canonical contentType when canonical is NOT excluded', () => {
+    // Regression test for icij/datashare#2351: excluding a whole category (only
+    // `contentTypeCategory` selected, `contentType` never set) must read as
+    // excluded rather than being silently reverted to included.
+    it('reads a divergent state as excluded when only contentTypeCategory is excluded', () => {
       searchStore.excludeFilter('contentTypeCategory')
 
       const { isFilterExcluded } = mountComposable()
 
-      expect(isFilterExcluded({ name: 'contentType' })).toBe(false)
-      expect(isFilterExcluded({ name: 'contentTypeCategory' })).toBe(false)
-      expect(searchStore.isFilterExcluded('contentTypeCategory')).toBe(false)
+      expect(isFilterExcluded({ name: 'contentType' })).toBe(true)
+      expect(isFilterExcluded({ name: 'contentTypeCategory' })).toBe(true)
     })
 
     it('still works for unpaired filters without cross-dimension writes', () => {


### PR DESCRIPTION
Fixes icij/datashare#2351.

Excluding a whole document-type category (only `contentTypeCategory` has values, `contentType` never
does) silently reverted: the URL briefly carried `f[-contentTypeCategory]`, then flipped back on the
very next render.

`useSearchFilter` had a dedicated `watchEffect` (`flush: 'sync'`) that kept the paired dimensions in
lockstep by trusting the canonical side. It raced two other mechanisms that already dual-write both
dimensions - `toggleExcludeFilter` on toggle, and the store's `reconcilePairedExcludeFilters` on route
hydration - observing a transient, not-yet-reconciled single-dimension state mid-parse and reverting it
before the second dimension caught up.

Removed that racy reconciler entirely rather than patching around when it fires: `isFilterExcluded` now
reads any excluded side as excluded (matching the OR semantics `filterValuesAsRouteQuery` and
`reconcilePairedExcludeFilters` already use), so no future write path can trigger this class of race
again.
