### PR TITLE
fix(search): ensure excluded paired filters apply `must_not` to prevent bucket collisions

### DIFF
--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -444,9 +444,14 @@ export function datasharePlugin(Client) {
    * The filters constraining a bucket aggregation when the filter is
    * contextualized.
    *
-   * A paired filter (contentType ↔ contentTypeCategory) drops its own
-   * selection: its buckets would otherwise collapse to the values already
-   * picked, and its sibling keeps constraining the aggregation anyway.
+   * A paired filter (contentType ↔ contentTypeCategory), when included, drops
+   * its own selection: its buckets would otherwise collapse to the values
+   * already picked, and its sibling keeps constraining the aggregation
+   * anyway. When excluded, its own must_not must stay applied instead - same
+   * rule as an unpaired filter below - otherwise its own aggregation is
+   * computed as if the exclusion weren't there, producing a real bucket for
+   * the excluded value that collides with FilterType's synthetic zero-count
+   * row for it
    *
    * Every other filter keeps its own selection, so its buckets describe the
    * current search results, which is what contextualizing is for. Without it,
@@ -457,7 +462,7 @@ export function datasharePlugin(Client) {
    * @returns {Array} The filters to apply to the aggregation body
    */
   Client.prototype._contextFilters = function (filter, filters) {
-    if (getPairedDimension(filter.name)) {
+    if (getPairedDimension(filter.name) && !isFilterExcludedWithValues(filter)) {
       return filters.filter(other => other.name !== filter.name)
     }
     return filters

--- a/tests/unit/specs/api/elasticsearch.searchFilter.spec.js
+++ b/tests/unit/specs/api/elasticsearch.searchFilter.spec.js
@@ -79,6 +79,19 @@ describe('elasticsearch searchFilter', () => {
     expect(findTermsClause(body.query, 'contentTypeCategory')).toEqual(['DOCUMENT'])
   })
 
+  it('applies a paired filter own selection as a must_not when excluded', async () => {
+    const values = { contentType: ['application/pdf'], contentTypeCategory: [] }
+    const contentType = bindFilter(new FilterText({ name: 'contentType', key: 'contentType' }), values, { excluded: true })
+
+    const body = await contextualizedBody(contentType, [contentType])
+
+    // Same rule as an unpaired filter (see above): dropping the paired
+    // filter's own must_not here leaves nothing to exclude the value from
+    // the real aggregation, so ES returns a genuine, non-zero bucket for it —
+    // colliding with FilterType's synthetic zero-count row for the same key.
+    expect(body.query.bool.filter.bool.must_not).toContainEqual({ terms: { contentType: ['application/pdf'] } })
+  })
+
   it('leaves the aggregation context unconstrained when not contextualized', async () => {
     const values = { tags: ['bar'] }
     const tags = bindFilter(new FilterText({ name: 'tags', key: 'tags' }), values)


### PR DESCRIPTION
Fix https://github.com/ICIJ/datashare/issues/2341
This change ensures that excluded paired filters retain their `must_not` clause to correctly exclude values from the aggregation, avoiding collisions with synthetic zero-count rows. Adds regression test coverage.