### PR TITLE
feat: skip missing indices when reading per-project stats

### DIFF
--- a/src/api/elasticsearch.js
+++ b/src/api/elasticsearch.js
@@ -24,6 +24,11 @@ const PREFERENCE = Object.freeze({
   MAX_EXTRACTION_DATE: 'max-extraction-date-by-project'
 })
 
+// Project statistics span projects whose index may not exist yet: elasticsearch
+// rejects the whole request when any named index is missing, which would zero out
+// the figures of every other project (icij/datashare#2384).
+const IGNORE_MISSING_INDEX = Object.freeze({ ignore_unavailable: true })
+
 // Caps how far into long fields the highlighter analyzes, preventing shard
 // failures on docs whose content exceeds the index's
 // `index.highlight.max_analyzed_offset` limit (default 1,000,000).
@@ -398,7 +403,7 @@ export function datasharePlugin(Client) {
    */
   Client.prototype.countDocuments = async function (index) {
     const body = { query: { query_string: { query: 'type:Document' } } }
-    const res = await this.count({ index, body, preference: PREFERENCE.DOCUMENTS_COUNT })
+    const res = await this.count({ index, body, preference: PREFERENCE.DOCUMENTS_COUNT, ...IGNORE_MISSING_INDEX })
     return res?.count ?? 0
   }
 
@@ -412,7 +417,7 @@ export function datasharePlugin(Client) {
       size: 0,
       aggs: { count: { cardinality: { field: 'tags' } } }
     }
-    const res = await this.search({ index, body, preference: PREFERENCE.TAGS_COUNT })
+    const res = await this.search({ index, body, preference: PREFERENCE.TAGS_COUNT, ...IGNORE_MISSING_INDEX })
     return res?.aggregations?.count?.value ?? 0
   }
 
@@ -429,7 +434,7 @@ export function datasharePlugin(Client) {
       query,
       aggs: { index: { terms: { field: '_index', size } } }
     }
-    return this._search({ index, body, preference: PREFERENCE.COUNT_BY_PROJECT })
+    return this._search({ index, body, preference: PREFERENCE.COUNT_BY_PROJECT, ...IGNORE_MISSING_INDEX })
   }
 
   /**
@@ -450,7 +455,7 @@ export function datasharePlugin(Client) {
         }
       }
     }
-    return this._search({ index, body, preference: PREFERENCE.MAX_EXTRACTION_DATE })
+    return this._search({ index, body, preference: PREFERENCE.MAX_EXTRACTION_DATE, ...IGNORE_MISSING_INDEX })
   }
 
   /**

--- a/src/views/Project/ProjectView/ProjectViewOverview/ProjectViewOverview.vue
+++ b/src/views/Project/ProjectView/ProjectViewOverview/ProjectViewOverview.vue
@@ -50,7 +50,7 @@ const lastIndexingDate = ref(null)
 
 const fetchDocumentsCount = async () => {
   const { name: index } = props
-  const { count } = await core.api.elasticsearch.count({ index })
+  const { count } = await core.api.elasticsearch.count({ index, ignore_unavailable: true })
   return count
 }
 

--- a/tests/unit/specs/api/elasticsearch.spec.js
+++ b/tests/unit/specs/api/elasticsearch.spec.js
@@ -333,6 +333,41 @@ describe('elasticsearch', () => {
     })
   })
 
+  describe('per-project statistics when an index is missing', () => {
+    // A project row can exist without its elasticsearch index, and elasticsearch
+    // rejects the whole request when any named index is missing (icij/datashare#2384).
+    const missingIndex = 'project-without-an-index'
+    const extractionDate = '2026-01-15T10:00:00.000Z'
+
+    beforeEach(async () => {
+      await letData(es)
+        .have(new IndexedDocument('document_stats_01', index).withIndexingDate(extractionDate))
+        .commit()
+    })
+
+    it('counts documents by project, skipping the missing index', async () => {
+      const query = { match: { type: 'Document' } }
+      const { aggregations } = await elasticsearch.countByProject(`${index},${missingIndex}`, query)
+      expect(aggregations.index.buckets).toHaveLength(1)
+      expect(aggregations.index.buckets[0]).toMatchObject({ key: index, doc_count: 1 })
+    })
+
+    it('gets the max extraction date by project, skipping the missing index', async () => {
+      const query = { match: { type: 'Document' } }
+      const { aggregations } = await elasticsearch.maxExtractionDateByProject(`${index},${missingIndex}`, query)
+      expect(aggregations.index.buckets).toHaveLength(1)
+      expect(aggregations.index.buckets[0].maxExtractionDate.value).toBe(Date.parse(extractionDate))
+    })
+
+    it('counts no document for a missing index', async () => {
+      await expect(elasticsearch.countDocuments(missingIndex)).resolves.toBe(0)
+    })
+
+    it('counts no tag for a missing index', async () => {
+      await expect(elasticsearch.countTags(missingIndex)).resolves.toBe(0)
+    })
+  })
+
   describe('rootSearch', () => {
     it('passes operator to default_operator in the body', () => {
       const body = elasticsearch.rootSearch([], 'foo bar', [], 'AND').build()


### PR DESCRIPTION
The projects overview reported 0 documents and "Jan 1, 1970" for every project as soon as one project had no Elasticsearch index. A project row can exist without its index, and Elasticsearch rejects the whole request when any named index is missing, so the counts and dates of every other project were lost with it.

The statistics requests now send `ignore_unavailable=true`, so Elasticsearch skips indices that are missing or closed and returns figures for the ones that exist. Document searches are unchanged: a missing index there is a real error worth showing.

Closes ICIJ/datashare#2384

- fix: skip missing indices when counting documents and tags per project
- fix: keep the indexing date on a project overview whose index is missing
- test: cover the four statistics calls against a missing index