### PR TITLE
feat: fall back to synchronous search on OpenSearch

### DIFF
--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -236,9 +236,10 @@ export function datasharePlugin(Client) {
    * @param {string[]} [options.fields=[]] - Fields to search in
    * @returns {Promise<Object>} Search results
    */
-  Client.prototype.searchDocs = function (options) {
+  Client.prototype.searchDocs = function (options, { signal } = {}) {
     const body = this.buildSearchDocsBody(options)
-    return this._search({ index: options.index, body })
+    const request = this.search({ index: options.index, body })
+    return abortableSearchRequest(request, signal)
   }
 
   /**

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -157,6 +157,20 @@ export class Api {
     return this.sendAction('/version')
   }
 
+  /**
+   * Same payload as `getVersion`, without `sendAction`'s `http::error` emission.
+   *
+   * This is a routing probe fired before searches: on a backend where /version
+   * fails (older version, blocking proxy, expired session), emitting would
+   * toast a global error on every search even though the search itself works.
+   * @param {Object} [config={}] - Extra axios request configuration
+   * @returns {Promise<Object|null>} The version payload
+   */
+  async getVersionSilently(config = {}) {
+    const r = await this.axios?.request({ url: Api.getFullUrl('/version'), ...config })
+    return r ? r.data : null
+  }
+
   getSettings() {
     return this.sendAction('/settings')
   }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -167,8 +167,8 @@ export class Api {
    * @returns {Promise<Object|null>} The version payload
    */
   async getVersionSilently(config = {}) {
-    const r = await this.axios?.request({ url: Api.getFullUrl('/version'), ...config })
-    return r ? r.data : null
+    const response = await this.axios?.request({ url: Api.getFullUrl('/version'), ...config })
+    return response ? response.data : null
   }
 
   getSettings() {

--- a/src/api/indexDistribution.js
+++ b/src/api/indexDistribution.js
@@ -1,36 +1,44 @@
-import { ES_DISTRIBUTION } from '@/enums/esDistributions'
+import { useOnce } from '@/composables/useOnce'
+import { ES_DISTRIBUTION, esDistributionValidator } from '@/enums/esDistributions'
 
-let versionPromise = null
+const PROBE_TIMEOUT = 2000
 
-function fetchVersionOnce(api) {
-  versionPromise ??= api.getVersion()
-  return versionPromise
+export class InconclusiveDistributionError extends Error {
+  constructor(distribution, options) {
+    super(`inconclusive index distribution "${distribution}"`, options)
+    this.name = 'InconclusiveDistributionError'
+    this.distribution = distribution
+  }
 }
+
+// Only a conclusive verdict may be cached for the session: the backend answers
+// "unknown" when its own index probe fails (RootResource), and memoizing that
+// would pin an OpenSearch deployment to the broken async path until reload.
+// Throwing makes useOnce retry the probe on the next search.
+const { run: probeDistribution } = useOnce(async (api) => {
+  const version = await api.getVersionSilently({ timeout: PROBE_TIMEOUT })
+  const distribution = version?.['index.distribution']
+  if (!esDistributionValidator(distribution)) {
+    throw new InconclusiveDistributionError(distribution)
+  }
+  return distribution
+})
 
 /**
  * Tells whether the backend index is an OpenSearch distribution, which has
- * no `_async_search` endpoint (icij/datashare#2349). The version is fetched
- * once and cached for the session.
+ * no `_async_search` endpoint (icij/datashare#2349). A conclusive verdict is
+ * fetched once and cached for the session.
  * @param {Object} api - The Datashare API instance
  * @returns {Promise<boolean>}
  */
 export async function isOpenSearchDistribution(api) {
   try {
-    const version = await fetchVersionOnce(api)
-    return version['index.distribution'] === ES_DISTRIBUTION.OPENSEARCH
+    const distribution = await probeDistribution(api)
+    return distribution === ES_DISTRIBUTION.OPENSEARCH
   }
   catch {
-    // A failed version probe must not break search: fall back to the async
-    // path and drop the cached promise so the next search retries the probe.
-    versionPromise = null
+    // An unreadable probe must not break search: Elasticsearch is the default
+    // distribution, so fall back to the async path until a probe succeeds.
     return false
   }
-}
-
-/**
- * Drops the cached version probe. Only meant for tests, which need a fresh
- * probe for each case.
- */
-export function resetIndexDistribution() {
-  versionPromise = null
 }

--- a/src/api/indexDistribution.js
+++ b/src/api/indexDistribution.js
@@ -1,0 +1,36 @@
+import { ES_DISTRIBUTION } from '@/enums/esDistributions'
+
+let versionPromise = null
+
+function fetchVersionOnce(api) {
+  versionPromise ??= api.getVersion()
+  return versionPromise
+}
+
+/**
+ * Tells whether the backend index is an OpenSearch distribution, which has
+ * no `_async_search` endpoint (icij/datashare#2349). The version is fetched
+ * once and cached for the session.
+ * @param {Object} api - The Datashare API instance
+ * @returns {Promise<boolean>}
+ */
+export async function isOpenSearchDistribution(api) {
+  try {
+    const version = await fetchVersionOnce(api)
+    return version['index.distribution'] === ES_DISTRIBUTION.OPENSEARCH
+  }
+  catch {
+    // A failed version probe must not break search: fall back to the async
+    // path and drop the cached promise so the next search retries the probe.
+    versionPromise = null
+    return false
+  }
+}
+
+/**
+ * Drops the cached version probe. Only meant for tests, which need a fresh
+ * probe for each case.
+ */
+export function resetIndexDistribution() {
+  versionPromise = null
+}

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -789,24 +789,29 @@ export const useSearchStore = defineSuffixedStore('search', () => {
   }
 
   /**
+   * Builds the search body with `api.elasticsearch.buildSearchDocsBody` and runs it
+   * through `runAsyncSearch`, which submits, polls, and cleans up the async search.
+   * @param {Object} searchParams - The search parameters to use for the query.
+   * @param {AbortSignal} [signal] - Aborts the in-flight async search.
+   * @returns {Promise<Object>} - The raw search response.
+   */
+  function searchDocsAsync(searchParams, signal) {
+    const body = api.elasticsearch.buildSearchDocsBody(searchParams)
+    return runAsyncSearch(api.elasticsearch, { index: searchParams.index, body }, { signal })
+  }
+
+  /**
    * Search for documents, through Elasticsearch async search or through a
    * synchronous `_search` on OpenSearch, which has no async search endpoint.
-   *
-   * On Elasticsearch, builds the search body with `api.elasticsearch.buildSearchDocsBody`
-   * and runs it through `runAsyncSearch`, which submits, polls, and cleans up the async search.
    * @param {Object} [searchParams=toSearchParams.value] - The search parameters to use for the query.
    * @param {AbortSignal} [signal] - Aborts the in-flight search (supersede / unmount).
    * @returns {Promise<Object>} - A promise that resolves to the raw Elasticsearch search response.
    */
   async function searchDocuments(searchParams = toSearchParams.value, signal) {
-    const syncSearch = await isOpenSearchDistribution(api)
+    const isOpenSearch = await isOpenSearchDistribution(api)
     // A run cancelled while the probe was pending must not submit anything.
     signal?.throwIfAborted()
-    if (syncSearch) {
-      return searchDocsSync(searchParams, signal)
-    }
-    const body = api.elasticsearch.buildSearchDocsBody(searchParams)
-    return runAsyncSearch(api.elasticsearch, { index: searchParams.index, body }, { signal })
+    return isOpenSearch ? searchDocsSync(searchParams, signal) : searchDocsAsync(searchParams, signal)
   }
 
   /**

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -17,13 +17,13 @@ import lucene from 'lucene'
 import { ref, computed, toRaw } from 'vue'
 
 import EsDocList from '@/api/resources/EsDocList'
+import { isOpenSearchDistribution } from '@/api/indexDistribution'
 import { runAsyncSearch } from '@/api/asyncSearch'
 import filterDefs, * as filterTypes from '@/store/filters'
 import { getPairedDimensions } from '@/store/filters/pairedDimensions'
 import { useAppStore, useSearchBreadcrumbStore } from '@/store/modules'
 import { apiInstance as api } from '@/api/apiInstance'
 import { defineSuffixedStore } from '@/store/defineSuffixedStore'
-import { ES_DISTRIBUTION } from '@/enums/esDistributions'
 import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 import settings from '@/utils/settings'
 
@@ -770,32 +770,6 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     }
   }
 
-  let versionPromise = null
-
-  function fetchVersionOnce() {
-    versionPromise ??= api.getVersion()
-    return versionPromise
-  }
-
-  /**
-   * Tells whether the backend index is an OpenSearch distribution, which has
-   * no `_async_search` endpoint (icij/datashare#2349). The version is fetched
-   * once and cached for the session.
-   * @returns {Promise<boolean>}
-   */
-  async function isOpenSearchDistribution() {
-    try {
-      const version = await fetchVersionOnce()
-      return version['index.distribution'] === ES_DISTRIBUTION.OPENSEARCH
-    }
-    catch {
-      // A failed version probe must not break search: fall back to the async
-      // path and drop the cached promise so the next search retries the probe.
-      versionPromise = null
-      return false
-    }
-  }
-
   /**
    * Search for documents, through Elasticsearch async search or through a
    * synchronous `_search` on OpenSearch, which has no async search endpoint.
@@ -809,7 +783,7 @@ export const useSearchStore = defineSuffixedStore('search', () => {
   async function searchDocuments(searchParams = toSearchParams.value, signal) {
     // The legacy ES client takes no abort signal, so a superseded synchronous
     // search still completes; the generation guard discards its response.
-    if (await isOpenSearchDistribution()) {
+    if (await isOpenSearchDistribution(api)) {
       return api.elasticsearch.searchDocs(searchParams)
     }
     const body = api.elasticsearch.buildSearchDocsBody(searchParams)

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -771,20 +771,39 @@ export const useSearchStore = defineSuffixedStore('search', () => {
   }
 
   /**
+   * Runs the synchronous `_search` used on OpenSearch. The transport rejects
+   * with its own error on abort, so a cancelled request is renamed to the
+   * AbortError the caller already handles, mirroring `runAsyncSearch`.
+   * @param {Object} searchParams - The search parameters to use for the query.
+   * @param {AbortSignal} [signal] - Aborts the in-flight search.
+   * @returns {Promise<Object>} - The raw search response.
+   */
+  async function searchDocsSync(searchParams, signal) {
+    try {
+      return await api.elasticsearch.searchDocs(searchParams, { signal })
+    }
+    catch (error) {
+      signal?.throwIfAborted()
+      throw error
+    }
+  }
+
+  /**
    * Search for documents, through Elasticsearch async search or through a
    * synchronous `_search` on OpenSearch, which has no async search endpoint.
    *
    * On Elasticsearch, builds the search body with `api.elasticsearch.buildSearchDocsBody`
    * and runs it through `runAsyncSearch`, which submits, polls, and cleans up the async search.
    * @param {Object} [searchParams=toSearchParams.value] - The search parameters to use for the query.
-   * @param {AbortSignal} [signal] - Aborts the in-flight async search (supersede / unmount).
+   * @param {AbortSignal} [signal] - Aborts the in-flight search (supersede / unmount).
    * @returns {Promise<Object>} - A promise that resolves to the raw Elasticsearch search response.
    */
   async function searchDocuments(searchParams = toSearchParams.value, signal) {
-    // The legacy ES client takes no abort signal, so a superseded synchronous
-    // search still completes; the generation guard discards its response.
-    if (await isOpenSearchDistribution(api)) {
-      return api.elasticsearch.searchDocs(searchParams)
+    const syncSearch = await isOpenSearchDistribution(api)
+    // A run cancelled while the probe was pending must not submit anything.
+    signal?.throwIfAborted()
+    if (syncSearch) {
+      return searchDocsSync(searchParams, signal)
     }
     const body = api.elasticsearch.buildSearchDocsBody(searchParams)
     return runAsyncSearch(api.elasticsearch, { index: searchParams.index, body }, { signal })

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -23,6 +23,7 @@ import { getPairedDimensions } from '@/store/filters/pairedDimensions'
 import { useAppStore, useSearchBreadcrumbStore } from '@/store/modules'
 import { apiInstance as api } from '@/api/apiInstance'
 import { defineSuffixedStore } from '@/store/defineSuffixedStore'
+import { ES_DISTRIBUTION } from '@/enums/esDistributions'
 import { SEARCH_OPERATORS } from '@/enums/searchOperators'
 import settings from '@/utils/settings'
 
@@ -769,16 +770,48 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     }
   }
 
+  let versionPromise = null
+
+  function fetchVersionOnce() {
+    versionPromise ??= api.getVersion()
+    return versionPromise
+  }
+
   /**
-   * Search for documents using Elasticsearch async search.
+   * Tells whether the backend index is an OpenSearch distribution, which has
+   * no `_async_search` endpoint (icij/datashare#2349). The version is fetched
+   * once and cached for the session.
+   * @returns {Promise<boolean>}
+   */
+  async function isOpenSearchDistribution() {
+    try {
+      const version = await fetchVersionOnce()
+      return version['index.distribution'] === ES_DISTRIBUTION.OPENSEARCH
+    }
+    catch {
+      // A failed version probe must not break search: fall back to the async
+      // path and drop the cached promise so the next search retries the probe.
+      versionPromise = null
+      return false
+    }
+  }
+
+  /**
+   * Search for documents, through Elasticsearch async search or through a
+   * synchronous `_search` on OpenSearch, which has no async search endpoint.
    *
-   * Builds the search body with `api.elasticsearch.buildSearchDocsBody` and runs it
-   * through `runAsyncSearch`, which submits, polls, and cleans up the async search.
+   * On Elasticsearch, builds the search body with `api.elasticsearch.buildSearchDocsBody`
+   * and runs it through `runAsyncSearch`, which submits, polls, and cleans up the async search.
    * @param {Object} [searchParams=toSearchParams.value] - The search parameters to use for the query.
    * @param {AbortSignal} [signal] - Aborts the in-flight async search (supersede / unmount).
    * @returns {Promise<Object>} - A promise that resolves to the raw Elasticsearch search response.
    */
-  function searchDocuments(searchParams = toSearchParams.value, signal) {
+  async function searchDocuments(searchParams = toSearchParams.value, signal) {
+    // The legacy ES client takes no abort signal, so a superseded synchronous
+    // search still completes; the generation guard discards its response.
+    if (await isOpenSearchDistribution()) {
+      return api.elasticsearch.searchDocs(searchParams)
+    }
     const body = api.elasticsearch.buildSearchDocsBody(searchParams)
     return runAsyncSearch(api.elasticsearch, { index: searchParams.index, body }, { signal })
   }

--- a/tests/unit/specs/api/indexDistribution.spec.js
+++ b/tests/unit/specs/api/indexDistribution.spec.js
@@ -1,0 +1,64 @@
+describe('indexDistribution', () => {
+  let api, isOpenSearchDistribution
+
+  beforeEach(async () => {
+    vi.resetModules()
+    ;({ isOpenSearchDistribution } = await import('@/api/indexDistribution'))
+    api = { getVersionSilently: vi.fn() }
+  })
+
+  it('resolves true when the backend reports an opensearch distribution', async () => {
+    api.getVersionSilently.mockResolvedValue({ 'index.distribution': 'opensearch' })
+
+    await expect(isOpenSearchDistribution(api)).resolves.toBe(true)
+  })
+
+  it('resolves false when the backend reports an elasticsearch distribution', async () => {
+    api.getVersionSilently.mockResolvedValue({ 'index.distribution': 'elasticsearch' })
+
+    await expect(isOpenSearchDistribution(api)).resolves.toBe(false)
+  })
+
+  it('caches a conclusive verdict for the session', async () => {
+    api.getVersionSilently.mockResolvedValue({ 'index.distribution': 'opensearch' })
+
+    await isOpenSearchDistribution(api)
+    await isOpenSearchDistribution(api)
+
+    expect(api.getVersionSilently).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves false on an "unknown" distribution and retries on the next call', async () => {
+    api.getVersionSilently.mockResolvedValueOnce({ 'index.distribution': 'unknown' })
+    api.getVersionSilently.mockResolvedValue({ 'index.distribution': 'opensearch' })
+
+    await expect(isOpenSearchDistribution(api)).resolves.toBe(false)
+    await expect(isOpenSearchDistribution(api)).resolves.toBe(true)
+
+    expect(api.getVersionSilently).toHaveBeenCalledTimes(2)
+  })
+
+  it('resolves false on a payload without the distribution key and retries on the next call', async () => {
+    api.getVersionSilently.mockResolvedValueOnce(null)
+    api.getVersionSilently.mockResolvedValue({ 'index.distribution': 'opensearch' })
+
+    await expect(isOpenSearchDistribution(api)).resolves.toBe(false)
+    await expect(isOpenSearchDistribution(api)).resolves.toBe(true)
+  })
+
+  it('resolves false when the probe rejects and retries on the next call', async () => {
+    api.getVersionSilently.mockRejectedValueOnce(new Error('backend unreachable'))
+    api.getVersionSilently.mockResolvedValue({ 'index.distribution': 'opensearch' })
+
+    await expect(isOpenSearchDistribution(api)).resolves.toBe(false)
+    await expect(isOpenSearchDistribution(api)).resolves.toBe(true)
+  })
+
+  it('shares a single in-flight probe between concurrent calls', async () => {
+    api.getVersionSilently.mockResolvedValue({ 'index.distribution': 'opensearch' })
+
+    await Promise.all([isOpenSearchDistribution(api), isOpenSearchDistribution(api)])
+
+    expect(api.getVersionSilently).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/specs/store/modules/search.asyncSearch.spec.js
+++ b/tests/unit/specs/store/modules/search.asyncSearch.spec.js
@@ -3,6 +3,7 @@ import { setActivePinia, createPinia } from 'pinia'
 
 import { useAppStore, useSearchStore } from '@/store/modules'
 import { apiInstance as api } from '@/api/apiInstance'
+import { resetIndexDistribution } from '@/api/indexDistribution'
 
 const runAsyncSearchMock = vi.fn()
 vi.mock('@/api/asyncSearch', () => ({
@@ -33,6 +34,7 @@ describe('SearchStore async search wiring', () => {
     searchStore.setIndex('local-index')
     appStore.setSettings('search', { perPage: 25, orderBy: ['_score', 'desc'] })
     runAsyncSearchMock.mockReset()
+    resetIndexDistribution()
     getVersionSpy = vi.spyOn(api, 'getVersion').mockResolvedValue({ 'index.distribution': 'elasticsearch' })
     searchDocsSpy = vi.spyOn(api.elasticsearch, 'searchDocs').mockResolvedValue(emptyResponse())
   })

--- a/tests/unit/specs/store/modules/search.asyncSearch.spec.js
+++ b/tests/unit/specs/store/modules/search.asyncSearch.spec.js
@@ -3,11 +3,15 @@ import { setActivePinia, createPinia } from 'pinia'
 
 import { useAppStore, useSearchStore } from '@/store/modules'
 import { apiInstance as api } from '@/api/apiInstance'
-import { resetIndexDistribution } from '@/api/indexDistribution'
 
 const runAsyncSearchMock = vi.fn()
 vi.mock('@/api/asyncSearch', () => ({
   runAsyncSearch: (...args) => runAsyncSearchMock(...args)
+}))
+
+const isOpenSearchMock = vi.fn()
+vi.mock('@/api/indexDistribution', () => ({
+  isOpenSearchDistribution: (...args) => isOpenSearchMock(...args)
 }))
 
 function emptyResponse() {
@@ -25,7 +29,7 @@ function deferred() {
 }
 
 describe('SearchStore async search wiring', () => {
-  let searchStore, appStore, getVersionSpy, searchDocsSpy
+  let searchStore, appStore, searchDocsSpy
 
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -34,8 +38,8 @@ describe('SearchStore async search wiring', () => {
     searchStore.setIndex('local-index')
     appStore.setSettings('search', { perPage: 25, orderBy: ['_score', 'desc'] })
     runAsyncSearchMock.mockReset()
-    resetIndexDistribution()
-    getVersionSpy = vi.spyOn(api, 'getVersion').mockResolvedValue({ 'index.distribution': 'elasticsearch' })
+    isOpenSearchMock.mockReset()
+    isOpenSearchMock.mockResolvedValue(false)
     searchDocsSpy = vi.spyOn(api.elasticsearch, 'searchDocs').mockResolvedValue(emptyResponse())
   })
 
@@ -55,7 +59,7 @@ describe('SearchStore async search wiring', () => {
     expect(options.signal).toBeInstanceOf(AbortSignal)
     expect(options.signal.aborted).toBe(false)
 
-    d.resolve({ hits: { hits: [], total: { value: 0 } } })
+    d.resolve(emptyResponse())
     await p
   })
 
@@ -74,8 +78,8 @@ describe('SearchStore async search wiring', () => {
 
     expect(firstSignal.aborted).toBe(true)
 
-    second.resolve({ hits: { hits: [], total: { value: 0 } } })
-    first.resolve({ hits: { hits: [], total: { value: 0 } } })
+    second.resolve(emptyResponse())
+    first.resolve(emptyResponse())
     await Promise.all([p1, p2])
   })
 
@@ -86,6 +90,7 @@ describe('SearchStore async search wiring', () => {
 
     searchStore.setQuery('alpha')
     const p1 = searchStore.refresh()
+    await flushPromises()
     searchStore.setQuery('beta')
     const p2 = searchStore.refresh()
 
@@ -105,6 +110,7 @@ describe('SearchStore async search wiring', () => {
 
     searchStore.setQuery('alpha')
     const p1 = searchStore.refresh()
+    await flushPromises()
     searchStore.setQuery('beta')
     const p2 = searchStore.refresh()
 
@@ -124,6 +130,7 @@ describe('SearchStore async search wiring', () => {
 
     searchStore.setQuery('alpha')
     const p = searchStore.refresh()
+    await flushPromises()
     searchStore.cancelActiveSearch()
 
     const abortError = new Error('Async search aborted')
@@ -149,7 +156,7 @@ describe('SearchStore async search wiring', () => {
   })
 
   it('runs the search only once for concurrent identical queries', async () => {
-    runAsyncSearchMock.mockResolvedValue({ hits: { hits: [], total: { value: 0 } } })
+    runAsyncSearchMock.mockResolvedValue(emptyResponse())
 
     await Promise.all([searchStore.query('bar'), searchStore.query('bar')])
 
@@ -157,8 +164,8 @@ describe('SearchStore async search wiring', () => {
   })
 
   describe('index distribution gating', () => {
-    it('searches synchronously when the backend reports an opensearch distribution', async () => {
-      getVersionSpy.mockResolvedValue({ 'index.distribution': 'opensearch' })
+    it('searches synchronously when the backend runs OpenSearch', async () => {
+      isOpenSearchMock.mockResolvedValue(true)
       searchDocsSpy.mockResolvedValue({ hits: { hits: [], total: { value: 3 } } })
 
       await searchStore.query('alpha')
@@ -168,7 +175,16 @@ describe('SearchStore async search wiring', () => {
       expect(searchStore.total).toBe(3)
     })
 
-    it('keeps the async search on an elasticsearch distribution', async () => {
+    it('passes the abort signal to the synchronous search', async () => {
+      isOpenSearchMock.mockResolvedValue(true)
+
+      await searchStore.query('alpha')
+
+      const [, options] = searchDocsSpy.mock.calls[0]
+      expect(options.signal).toBeInstanceOf(AbortSignal)
+    })
+
+    it('keeps the async search when the backend does not run OpenSearch', async () => {
       runAsyncSearchMock.mockResolvedValue(emptyResponse())
 
       await searchStore.query('alpha')
@@ -177,35 +193,38 @@ describe('SearchStore async search wiring', () => {
       expect(searchDocsSpy).not.toHaveBeenCalled()
     })
 
-    it('fetches the version only once across consecutive searches', async () => {
-      runAsyncSearchMock.mockResolvedValue(emptyResponse())
+    it('treats a cancelled synchronous search as an abort, not an error', async () => {
+      isOpenSearchMock.mockResolvedValue(true)
+      // The transport rejects with its own error on abort, never an AbortError.
+      searchDocsSpy.mockImplementation((searchParams, { signal }) => {
+        return new Promise((resolve, reject) => {
+          signal.addEventListener('abort', () => reject(new Error('Request aborted by the transport')))
+        })
+      })
 
-      await searchStore.query('alpha')
-      await searchStore.query('beta')
+      searchStore.setQuery('alpha')
+      const p = searchStore.refresh()
+      await flushPromises()
+      searchStore.cancelActiveSearch()
+      await p
 
-      expect(getVersionSpy).toHaveBeenCalledTimes(1)
-    })
-
-    it('falls back to the async search when the version request fails', async () => {
-      getVersionSpy.mockRejectedValue(new Error('backend unreachable'))
-      runAsyncSearchMock.mockResolvedValue(emptyResponse())
-
-      await searchStore.query('alpha')
-
-      expect(runAsyncSearchMock).toHaveBeenCalledTimes(1)
       expect(searchStore.error).toBeNull()
+      expect(searchStore.isReady).toBe(true)
     })
 
-    it('retries the version request on the next search after a failure', async () => {
-      getVersionSpy.mockRejectedValueOnce(new Error('backend unreachable'))
-      getVersionSpy.mockResolvedValue({ 'index.distribution': 'opensearch' })
-      runAsyncSearchMock.mockResolvedValue(emptyResponse())
+    it('does not submit a search when the run is aborted during the probe', async () => {
+      const probe = deferred()
+      isOpenSearchMock.mockReturnValue(probe.promise)
 
-      await searchStore.query('alpha')
-      await searchStore.query('beta')
+      searchStore.setQuery('alpha')
+      const p = searchStore.refresh()
+      searchStore.cancelActiveSearch()
+      probe.resolve(false)
+      await p
 
-      expect(getVersionSpy).toHaveBeenCalledTimes(2)
-      expect(searchDocsSpy).toHaveBeenCalledTimes(1)
+      expect(runAsyncSearchMock).not.toHaveBeenCalled()
+      expect(searchDocsSpy).not.toHaveBeenCalled()
+      expect(searchStore.error).toBeNull()
     })
   })
 })

--- a/tests/unit/specs/store/modules/search.asyncSearch.spec.js
+++ b/tests/unit/specs/store/modules/search.asyncSearch.spec.js
@@ -1,11 +1,17 @@
+import { flushPromises } from '@vue/test-utils'
 import { setActivePinia, createPinia } from 'pinia'
 
 import { useAppStore, useSearchStore } from '@/store/modules'
+import { apiInstance as api } from '@/api/apiInstance'
 
 const runAsyncSearchMock = vi.fn()
 vi.mock('@/api/asyncSearch', () => ({
   runAsyncSearch: (...args) => runAsyncSearchMock(...args)
 }))
+
+function emptyResponse() {
+  return { hits: { hits: [], total: { value: 0 } } }
+}
 
 function deferred() {
   let resolveFn
@@ -18,7 +24,7 @@ function deferred() {
 }
 
 describe('SearchStore async search wiring', () => {
-  let searchStore, appStore
+  let searchStore, appStore, getVersionSpy, searchDocsSpy
 
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -27,6 +33,12 @@ describe('SearchStore async search wiring', () => {
     searchStore.setIndex('local-index')
     appStore.setSettings('search', { perPage: 25, orderBy: ['_score', 'desc'] })
     runAsyncSearchMock.mockReset()
+    getVersionSpy = vi.spyOn(api, 'getVersion').mockResolvedValue({ 'index.distribution': 'elasticsearch' })
+    searchDocsSpy = vi.spyOn(api.elasticsearch, 'searchDocs').mockResolvedValue(emptyResponse())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('passes an abort signal to the runner', async () => {
@@ -35,6 +47,7 @@ describe('SearchStore async search wiring', () => {
 
     searchStore.setQuery('alpha')
     const p = searchStore.refresh()
+    await flushPromises()
 
     const [, , options] = runAsyncSearchMock.mock.calls[0]
     expect(options.signal).toBeInstanceOf(AbortSignal)
@@ -51,6 +64,7 @@ describe('SearchStore async search wiring', () => {
 
     searchStore.setQuery('alpha')
     const p1 = searchStore.refresh()
+    await flushPromises()
     const firstSignal = runAsyncSearchMock.mock.calls[0][2].signal
 
     searchStore.setQuery('beta')
@@ -138,5 +152,58 @@ describe('SearchStore async search wiring', () => {
     await Promise.all([searchStore.query('bar'), searchStore.query('bar')])
 
     expect(runAsyncSearchMock).toHaveBeenCalledTimes(1)
+  })
+
+  describe('index distribution gating', () => {
+    it('searches synchronously when the backend reports an opensearch distribution', async () => {
+      getVersionSpy.mockResolvedValue({ 'index.distribution': 'opensearch' })
+      searchDocsSpy.mockResolvedValue({ hits: { hits: [], total: { value: 3 } } })
+
+      await searchStore.query('alpha')
+
+      expect(searchDocsSpy).toHaveBeenCalledTimes(1)
+      expect(runAsyncSearchMock).not.toHaveBeenCalled()
+      expect(searchStore.total).toBe(3)
+    })
+
+    it('keeps the async search on an elasticsearch distribution', async () => {
+      runAsyncSearchMock.mockResolvedValue(emptyResponse())
+
+      await searchStore.query('alpha')
+
+      expect(runAsyncSearchMock).toHaveBeenCalledTimes(1)
+      expect(searchDocsSpy).not.toHaveBeenCalled()
+    })
+
+    it('fetches the version only once across consecutive searches', async () => {
+      runAsyncSearchMock.mockResolvedValue(emptyResponse())
+
+      await searchStore.query('alpha')
+      await searchStore.query('beta')
+
+      expect(getVersionSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('falls back to the async search when the version request fails', async () => {
+      getVersionSpy.mockRejectedValue(new Error('backend unreachable'))
+      runAsyncSearchMock.mockResolvedValue(emptyResponse())
+
+      await searchStore.query('alpha')
+
+      expect(runAsyncSearchMock).toHaveBeenCalledTimes(1)
+      expect(searchStore.error).toBeNull()
+    })
+
+    it('retries the version request on the next search after a failure', async () => {
+      getVersionSpy.mockRejectedValueOnce(new Error('backend unreachable'))
+      getVersionSpy.mockResolvedValue({ 'index.distribution': 'opensearch' })
+      runAsyncSearchMock.mockResolvedValue(emptyResponse())
+
+      await searchStore.query('alpha')
+      await searchStore.query('beta')
+
+      expect(getVersionSpy).toHaveBeenCalledTimes(2)
+      expect(searchDocsSpy).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/tests/unit/specs/store/modules/search.spec.js
+++ b/tests/unit/specs/store/modules/search.spec.js
@@ -11,6 +11,12 @@ import NamedEntity from '@/api/resources/NamedEntity'
 import { useAppStore, useSearchStore } from '@/store/modules'
 import { apiInstance as api } from '@/api/apiInstance'
 
+// This suite runs against a live Elasticsearch: pin the async route so no
+// search waits on a real /version probe against the test host.
+vi.mock('@/api/indexDistribution', () => ({
+  isOpenSearchDistribution: () => Promise.resolve(false)
+}))
+
 describe('SearchStore', () => {
   const { index, es } = esConnectionHelper.build()
   const { index: anotherIndex } = esConnectionHelper.build()
@@ -158,19 +164,16 @@ describe('SearchStore', () => {
       expect(spy).toHaveBeenCalledTimes(1)
     })
 
-    it('does not mark a cancelled query as applied, so returning to it retries the search', () => {
-      const spy = vi.spyOn(api.elasticsearch, 'submitAsyncSearch')
-
-      // Never settles, so the assertion below must hold synchronously -
-      // before any abort rejection could unwind through doRefresh.
-      spy.mockImplementationOnce(() => new Promise(() => {}))
-
-      searchStore.query('bar')
+    it('does not mark a cancelled query as applied, so returning to it retries the search', async () => {
+      // A run cancelled this early never submits anything: the abort lands
+      // while searchDocuments is still probing the index distribution.
+      const promise = searchStore.query('bar')
       searchStore.cancelActiveSearch()
 
       // Same check useSearchFilter's route guards use to decide whether to
       // refetch on route re-entry: a cancelled query must not count as applied.
       expect(searchStore.sameAppliedQuery(searchStore.toRouteQuery, ['from'])).toBe(false)
+      await promise
     })
 
     it('should return document from local project', async () => {


### PR DESCRIPTION
Implements option 2 from icij/datashare#2349: OpenSearch has no `_async_search` endpoint, so the client now checks the `index.distribution` reported by the backend's `/version` endpoint and searches synchronously on OpenSearch, keeping async search on Elasticsearch.

- fix: gate `searchDocuments` on a memoized `index.distribution` probe, falling back to the synchronous `searchDocs` on OpenSearch
- fix: only cache conclusive probe verdicts (the backend answers `unknown` when its own index probe fails) and retry inconclusive or failed probes on the next search
- fix: probe through a silent, timeboxed `/version` request so a failing probe never toasts or hangs a search
- fix: wire the abort signal into the synchronous search and skip submission when a run is cancelled during the probe
- test: cover the distribution probe caching/retry semantics and the sync-path cancellation

Closes icij/datashare#2349