### PR TITLE
feat: keep the text tab responsive on oversized markdown pages

### DIFF
--- a/src/components/Document/DocumentContent.vue
+++ b/src/components/Document/DocumentContent.vue
@@ -323,11 +323,6 @@ function fallbackToTextForEmptyMarkdown() {
   preferMarkdown.value = false
 }
 
-function fallbackToTextForOversizedMarkdown() {
-  markdownOversized.value = true
-  preferMarkdown.value = false
-}
-
 // Both paginations describe the same physical pages when their counts match,
 // so the page number survives the toggle; anything else has no page
 // correspondence and goes back to the first page.
@@ -690,7 +685,7 @@ async function loadContentSliceAround(desiredOffset) {
         :render-oversized="markdownOversized"
         @fallback="preferMarkdown = false"
         @empty="fallbackToTextForEmptyMarkdown"
-        @oversized="fallbackToTextForOversizedMarkdown"
+        @oversized="markdownOversized = true; preferMarkdown = false"
       />
       <div
         v-else-if="hasExtractedContent"

--- a/src/components/Document/DocumentContent.vue
+++ b/src/components/Document/DocumentContent.vue
@@ -325,7 +325,7 @@ function fallbackToTextForEmptyMarkdown() {
 
 // Both paginations describe the same physical pages when their counts match,
 // so the page number survives the toggle; anything else has no page
-// correspondence and goes back to the first page.
+// correspondence, so each side keeps its own last position.
 async function syncPagePosition(markdown) {
   // A translation forces text mode through its own contract (start at offset
   // 0, handled by the targetLanguage watcher): its offsets describe another
@@ -336,7 +336,12 @@ async function syncPagePosition(markdown) {
   }
   const aligned = !!syncedPages.value?.length && syncedPages.value.length === markdownPagesCount.value
   if (markdown) {
-    markdownPage.value = aligned ? pageForOffset(activeContentSliceOffset.value) : 1
+    // An unaligned flip is a mode toggle, not a navigation: a page-1 reset here
+    // would fire the `markdownPage` watcher and silently clear the "render
+    // anyway" consent the reader just gave for the page they were on.
+    if (aligned) {
+      markdownPage.value = pageForOffset(activeContentSliceOffset.value)
+    }
     return
   }
   // The restored page needs its text slice loaded, and going through
@@ -686,6 +691,7 @@ async function loadContentSliceAround(desiredOffset) {
         @fallback="preferMarkdown = false"
         @empty="fallbackToTextForEmptyMarkdown"
         @oversized="markdownOversized = true; preferMarkdown = false"
+        @rendered="markdownOversized = false"
       />
       <div
         v-else-if="hasExtractedContent"

--- a/src/components/Document/DocumentContent.vue
+++ b/src/components/Document/DocumentContent.vue
@@ -64,6 +64,10 @@ const preferMarkdown = ref(true)
 // That only shows once its first page comes back empty, so the toggle is built
 // from the manifest and this runtime finding together.
 const isMarkdownEmpty = ref(false)
+// An oversized page already sent the reader to plain text once for this
+// document: the dropdown's "Formatted" entry then becomes their explicit
+// "render anyway", so the child renders it instead of re-emitting.
+const markdownOversized = ref(false)
 const markdownPage = ref(1)
 const markdownMatches = ref([])
 // The term the occurrence counts were computed for. The marks a page renders
@@ -251,6 +255,7 @@ watch(isMarkdownMode, async (markdown) => {
 watch(docId, async () => {
   preferMarkdown.value = true
   isMarkdownEmpty.value = false
+  markdownOversized.value = false
   markdownPage.value = 1
   markdownMatches.value = []
   markdownAppliedTerm.value = ''
@@ -309,6 +314,11 @@ function fallbackToTextForEmptyMarkdown() {
     return
   }
   isMarkdownEmpty.value = true
+  preferMarkdown.value = false
+}
+
+function fallbackToTextForOversizedMarkdown() {
+  markdownOversized.value = true
   preferMarkdown.value = false
 }
 
@@ -638,6 +648,7 @@ async function loadContentSliceAround(desiredOffset) {
           v-if="hasMarkdown"
           v-model="preferMarkdown"
           :markdown-disabled="isMarkdownEmpty"
+          :markdown-slow="markdownOversized"
           :translation="isTranslation"
           class="flex-shrink-0 ms-auto"
         />
@@ -670,8 +681,10 @@ async function loadContentSliceAround(desiredOffset) {
         :term="markdownAppliedTerm"
         :global-search-terms="globalSearchTerms"
         :active-match="activeMarkdownMatch"
+        :render-oversized="markdownOversized"
         @fallback="preferMarkdown = false"
         @empty="fallbackToTextForEmptyMarkdown"
+        @oversized="fallbackToTextForOversizedMarkdown"
       />
       <div
         v-else-if="hasExtractedContent"

--- a/src/components/Document/DocumentContent.vue
+++ b/src/components/Document/DocumentContent.vue
@@ -249,6 +249,12 @@ watch(isMarkdownMode, async (markdown) => {
   }
 })
 
+// Consent to render an oversized page is given for that page, not for the
+// document: the next page gets the size guard again.
+watch(markdownPage, () => {
+  markdownOversized.value = false
+})
+
 // The manifest, the page and the matches all describe one document. The mount
 // probe cannot cover a host that swaps the prop without remounting, so the
 // document identity re-runs it and clears what belonged to the previous one.

--- a/src/components/Document/DocumentContentDropdown.vue
+++ b/src/components/Document/DocumentContentDropdown.vue
@@ -55,6 +55,18 @@ const scrollParent = useScrollParent({ node: document.body })
     :aria-label="t('documentContent.view.ariaLabel')"
     class="document-content-dropdown"
   >
+    <b-dropdown-text
+      v-if="translation"
+      text-class="document-content-dropdown__reason bg-warning-subtle text-warning-emphasis small mb-1 py-2"
+    >
+      {{ t('documentContent.view.translationTooltip') }}
+    </b-dropdown-text>
+    <b-dropdown-text
+      v-else-if="markdownSlow"
+      text-class="document-content-dropdown__reason bg-warning-subtle text-warning-emphasis small mb-1 py-2"
+    >
+      {{ t('documentContent.view.oversizedTooltip') }}
+    </b-dropdown-text>
     <b-dropdown-item-button
       :active="isMarkdownActive"
       :disabled="markdownDisabled || translation"
@@ -77,17 +89,5 @@ const scrollParent = useScrollParent({ node: document.body })
         {{ t('documentContent.view.text') }}
       </span>
     </b-dropdown-item-button>
-    <b-dropdown-text
-      v-if="translation"
-      text-class="document-content-dropdown__reason"
-    >
-      {{ t('documentContent.view.translationTooltip') }}
-    </b-dropdown-text>
-    <b-dropdown-text
-      v-else-if="markdownSlow"
-      text-class="document-content-dropdown__reason"
-    >
-      {{ t('documentContent.view.oversizedTooltip') }}
-    </b-dropdown-text>
   </app-dropdown>
 </template>

--- a/src/components/Document/DocumentContentDropdown.vue
+++ b/src/components/Document/DocumentContentDropdown.vue
@@ -91,3 +91,12 @@ const scrollParent = useScrollParent({ node: document.body })
     </b-dropdown-item-button>
   </app-dropdown>
 </template>
+
+<style lang="scss">
+// The menu sizes itself to its widest child, so a one-line reason would
+// stretch it to the sentence's full length: cap it and let the text wrap.
+.document-content-dropdown__reason {
+  max-width: 240px;
+  white-space: normal;
+}
+</style>

--- a/src/components/Document/DocumentContentDropdown.vue
+++ b/src/components/Document/DocumentContentDropdown.vue
@@ -27,6 +27,14 @@ const props = defineProps({
   translation: {
     type: Boolean,
     default: false
+  },
+  /**
+   * The formatted view exists but is very large: the reader fell back to
+   * plain text and picking Formatted again will render it anyway, slowly.
+   */
+  markdownSlow: {
+    type: Boolean,
+    default: false
   }
 })
 
@@ -74,6 +82,12 @@ const scrollParent = useScrollParent({ node: document.body })
       text-class="document-content-dropdown__reason"
     >
       {{ t('documentContent.view.translationTooltip') }}
+    </b-dropdown-text>
+    <b-dropdown-text
+      v-else-if="markdownSlow"
+      text-class="document-content-dropdown__reason"
+    >
+      {{ t('documentContent.view.oversizedTooltip') }}
     </b-dropdown-text>
   </app-dropdown>
 </template>

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -2,7 +2,7 @@
 import { computed, nextTick, reactive, ref, toRef, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { addSearchMarksClassInHtml } from '@/utils/strings'
+import { addSearchMarksClassesInHtml } from '@/utils/strings'
 import { renderMarkdownOffThread } from '@/utils/markdownOffThread'
 import { useMarkdownAnchors } from '@/composables/useMarkdownAnchors'
 import { useUtils } from '@/composables/useUtils'
@@ -88,15 +88,18 @@ function cacheKeyFor(page) {
 
 const markedHtml = computed(() => {
   const html = renderedPages[cacheKeyFor(props.page)] ?? ''
-  const locallyMarked = addSearchMarksClassInHtml(html, props.term)
-  // Global marks go on last so they nest inside the local ones, the order the
+  const globalMarks = props.globalSearchTerms.map(({ label }, index) => {
+    const style = `border-color: ${getTermIndexColor(index)}`
+    return { term: label, className: 'global-search-term', style }
+  })
+  // Global marks come after the local one so they nest inside it, the order the
   // `extracted-text` pipeline chain produces for the plain text view. Unlike that
   // chain, a `regex` term is matched literally: this marker walks text nodes so it
-  // never marks inside an href, which a regex over rendered HTML would.
-  return props.globalSearchTerms.reduce((marked, { label }, index) => {
-    const style = `border-color: ${getTermIndexColor(index)}`
-    return addSearchMarksClassInHtml(marked, label, { className: 'global-search-term', style })
-  }, locallyMarked)
+  // never marks inside an href, which a regex over rendered HTML would. All of
+  // them share one parse, so a page the reader forced open past the size
+  // threshold does not pay a full parse per term on every keystroke.
+  const marks = [{ term: props.term, className: 'local-search-term' }, ...globalMarks]
+  return addSearchMarksClassesInHtml(html, marks)
 })
 
 // A legitimately empty structure page renders to an empty string, which is

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -47,10 +47,26 @@ const props = defineProps({
   globalSearchTerms: {
     type: Array,
     default: () => []
+  },
+  /**
+   * Raw markdown size (in characters) above which a page is not rendered:
+   * the component emits `oversized` and lets the parent decide.
+   */
+  oversizedThreshold: {
+    type: Number,
+    default: 5e5
+  },
+  /**
+   * Render a page even when it exceeds the threshold — the parent sets this
+   * once the reader has explicitly asked for the formatted view again.
+   */
+  renderOversized: {
+    type: Boolean,
+    default: false
   }
 })
 
-const emit = defineEmits(['fallback', 'empty'])
+const emit = defineEmits(['fallback', 'empty', 'oversized'])
 
 const { t } = useI18n()
 const { getTermIndexColor } = useUtils()
@@ -102,8 +118,9 @@ async function loadPage() {
   error.value = null
   loading.value = true
   let loadError = null
+  let status = null
   try {
-    await renderPageOnce()
+    status = await renderPageOnce()
   }
   catch (failure) {
     loadError = failure
@@ -113,9 +130,17 @@ async function loadPage() {
   }
   error.value = loadError
   loading.value = false
-  if (!loadError) {
-    reportEmptyPage()
+  if (loadError) {
+    return
   }
+  // An oversized page is deliberately left unrendered and uncached, so it must
+  // not be mistaken for an empty one: `empty` permanently disables the
+  // formatted option, `oversized` only steers the reader to plain text.
+  if (status === 'oversized') {
+    emit('oversized')
+    return
+  }
+  reportEmptyPage()
 }
 
 // A page can legitimately be blank (a blank cover page in a scanned PDF) without
@@ -139,11 +164,15 @@ async function renderPageOnce() {
   // `in` (rather than a truthiness check) treats an already-cached empty
   // page as a hit instead of re-fetching it on every visit.
   if (targetCacheKey in renderedPages) {
-    return
+    return 'rendered'
   }
   const { index, id, routing } = props.document
   const markdown = await api.getStructurePage(index, id, targetPage, routing)
+  if (markdown.length > props.oversizedThreshold && !props.renderOversized) {
+    return 'oversized'
+  }
   renderedPages[targetCacheKey] = await renderMarkdownOffThread(markdown)
+  return 'rendered'
 }
 
 let lastCook = 0

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -2,26 +2,58 @@
 import { reactive } from 'vue'
 
 // Module scope, so a Formatted/Plain toggle, which unmounts this component,
-// does not throw away pages already downloaded and rendered. Both are cleared
-// when the document changes, so they stay bounded to one document.
+// does not throw away pages already downloaded and rendered. Every key is
+// prefixed with its document id, so the caches can hold several documents at
+// once and evict them one at a time.
 const renderedPages = reactive({})
 // The markdown of pages the threshold refused to render, kept so consenting to
 // one does not download it a second time.
 const oversizedSources = {}
-let cachedDocumentId = null
+// How many mounted instances currently show each document id. Instances share
+// these caches, so no instance may drop keys another one is still rendering.
+const shownDocumentIds = new Map()
 
-function switchPageCacheTo(documentId) {
-  if (cachedDocumentId === documentId) {
+function dropDocumentPages(documentId) {
+  const prefix = `${documentId}:`
+  const drop = (cache) => {
+    Object.keys(cache)
+      .filter(key => key.startsWith(prefix))
+      .forEach(key => delete cache[key])
+  }
+  drop(renderedPages)
+  drop(oversizedSources)
+}
+
+// Deferred rather than done on unmount: unmounting is also what a Formatted/
+// Plain toggle does, and those pages are wanted again seconds later. A document
+// nobody shows is dropped once a different one is opened, which is the point at
+// which holding on to it stops paying for itself.
+function dropUnshownDocuments() {
+  for (const [documentId, count] of shownDocumentIds) {
+    if (count > 0) {
+      continue
+    }
+    shownDocumentIds.delete(documentId)
+    dropDocumentPages(documentId)
+  }
+}
+
+function showDocument(documentId) {
+  shownDocumentIds.set(documentId, (shownDocumentIds.get(documentId) ?? 0) + 1)
+  dropUnshownDocuments()
+}
+
+function hideDocument(documentId) {
+  const count = shownDocumentIds.get(documentId)
+  if (count === undefined) {
     return
   }
-  cachedDocumentId = documentId
-  Object.keys(renderedPages).forEach(key => delete renderedPages[key])
-  Object.keys(oversizedSources).forEach(key => delete oversizedSources[key])
+  shownDocumentIds.set(documentId, count - 1)
 }
 </script>
 
 <script setup>
-import { computed, nextTick, ref, toRef, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, onUnmounted, ref, toRef, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { addSearchMarksClassesInHtml } from '@/utils/strings'
@@ -109,6 +141,19 @@ function cacheKeyFor(page) {
   return `${props.document.id}:${page}`
 }
 
+let shownDocumentId = null
+
+function showOnlyDocument(documentId) {
+  if (shownDocumentId === documentId) {
+    return
+  }
+  hideDocument(shownDocumentId)
+  shownDocumentId = documentId
+  showDocument(documentId)
+}
+
+onUnmounted(() => hideDocument(shownDocumentId))
+
 const markedHtml = computed(() => {
   const html = renderedPages[cacheKeyFor(props.page)] ?? ''
   const globalMarks = props.globalSearchTerms.map(({ label }, index) => {
@@ -159,9 +204,10 @@ async function loadPage() {
   if (loadError) {
     return
   }
-  // An oversized page is deliberately left unrendered and uncached, so it must
-  // not be mistaken for an empty one: `empty` permanently disables the
-  // formatted option, `oversized` only steers the reader to plain text.
+  // An oversized page is deliberately left unrendered (only its raw markdown is
+  // kept, for the render-anyway path), so it must not be mistaken for an empty
+  // one: `empty` permanently disables the formatted option, `oversized` only
+  // steers the reader to plain text.
   if (status === 'oversized') {
     emit('oversized')
     return
@@ -255,8 +301,8 @@ function activateMatch() {
 // two watchers would fire twice and issue the same request twice.
 watch([() => props.page, () => props.document?.id], ([, id]) => {
   // Rendered pages are worth keeping while the reader pages through a document,
-  // not once they have left it.
-  switchPageCacheTo(id)
+  // and while any other instance still shows it.
+  showOnlyDocument(id)
   loadPage()
 }, { immediate: true })
 watch(markedHtml, cookHtml, { immediate: true })

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -122,7 +122,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['fallback', 'empty', 'oversized'])
+const emit = defineEmits(['fallback', 'empty', 'oversized', 'rendered'])
 
 const { t } = useI18n()
 const { getTermIndexColor } = useUtils()
@@ -212,6 +212,10 @@ async function loadPage() {
     emit('oversized')
     return
   }
+  // Tells the parent the page displays fine (a cache hit serves it instantly
+  // from now on), so a "may be slow" warning earned earlier can be cleared even
+  // when no page or document change ever fires the watchers that clear it.
+  emit('rendered')
   reportEmptyPage()
 }
 
@@ -229,9 +233,7 @@ function reportEmptyPage() {
 
 async function fetchPageSource(cacheKey, page) {
   if (cacheKey in oversizedSources) {
-    const source = oversizedSources[cacheKey]
-    delete oversizedSources[cacheKey]
-    return source
+    return oversizedSources[cacheKey]
   }
   const { index, id, routing } = props.document
   return api.getStructurePage(index, id, page, routing)
@@ -261,6 +263,9 @@ async function renderPageOnce(load) {
     return false
   }
   renderedPages[targetCacheKey] = html
+  // Only now has the render actually succeeded: dropping the raw markdown any
+  // earlier would force a failed render's retry to download the page again.
+  delete oversizedSources[targetCacheKey]
   return false
 }
 

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -189,9 +189,9 @@ async function loadPage() {
   error.value = null
   loading.value = true
   let loadError = null
-  let status = null
+  let oversized = false
   try {
-    status = await renderPageOnce(load)
+    oversized = await renderPageOnce(load)
   }
   catch (failure) {
     loadError = failure
@@ -208,7 +208,7 @@ async function loadPage() {
   // kept, for the render-anyway path), so it must not be mistaken for an empty
   // one: `empty` permanently disables the formatted option, `oversized` only
   // steers the reader to plain text.
-  if (status === 'oversized') {
+  if (oversized) {
     emit('oversized')
     return
   }
@@ -246,21 +246,22 @@ async function renderPageOnce(load) {
   // `in` (rather than a truthiness check) treats an already-cached empty
   // page as a hit instead of re-fetching it on every visit.
   if (targetCacheKey in renderedPages) {
-    return 'rendered'
+    return false
   }
   const markdown = await fetchPageSource(targetCacheKey, targetPage)
   if ((markdown?.length ?? 0) > props.oversizedThreshold && !props.renderOversized) {
     oversizedSources[targetCacheKey] = markdown
-    return 'oversized'
+    return true
   }
   const html = await renderMarkdownOffThread(markdown)
   // A document swap cleared the cache while this render was in flight: writing
-  // now would put an unreachable page back into it.
+  // now would put an unreachable page back into it. The caller's own staleness
+  // check fires before it reads the returned value.
   if (load !== lastPageLoad) {
-    return 'stale'
+    return false
   }
   renderedPages[targetCacheKey] = html
-  return 'rendered'
+  return false
 }
 
 let lastCook = 0

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -376,10 +376,12 @@ watch(toRef(props, 'activeMatch'), activateMatch, { flush: 'post' })
 <style lang="scss">
 .document-content-markdown__body {
   // Tables and code blocks are the expensive blocks, so only they skip layout
-  // and paint while off screen. Paragraphs lay out normally, which keeps the
-  // scroll offsets an anchor jump or a mark's scrollIntoView lands on accurate.
-  > table,
-  > pre {
+  // and paint while off screen, however deeply nested (a table in a blockquote
+  // costs as much as a top-level one). Paragraphs lay out normally, which keeps
+  // the scroll offsets an anchor jump or a mark's scrollIntoView lands on
+  // accurate.
+  table,
+  pre {
     content-visibility: auto;
     contain-intrinsic-size: auto 300px;
   }

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -280,3 +280,14 @@ watch(toRef(props, 'activeMatch'), activateMatch, { flush: 'post' })
     />
   </div>
 </template>
+
+<style lang="scss">
+.document-content-markdown__body {
+  // Off-screen blocks skip layout and paint. Anchor jumps and mark
+  // scrollIntoView still work: the browser renders the target on demand.
+  > * {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 300px;
+  }
+}
+</style>

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -3,7 +3,7 @@ import { computed, nextTick, reactive, ref, toRef, useTemplateRef, watch } from 
 import { useI18n } from 'vue-i18n'
 
 import { addSearchMarksClassInHtml } from '@/utils/strings'
-import { renderMarkdownOffThread } from '@/utils/markdown'
+import { renderMarkdownOffThread } from '@/utils/markdownOffThread'
 import { useMarkdownAnchors } from '@/composables/useMarkdownAnchors'
 import { useUtils } from '@/composables/useUtils'
 import { usePipelinesStore } from '@/store/modules'

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -3,7 +3,7 @@ import { computed, nextTick, reactive, ref, toRef, useTemplateRef, watch } from 
 import { useI18n } from 'vue-i18n'
 
 import { addSearchMarksClassInHtml } from '@/utils/strings'
-import { renderMarkdown } from '@/utils/markdown'
+import { renderMarkdownOffThread } from '@/utils/markdown'
 import { useMarkdownAnchors } from '@/composables/useMarkdownAnchors'
 import { useUtils } from '@/composables/useUtils'
 import { usePipelinesStore } from '@/store/modules'
@@ -143,7 +143,7 @@ async function renderPageOnce() {
   }
   const { index, id, routing } = props.document
   const markdown = await api.getStructurePage(index, id, targetPage, routing)
-  renderedPages[targetCacheKey] = await renderMarkdown(markdown)
+  renderedPages[targetCacheKey] = await renderMarkdownOffThread(markdown)
 }
 
 let lastCook = 0

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -323,9 +323,11 @@ watch(toRef(props, 'activeMatch'), activateMatch, { flush: 'post' })
 
 <style lang="scss">
 .document-content-markdown__body {
-  // Off-screen blocks skip layout and paint. Anchor jumps and mark
-  // scrollIntoView still work: the browser renders the target on demand.
-  > * {
+  // Tables and code blocks are the expensive blocks, so only they skip layout
+  // and paint while off screen. Paragraphs lay out normally, which keeps the
+  // scroll offsets an anchor jump or a mark's scrollIntoView lands on accurate.
+  > table,
+  > pre {
     content-visibility: auto;
     contain-intrinsic-size: auto 300px;
   }

--- a/src/components/Document/DocumentContentMarkdown.vue
+++ b/src/components/Document/DocumentContentMarkdown.vue
@@ -1,5 +1,27 @@
+<script>
+import { reactive } from 'vue'
+
+// Module scope, so a Formatted/Plain toggle, which unmounts this component,
+// does not throw away pages already downloaded and rendered. Both are cleared
+// when the document changes, so they stay bounded to one document.
+const renderedPages = reactive({})
+// The markdown of pages the threshold refused to render, kept so consenting to
+// one does not download it a second time.
+const oversizedSources = {}
+let cachedDocumentId = null
+
+function switchPageCacheTo(documentId) {
+  if (cachedDocumentId === documentId) {
+    return
+  }
+  cachedDocumentId = documentId
+  Object.keys(renderedPages).forEach(key => delete renderedPages[key])
+  Object.keys(oversizedSources).forEach(key => delete oversizedSources[key])
+}
+</script>
+
 <script setup>
-import { computed, nextTick, reactive, ref, toRef, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, ref, toRef, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { addSearchMarksClassesInHtml } from '@/utils/strings'
@@ -8,6 +30,7 @@ import { useMarkdownAnchors } from '@/composables/useMarkdownAnchors'
 import { useUtils } from '@/composables/useUtils'
 import { usePipelinesStore } from '@/store/modules'
 import { apiInstance as api } from '@/api/apiInstance'
+import settings from '@/utils/settings'
 
 /**
  * Display one markdown structure page of a document, with local search marks.
@@ -50,14 +73,15 @@ const props = defineProps({
   },
   /**
    * Raw markdown size (in characters) above which a page is not rendered:
-   * the component emits `oversized` and lets the parent decide.
+   * the component emits `oversized` and lets the parent decide. The default
+   * lives in `settings.oversizedMarkdownThreshold`.
    */
   oversizedThreshold: {
     type: Number,
-    default: 5e5
+    default: settings.oversizedMarkdownThreshold
   },
   /**
-   * Render a page even when it exceeds the threshold — the parent sets this
+   * Render a page even when it exceeds the threshold: the parent sets this
    * once the reader has explicitly asked for the formatted view again.
    */
   renderOversized: {
@@ -74,7 +98,6 @@ const pipelinesStore = usePipelinesStore()
 const elementRef = useTemplateRef('element')
 const { scrollToAnchor } = useMarkdownAnchors(elementRef)
 
-const renderedPages = reactive({})
 const cookedHtml = ref('')
 const error = ref(null)
 const loading = ref(false)
@@ -123,7 +146,7 @@ async function loadPage() {
   let loadError = null
   let status = null
   try {
-    status = await renderPageOnce()
+    status = await renderPageOnce(load)
   }
   catch (failure) {
     loadError = failure
@@ -158,7 +181,17 @@ function reportEmptyPage() {
   }
 }
 
-async function renderPageOnce() {
+async function fetchPageSource(cacheKey, page) {
+  if (cacheKey in oversizedSources) {
+    const source = oversizedSources[cacheKey]
+    delete oversizedSources[cacheKey]
+    return source
+  }
+  const { index, id, routing } = props.document
+  return api.getStructurePage(index, id, page, routing)
+}
+
+async function renderPageOnce(load) {
   // Capture the page and document once: re-reading `props` after the
   // `await` below could pick up values changed by navigation while this
   // fetch was in flight, and would write the response under the wrong key.
@@ -169,12 +202,18 @@ async function renderPageOnce() {
   if (targetCacheKey in renderedPages) {
     return 'rendered'
   }
-  const { index, id, routing } = props.document
-  const markdown = await api.getStructurePage(index, id, targetPage, routing)
-  if (markdown.length > props.oversizedThreshold && !props.renderOversized) {
+  const markdown = await fetchPageSource(targetCacheKey, targetPage)
+  if ((markdown?.length ?? 0) > props.oversizedThreshold && !props.renderOversized) {
+    oversizedSources[targetCacheKey] = markdown
     return 'oversized'
   }
-  renderedPages[targetCacheKey] = await renderMarkdownOffThread(markdown)
+  const html = await renderMarkdownOffThread(markdown)
+  // A document swap cleared the cache while this render was in flight: writing
+  // now would put an unreachable page back into it.
+  if (load !== lastPageLoad) {
+    return 'stale'
+  }
+  renderedPages[targetCacheKey] = html
   return 'rendered'
 }
 
@@ -214,12 +253,10 @@ function activateMatch() {
 // The page number can stay the same while the document itself changes (both on
 // page 1), and the page can change on its own, so the pair is watched together:
 // two watchers would fire twice and issue the same request twice.
-watch([() => props.page, () => props.document?.id], ([, id], [, previousId]) => {
-  if (id !== previousId) {
-    // Rendered pages are worth keeping while the reader pages through a document,
-    // not once they have left it.
-    Object.keys(renderedPages).forEach(key => delete renderedPages[key])
-  }
+watch([() => props.page, () => props.document?.id], ([, id]) => {
+  // Rendered pages are worth keeping while the reader pages through a document,
+  // not once they have left it.
+  switchPageCacheTo(id)
   loadPage()
 }, { immediate: true })
 watch(markedHtml, cookHtml, { immediate: true })

--- a/src/components/Document/DocumentViewer/DocumentViewerMarkdown.vue
+++ b/src/components/Document/DocumentViewer/DocumentViewerMarkdown.vue
@@ -3,7 +3,7 @@ import { ref, useTemplateRef, watch } from 'vue'
 
 import { useDocumentSource } from '@/composables/useDocumentSource'
 import { useMarkdownAnchors } from '@/composables/useMarkdownAnchors'
-import { renderMarkdown } from '@/utils/markdown'
+import { renderMarkdownOffThread } from '@/utils/markdownOffThread'
 
 /**
  * Display a Markdown document as safely-sanitized formatted HTML.
@@ -35,7 +35,7 @@ async function load(document) {
   error.value = null
   try {
     const source = await fetchSource(document, { responseType: 'text' })
-    html.value = await renderMarkdown(source)
+    html.value = await renderMarkdownOffThread(source)
   }
   catch (e) {
     error.value = e.message

--- a/src/components/Document/DocumentViewer/DocumentViewerMarkdown.vue
+++ b/src/components/Document/DocumentViewer/DocumentViewerMarkdown.vue
@@ -27,21 +27,33 @@ const html = ref('')
 const error = ref(null)
 const loading = ref(false)
 
+let lastLoad = 0
+
 async function load(document) {
   if (!document) {
     return
   }
+  // Documents can swap while a slow render is in flight: only the newest load
+  // may write, so a stale render cannot overwrite the document now on screen.
+  const loadId = ++lastLoad
   loading.value = true
   error.value = null
   try {
     const source = await fetchSource(document, { responseType: 'text' })
-    html.value = await renderMarkdownOffThread(source)
+    const rendered = await renderMarkdownOffThread(source)
+    if (loadId === lastLoad) {
+      html.value = rendered
+    }
   }
   catch (e) {
-    error.value = e.message
+    if (loadId === lastLoad) {
+      error.value = e.message
+    }
   }
   finally {
-    loading.value = false
+    if (loadId === lastLoad) {
+      loading.value = false
+    }
   }
 }
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -450,6 +450,7 @@
       "markdown": "Formatted",
       "text": "Plain text",
       "translationTooltip": "Translations are only available as plain text",
+      "oversizedTooltip": "The formatted view of this document is very large and may be slow to display",
       "ariaLabel": "Text rendering"
     }
   },

--- a/src/utils/markdown.js
+++ b/src/utils/markdown.js
@@ -248,3 +248,48 @@ export async function renderMarkdown(source, { base = window.location.href } = {
   const value = normalizeHeaderlessTables(source)
   return String(await processor.process({ value, data: { base } }))
 }
+
+let worker = null
+let lastRenderId = 0
+const pendingRenders = new Map()
+
+function onWorkerMessage({ data: { id, html, error } }) {
+  const pending = pendingRenders.get(id)
+  pendingRenders.delete(id)
+  if (!pending) {
+    return
+  }
+  if (error === undefined) {
+    pending.resolve(html)
+  }
+  else {
+    pending.reject(new Error(error))
+  }
+}
+
+function getWorker() {
+  if (!worker) {
+    worker = new Worker(new URL('./markdown.worker.js', import.meta.url), { type: 'module' })
+    worker.onmessage = onWorkerMessage
+  }
+  return worker
+}
+
+/**
+ * Render markdown in a shared Web Worker so a large document cannot freeze
+ * the page. Falls back to an inline render where workers do not exist (jsdom).
+ *
+ * @param {string} source - Raw markdown text.
+ * @returns {Promise<string>} Sanitized HTML (empty string for empty input).
+ */
+export function renderMarkdownOffThread(source) {
+  if (typeof Worker === 'undefined') {
+    return renderMarkdown(source)
+  }
+  const id = ++lastRenderId
+  const base = window.location.href
+  return new Promise((resolve, reject) => {
+    pendingRenders.set(id, { resolve, reject })
+    getWorker().postMessage({ id, source, base })
+  })
+}

--- a/src/utils/markdown.js
+++ b/src/utils/markdown.js
@@ -267,10 +267,20 @@ function onWorkerMessage({ data: { id, html, error } }) {
   }
 }
 
+function onWorkerError(error) {
+  const message = error?.message || 'Worker initialization failed'
+  pendingRenders.forEach(pending => {
+    pending.reject(new Error(message))
+  })
+  pendingRenders.clear()
+  worker = null
+}
+
 function getWorker() {
   if (!worker) {
     worker = new Worker(new URL('./markdown.worker.js', import.meta.url), { type: 'module' })
     worker.onmessage = onWorkerMessage
+    worker.onerror = onWorkerError
   }
   return worker
 }

--- a/src/utils/markdown.js
+++ b/src/utils/markdown.js
@@ -269,7 +269,7 @@ function onWorkerMessage({ data: { id, html, error } }) {
 
 function onWorkerError(error) {
   const message = error?.message || 'Worker initialization failed'
-  pendingRenders.forEach(pending => {
+  pendingRenders.forEach((pending) => {
     pending.reject(new Error(message))
   })
   pendingRenders.clear()

--- a/src/utils/markdown.js
+++ b/src/utils/markdown.js
@@ -61,8 +61,14 @@ function unwrapLink(node, index, parent) {
 // are in-document navigation, and are left alone.
 function rehypeConstrainLinks() {
   return (tree, file) => {
-    const base = file.data.base
-    const baseHost = new URL(base).host
+    // A base that does not parse degrades to "no base at all" rather than
+    // throwing and failing the whole document over one caller's mistake:
+    // absolute hrefs still resolve, relative ones lose their anchor, and a
+    // null host matches nothing so nothing is unwrapped as same-host. Passing
+    // the empty string on as a base would instead break absolute hrefs too.
+    const parsedBase = URL.canParse(file.data.base) ? new URL(file.data.base) : null
+    const base = parsedBase?.href
+    const baseHost = parsedBase?.host ?? null
     visit(tree, 'element', (node, index, parent) => {
       if (node.tagName !== 'a') {
         return
@@ -238,10 +244,10 @@ export function normalizeHeaderlessTables(source) {
  *
  * @param {string} source - Raw markdown text.
  * @param {Object} [options={}] - The render options.
- * @param {string} [options.base=window.location.href] - Page URL that same-host links are unwrapped against.
+ * @param {string} [options.base=globalThis.location?.href] - Page URL that same-host links are unwrapped against.
  * @returns {Promise<string>} Sanitized HTML (empty string for empty input).
  */
-export async function renderMarkdown(source, { base = window.location.href } = {}) {
+export async function renderMarkdown(source, { base = globalThis.location?.href } = {}) {
   if (!source) {
     return ''
   }

--- a/src/utils/markdown.js
+++ b/src/utils/markdown.js
@@ -233,8 +233,8 @@ export function normalizeHeaderlessTables(source) {
  * Convert Markdown source to sanitized, safe-to-render HTML.
  *
  * The unified pipeline runs synchronously on the calling thread; use
- * `renderMarkdownOffThread` from a component so a large document does not
- * freeze the page.
+ * `renderMarkdownOffThread` from `@/utils/markdownOffThread` in a component so
+ * a large document does not freeze the page.
  *
  * @param {string} source - Raw markdown text.
  * @param {Object} [options={}] - The render options.
@@ -247,60 +247,4 @@ export async function renderMarkdown(source, { base = window.location.href } = {
   }
   const value = normalizeHeaderlessTables(source)
   return String(await processor.process({ value, data: { base } }))
-}
-
-let worker = null
-let lastRenderId = 0
-const pendingRenders = new Map()
-
-function onWorkerMessage({ data: { id, html, error } }) {
-  const pending = pendingRenders.get(id)
-  pendingRenders.delete(id)
-  if (!pending) {
-    return
-  }
-  if (error === undefined) {
-    pending.resolve(html)
-  }
-  else {
-    pending.reject(new Error(error))
-  }
-}
-
-function onWorkerError(error) {
-  const message = error?.message || 'Worker initialization failed'
-  pendingRenders.forEach((pending) => {
-    pending.reject(new Error(message))
-  })
-  pendingRenders.clear()
-  worker.terminate()
-  worker = null
-}
-
-function getWorker() {
-  if (!worker) {
-    worker = new Worker(new URL('./markdown.worker.js', import.meta.url), { type: 'module' })
-    worker.onmessage = onWorkerMessage
-    worker.onerror = onWorkerError
-  }
-  return worker
-}
-
-/**
- * Render markdown in a shared Web Worker so a large document cannot freeze
- * the page. Falls back to an inline render where workers do not exist (jsdom).
- *
- * @param {string} source - Raw markdown text.
- * @returns {Promise<string>} Sanitized HTML (empty string for empty input).
- */
-export function renderMarkdownOffThread(source) {
-  if (typeof Worker === 'undefined') {
-    return renderMarkdown(source)
-  }
-  const id = ++lastRenderId
-  const base = window.location.href
-  return new Promise((resolve, reject) => {
-    pendingRenders.set(id, { resolve, reject })
-    getWorker().postMessage({ id, source, base })
-  })
 }

--- a/src/utils/markdown.js
+++ b/src/utils/markdown.js
@@ -273,6 +273,7 @@ function onWorkerError(error) {
     pending.reject(new Error(message))
   })
   pendingRenders.clear()
+  worker.terminate()
   worker = null
 }
 

--- a/src/utils/markdown.js
+++ b/src/utils/markdown.js
@@ -39,8 +39,7 @@ const linkableProtocols = schema.protocols.href.map(protocol => `${protocol}:`)
 // document's author wrote something that is not a URL at all. Authors control
 // this string, and an unparseable one thrown from here would fail the whole
 // document's render rather than the one link.
-function resolveHref(href) {
-  const base = window.location.href
+function resolveHref(href, base) {
   if (!URL.canParse(href, base)) {
     return null
   }
@@ -61,7 +60,9 @@ function unwrapLink(node, index, parent) {
 // reader out of the document they were reading. Same-page (#fragment) links
 // are in-document navigation, and are left alone.
 function rehypeConstrainLinks() {
-  return (tree) => {
+  return (tree, file) => {
+    const base = file.data.base
+    const baseHost = new URL(base).host
     visit(tree, 'element', (node, index, parent) => {
       if (node.tagName !== 'a') {
         return
@@ -70,7 +71,7 @@ function rehypeConstrainLinks() {
       if (typeof href !== 'string' || href.startsWith('#')) {
         return
       }
-      const url = resolveHref(href)
+      const url = resolveHref(href, base)
       // Neither a URL nor a scheme that survives sanitization is a working
       // link: both are treated like the same-host ones below rather than left
       // for the reader to click on in vain.
@@ -80,7 +81,7 @@ function rehypeConstrainLinks() {
       if (!webProtocols.includes(url.protocol)) {
         return
       }
-      if (url.host === window.location.host) {
+      if (url.host === baseHost) {
         return unwrapLink(node, index, parent)
       }
       node.properties.rel = ['noopener', 'noreferrer', 'nofollow']
@@ -231,14 +232,19 @@ export function normalizeHeaderlessTables(source) {
 /**
  * Convert Markdown source to sanitized, safe-to-render HTML.
  *
- * Processing is asynchronous so a large document never blocks the main thread.
+ * The unified pipeline runs synchronously on the calling thread; use
+ * `renderMarkdownOffThread` from a component so a large document does not
+ * freeze the page.
  *
  * @param {string} source - Raw markdown text.
+ * @param {Object} [options={}] - The render options.
+ * @param {string} [options.base=window.location.href] - Page URL that same-host links are unwrapped against.
  * @returns {Promise<string>} Sanitized HTML (empty string for empty input).
  */
-export async function renderMarkdown(source) {
+export async function renderMarkdown(source, { base = window.location.href } = {}) {
   if (!source) {
     return ''
   }
-  return String(await processor.process(normalizeHeaderlessTables(source)))
+  const value = normalizeHeaderlessTables(source)
+  return String(await processor.process({ value, data: { base } }))
 }

--- a/src/utils/markdown.worker.js
+++ b/src/utils/markdown.worker.js
@@ -1,0 +1,13 @@
+import { renderMarkdown } from '@/utils/markdown'
+
+// `base` always comes from the caller: in a worker, `self.location` is the
+// worker script URL, not the page the document is shown on.
+self.onmessage = async ({ data: { id, source, base } }) => {
+  try {
+    const html = await renderMarkdown(source, { base })
+    self.postMessage({ id, html })
+  }
+  catch (error) {
+    self.postMessage({ id, error: error.message })
+  }
+}

--- a/src/utils/markdown.worker.js
+++ b/src/utils/markdown.worker.js
@@ -8,6 +8,6 @@ self.onmessage = async ({ data: { id, source, base } }) => {
     self.postMessage({ id, html })
   }
   catch (error) {
-    self.postMessage({ id, error: error.message })
+    self.postMessage({ id, error: String(error?.message ?? error) })
   }
 }

--- a/src/utils/markdownOffThread.js
+++ b/src/utils/markdownOffThread.js
@@ -34,17 +34,37 @@ function onWorkerMessage({ data: { id, html, error } }) {
   }
 }
 
-// One failure path for every way the worker can die: an error event, a
-// structured-clone failure (messageerror carries no id), or a render that never
-// answers (the browser can kill an OOM worker without any event). A wedged
-// worker blocks its whole queue, so every pending render fails, not just the
-// one that timed out.
+// One failure path for the ways the worker can die without naming a render: an
+// error event, or a structured-clone failure (messageerror carries no id).
+// Nothing says which render broke it, so every pending render fails.
 function failWorker(message) {
   pendingRenders.forEach((pending, id) => {
     settle(id)?.reject(new Error(message))
   })
   worker?.terminate()
   worker = null
+}
+
+// The worker answers in posting order, so the first timer to fire belongs to
+// the render the worker is stuck on (or the browser killed it OOM, without any
+// event). Only that render fails: the queued ones behind it never started, so
+// they are reposted to a fresh worker instead of failing along with it.
+function timeoutRender(id) {
+  settle(id)?.reject(new Error('Markdown worker timed out'))
+  worker?.terminate()
+  worker = null
+  repostPendingRenders()
+}
+
+function repostPendingRenders() {
+  try {
+    pendingRenders.forEach(({ source, base }, id) => {
+      getWorker().postMessage({ id, source, base })
+    })
+  }
+  catch {
+    failWorker('Markdown worker could not be restarted')
+  }
 }
 
 function getWorker() {
@@ -86,8 +106,8 @@ export function renderMarkdownOffThread(source) {
   const id = ++lastRenderId
   const base = window.location.href
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => failWorker('Markdown worker timed out'), RENDER_TIMEOUT)
-    pendingRenders.set(id, { resolve, reject, timer })
+    const timer = setTimeout(() => timeoutRender(id), RENDER_TIMEOUT)
+    pendingRenders.set(id, { resolve, reject, timer, source, base })
     try {
       getWorker().postMessage({ id, source, base })
     }

--- a/src/utils/markdownOffThread.js
+++ b/src/utils/markdownOffThread.js
@@ -1,0 +1,99 @@
+const RENDER_TIMEOUT = 120000
+
+let worker = null
+let lastRenderId = 0
+const pendingRenders = new Map()
+
+// Imported dynamically so the unified stack stays out of the main bundle: the
+// worker chunk is the only place it is statically reachable from.
+async function renderInline(source) {
+  const { renderMarkdown } = await import('@/utils/markdown')
+  return renderMarkdown(source)
+}
+
+function settle(id) {
+  const pending = pendingRenders.get(id)
+  if (!pending) {
+    return null
+  }
+  pendingRenders.delete(id)
+  clearTimeout(pending.timer)
+  return pending
+}
+
+function onWorkerMessage({ data: { id, html, error } }) {
+  const pending = settle(id)
+  if (!pending) {
+    return
+  }
+  if (error === undefined) {
+    pending.resolve(html)
+  }
+  else {
+    pending.reject(new Error(error))
+  }
+}
+
+// One failure path for every way the worker can die: an error event, a
+// structured-clone failure (messageerror carries no id), or a render that never
+// answers (the browser can kill an OOM worker without any event). A wedged
+// worker blocks its whole queue, so every pending render fails, not just the
+// one that timed out.
+function failWorker(message) {
+  pendingRenders.forEach((pending, id) => {
+    settle(id)?.reject(new Error(message))
+  })
+  worker?.terminate()
+  worker = null
+}
+
+function getWorker() {
+  if (!worker) {
+    const spawned = new Worker(new URL('./markdown.worker.js', import.meta.url), { type: 'module' })
+    spawned.onmessage = onWorkerMessage
+    // A late event from a worker already replaced by failWorker must not
+    // terminate its healthy successor.
+    spawned.onerror = (error) => {
+      if (worker === spawned) {
+        failWorker(error?.message || 'Worker initialization failed')
+      }
+    }
+    spawned.onmessageerror = () => {
+      if (worker === spawned) {
+        failWorker('Worker reply could not be deserialized')
+      }
+    }
+    worker = spawned
+  }
+  return worker
+}
+
+/**
+ * Render markdown in a shared Web Worker so a large document cannot freeze
+ * the page. Falls back to an inline render where workers do not exist (jsdom)
+ * or cannot be constructed (a worker-src CSP).
+ *
+ * @param {string} source - Raw markdown text.
+ * @returns {Promise<string>} Sanitized HTML (empty string for empty input).
+ */
+export function renderMarkdownOffThread(source) {
+  if (!source) {
+    return Promise.resolve('')
+  }
+  if (typeof Worker === 'undefined') {
+    return renderInline(source)
+  }
+  const id = ++lastRenderId
+  const base = window.location.href
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => failWorker('Markdown worker timed out'), RENDER_TIMEOUT)
+    pendingRenders.set(id, { resolve, reject, timer })
+    try {
+      getWorker().postMessage({ id, source, base })
+    }
+    catch {
+      settle(id)
+      renderInline(source).then(resolve).catch(reject)
+    }
+  })
+}

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -65,6 +65,7 @@ export default {
     }
   ],
   previewRawMaxContentLength: 5e6,
+  oversizedMarkdownThreshold: 5e5,
   iso6392: {
     tesseract: {
       zho: 'chi_sim'

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -155,28 +155,7 @@ function wrapTextNodeMatches(node, matches, { className, style }) {
   }
 }
 
-/**
- * Highlight term occurrences inside an HTML string, matching text nodes only
- * (never attributes, never across element boundaries), with the same case and
- * diacritic folding as the backend artifact search.
- *
- * @param {string} [html=''] - The HTML content to mark.
- * @param {string} [term=''] - The search term.
- * @param {Object} [options={}] - The mark options.
- * @param {string} [options.className='local-search-term'] - Class of the mark tags.
- * @param {string} [options.style=''] - Inline style of the mark tags.
- * @return {string} - The HTML with `<mark>` around matches.
- */
-export function addSearchMarksClassInHtml(html = '', term = '', { className = 'local-search-term', style = '' } = {}) {
-  const trimmedTerm = term.trim()
-  if (!trimmedTerm) {
-    return html
-  }
-  const { folded: foldedTerm } = foldWithSourceIndexes(trimmedTerm)
-  if (!foldedTerm) {
-    return html
-  }
-  const parsed = new DOMParser().parseFromString(html, 'text/html')
+function markTermInDocument(parsed, foldedTerm, { className, style }) {
   const walker = parsed.createTreeWalker(parsed.body, NodeFilter.SHOW_TEXT)
   // Collect first: wrapping mutates the tree and would derail a live walker
   const textNodes = []
@@ -186,7 +165,54 @@ export function addSearchMarksClassInHtml(html = '', term = '', { className = 'l
   for (const node of textNodes) {
     wrapTextNodeMatches(node, findFoldedMatches(node.nodeValue, foldedTerm), { className, style })
   }
+}
+
+/**
+ * Highlight occurrences of several terms inside an HTML string in a single
+ * parse, matching text nodes only (never attributes, never across element
+ * boundaries), with the same case and diacritic folding as the backend
+ * artifact search.
+ *
+ * Each spec is applied in order over the same document, so a later term's
+ * marks nest inside the marks an earlier one already placed. A spec whose
+ * term is blank (or folds to nothing) is skipped.
+ *
+ * @param {string} [html=''] - The HTML content to mark.
+ * @param {Object[]} [marks=[]] - The marks to apply, in order.
+ * @param {string} marks[].term - The search term.
+ * @param {string} [marks[].className='local-search-term'] - Class of the mark tags.
+ * @param {string} [marks[].style=''] - Inline style of the mark tags.
+ * @return {string} - The HTML with `<mark>` around matches.
+ */
+export function addSearchMarksClassesInHtml(html = '', marks = []) {
+  const foldedMarks = marks
+    .map(({ term = '', className = 'local-search-term', style = '' }) => {
+      const { folded: foldedTerm } = foldWithSourceIndexes(term.trim())
+      return { foldedTerm, className, style }
+    })
+    .filter(({ foldedTerm }) => !!foldedTerm)
+  if (!foldedMarks.length) {
+    return html
+  }
+  const parsed = new DOMParser().parseFromString(html, 'text/html')
+  for (const { foldedTerm, className, style } of foldedMarks) {
+    markTermInDocument(parsed, foldedTerm, { className, style })
+  }
   return parsed.body.innerHTML
+}
+
+/**
+ * Highlight one term's occurrences inside an HTML string.
+ *
+ * @param {string} [html=''] - The HTML content to mark.
+ * @param {string} [term=''] - The search term.
+ * @param {Object} [options={}] - The mark options.
+ * @param {string} [options.className='local-search-term'] - Class of the mark tags.
+ * @param {string} [options.style=''] - Inline style of the mark tags.
+ * @return {string} - The HTML with `<mark>` around matches.
+ */
+export function addSearchMarksClassInHtml(html = '', term = '', { className = 'local-search-term', style = '' } = {}) {
+  return addSearchMarksClassesInHtml(html, [{ term, className, style }])
 }
 
 /**

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -202,20 +202,6 @@ export function addSearchMarksClassesInHtml(html = '', marks = []) {
 }
 
 /**
- * Highlight one term's occurrences inside an HTML string.
- *
- * @param {string} [html=''] - The HTML content to mark.
- * @param {string} [term=''] - The search term.
- * @param {Object} [options={}] - The mark options.
- * @param {string} [options.className='local-search-term'] - Class of the mark tags.
- * @param {string} [options.style=''] - Inline style of the mark tags.
- * @return {string} - The HTML with `<mark>` around matches.
- */
-export function addSearchMarksClassInHtml(html = '', term = '', { className = 'local-search-term', style = '' } = {}) {
-  return addSearchMarksClassesInHtml(html, [{ term, className, style }])
-}
-
-/**
  * Highlight search term occurrences in the given content.
  *
  * @param {string} [content='<div></div>'] - The HTML content to search in.

--- a/tests/unit/specs/components/Document/DocumentContent.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContent.spec.js
@@ -450,6 +450,47 @@ describe('DocumentContent.vue', () => {
       expect(wrapper.findComponent(DocumentContentDropdown).props('markdownDisabled')).toBe(false)
     })
 
+    it('falls back to plain text on an oversized page, keeping the formatted option available', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      wrapper.findComponent({ name: 'DocumentContentMarkdown' }).vm.$emit('oversized')
+      await flushPromises()
+      expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).exists()).toBe(false)
+      expect(wrapper.find('div.document-content__body').exists()).toBe(true)
+      expect(wrapper.findComponent(DocumentContentDropdown).props('markdownDisabled')).toBe(false)
+    })
+
+    it('renders the oversized page for real when the reader flips back to formatted', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      wrapper.findComponent({ name: 'DocumentContentMarkdown' }).vm.$emit('oversized')
+      await flushPromises()
+      wrapper.vm.preferMarkdown = true
+      await flushPromises()
+      const markdownBody = wrapper.findComponent({ name: 'DocumentContentMarkdown' })
+      expect(markdownBody.exists()).toBe(true)
+      expect(markdownBody.props('renderOversized')).toBe(true)
+    })
+
+    it('drops the oversized state when the document changes', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      wrapper.findComponent({ name: 'DocumentContentMarkdown' }).vm.$emit('oversized')
+      await flushPromises()
+      const other = { index: document.index, id: 'other-document-id', routing: 'other-document-id' }
+      await wrapper.setProps({ document: other })
+      await flushPromises()
+      const markdownBody = wrapper.findComponent({ name: 'DocumentContentMarkdown' })
+      expect(markdownBody.exists()).toBe(true)
+      expect(markdownBody.props('renderOversized')).toBe(false)
+    })
+
     it('paginates by the manifest page count in markdown mode', async () => {
       const { document } = await mockDocumentContentSlice('Hello world')
       const { plugins } = core

--- a/tests/unit/specs/components/Document/DocumentContent.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContent.spec.js
@@ -507,6 +507,37 @@ describe('DocumentContent.vue', () => {
       expect(markdownBody.props('renderOversized')).toBe(false)
     })
 
+    it('keeps the page and the render consent when flipping back to formatted on an unaligned document', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      wrapper.vm.markdownPage = 3
+      await flushPromises()
+      wrapper.findComponent({ name: 'DocumentContentMarkdown' }).vm.$emit('oversized')
+      await flushPromises()
+      wrapper.vm.preferMarkdown = true
+      await flushPromises()
+      const markdownBody = wrapper.findComponent({ name: 'DocumentContentMarkdown' })
+      expect(wrapper.vm.markdownPage).toBe(3)
+      expect(markdownBody.props('renderOversized')).toBe(true)
+    })
+
+    it('clears the slow warning once the oversized page actually renders', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      wrapper.findComponent({ name: 'DocumentContentMarkdown' }).vm.$emit('oversized')
+      await flushPromises()
+      wrapper.vm.preferMarkdown = true
+      await flushPromises()
+      wrapper.findComponent({ name: 'DocumentContentMarkdown' }).vm.$emit('rendered')
+      await flushPromises()
+      expect(wrapper.findComponent(DocumentContentDropdown).props('markdownSlow')).toBe(false)
+      expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).exists()).toBe(true)
+    })
+
     it('paginates by the manifest page count in markdown mode', async () => {
       const { document } = await mockDocumentContentSlice('Hello world')
       const { plugins } = core

--- a/tests/unit/specs/components/Document/DocumentContent.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContent.spec.js
@@ -477,6 +477,21 @@ describe('DocumentContent.vue', () => {
       expect(markdownBody.props('renderOversized')).toBe(true)
     })
 
+    it('drops the oversized state when the reader moves to another page', async () => {
+      const { document } = await mockDocumentContentSlice('Hello world')
+      const { plugins } = core
+      const wrapper = shallowMount(DocumentContent, { props: { document }, global: { plugins } })
+      await flushPromises()
+      wrapper.findComponent({ name: 'DocumentContentMarkdown' }).vm.$emit('oversized')
+      await flushPromises()
+      wrapper.vm.preferMarkdown = true
+      await flushPromises()
+      expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).props('renderOversized')).toBe(true)
+      wrapper.vm.markdownPage = 2
+      await flushPromises()
+      expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).props('renderOversized')).toBe(false)
+    })
+
     it('drops the oversized state when the document changes', async () => {
       const { document } = await mockDocumentContentSlice('Hello world')
       const { plugins } = core

--- a/tests/unit/specs/components/Document/DocumentContent.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContent.spec.js
@@ -460,6 +460,7 @@ describe('DocumentContent.vue', () => {
       expect(wrapper.findComponent({ name: 'DocumentContentMarkdown' }).exists()).toBe(false)
       expect(wrapper.find('div.document-content__body').exists()).toBe(true)
       expect(wrapper.findComponent(DocumentContentDropdown).props('markdownDisabled')).toBe(false)
+      expect(wrapper.findComponent(DocumentContentDropdown).props('markdownSlow')).toBe(true)
     })
 
     it('renders the oversized page for real when the reader flips back to formatted', async () => {

--- a/tests/unit/specs/components/Document/DocumentContentDropdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContentDropdown.spec.js
@@ -99,4 +99,19 @@ describe('DocumentContentDropdown.vue', () => {
       expect(wrapper.find('.document-content-dropdown__reason').exists()).toBe(false)
     })
   })
+
+  describe('when the formatted view is oversized', () => {
+    it('warns that the formatted view may be slow, keeping both entries reachable', () => {
+      const wrapper = factory({ modelValue: false, markdownSlow: true })
+      const reason = wrapper.find('.document-content-dropdown__reason')
+      expect(reason.text()).toBe('The formatted view of this document is very large and may be slow to display')
+      expect(findMarkdownEntry(wrapper).attributes('disabled')).toBeUndefined()
+    })
+
+    it('lets the translation reason win when both apply', () => {
+      const wrapper = factory({ modelValue: false, markdownSlow: true, translation: true })
+      const reason = wrapper.find('.document-content-dropdown__reason')
+      expect(reason.text()).toBe('Translations are only available as plain text')
+    })
+  })
 })

--- a/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
@@ -4,6 +4,9 @@ import CoreSetup from '~tests/unit/CoreSetup'
 import DocumentContentMarkdown from '@/components/Document/DocumentContentMarkdown'
 import { usePipelinesStore } from '@/store/modules'
 import { apiInstance as api } from '@/api/apiInstance'
+// The off-thread renderer reaches its inline fallback through a dynamic import;
+// loading the module up front keeps that fallback within one promise flush.
+import '@/utils/markdown'
 
 vi.mock('@/api/apiInstance', async (importOriginal) => {
   const { apiInstance } = await importOriginal()

--- a/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
@@ -22,13 +22,17 @@ vi.mock('@/api/apiInstance', async (importOriginal) => {
 window.HTMLElement.prototype.scrollIntoView = vi.fn()
 
 describe('DocumentContentMarkdown.vue', () => {
-  const document = { index: 'foo', id: 'doc-id', routing: 'root-id' }
-
   let core
+  let document
+  let nextDocumentId = 0
 
   beforeEach(() => {
     vi.clearAllMocks()
     core = CoreSetup.init().useAll()
+    // The rendered-page cache lives at module scope so it survives the
+    // Formatted/Plain unmount cycle: a distinct document per test keeps the
+    // tests from sharing it.
+    document = { index: 'foo', id: `doc-id-${++nextDocumentId}`, routing: 'root-id' }
     api.getStructurePage.mockResolvedValue('# Hello *world*')
   })
 
@@ -42,7 +46,7 @@ describe('DocumentContentMarkdown.vue', () => {
 
   it('fetches and renders the markdown page as sanitized html', async () => {
     const wrapper = await mountComponent()
-    expect(api.getStructurePage).toBeCalledWith('foo', 'doc-id', 1, 'root-id')
+    expect(api.getStructurePage).toBeCalledWith('foo', document.id, 1, 'root-id')
     expect(wrapper.find('h1').text()).toBe('Hello world')
     expect(wrapper.find('em').text()).toBe('world')
   })
@@ -160,7 +164,7 @@ describe('DocumentContentMarkdown.vue', () => {
     await flushPromises()
     await wrapper.setProps({ document })
     await flushPromises()
-    const firstDocumentCalls = api.getStructurePage.mock.calls.filter(([, id]) => id === 'doc-id')
+    const firstDocumentCalls = api.getStructurePage.mock.calls.filter(([, id]) => id === document.id)
     expect(firstDocumentCalls).toHaveLength(2)
   })
 
@@ -302,5 +306,30 @@ describe('DocumentContentMarkdown.vue', () => {
     const wrapper = await mountComponent({ oversizedThreshold: 3, renderOversized: true })
     expect(wrapper.emitted('oversized')).toBeUndefined()
     expect(wrapper.find('h1').text()).toBe('Big page')
+  })
+
+  it('keeps the rendered page across an unmount, so a view toggle does not refetch', async () => {
+    const wrapper = await mountComponent()
+    wrapper.unmount()
+    const remounted = await mountComponent()
+    expect(remounted.find('h1').text()).toContain('world')
+    expect(api.getStructurePage).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders an oversized page from the payload it already downloaded', async () => {
+    api.getStructurePage.mockResolvedValue('# Big page')
+    const wrapper = await mountComponent({ oversizedThreshold: 3 })
+    expect(wrapper.emitted('oversized')).toHaveLength(1)
+    wrapper.unmount()
+    const remounted = await mountComponent({ oversizedThreshold: 3, renderOversized: true })
+    expect(remounted.find('h1').text()).toBe('Big page')
+    expect(api.getStructurePage).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the no-content message rather than an error for a page with no payload', async () => {
+    api.getStructurePage.mockResolvedValue(undefined)
+    const wrapper = await mountComponent()
+    expect(wrapper.find('.document-content-markdown__error').exists()).toBe(false)
+    expect(wrapper.text()).toContain('No content extracted for this document')
   })
 })

--- a/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
@@ -326,6 +326,28 @@ describe('DocumentContentMarkdown.vue', () => {
     expect(api.getStructurePage).toHaveBeenCalledTimes(1)
   })
 
+  it('leaves a sibling showing another document untouched', async () => {
+    const wrapper = await mountComponent()
+    const other = { index: 'foo', id: `${document.id}-sibling`, routing: 'root-id' }
+    const sibling = await mountComponent({ document: other })
+    expect(sibling.find('h1').exists()).toBe(true)
+    // The sibling's own load must not evict the pages this one is showing
+    expect(wrapper.find('h1').exists()).toBe(true)
+    const firstDocumentCalls = api.getStructurePage.mock.calls.filter(([, id]) => id === document.id)
+    expect(firstDocumentCalls).toHaveLength(1)
+  })
+
+  it('drops a document nobody shows any more once another one is opened', async () => {
+    const wrapper = await mountComponent()
+    wrapper.unmount()
+    const other = { index: 'foo', id: `${document.id}-other`, routing: 'root-id' }
+    const openedNext = await mountComponent({ document: other })
+    openedNext.unmount()
+    await mountComponent()
+    const firstDocumentCalls = api.getStructurePage.mock.calls.filter(([, id]) => id === document.id)
+    expect(firstDocumentCalls).toHaveLength(2)
+  })
+
   it('shows the no-content message rather than an error for a page with no payload', async () => {
     api.getStructurePage.mockResolvedValue(undefined)
     const wrapper = await mountComponent()

--- a/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
@@ -90,6 +90,31 @@ describe('DocumentContentMarkdown.vue', () => {
     expect(wrapper.find('h1').text()).toBe('Page two')
   })
 
+  it('does not let a superseded fetch overwrite the current page with an oversized result', async () => {
+    let resolvePageOne
+    const pageOnePromise = new Promise((resolve) => {
+      resolvePageOne = resolve
+    })
+    api.getStructurePage.mockImplementation((index, id, page) => {
+      return page === 1 ? pageOnePromise : Promise.resolve('# Page two')
+    })
+    const wrapper = mount(DocumentContentMarkdown, {
+      props: { document, page: 1, oversizedThreshold: 99 },
+      global: { plugins: core.plugins }
+    })
+    await flushPromises()
+    await wrapper.setProps({ page: 2 })
+    await flushPromises()
+    await flushPromises()
+    expect(wrapper.find('h1').text()).toBe('Page two')
+    // Page 1's oversized payload resolves only now, after navigation moved on to page 2
+    resolvePageOne('a'.repeat(100))
+    await flushPromises()
+    await flushPromises()
+    expect(wrapper.emitted('oversized')).toBeUndefined()
+    expect(wrapper.find('h1').text()).toBe('Page two')
+  })
+
   it('fetches an empty page only once across two visits', async () => {
     api.getStructurePage.mockResolvedValue('')
     const wrapper = await mountComponent()

--- a/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
@@ -4,9 +4,14 @@ import CoreSetup from '~tests/unit/CoreSetup'
 import DocumentContentMarkdown from '@/components/Document/DocumentContentMarkdown'
 import { usePipelinesStore } from '@/store/modules'
 import { apiInstance as api } from '@/api/apiInstance'
+import { renderMarkdownOffThread } from '@/utils/markdownOffThread'
 // The off-thread renderer reaches its inline fallback through a dynamic import;
 // loading the module up front keeps that fallback within one promise flush.
 import '@/utils/markdown'
+
+// Spied rather than replaced: the real renderer still runs, and a single test
+// can make one render fail to exercise the retry path.
+vi.mock('@/utils/markdownOffThread', { spy: true })
 
 vi.mock('@/api/apiInstance', async (importOriginal) => {
   const { apiInstance } = await importOriginal()
@@ -324,6 +329,32 @@ describe('DocumentContentMarkdown.vue', () => {
     const remounted = await mountComponent({ oversizedThreshold: 3, renderOversized: true })
     expect(remounted.find('h1').text()).toBe('Big page')
     expect(api.getStructurePage).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the downloaded oversized payload for retry when the forced render fails', async () => {
+    api.getStructurePage.mockResolvedValue('# Big page')
+    const wrapper = await mountComponent({ oversizedThreshold: 3 })
+    expect(wrapper.emitted('oversized')).toHaveLength(1)
+    wrapper.unmount()
+    renderMarkdownOffThread.mockRejectedValueOnce(new Error('worker died'))
+    const remounted = await mountComponent({ oversizedThreshold: 3, renderOversized: true })
+    expect(remounted.find('.document-content-markdown__error').exists()).toBe(true)
+    await remounted.find('.document-content-markdown__error__retry').trigger('click')
+    await flushPromises()
+    await flushPromises()
+    expect(remounted.find('h1').text()).toBe('Big page')
+    expect(api.getStructurePage).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits rendered once the page displays, so the parent can clear its slow warning', async () => {
+    const wrapper = await mountComponent()
+    expect(wrapper.emitted('rendered')).toHaveLength(1)
+  })
+
+  it('does not emit rendered for an oversized page it refused to render', async () => {
+    api.getStructurePage.mockResolvedValue('a'.repeat(100))
+    const wrapper = await mountComponent({ oversizedThreshold: 99 })
+    expect(wrapper.emitted('rendered')).toBeUndefined()
   })
 
   it('leaves a sibling showing another document untouched', async () => {

--- a/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentContentMarkdown.spec.js
@@ -248,4 +248,31 @@ describe('DocumentContentMarkdown.vue', () => {
       expect(wrapper.find('h1').exists()).toBe(true)
     })
   })
+
+  it('emits oversized instead of rendering a page bigger than the threshold', async () => {
+    api.getStructurePage.mockResolvedValue('a'.repeat(100))
+    const wrapper = await mountComponent({ oversizedThreshold: 99 })
+    expect(wrapper.emitted('oversized')).toHaveLength(1)
+    expect(wrapper.find('.document-content-markdown__body').exists()).toBe(false)
+  })
+
+  it('does not report an oversized page as empty', async () => {
+    api.getStructurePage.mockResolvedValue('a'.repeat(100))
+    const wrapper = await mountComponent({ oversizedThreshold: 99 })
+    expect(wrapper.emitted('empty')).toBeUndefined()
+  })
+
+  it('renders a page at the threshold exactly', async () => {
+    api.getStructurePage.mockResolvedValue('a'.repeat(99))
+    const wrapper = await mountComponent({ oversizedThreshold: 99 })
+    expect(wrapper.emitted('oversized')).toBeUndefined()
+    expect(wrapper.find('.document-content-markdown__body').exists()).toBe(true)
+  })
+
+  it('renders an oversized page when the reader insists', async () => {
+    api.getStructurePage.mockResolvedValue('# Big page')
+    const wrapper = await mountComponent({ oversizedThreshold: 3, renderOversized: true })
+    expect(wrapper.emitted('oversized')).toBeUndefined()
+    expect(wrapper.find('h1').text()).toBe('Big page')
+  })
 })

--- a/tests/unit/specs/components/Document/DocumentViewer/DocumentViewerMarkdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentViewer/DocumentViewerMarkdown.spec.js
@@ -139,6 +139,32 @@ describe('DocumentViewerMarkdown.vue', () => {
     expect(event.defaultPrevented).toBe(false)
   })
 
+  it('does not let a slow load of a previous document overwrite the current one', async () => {
+    let resolveSlowSource
+    apiInstance.getSource.mockImplementation((document) => {
+      if (document.url === 'slow') {
+        return new Promise((resolve) => {
+          resolveSlowSource = resolve
+        })
+      }
+      return Promise.resolve('# fast')
+    })
+    const { plugins } = CoreSetup.init().useAll()
+    const wrapper = shallowMount(DocumentViewerMarkdown, {
+      global: { plugins },
+      props: { document: { url: 'slow' } }
+    })
+    await wrapper.setProps({ document: { url: 'fast' } })
+    await flushPromises()
+    expect(wrapper.find('.markdown-viewer__content').html()).toContain('fast')
+
+    // The slow document's source resolves only now, after navigation moved on.
+    resolveSlowSource('# slow')
+    await flushPromises()
+    expect(wrapper.find('.markdown-viewer__content').html()).toContain('fast')
+    expect(wrapper.find('.markdown-viewer__content').html()).not.toContain('slow')
+  })
+
   it('shows the generic not-available message for non-404 failures', async () => {
     apiInstance.getSource.mockRejectedValue({ response: { status: 500 } })
     const { plugins } = CoreSetup.init().useAll()

--- a/tests/unit/specs/components/Document/DocumentViewer/DocumentViewerMarkdown.spec.js
+++ b/tests/unit/specs/components/Document/DocumentViewer/DocumentViewerMarkdown.spec.js
@@ -3,6 +3,9 @@ import { shallowMount, flushPromises } from '@vue/test-utils'
 import CoreSetup from '~tests/unit/CoreSetup'
 import DocumentViewerMarkdown from '@/components/Document/DocumentViewer/DocumentViewerMarkdown'
 import messages from '@/lang/en.json'
+// The off-thread renderer reaches its inline fallback through a dynamic import;
+// loading the module up front keeps that fallback within one promise flush.
+import '@/utils/markdown'
 
 vi.mock('@/api/apiInstance', () => {
   return {

--- a/tests/unit/specs/utils/markdown.spec.js
+++ b/tests/unit/specs/utils/markdown.spec.js
@@ -1,4 +1,4 @@
-import { renderMarkdown, normalizeHeaderlessTables } from '@/utils/markdown'
+import { renderMarkdown, renderMarkdownOffThread, normalizeHeaderlessTables } from '@/utils/markdown'
 
 describe('renderMarkdown', () => {
   it('renders GFM features', async () => {
@@ -310,5 +310,34 @@ describe('renderMarkdown table header stripping', () => {
     expect(firstTable).not.toContain('<thead>')
     expect(secondTable).toContain('<thead>')
     expect(secondTable).toContain('<th>x</th>')
+  })
+})
+
+describe('renderMarkdownOffThread', () => {
+  it('renders inline when the environment has no Worker (jsdom)', async () => {
+    expect(typeof Worker).toBe('undefined')
+    const html = await renderMarkdownOffThread('# Hello')
+    expect(html).toContain('<h1 id="hello">Hello</h1>')
+  })
+
+  // Stubbing Worker caches the fake in the module's singleton, so this test
+  // must stay after every test that relies on the inline fallback above.
+  it('resolves and rejects through the worker protocol', async () => {
+    class FakeWorker {
+      onmessage = null
+
+      postMessage({ id, source }) {
+        const reply = source === 'bad' ? { id, error: 'boom' } : { id, html: `<p>${source}</p>` }
+        queueMicrotask(() => this.onmessage({ data: reply }))
+      }
+    }
+    vi.stubGlobal('Worker', FakeWorker)
+    try {
+      await expect(renderMarkdownOffThread('good')).resolves.toBe('<p>good</p>')
+      await expect(renderMarkdownOffThread('bad')).rejects.toThrow('boom')
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
   })
 })

--- a/tests/unit/specs/utils/markdown.spec.js
+++ b/tests/unit/specs/utils/markdown.spec.js
@@ -119,6 +119,18 @@ describe('renderMarkdown', () => {
   it('returns an empty string for empty input', async () => {
     expect(await renderMarkdown('')).toBe('')
   })
+
+  it('unwraps links matching the injected base host instead of the window host', async () => {
+    const html = await renderMarkdown('[in-app](https://datashare.example/doc)', { base: 'https://datashare.example/' })
+    expect(html).not.toContain('<a')
+    expect(html).toContain('in-app')
+  })
+
+  it('hardens a window-host link as external when the injected base is another host', async () => {
+    const windowHostUrl = `${window.location.origin}/somewhere`
+    const html = await renderMarkdown(`[away](${windowHostUrl})`, { base: 'https://datashare.example/' })
+    expect(html).toContain('target="_blank"')
+  })
 })
 
 describe('normalizeHeaderlessTables', () => {

--- a/tests/unit/specs/utils/markdown.spec.js
+++ b/tests/unit/specs/utils/markdown.spec.js
@@ -340,4 +340,35 @@ describe('renderMarkdownOffThread', () => {
       vi.unstubAllGlobals()
     }
   })
+
+  it('rejects pending renders when the worker fails to initialize', async () => {
+    // Reload the module to clear the cached worker singleton from previous tests
+    vi.resetModules()
+    const markdown = await import('@/utils/markdown')
+    const freshRenderMarkdownOffThread = markdown.renderMarkdownOffThread
+
+    let workerCount = 0
+    class FailingWorker {
+      onerror = null
+
+      constructor() {
+        workerCount++
+      }
+
+      postMessage() {
+        queueMicrotask(() => this.onerror(new Error('worker died')))
+      }
+    }
+    vi.stubGlobal('Worker', FailingWorker)
+    try {
+      await expect(freshRenderMarkdownOffThread('test')).rejects.toThrow('worker died')
+      expect(workerCount).toBe(1)
+      // Next call constructs a fresh worker since the previous one was reset to null
+      await expect(freshRenderMarkdownOffThread('retry')).rejects.toThrow('worker died')
+      expect(workerCount).toBe(2)
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
+  })
 })

--- a/tests/unit/specs/utils/markdown.spec.js
+++ b/tests/unit/specs/utils/markdown.spec.js
@@ -1,4 +1,4 @@
-import { renderMarkdown, renderMarkdownOffThread, normalizeHeaderlessTables } from '@/utils/markdown'
+import { renderMarkdown, normalizeHeaderlessTables } from '@/utils/markdown'
 
 describe('renderMarkdown', () => {
   it('renders GFM features', async () => {
@@ -310,67 +310,5 @@ describe('renderMarkdown table header stripping', () => {
     expect(firstTable).not.toContain('<thead>')
     expect(secondTable).toContain('<thead>')
     expect(secondTable).toContain('<th>x</th>')
-  })
-})
-
-describe('renderMarkdownOffThread', () => {
-  it('renders inline when the environment has no Worker (jsdom)', async () => {
-    expect(typeof Worker).toBe('undefined')
-    const html = await renderMarkdownOffThread('# Hello')
-    expect(html).toContain('<h1 id="hello">Hello</h1>')
-  })
-
-  // Stubbing Worker caches the fake in the module's singleton, so this test
-  // must stay after every test that relies on the inline fallback above.
-  it('resolves and rejects through the worker protocol', async () => {
-    class FakeWorker {
-      onmessage = null
-
-      postMessage({ id, source }) {
-        const reply = source === 'bad' ? { id, error: 'boom' } : { id, html: `<p>${source}</p>` }
-        queueMicrotask(() => this.onmessage({ data: reply }))
-      }
-    }
-    vi.stubGlobal('Worker', FakeWorker)
-    try {
-      await expect(renderMarkdownOffThread('good')).resolves.toBe('<p>good</p>')
-      await expect(renderMarkdownOffThread('bad')).rejects.toThrow('boom')
-    }
-    finally {
-      vi.unstubAllGlobals()
-    }
-  })
-
-  it('rejects pending renders when the worker fails to initialize', async () => {
-    // Reload the module to clear the cached worker singleton from previous tests
-    vi.resetModules()
-    const markdown = await import('@/utils/markdown')
-    const freshRenderMarkdownOffThread = markdown.renderMarkdownOffThread
-
-    let workerCount = 0
-    class FailingWorker {
-      onerror = null
-
-      constructor() {
-        workerCount++
-      }
-
-      postMessage() {
-        queueMicrotask(() => this.onerror(new Error('worker died')))
-      }
-
-      terminate() {}
-    }
-    vi.stubGlobal('Worker', FailingWorker)
-    try {
-      await expect(freshRenderMarkdownOffThread('test')).rejects.toThrow('worker died')
-      expect(workerCount).toBe(1)
-      // Next call constructs a fresh worker since the previous one was reset to null
-      await expect(freshRenderMarkdownOffThread('retry')).rejects.toThrow('worker died')
-      expect(workerCount).toBe(2)
-    }
-    finally {
-      vi.unstubAllGlobals()
-    }
   })
 })

--- a/tests/unit/specs/utils/markdown.spec.js
+++ b/tests/unit/specs/utils/markdown.spec.js
@@ -70,6 +70,19 @@ describe('renderMarkdown', () => {
     expect(html).toContain('doc')
   })
 
+  it('keeps hardening external links when the base is unresolvable', async () => {
+    const html = await renderMarkdown('[x](https://other.example/a)', { base: '' })
+    expect(html).toContain('href="https://other.example/a"')
+    expect(html).toContain('rel="noopener noreferrer nofollow"')
+    expect(html).toContain('target="_blank"')
+  })
+
+  it('unwraps a relative link when the base is unresolvable', async () => {
+    const html = await renderMarkdown('[x](/relative)', { base: '' })
+    expect(html).not.toContain('<a')
+    expect(html).toContain('x')
+  })
+
   it('unlinks an absolute link back to the host serving the app', async () => {
     const html = await renderMarkdown(`[home](${window.location.origin}/some/page)`)
     expect(html).not.toContain('<a')

--- a/tests/unit/specs/utils/markdown.spec.js
+++ b/tests/unit/specs/utils/markdown.spec.js
@@ -358,6 +358,8 @@ describe('renderMarkdownOffThread', () => {
       postMessage() {
         queueMicrotask(() => this.onerror(new Error('worker died')))
       }
+
+      terminate() {}
     }
     vi.stubGlobal('Worker', FailingWorker)
     try {

--- a/tests/unit/specs/utils/markdownOffThread.spec.js
+++ b/tests/unit/specs/utils/markdownOffThread.spec.js
@@ -115,6 +115,50 @@ describe('renderMarkdownOffThread', () => {
     }
   })
 
+  it('fails only the stuck render on timeout and moves the queued ones to a fresh worker', async () => {
+    vi.resetModules()
+    const { renderMarkdownOffThread: freshRenderMarkdownOffThread } = await import('@/utils/markdownOffThread')
+
+    vi.useFakeTimers()
+    const spawned = []
+    class StuckWorker {
+      onmessage = null
+
+      constructor() {
+        spawned.push(this)
+        this.posted = []
+      }
+
+      postMessage(message) {
+        this.posted.push(message)
+      }
+
+      terminate() {}
+    }
+    vi.stubGlobal('Worker', StuckWorker)
+    try {
+      const stuck = freshRenderMarkdownOffThread('stuck')
+      // The timer below rejects this promise before the assertion attaches its
+      // own handler, so a no-op one keeps the rejection from going unhandled.
+      stuck.catch(() => {})
+      // The queued render is requested a moment later, so only the stuck one
+      // reaches its deadline when the clock advances by the render timeout.
+      vi.advanceTimersByTime(10)
+      const queued = freshRenderMarkdownOffThread('queued')
+      vi.advanceTimersByTime(119990)
+      await expect(stuck).rejects.toThrow('Markdown worker timed out')
+      expect(spawned).toHaveLength(2)
+      const [, freshWorker] = spawned
+      const { id } = freshWorker.posted.find(({ source }) => source === 'queued')
+      freshWorker.onmessage({ data: { id, html: '<p>queued</p>' } })
+      await expect(queued).resolves.toBe('<p>queued</p>')
+    }
+    finally {
+      vi.useRealTimers()
+      vi.unstubAllGlobals()
+    }
+  })
+
   it('ignores a late error from a worker that was already replaced', async () => {
     vi.resetModules()
     const { renderMarkdownOffThread: freshRenderMarkdownOffThread } = await import('@/utils/markdownOffThread')

--- a/tests/unit/specs/utils/markdownOffThread.spec.js
+++ b/tests/unit/specs/utils/markdownOffThread.spec.js
@@ -1,0 +1,154 @@
+import { renderMarkdownOffThread } from '@/utils/markdownOffThread'
+
+describe('renderMarkdownOffThread', () => {
+  it('resolves an empty string without touching Worker', async () => {
+    const constructor = vi.fn()
+    vi.stubGlobal('Worker', constructor)
+    try {
+      await expect(renderMarkdownOffThread('')).resolves.toBe('')
+      expect(constructor).not.toHaveBeenCalled()
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('renders inline when the environment has no Worker (jsdom)', async () => {
+    expect(typeof Worker).toBe('undefined')
+    const html = await renderMarkdownOffThread('# Hello')
+    expect(html).toContain('<h1 id="hello">Hello</h1>')
+  })
+
+  // Stubbing Worker caches the fake in the module's singleton, so this test
+  // must stay after every test that relies on the inline fallback above.
+  it('resolves and rejects through the worker protocol', async () => {
+    class FakeWorker {
+      onmessage = null
+
+      postMessage({ id, source }) {
+        const reply = source === 'bad' ? { id, error: 'boom' } : { id, html: `<p>${source}</p>` }
+        queueMicrotask(() => this.onmessage({ data: reply }))
+      }
+    }
+    vi.stubGlobal('Worker', FakeWorker)
+    try {
+      await expect(renderMarkdownOffThread('good')).resolves.toBe('<p>good</p>')
+      await expect(renderMarkdownOffThread('bad')).rejects.toThrow('boom')
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('rejects pending renders when the worker fails to initialize', async () => {
+    // Reload the module to clear the cached worker singleton from previous tests
+    vi.resetModules()
+    const { renderMarkdownOffThread: freshRenderMarkdownOffThread } = await import('@/utils/markdownOffThread')
+
+    let workerCount = 0
+    class FailingWorker {
+      onerror = null
+
+      constructor() {
+        workerCount++
+      }
+
+      postMessage() {
+        queueMicrotask(() => this.onerror(new Error('worker died')))
+      }
+
+      terminate() {}
+    }
+    vi.stubGlobal('Worker', FailingWorker)
+    try {
+      await expect(freshRenderMarkdownOffThread('test')).rejects.toThrow('worker died')
+      expect(workerCount).toBe(1)
+      // Next call constructs a fresh worker since the previous one was reset to null
+      await expect(freshRenderMarkdownOffThread('retry')).rejects.toThrow('worker died')
+      expect(workerCount).toBe(2)
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('falls back to an inline render when the worker cannot be posted to', async () => {
+    vi.resetModules()
+    const { renderMarkdownOffThread: freshRenderMarkdownOffThread } = await import('@/utils/markdownOffThread')
+
+    class UnusableWorker {
+      postMessage() {
+        throw new Error('worker-src blocked')
+      }
+
+      terminate() {}
+    }
+    vi.stubGlobal('Worker', UnusableWorker)
+    try {
+      const html = await freshRenderMarkdownOffThread('# Hello')
+      expect(html).toContain('<h1 id="hello">Hello</h1>')
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('rejects pending renders when a worker reply cannot be deserialized', async () => {
+    vi.resetModules()
+    const { renderMarkdownOffThread: freshRenderMarkdownOffThread } = await import('@/utils/markdownOffThread')
+
+    class UndeserializableWorker {
+      onmessageerror = null
+
+      postMessage() {
+        queueMicrotask(() => this.onmessageerror(new MessageEvent('messageerror')))
+      }
+
+      terminate() {}
+    }
+    vi.stubGlobal('Worker', UndeserializableWorker)
+    try {
+      await expect(freshRenderMarkdownOffThread('test')).rejects.toThrow('Worker reply could not be deserialized')
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('ignores a late error from a worker that was already replaced', async () => {
+    vi.resetModules()
+    const { renderMarkdownOffThread: freshRenderMarkdownOffThread } = await import('@/utils/markdownOffThread')
+
+    const spawned = []
+    class LateErrorWorker {
+      onmessage = null
+      onerror = null
+
+      constructor() {
+        spawned.push(this)
+      }
+
+      postMessage({ id, source }) {
+        if (source === 'first') {
+          queueMicrotask(() => this.onerror(new Error('worker died')))
+          return
+        }
+        queueMicrotask(() => this.onmessage({ data: { id, html: `<p>${source}</p>` } }))
+      }
+
+      terminate() {}
+    }
+    vi.stubGlobal('Worker', LateErrorWorker)
+    try {
+      await expect(freshRenderMarkdownOffThread('first')).rejects.toThrow('worker died')
+      const [firstWorker] = spawned
+      const second = freshRenderMarkdownOffThread('second')
+      firstWorker.onerror(new Error('late echo'))
+      await expect(second).resolves.toBe('<p>second</p>')
+      expect(spawned).toHaveLength(2)
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})

--- a/tests/unit/specs/utils/strings.spec.js
+++ b/tests/unit/specs/utils/strings.spec.js
@@ -1,4 +1,4 @@
-import { addLocalSearchMarksClass, addLocalSearchMarksClassByOffsets, isUrl, getConsonants, foldWithSourceIndexes, addSearchMarksClassInHtml } from '@/utils/strings'
+import { addLocalSearchMarksClass, addLocalSearchMarksClassByOffsets, isUrl, getConsonants, foldWithSourceIndexes, addSearchMarksClassInHtml, addSearchMarksClassesInHtml } from '@/utils/strings'
 
 describe('strings', () => {
   describe('addLocalSearchMarksClass', () => {
@@ -287,6 +287,29 @@ describe('strings', () => {
       expect(() => addSearchMarksClassInHtml('<p>Ⅲi</p>', 'ii')).not.toThrow()
       const marked = addSearchMarksClassInHtml('<p>Ⅲi</p>', 'ii')
       expect(marked.match(/<mark class="local-search-term">/g)).toHaveLength(1)
+    })
+  })
+
+  describe('addSearchMarksClassesInHtml', () => {
+    it('nests the later marks inside the earlier ones, as chained calls did', () => {
+      const html = '<p>lorem ipsum dolor</p>'
+      const marks = [
+        { term: 'ipsum dolor', className: 'local-search-term' },
+        { term: 'dolor', className: 'global-search-term', style: 'border-color: red' }
+      ]
+      const marked = addSearchMarksClassesInHtml(html, marks)
+      const chained = addSearchMarksClassInHtml(
+        addSearchMarksClassInHtml(html, 'ipsum dolor'),
+        'dolor',
+        { className: 'global-search-term', style: 'border-color: red' }
+      )
+      expect(marked).toBe(chained)
+      expect(marked).toContain('<mark class="local-search-term">ipsum <mark class="global-search-term"')
+    })
+
+    it('skips a mark whose term is blank instead of throwing', () => {
+      const marked = addSearchMarksClassesInHtml('<p>lorem ipsum</p>', [{ term: '  ' }, { term: 'ipsum' }])
+      expect(marked).toBe('<p>lorem <mark class="local-search-term">ipsum</mark></p>')
     })
   })
 })

--- a/tests/unit/specs/utils/strings.spec.js
+++ b/tests/unit/specs/utils/strings.spec.js
@@ -1,4 +1,6 @@
-import { addLocalSearchMarksClass, addLocalSearchMarksClassByOffsets, isUrl, getConsonants, foldWithSourceIndexes, addSearchMarksClassInHtml, addSearchMarksClassesInHtml } from '@/utils/strings'
+import { addLocalSearchMarksClass, addLocalSearchMarksClassByOffsets, isUrl, getConsonants, foldWithSourceIndexes, addSearchMarksClassesInHtml } from '@/utils/strings'
+
+const addSearchMarksClassInHtml = (html, term, options = {}) => addSearchMarksClassesInHtml(html, [{ term, ...options }])
 
 describe('strings', () => {
   describe('addLocalSearchMarksClass', () => {
@@ -217,7 +219,7 @@ describe('strings', () => {
     })
   })
 
-  describe('addSearchMarksClassInHtml', () => {
+  describe('addSearchMarksClassesInHtml with a single mark', () => {
     it('wraps a case-insensitive match in a mark tag', () => {
       const html = '<p>Hello World</p>'
       const marked = addSearchMarksClassInHtml(html, 'world')

--- a/vite.config.js
+++ b/vite.config.js
@@ -92,6 +92,11 @@ export default ({ mode }) => {
         '~tests': resolve(__dirname, 'tests')
       }
     },
+    // The markdown worker is instantiated with `{ type: 'module' }`; Vite's
+    // default worker format is 'iife', which would disagree with that.
+    worker: {
+      format: 'es'
+    },
     css: {
       preprocessorOptions: {
         scss: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -84,6 +84,9 @@ export default ({ mode }) => {
       extensions: ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json', '.vue'],
       alias: {
         'path': 'path-browserify',
+        // Its browser build decodes entities through `document`, which the
+        // markdown worker does not have; the map-based build works everywhere.
+        'decode-named-character-reference': resolve(__dirname, 'node_modules/decode-named-character-reference/index.js'),
         'vue': resolve(__dirname, 'node_modules/vue/dist/vue.esm-bundler.js'),
         '@': resolve(__dirname, './src'),
         '~storybook': resolve('.storybook'),


### PR DESCRIPTION
Huge markdown structure pages froze the document text tab. This moves rendering off the main thread, caps what gets rendered without consent, and trims the layout cost.

- fix: render markdown structure pages and the markdown viewer in a Web Worker, with an inline fallback when workers are unavailable, a render timeout, and hardened worker failure paths
- fix: skip rendering pages above a size threshold, fall back to plain text, and let the reader render anyway per page from the view dropdown
- fix: keep the rendered page cache across view toggles, evicted per document
- fix: degrade link constraining instead of failing the render on an unresolvable base URL
- perf: mark all search terms in a single parse
- perf: limit content-visibility to tables and code blocks
- build: emit the markdown worker as an ES module chunk