### PR TITLE
fix(search): name the highlight offset field per index distribution

### DIFF
--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -24,27 +24,37 @@ const PREFERENCE = Object.freeze({
   MAX_EXTRACTION_DATE: 'max-extraction-date-by-project'
 })
 
-// Highlight configuration for search results.
-// `max_analyzed_offset` caps how far into long fields the highlighter analyzes,
-// preventing shard failures on docs whose content exceeds the index's
+// Caps how far into long fields the highlighter analyzes, preventing shard
+// failures on docs whose content exceeds the index's
 // `index.highlight.max_analyzed_offset` limit (default 1,000,000).
-const HIGHLIGHT_CONFIG = Object.freeze({
-  max_analyzed_offset: 999999,
-  fields: {
-    'content': {
-      fragment_size: 280,
-      number_of_fragments: 2,
-      pre_tags: ['<mark>'],
-      post_tags: ['</mark>']
-    },
-    'content_translated.content': {
-      fragment_size: 280,
-      number_of_fragments: 2,
-      pre_tags: ['<mark>'],
-      post_tags: ['</mark>']
-    }
+const HIGHLIGHT_MAX_OFFSET = 999999
+
+const HIGHLIGHT_FIELDS = Object.freeze({
+  'content': {
+    fragment_size: 280,
+    number_of_fragments: 2,
+    pre_tags: ['<mark>'],
+    post_tags: ['</mark>']
+  },
+  'content_translated.content': {
+    fragment_size: 280,
+    number_of_fragments: 2,
+    pre_tags: ['<mark>'],
+    post_tags: ['</mark>']
   }
 })
+
+/**
+ * Highlight configuration for search results. OpenSearch names the offset
+ * option `max_analyzer_offset` and rejects the Elasticsearch spelling with a
+ * 400 (icij/datashare#2383), even though both share the index setting name.
+ * @param {boolean} [isOpenSearch=false] - Whether the index is an OpenSearch distribution
+ * @returns {Object} The highlight option for the search body
+ */
+function highlightConfig(isOpenSearch = false) {
+  const offsetField = isOpenSearch ? 'max_analyzer_offset' : 'max_analyzed_offset'
+  return { [offsetField]: HIGHLIGHT_MAX_OFFSET, fields: HIGHLIGHT_FIELDS }
+}
 
 /**
  * Normalizes a query string, returning the default query for empty values.
@@ -211,7 +221,8 @@ export function datasharePlugin(Client) {
     perPage = 25,
     sort = { _score: { order: 'desc' } },
     fields = [],
-    operator = SEARCH_OPERATORS.OR
+    operator = SEARCH_OPERATORS.OR,
+    isOpenSearch = false
   } = {}) {
     return this._buildSearchBody({
       query: normalizeQuery(query),
@@ -220,7 +231,8 @@ export function datasharePlugin(Client) {
       from,
       size: perPage,
       sort,
-      operator
+      operator,
+      isOpenSearch
     })
   }
 
@@ -234,6 +246,7 @@ export function datasharePlugin(Client) {
    * @param {number} [options.perPage=25] - Number of results per page
    * @param {Object} [options.sort] - Sort configuration
    * @param {string[]} [options.fields=[]] - Fields to search in
+   * @param {boolean} [options.isOpenSearch=false] - Whether the index is an OpenSearch distribution
    * @returns {Promise<Object>} Search results
    */
   Client.prototype.searchDocs = function (options, { signal } = {}) {
@@ -555,9 +568,10 @@ export function datasharePlugin(Client) {
    * @param {number} options.size - Number of results
    * @param {Object} options.sort - Sort configuration
    * @param {string} options.operator - Default search operator for the query string (AND or OR)
+   * @param {boolean} options.isOpenSearch - Whether the index is an OpenSearch distribution
    * @returns {Object} The built search body
    */
-  Client.prototype._buildSearchBody = function ({ query, filters, fields, from, size, sort, operator }) {
+  Client.prototype._buildSearchBody = function ({ query, filters, fields, from, size, sort, operator, isOpenSearch }) {
     const body = bodybuilder()
 
     // Apply filters (handles paired-dimension OR combine)
@@ -579,7 +593,7 @@ export function datasharePlugin(Client) {
     })
 
     // Add highlighting
-    body.rawOption('highlight', HIGHLIGHT_CONFIG)
+    body.rawOption('highlight', highlightConfig(isOpenSearch))
 
     // Ensure accurate total hits count (ES 8+ compatibility)
     body.rawOption('track_total_hits', true)
@@ -672,7 +686,7 @@ export function datasharePlugin(Client) {
     const body = this.rootSearch(filters, query, fields)
     body.from(from).size(size).sort(sort)
     body.rawOption('_source', { includes: ['*'], excludes: CONTENT_FIELDS })
-    body.rawOption('highlight', HIGHLIGHT_CONFIG)
+    body.rawOption('highlight', highlightConfig())
     return body
   }
 }

--- a/src/composables/useSearchNav.js
+++ b/src/composables/useSearchNav.js
@@ -3,6 +3,7 @@ import { useRouter, useRoute } from 'vue-router'
 import clamp from 'lodash/clamp'
 import matches from 'lodash/matches'
 import EsDocList from '@/api/resources/EsDocList'
+import { isOpenSearchDistribution } from '@/api/indexDistribution'
 import { useBreakpoints } from '@/composables/useBreakpoints'
 import { useCore } from '@/composables/useCore'
 import { useDocument } from '@/composables/useDocument'
@@ -101,7 +102,8 @@ export function useSearchNav(currentDocument = null) {
     const halfCarousel = Math.floor(carouselSize / 2)
     const maxStart = Math.max(0, total.value - carouselSize)
     const from = clamp(position - halfCarousel, 0, maxStart)
-    const raw = await core.api.elasticsearch.searchDocs({ ...params, from, perPage: carouselSize })
+    const isOpenSearch = await isOpenSearchDistribution(core.api)
+    const raw = await core.api.elasticsearch.searchDocs({ ...params, from, perPage: carouselSize, isOpenSearch })
     const response = new EsDocList(raw, null, null, from)
     return response.hits
   }

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -873,7 +873,8 @@ export const useSearchStore = defineSuffixedStore('search', () => {
     const isOpenSearch = await isOpenSearchDistribution(api)
     // A run cancelled while the probe was pending must not submit anything.
     signal?.throwIfAborted()
-    return isOpenSearch ? searchDocsSync(searchParams, signal) : searchDocsAsync(searchParams, signal)
+    const params = { ...searchParams, isOpenSearch }
+    return isOpenSearch ? searchDocsSync(params, signal) : searchDocsAsync(params, signal)
   }
 
   /**

--- a/tests/unit/specs/api/elasticsearch.asyncSearch.spec.js
+++ b/tests/unit/specs/api/elasticsearch.asyncSearch.spec.js
@@ -17,6 +17,22 @@ describe('elasticsearch async search wrappers', () => {
       expect(body.highlight).toBeDefined()
     })
 
+    it('caps the highlighter with the Elasticsearch offset field by default', () => {
+      const body = elasticsearch.buildSearchDocsBody({ index: 'idx', query: 'foo' })
+      expect(body.highlight.max_analyzed_offset).toBe(999999)
+      expect(body.highlight.max_analyzer_offset).toBeUndefined()
+      expect(body.highlight.fields).toHaveProperty('content')
+    })
+
+    it('caps the highlighter with the OpenSearch offset field on an OpenSearch index', () => {
+      const body = elasticsearch.buildSearchDocsBody({ index: 'idx', query: 'foo', isOpenSearch: true })
+      expect(body.highlight.max_analyzer_offset).toBe(999999)
+      expect(body.highlight.max_analyzed_offset).toBeUndefined()
+      expect(body.highlight.fields).toEqual(
+        elasticsearch.buildSearchDocsBody({ index: 'idx', query: 'foo' }).highlight.fields
+      )
+    })
+
     it('normalizes an empty query to the default', () => {
       const emptyBody = elasticsearch.buildSearchDocsBody({ index: 'idx', query: '' })
       const starBody = elasticsearch.buildSearchDocsBody({ index: 'idx', query: '*' })

--- a/tests/unit/specs/store/modules/search.asyncSearch.spec.js
+++ b/tests/unit/specs/store/modules/search.asyncSearch.spec.js
@@ -193,6 +193,25 @@ describe('SearchStore async search wiring', () => {
       expect(searchDocsSpy).not.toHaveBeenCalled()
     })
 
+    it('tells the synchronous search it runs against OpenSearch', async () => {
+      isOpenSearchMock.mockResolvedValue(true)
+
+      await searchStore.query('alpha')
+
+      const [searchParams] = searchDocsSpy.mock.calls[0]
+      expect(searchParams.isOpenSearch).toBe(true)
+    })
+
+    it('builds the async search body with the Elasticsearch offset field', async () => {
+      runAsyncSearchMock.mockResolvedValue(emptyResponse())
+      const buildSpy = vi.spyOn(api.elasticsearch, 'buildSearchDocsBody')
+
+      await searchStore.query('alpha')
+
+      const [searchParams] = buildSpy.mock.calls[0]
+      expect(searchParams.isOpenSearch).toBe(false)
+    })
+
     it('treats a cancelled synchronous search as an abort, not an error', async () => {
       isOpenSearchMock.mockResolvedValue(true)
       // The transport rejects with its own error on abort, never an AbortError.


### PR DESCRIPTION
Search returned a 500 on every OpenSearch index because the highlight option was hardcoded to the Elasticsearch field name, which OpenSearch rejects with a 400. The field name now follows the distribution the client already probes.

- fix: pick `max_analyzer_offset` on OpenSearch and keep `max_analyzed_offset` on Elasticsearch
- fix: pass the probed distribution to the document carousel, which hit the same 500
- test: cover both field names in the search body and the flag passed by the store

Fixes ICIJ/datashare#2383