### PR TITLE
fix: false "Unsupported format" warning on audio and video player

### DIFF
--- a/src/components/Document/DocumentViewer/DocumentViewerAudio.vue
+++ b/src/components/Document/DocumentViewer/DocumentViewerAudio.vue
@@ -11,6 +11,8 @@
       :src="document.inlineFullUrl"
       :type="document.contentType"
       class="audio-viewer__player w-100 d-inline-block"
+      @error="onPlayerError"
+      @canplay="onCanPlay"
     />
     <template #footer>
       <div class="d-lg-flex">
@@ -34,7 +36,7 @@
           </b-form-checkbox>
         </div>
         <b-alert
-          :model-value="cannotPlayAudioFormat"
+          :model-value="cannotPlay"
           variant="warning"
           class="ms-auto mt-3 mb-0 my-lg-auto"
         >
@@ -56,7 +58,7 @@ import { useI18n } from 'vue-i18n'
 import { usePlayerStore } from '@/store/modules/player'
 
 /**
- * Display a preview video of the document.
+ * Display a preview audio of the document.
  */
 export default {
   name: 'DocumentViewerAudio',
@@ -75,17 +77,24 @@ export default {
     const { t } = useI18n()
     return { t }
   },
+  data() {
+    return {
+      cannotPlay: false
+    }
+  },
   computed: {
-    cannotPlayAudioFormat() {
-      return !this.canPlayAudioFormat
-    },
-    canPlayAudioFormat() {
-      return document.createElement('audio').canPlayType(this.document.contentType) !== ''
-    },
     cardVariant() {
-      return this.cannotPlayAudioFormat ? 'warning' : null
+      return this.cannotPlay ? 'warning' : null
     },
     ...mapWritableState(usePlayerStore, ['loop', 'autoplay'])
+  },
+  methods: {
+    onPlayerError(e) {
+      this.cannotPlay = e.target?.error?.code === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED
+    },
+    onCanPlay() {
+      this.cannotPlay = false
+    }
   }
 }
 </script>

--- a/src/components/Document/DocumentViewer/DocumentViewerVideo.vue
+++ b/src/components/Document/DocumentViewer/DocumentViewerVideo.vue
@@ -13,13 +13,12 @@
         controls
         :autoplay="autoplay"
         :loop="loop"
+        :src="document.inlineFullUrl"
+        :type="document.contentType"
         class="video-viewer__player w-100"
-      >
-        <source
-          :src="document.inlineFullUrl"
-          :type="document.contentType"
-        >
-      </video>
+        @error="onPlayerError"
+        @canplay="onCanPlay"
+      />
     </dismissable-content-warning>
     <template #footer>
       <div class="d-lg-flex">
@@ -43,7 +42,7 @@
           </b-form-checkbox>
         </div>
         <b-alert
-          :model-value="cannotPlayVideoFormat"
+          :model-value="cannotPlay"
           variant="warning"
           class="ms-auto mt-3 mb-0 my-lg-auto"
         >
@@ -91,18 +90,13 @@ export default {
   data() {
     return {
       blurred: true,
-      blurredContent: null
+      blurredContent: null,
+      cannotPlay: false
     }
   },
   computed: {
-    cannotPlayVideoFormat() {
-      return !this.canPlayVideoFormat
-    },
-    canPlayVideoFormat() {
-      return document.createElement('video').canPlayType(this.document.contentType) !== ''
-    },
     cardVariant() {
-      return this.cannotPlayVideoFormat ? 'warning' : null
+      return this.cannotPlay ? 'warning' : null
     },
     ...mapWritableState(usePlayerStore, ['autoplay', 'loop'])
   },
@@ -110,6 +104,14 @@ export default {
     this.blurred = await this.isBlurred(this.document)
     if (this.blurred) {
       this.blurredContent = await this.getBlurredContentBanner(this.document)
+    }
+  },
+  methods: {
+    onPlayerError(e) {
+      this.cannotPlay = e.target?.error?.code === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED
+    },
+    onCanPlay() {
+      this.cannotPlay = false
     }
   }
 }


### PR DESCRIPTION
## Summary

The audio and video players used canPlayType() to check if the browser supports the file format. This method tests the MIME type string assigned by Tika, which often differs from the standard types browsers recognize (for example audio/vnd.wave instead of audio/wav, audio/vorbis instead of audio/ogg). This caused false "Unsupported format" warnings on files the browser could play perfectly fine. 

## Proposal

The fix replaces this with actual player events: @error with MEDIA_ERR_SRC_NOT_SUPPORTED fires only when the browser truly cannot decode the file, and @canplay clears the warning when playback succeeds.